### PR TITLE
State of the PC not copied over to oPCopy

### DIFF
--- a/Appearance/Scripts/lib_app.nss
+++ b/Appearance/Scripts/lib_app.nss
@@ -299,7 +299,7 @@ void DressingRoomCreateCopy(object oPC)
 
     location lSpawnLocation = GetLocation(oWP);
 
-    json jsonPC = ObjectToJson(oPC);
+    json jsonPC = ObjectToJson(oPC, TRUE);
     jsonPC = JsonObjectSet(jsonPC, "ItemList", JsonObjectSet(JsonObjectGet(jsonPC, "ItemList"), "value", JsonArray()));
     object oPCopy = JsonToObject(jsonPC, lSpawnLocation, OBJECT_INVALID, TRUE);
 


### PR DESCRIPTION
After the previous fix, using ObjectToJson and JsonToObject, the state of the PC wasn't copied over (variables etc). I added TRUE to ObjectToJson