### PR TITLE
Use ObjectToJson empty ItemList then use JsonToObject

### DIFF
--- a/Appearance/Scripts/lib_app.nss
+++ b/Appearance/Scripts/lib_app.nss
@@ -299,12 +299,9 @@ void DressingRoomCreateCopy(object oPC)
 
     location lSpawnLocation = GetLocation(oWP);
 
-    object oPCopy = CopyObject(
-        oPC, 
-        lSpawnLocation,
-        OBJECT_INVALID,
-        "",
-        TRUE);
+    json jsonPC = ObjectToJson(oPC);
+    jsonPC = JsonObjectSet(jsonPC, "ItemList", JsonObjectSet(JsonObjectGet(jsonPC, "ItemList"), "value", JsonArray()));
+    object oPCopy = JsonToObject(jsonPC, lSpawnLocation, OBJECT_INVALID, TRUE);
 
     SetObjectVisibleDistance(oPCopy, 200.0);
 


### PR DESCRIPTION
Use ObjectToJson and empty ItemList because CopyObject crashes when too many items in inventory