### PR TITLE
feat: Honor Duels

### DIFF
--- a/Honor Duels/INTEGRATION.md
+++ b/Honor Duels/INTEGRATION.md
@@ -1,0 +1,110 @@
+# Honor Duels — integracja
+
+System honorowych pojedynkow PvP z konfiguracja regul, stawkami w zlocie,
+arena ograniczona miejscem wyzwania i rankingiem honoru.
+
+## Co dostajesz
+
+- Tablica honoru (placeable -> NUI z 3 zakladkami: Wyzwania / Historia / Ranking).
+- Wyzwanie w trybie targetingu z wyborem przeciwnika.
+- Konfiguracja przed wyslaniem: warunek zwyciestwa (pierwsza krew / na smierc /
+  do poddania), reguly (bez magii, bez mikstur, bez krytykow), stawka w zlocie.
+- Popup u wyzwanego: przyjmij / odrzuc.
+- Odliczanie 5s, automatyczne ustawienie wrogosci tymczasowej, HUD z paskami HP.
+- Tick co 1s: sprawdza HP, granice areny (10m), warunki zwyciestwa.
+- Forfeit za ucieczke (>6s poza arena) lub poddanie sie.
+- Honor: +10 wygrana, -3 porazka, -15 odmowa, -25 forfeit, +5 bonus za smiertelny cios.
+- Stawka: zwyciezca zabiera obie polowy, remis = zwrot.
+- Persystencja: SQLite (campaign-scope, baza "duel").
+
+## Wymagania
+
+- NWN:EE (NUI + JSON API).
+- Brak NWNX (czysty NWScript).
+
+## Podpiecie hookow modulu
+
+W plikach swojego modulu wlacz (lub dodaj) odpowiednie wywolania:
+
+### `OnModuleLoad`
+```nwscript
+ExecuteScript("sys_on_load", OBJECT_SELF);
+```
+Tworzy schemat SQL i czysci wygasle wyzwania.
+
+### `OnClientEnter`
+```nwscript
+ExecuteScript("sys_on_enter", OBJECT_SELF);
+```
+Rejestruje gracza w tabeli honoru i pokazuje liczbe oczekujacych wyzwan.
+
+### `OnPlayerTarget`
+```nwscript
+ExecuteScript("sys_on_target", OBJECT_SELF);
+```
+Obsluguje wybor przeciwnika po klikniecu "Rzuc rekawice".
+Jezeli juz uzywasz `sys_on_target` z innego modulu (np. Mailbox, Spell Macro),
+polacz logike: wywolaj kazdy z handlerow lub dodaj wlasny dispatcher.
+
+## Otwarcie tablicy honoru
+
+Na placeable typu "tablica honoru" / "rynek miejski" / podpis na ladnym sztandarze:
+```nwscript
+// OnUsed:
+#include "lib_duel"
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+    CreateDuelMainWindow(oPC);
+}
+```
+(rownowazne `test_duel.nss` zalaczone w module).
+
+## Uwagi projektowe
+
+- **Arena** to lokalizacja wyzywajacego w momencie utworzenia wyzwania.
+  Promien 10m. Wyzwany musi stawic sie w 1.5x promienia, by przyjac.
+- **Reguly bez_magii / bez_mikstur / bez_krytykow** sa zapisywane i wyswietlane,
+  ale ich egzekucja (blokada rzucania, blokada uzycia itemu, neutralizacja
+  krytyka) nie jest zaszyta w tej wersji — wymaga hookow OnSpellCastAt /
+  OnUseItem. Zostawione jako rozszerzenie.
+- **Wrogosc** ustawiana przez `SetIsTemporaryEnemy` / `SetIsTemporaryNeutral`.
+  Inni gracze nie sa blokowani od interwencji — w docelowym serwerze wprowadz
+  zone PvP lub zakaz przez OnPhysicalAttacked.
+- **Stawka offline:** jezeli wyzywajacy wyloguje sie przed odpowiedzia,
+  zlote idzie w zapomnienie (limit MVP). Realny serwer powinien zwracac przez
+  Mailbox.
+- **Smiertelny cios** liczony tylko przy warunku TO_DEATH; pierwsza krew i
+  poddanie nie zwiekszaja licznika `kills`.
+
+## Pliki
+
+| Plik                  | LOC | Rola                                        |
+|-----------------------|----:|---------------------------------------------|
+| `lib_duel_def.nss`    | 240 | Stale, statusy, reguly, layout, helpery.    |
+| `sql_duel.nss`        | 339 | Schemat (duels + duel_honor) + CRUD.        |
+| `lib_duel_flow.nss`   | 526 | State machine: submit/accept/decline/begin/ |
+|                       |     | tick/yield/end + honor i stawka.            |
+| `lib_duel_ui.nss`     | 290 | Glowne okno (3 zakladki) + feedy listy.     |
+| `lib_duel_hud.nss`    | 250 | HUD aktywnego pojedynku + popup wyzwania +  |
+|                       |     | popup konfiguracji wyzwania.                |
+| `lib_duel_ev.nss`     | 230 | Router eventow NUI dla 4 okien.             |
+| `lib_duel.nss`        |  35 | Fasada (#include + DuelStartChallengeTargeting). |
+| `sys_on_load.nss`     |   6 | Init schematu + expire.                     |
+| `sys_on_enter.nss`    |  16 | Rejestracja honoru + powiadomienie.         |
+| `sys_on_target.nss`   |  10 | Targeting -> popup konfiguracji.            |
+| `test_duel.nss`       |   7 | Otwarcie tablicy honoru z placeable.        |
+| `lib_nui.nss`         | 108 | Pomocnicza warstwa NUI (kopia z Mailbox).   |
+| `lib_nui_utility.nss` |  98 | Pomocnicza warstwa NUI (kopia z Mailbox).   |
+
+## Co celowo pominieto (do rozwazenia w v2)
+
+- Egzekucja regul (no_magic / no_items / no_crit) wymaga hookow OnSpellCastAt
+  i OnUseItem — duzy refactor poza zakres.
+- Sekundanci / swiadkowie.
+- Animacje powitalne (sklon, salut mieczem) — wymaga `PlayAnimation` w
+  `DuelBegin` ale moze sie gryzc z gotowoscia bojowa.
+- Zone PvP (blokada interwencji innych graczy).
+- Zwrot stawki przez Mailbox dla offline'owych graczy.
+- HAK z grafika tla do glownego okna i ikona tablicy honoru.

--- a/Honor Duels/INTEGRATION.md
+++ b/Honor Duels/INTEGRATION.md
@@ -1,56 +1,57 @@
-# Honor Duels — integracja
+# Honor Duels — integration
 
-System honorowych pojedynkow PvP z konfiguracja regul, stawkami w zlocie,
-arena ograniczona miejscem wyzwania i rankingiem honoru.
+PvP honor-duel system with configurable rules, gold stakes, an arena
+bounded by the challenger's location, and an honor ranking.
 
-## Co dostajesz
+## What you get
 
-- Tablica honoru (placeable -> NUI z 3 zakladkami: Wyzwania / Historia / Ranking).
-- Wyzwanie w trybie targetingu z wyborem przeciwnika.
-- Konfiguracja przed wyslaniem: warunek zwyciestwa (pierwsza krew / na smierc /
-  do poddania), reguly (bez magii, bez mikstur, bez krytykow), stawka w zlocie.
-- Popup u wyzwanego: przyjmij / odrzuc.
-- Odliczanie 5s, automatyczne ustawienie wrogosci tymczasowej, HUD z paskami HP.
-- Tick co 1s: sprawdza HP, granice areny (10m), warunki zwyciestwa.
-- Forfeit za ucieczke (>6s poza arena) lub poddanie sie.
-- Honor: +10 wygrana, -3 porazka, -15 odmowa, -25 forfeit, +5 bonus za smiertelny cios.
-- Stawka: zwyciezca zabiera obie polowy, remis = zwrot.
-- Persystencja: SQLite (campaign-scope, baza "duel").
+- Honor board (placeable -> NUI window with 3 tabs: Challenges / History / Ranking).
+- Challenge via targeting mode with opponent selection.
+- Pre-send configuration: win condition (first blood / to the death /
+  until yield), rules (no magic, no potions/scrolls, no crits), gold stake.
+- Popup on the challenged side: accept / decline.
+- 5-second countdown, automatic temporary hostility, HUD with HP bars.
+- Tick every 1s: HP check, arena bounds (10m radius), win condition.
+- Forfeit on flee (>6s outside the arena) or yield.
+- Honor: +10 win, -3 loss, -15 decline, -25 forfeit, +5 bonus on a death-duel kill.
+- Stakes: winner takes both halves; mutual death = refund.
+- Persistence: SQLite (campaign-scope, database name `duel`).
 
-## Wymagania
+## Requirements
 
 - NWN:EE (NUI + JSON API).
-- Brak NWNX (czysty NWScript).
+- No NWNX (pure NWScript).
 
-## Podpiecie hookow modulu
+## Wiring module hooks
 
-W plikach swojego modulu wlacz (lub dodaj) odpowiednie wywolania:
+In your module's event handlers, call the corresponding entry points:
 
 ### `OnModuleLoad`
 ```nwscript
 ExecuteScript("sys_on_load", OBJECT_SELF);
 ```
-Tworzy schemat SQL i czysci wygasle wyzwania.
+Creates the SQL schema and expires stale challenges.
 
 ### `OnClientEnter`
 ```nwscript
 ExecuteScript("sys_on_enter", OBJECT_SELF);
 ```
-Rejestruje gracza w tabeli honoru i pokazuje liczbe oczekujacych wyzwan.
+Registers the player in the honor table and notifies them about pending challenges.
 
 ### `OnPlayerTarget`
 ```nwscript
 ExecuteScript("sys_on_target", OBJECT_SELF);
 ```
-Obsluguje wybor przeciwnika po klikniecu "Rzuc rekawice".
-Jezeli juz uzywasz `sys_on_target` z innego modulu (np. Mailbox, Spell Macro),
-polacz logike: wywolaj kazdy z handlerow lub dodaj wlasny dispatcher.
+Handles target selection after the player clicks "Throw down the gauntlet".
+If you already use `OnPlayerTarget` for another module (e.g. Mailbox, Spell Macro),
+merge the dispatch logic — call each handler conditionally based on context.
 
-## Otwarcie tablicy honoru
+## Opening the honor board
 
-Na placeable typu "tablica honoru" / "rynek miejski" / podpis na ladnym sztandarze:
+On a placeable (e.g. an honor board, town square notice, signpost), set its
+OnUsed handler to:
+
 ```nwscript
-// OnUsed:
 #include "lib_duel"
 void main()
 {
@@ -59,52 +60,52 @@ void main()
     CreateDuelMainWindow(oPC);
 }
 ```
-(rownowazne `test_duel.nss` zalaczone w module).
+(Equivalent to the bundled `test_duel.nss`.)
 
-## Uwagi projektowe
+## Design notes
 
-- **Arena** to lokalizacja wyzywajacego w momencie utworzenia wyzwania.
-  Promien 10m. Wyzwany musi stawic sie w 1.5x promienia, by przyjac.
-- **Reguly bez_magii / bez_mikstur / bez_krytykow** sa zapisywane i wyswietlane,
-  ale ich egzekucja (blokada rzucania, blokada uzycia itemu, neutralizacja
-  krytyka) nie jest zaszyta w tej wersji — wymaga hookow OnSpellCastAt /
-  OnUseItem. Zostawione jako rozszerzenie.
-- **Wrogosc** ustawiana przez `SetIsTemporaryEnemy` / `SetIsTemporaryNeutral`.
-  Inni gracze nie sa blokowani od interwencji — w docelowym serwerze wprowadz
-  zone PvP lub zakaz przez OnPhysicalAttacked.
-- **Stawka offline:** jezeli wyzywajacy wyloguje sie przed odpowiedzia,
-  zlote idzie w zapomnienie (limit MVP). Realny serwer powinien zwracac przez
-  Mailbox.
-- **Smiertelny cios** liczony tylko przy warunku TO_DEATH; pierwsza krew i
-  poddanie nie zwiekszaja licznika `kills`.
+- **Arena** is the challenger's location at the moment the challenge is created.
+  Radius is 10m. The challenged player must come within 1.5x the radius to
+  accept.
+- **Rules** (no_magic / no_items / no_crit) are persisted and displayed,
+  but their enforcement (block spellcasting, block item use, neutralize crits)
+  is **not** wired up in this version — that requires `OnSpellCastAt` /
+  `OnUseItem` hooks. Left as a future extension.
+- **Hostility** uses `SetIsTemporaryEnemy` / `SetIsTemporaryNeutral`. Other
+  players are not blocked from interfering — for a real server, add a PvP
+  zone or block intervention via `OnPhysicalAttacked`.
+- **Offline stakes**: if the challenger logs out before a response, the gold
+  is lost (MVP limitation). A real server should refund via Mailbox.
+- **Killing blow** counter only increments when the win condition is
+  TO_DEATH; first blood and yield do not increment `kills`.
 
-## Pliki
+## Files
 
-| Plik                  | LOC | Rola                                        |
-|-----------------------|----:|---------------------------------------------|
-| `lib_duel_def.nss`    | 240 | Stale, statusy, reguly, layout, helpery.    |
-| `sql_duel.nss`        | 339 | Schemat (duels + duel_honor) + CRUD.        |
-| `lib_duel_flow.nss`   | 526 | State machine: submit/accept/decline/begin/ |
-|                       |     | tick/yield/end + honor i stawka.            |
-| `lib_duel_ui.nss`     | 290 | Glowne okno (3 zakladki) + feedy listy.     |
-| `lib_duel_hud.nss`    | 250 | HUD aktywnego pojedynku + popup wyzwania +  |
-|                       |     | popup konfiguracji wyzwania.                |
-| `lib_duel_ev.nss`     | 230 | Router eventow NUI dla 4 okien.             |
-| `lib_duel.nss`        |  35 | Fasada (#include + DuelStartChallengeTargeting). |
-| `sys_on_load.nss`     |   6 | Init schematu + expire.                     |
-| `sys_on_enter.nss`    |  16 | Rejestracja honoru + powiadomienie.         |
-| `sys_on_target.nss`   |  10 | Targeting -> popup konfiguracji.            |
-| `test_duel.nss`       |   7 | Otwarcie tablicy honoru z placeable.        |
-| `lib_nui.nss`         | 108 | Pomocnicza warstwa NUI (kopia z Mailbox).   |
-| `lib_nui_utility.nss` |  98 | Pomocnicza warstwa NUI (kopia z Mailbox).   |
+| File                  | LOC | Role                                            |
+|-----------------------|----:|-------------------------------------------------|
+| `lib_duel_def.nss`    | 240 | Constants, statuses, rules, layout, formatters. |
+| `sql_duel.nss`        | 339 | Schema (`duels` + `duel_honor`) + CRUD.         |
+| `lib_duel_flow.nss`   | 526 | State machine: submit/accept/decline/begin/    |
+|                       |     | tick/yield/end + honor and stake handling.      |
+| `lib_duel_ui.nss`     | 338 | Main window (3 tabs) + list feed.               |
+| `lib_duel_hud.nss`    | 272 | Active-duel HUD + incoming + challenge config   |
+|                       |     | popups.                                         |
+| `lib_duel_ev.nss`     | 261 | NUI event router for all 4 windows.             |
+| `lib_duel.nss`        |  38 | Public facade (`#include` + targeting helper).  |
+| `sys_on_load.nss`     |   7 | Schema init + expire.                           |
+| `sys_on_enter.nss`    |  18 | Honor registration + pending notification.      |
+| `sys_on_target.nss`   |  13 | Targeting -> challenge config popup.            |
+| `test_duel.nss`       |   8 | OnUsed entry point for the honor-board placeable.|
+| `lib_nui.nss`         | 108 | NUI helper layer (copied from Mailbox).         |
+| `lib_nui_utility.nss` |  98 | NUI helper layer (copied from Mailbox).         |
 
-## Co celowo pominieto (do rozwazenia w v2)
+## Intentionally omitted (consider for v2)
 
-- Egzekucja regul (no_magic / no_items / no_crit) wymaga hookow OnSpellCastAt
-  i OnUseItem — duzy refactor poza zakres.
-- Sekundanci / swiadkowie.
-- Animacje powitalne (sklon, salut mieczem) — wymaga `PlayAnimation` w
-  `DuelBegin` ale moze sie gryzc z gotowoscia bojowa.
-- Zone PvP (blokada interwencji innych graczy).
-- Zwrot stawki przez Mailbox dla offline'owych graczy.
-- HAK z grafika tla do glownego okna i ikona tablicy honoru.
+- Rule enforcement (no_magic / no_items / no_crit) requires `OnSpellCastAt`
+  and `OnUseItem` hooks — significant refactor outside MVP scope.
+- Seconds / witnesses.
+- Salute animations (bow, sword salute) — risk of conflict with combat
+  readiness.
+- PvP zone (block other players from interfering).
+- Refunding stakes via Mailbox for offline players.
+- HAK with main-window background art and an honor-board icon.

--- a/Honor Duels/Scripts/lib_duel.nss
+++ b/Honor Duels/Scripts/lib_duel.nss
@@ -1,0 +1,38 @@
+// Honor Duels — public facade.
+// Includes both UI and flow modules so callers only need #include "lib_duel".
+#include "lib_duel_ui"
+#include "lib_duel_hud"
+#include "lib_duel_flow"
+
+void DuelStartChallengeTargeting(object oPC)
+{
+    if(DuelHasAnyActive(GetObjectUUID(oPC)))
+    {
+        SendMessageToPC(oPC, "[Pojedynek] Konczysz najpierw obecny pojedynek.");
+        return;
+    }
+    SendMessageToPC(oPC,
+        "[Pojedynek] Wybierz wroga w zasiegu wzroku. Klamcy spluwaja na kodeks.");
+    EnterTargetingMode(oPC, OBJECT_TYPE_CREATURE);
+}
+
+void DuelOnPlayerTarget(object oPC)
+{
+    object oTarget = GetTargetingModeSelectedObject();
+    if(!GetIsObjectValid(oTarget))
+    {
+        SendMessageToPC(oPC, "[Pojedynek] Wybor anulowany.");
+        return;
+    }
+    if(!GetIsPC(oTarget))
+    {
+        SendMessageToPC(oPC, "[Pojedynek] Tylko grajacy moga stanac do honorowej walki.");
+        return;
+    }
+    if(oTarget == oPC)
+    {
+        SendMessageToPC(oPC, "[Pojedynek] Nie wyzywaj samego siebie.");
+        return;
+    }
+    DuelShowChallengeConfig(oPC, GetObjectUUID(oTarget), GetName(oTarget));
+}

--- a/Honor Duels/Scripts/lib_duel.nss
+++ b/Honor Duels/Scripts/lib_duel.nss
@@ -8,11 +8,11 @@ void DuelStartChallengeTargeting(object oPC)
 {
     if(DuelHasAnyActive(GetObjectUUID(oPC)))
     {
-        SendMessageToPC(oPC, "[Pojedynek] Konczysz najpierw obecny pojedynek.");
+        SendMessageToPC(oPC, "[Duel] Finish your current duel first.");
         return;
     }
     SendMessageToPC(oPC,
-        "[Pojedynek] Wybierz wroga w zasiegu wzroku. Klamcy spluwaja na kodeks.");
+        "[Duel] Choose your foe within sight. Liars spit on the code.");
     EnterTargetingMode(oPC, OBJECT_TYPE_CREATURE);
 }
 
@@ -21,17 +21,17 @@ void DuelOnPlayerTarget(object oPC)
     object oTarget = GetTargetingModeSelectedObject();
     if(!GetIsObjectValid(oTarget))
     {
-        SendMessageToPC(oPC, "[Pojedynek] Wybor anulowany.");
+        SendMessageToPC(oPC, "[Duel] Selection canceled.");
         return;
     }
     if(!GetIsPC(oTarget))
     {
-        SendMessageToPC(oPC, "[Pojedynek] Tylko grajacy moga stanac do honorowej walki.");
+        SendMessageToPC(oPC, "[Duel] Only living players may answer the code of honor.");
         return;
     }
     if(oTarget == oPC)
     {
-        SendMessageToPC(oPC, "[Pojedynek] Nie wyzywaj samego siebie.");
+        SendMessageToPC(oPC, "[Duel] You cannot challenge yourself.");
         return;
     }
     DuelShowChallengeConfig(oPC, GetObjectUUID(oTarget), GetName(oTarget));

--- a/Honor Duels/Scripts/lib_duel_def.nss
+++ b/Honor Duels/Scripts/lib_duel_def.nss
@@ -1,0 +1,240 @@
+#include "lib_nui"
+#include "sql_duel"
+
+// ----------------------------------------------------------------
+// Window IDs
+// ----------------------------------------------------------------
+
+const string DUEL_WINDOW            = "DUEL_WINDOW";
+const string DUEL_WIN_CHALLENGE     = "DUEL_WIN_CHALLENGE";
+const string DUEL_WIN_INCOMING      = "DUEL_WIN_INCOMING";
+const string DUEL_WIN_HUD           = "DUEL_WIN_HUD";
+const string DUEL_EV_SCRIPT         = "lib_duel_ev";
+
+// ----------------------------------------------------------------
+// View tabs (main window)
+// ----------------------------------------------------------------
+
+const int DUEL_VIEW_INCOMING        = 0;
+const int DUEL_VIEW_HISTORY         = 1;
+const int DUEL_VIEW_RANKING         = 2;
+
+// ----------------------------------------------------------------
+// Duel status
+// ----------------------------------------------------------------
+
+const int DUEL_STATUS_PENDING       = 0; // challenge sent, awaiting response
+const int DUEL_STATUS_ACCEPTED      = 1; // accepted, countdown starting
+const int DUEL_STATUS_IN_PROGRESS   = 2; // duel in progress
+const int DUEL_STATUS_COMPLETED     = 3; // finished with a winner
+const int DUEL_STATUS_DECLINED      = 4; // refused by challenged
+const int DUEL_STATUS_EXPIRED       = 5; // timed out without response
+const int DUEL_STATUS_CANCELED      = 6; // canceled by challenger
+
+// ----------------------------------------------------------------
+// Win conditions
+// ----------------------------------------------------------------
+
+const int DUEL_WIN_FIRST_BLOOD      = 0; // HP drops below threshold
+const int DUEL_WIN_TO_DEATH         = 1; // until someone dies
+const int DUEL_WIN_TO_YIELD         = 2; // until one yields
+
+// ----------------------------------------------------------------
+// Rule flags (bitmask on rules_mask column)
+// ----------------------------------------------------------------
+
+const int DUEL_RULE_NO_MAGIC        = 0x01;
+const int DUEL_RULE_NO_ITEMS        = 0x02;
+const int DUEL_RULE_NO_CRIT         = 0x04;
+
+// ----------------------------------------------------------------
+// Honor adjustments
+// ----------------------------------------------------------------
+
+const int DUEL_HONOR_WIN            = 10;
+const int DUEL_HONOR_LOSE           = -3;   // graceful loss is not severe
+const int DUEL_HONOR_DECLINE        = -15;  // refusing a challenge stains honor
+const int DUEL_HONOR_FORFEIT        = -25;  // leaving arena or yielding mid-duel
+const int DUEL_HONOR_KILL_BONUS     = 5;    // extra honor for death duels
+
+// ----------------------------------------------------------------
+// Mechanics
+// ----------------------------------------------------------------
+
+const float DUEL_ARENA_RADIUS       = 10.0; // meters from arena center
+const float DUEL_OUT_OF_BOUNDS_TIME = 6.0;  // seconds outside before forfeit
+const int   DUEL_COUNTDOWN_SECONDS  = 5;
+const int   DUEL_PENDING_TTL        = 300;  // 5 min for response
+const float DUEL_FIRST_BLOOD_FRAC   = 0.50; // forfeit at <50% HP
+const int   DUEL_HISTORY_LIMIT      = 20;
+const int   DUEL_RANKING_LIMIT      = 10;
+const int   DUEL_TICK_PERIOD        = 1;    // seconds, periodic checks
+
+// ----------------------------------------------------------------
+// Effect tags
+// ----------------------------------------------------------------
+
+const string DUEL_EFFECT_TAG        = "DUEL_INVULN_PRESTART";
+
+// ----------------------------------------------------------------
+// LVARs on PC
+// ----------------------------------------------------------------
+
+const string DUEL_LVAR_DRAFT_TARGET     = "DUEL_DRAFT_TARGET_UUID";
+const string DUEL_LVAR_DRAFT_NAME       = "DUEL_DRAFT_TARGET_NAME";
+const string DUEL_LVAR_DRAFT_RULES      = "DUEL_DRAFT_RULES";
+const string DUEL_LVAR_DRAFT_WIN        = "DUEL_DRAFT_WIN";
+const string DUEL_LVAR_DRAFT_STAKE      = "DUEL_DRAFT_STAKE";
+const string DUEL_LVAR_ACTIVE_DUEL      = "DUEL_ACTIVE_ID";
+const string DUEL_LVAR_OUT_OF_BOUNDS    = "DUEL_OOB_TICKS";
+const string DUEL_LVAR_VIEW             = "DUEL_VIEW";
+const string DUEL_LVAR_INCOMING_ID      = "DUEL_INCOMING_ID";
+
+// ----------------------------------------------------------------
+// Bind names
+// ----------------------------------------------------------------
+
+// Main window
+const string DUEL_BIND_TITLE            = "duel_title";
+const string DUEL_BIND_HONOR_LBL        = "duel_honor_lbl";
+const string DUEL_BIND_RECORD_LBL       = "duel_record_lbl";
+
+// Tabs
+const string DUEL_BIND_TAB_INCOMING_ENC = "duel_tab_inc_enc";
+const string DUEL_BIND_TAB_HISTORY_ENC  = "duel_tab_his_enc";
+const string DUEL_BIND_TAB_RANKING_ENC  = "duel_tab_rnk_enc";
+
+// Row binds (shared list)
+const string DUEL_BIND_ROW_PRIMARY      = "duel_row_primary";   // main label
+const string DUEL_BIND_ROW_SECONDARY    = "duel_row_secondary"; // detail label
+const string DUEL_BIND_ROW_RIGHT        = "duel_row_right";     // right-aligned label
+const string DUEL_BIND_ROW_COLOR        = "duel_row_color";
+
+// Empty placeholder
+const string DUEL_BIND_EMPTY_VIS        = "duel_empty_vis";
+const string DUEL_BIND_EMPTY_TXT        = "duel_empty_txt";
+
+// Challenge config window
+const string DUEL_BIND_CH_TARGET_LBL    = "duel_ch_target_lbl";
+const string DUEL_BIND_CH_RULE_NOMAGIC  = "duel_ch_rule_nomagic";
+const string DUEL_BIND_CH_RULE_NOITEMS  = "duel_ch_rule_noitems";
+const string DUEL_BIND_CH_RULE_NOCRIT   = "duel_ch_rule_nocrit";
+const string DUEL_BIND_CH_WIN_FB        = "duel_ch_win_fb";
+const string DUEL_BIND_CH_WIN_DEATH     = "duel_ch_win_death";
+const string DUEL_BIND_CH_WIN_YIELD     = "duel_ch_win_yield";
+const string DUEL_BIND_CH_STAKE_TXT     = "duel_ch_stake_txt";
+const string DUEL_BIND_CH_SEND_ENA      = "duel_ch_send_ena";
+
+// Incoming challenge popup
+const string DUEL_BIND_INC_TITLE        = "duel_inc_title";
+const string DUEL_BIND_INC_RULES        = "duel_inc_rules";
+const string DUEL_BIND_INC_STAKE        = "duel_inc_stake";
+const string DUEL_BIND_INC_WIN          = "duel_inc_win";
+
+// HUD (active duel overlay)
+const string DUEL_BIND_HUD_TITLE        = "duel_hud_title";
+const string DUEL_BIND_HUD_OPP_HP       = "duel_hud_opp_hp";
+const string DUEL_BIND_HUD_OPP_HP_TIP   = "duel_hud_opp_hp_tip";
+const string DUEL_BIND_HUD_SELF_HP      = "duel_hud_self_hp";
+const string DUEL_BIND_HUD_SELF_HP_TIP  = "duel_hud_self_hp_tip";
+const string DUEL_BIND_HUD_STATE        = "duel_hud_state";
+const string DUEL_BIND_HUD_BOUNDS       = "duel_hud_bounds";
+const string DUEL_BIND_HUD_GEOM         = "duel_hud_geom";
+
+// ----------------------------------------------------------------
+// Button IDs
+// ----------------------------------------------------------------
+
+const string DUEL_BTN_CHALLENGE         = "duel_btn_challenge";
+const string DUEL_BTN_CLOSE             = "duel_btn_close";
+const string DUEL_BTN_TAB_INCOMING      = "duel_btn_tab_inc";
+const string DUEL_BTN_TAB_HISTORY       = "duel_btn_tab_his";
+const string DUEL_BTN_TAB_RANKING       = "duel_btn_tab_rnk";
+
+const string DUEL_BTN_INC_ACCEPT        = "duel_btn_inc_accept";
+const string DUEL_BTN_INC_DECLINE       = "duel_btn_inc_decline";
+const string DUEL_BTN_ROW               = "duel_btn_row";        // pending challenge row in incoming list
+const string DUEL_BTN_CANCEL_OUTGOING   = "duel_btn_cancel_out"; // cancel an outgoing challenge
+
+const string DUEL_BTN_CH_RULE_NOMAGIC   = "duel_btn_ch_rule_nm";
+const string DUEL_BTN_CH_RULE_NOITEMS   = "duel_btn_ch_rule_ni";
+const string DUEL_BTN_CH_RULE_NOCRIT    = "duel_btn_ch_rule_nc";
+const string DUEL_BTN_CH_WIN_FB         = "duel_btn_ch_win_fb";
+const string DUEL_BTN_CH_WIN_DEATH      = "duel_btn_ch_win_death";
+const string DUEL_BTN_CH_WIN_YIELD      = "duel_btn_ch_win_yield";
+const string DUEL_BTN_CH_SEND           = "duel_btn_ch_send";
+const string DUEL_BTN_CH_CANCEL         = "duel_btn_ch_cancel";
+
+const string DUEL_BTN_HUD_YIELD         = "duel_btn_hud_yield";
+
+// ----------------------------------------------------------------
+// Layout
+// ----------------------------------------------------------------
+
+const float DUEL_W                  = 600.0;
+const float DUEL_H                  = 500.0;
+const float DUEL_CHALLENGE_W        = 420.0;
+const float DUEL_CHALLENGE_H        = 360.0;
+const float DUEL_INCOMING_W         = 460.0;
+const float DUEL_INCOMING_H         = 260.0;
+const float DUEL_HUD_W              = 240.0;
+const float DUEL_HUD_H              = 130.0;
+
+// ----------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------
+
+string DuelStatusToString(int nStatus)
+{
+    switch(nStatus)
+    {
+        case DUEL_STATUS_PENDING:     return "Oczekuje";
+        case DUEL_STATUS_ACCEPTED:    return "Przyjete";
+        case DUEL_STATUS_IN_PROGRESS: return "W trakcie";
+        case DUEL_STATUS_COMPLETED:   return "Zakonczone";
+        case DUEL_STATUS_DECLINED:    return "Odrzucone";
+        case DUEL_STATUS_EXPIRED:     return "Wygaslo";
+        case DUEL_STATUS_CANCELED:    return "Anulowane";
+    }
+    return "?";
+}
+
+string DuelWinConditionToString(int nWin)
+{
+    switch(nWin)
+    {
+        case DUEL_WIN_FIRST_BLOOD: return "Pierwsza krew";
+        case DUEL_WIN_TO_DEATH:    return "Na smierc";
+        case DUEL_WIN_TO_YIELD:    return "Do poddania";
+    }
+    return "?";
+}
+
+string DuelRulesToString(int nMask)
+{
+    string sOut = "";
+    if(nMask & DUEL_RULE_NO_MAGIC) sOut += "bez magii, ";
+    if(nMask & DUEL_RULE_NO_ITEMS) sOut += "bez mikstur, ";
+    if(nMask & DUEL_RULE_NO_CRIT)  sOut += "bez krytykow, ";
+    if(sOut == "") return "honorowy";
+    return GetStringLeft(sOut, GetStringLength(sOut) - 2);
+}
+
+object DuelGetPCByUUID(string sUuid)
+{
+    if(sUuid == "") return OBJECT_INVALID;
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        if(GetObjectUUID(oPC) == sUuid) return oPC;
+        oPC = GetNextPC();
+    }
+    return OBJECT_INVALID;
+}
+
+int DuelIsActiveStatus(int nStatus)
+{
+    return (nStatus == DUEL_STATUS_PENDING
+         || nStatus == DUEL_STATUS_ACCEPTED
+         || nStatus == DUEL_STATUS_IN_PROGRESS);
+}

--- a/Honor Duels/Scripts/lib_duel_def.nss
+++ b/Honor Duels/Scripts/lib_duel_def.nss
@@ -188,13 +188,13 @@ string DuelStatusToString(int nStatus)
 {
     switch(nStatus)
     {
-        case DUEL_STATUS_PENDING:     return "Oczekuje";
-        case DUEL_STATUS_ACCEPTED:    return "Przyjete";
-        case DUEL_STATUS_IN_PROGRESS: return "W trakcie";
-        case DUEL_STATUS_COMPLETED:   return "Zakonczone";
-        case DUEL_STATUS_DECLINED:    return "Odrzucone";
-        case DUEL_STATUS_EXPIRED:     return "Wygaslo";
-        case DUEL_STATUS_CANCELED:    return "Anulowane";
+        case DUEL_STATUS_PENDING:     return "Pending";
+        case DUEL_STATUS_ACCEPTED:    return "Accepted";
+        case DUEL_STATUS_IN_PROGRESS: return "In progress";
+        case DUEL_STATUS_COMPLETED:   return "Completed";
+        case DUEL_STATUS_DECLINED:    return "Declined";
+        case DUEL_STATUS_EXPIRED:     return "Expired";
+        case DUEL_STATUS_CANCELED:    return "Canceled";
     }
     return "?";
 }
@@ -203,9 +203,9 @@ string DuelWinConditionToString(int nWin)
 {
     switch(nWin)
     {
-        case DUEL_WIN_FIRST_BLOOD: return "Pierwsza krew";
-        case DUEL_WIN_TO_DEATH:    return "Na smierc";
-        case DUEL_WIN_TO_YIELD:    return "Do poddania";
+        case DUEL_WIN_FIRST_BLOOD: return "First blood";
+        case DUEL_WIN_TO_DEATH:    return "To the death";
+        case DUEL_WIN_TO_YIELD:    return "Until yield";
     }
     return "?";
 }
@@ -213,10 +213,10 @@ string DuelWinConditionToString(int nWin)
 string DuelRulesToString(int nMask)
 {
     string sOut = "";
-    if(nMask & DUEL_RULE_NO_MAGIC) sOut += "bez magii, ";
-    if(nMask & DUEL_RULE_NO_ITEMS) sOut += "bez mikstur, ";
-    if(nMask & DUEL_RULE_NO_CRIT)  sOut += "bez krytykow, ";
-    if(sOut == "") return "honorowy";
+    if(nMask & DUEL_RULE_NO_MAGIC) sOut += "no magic, ";
+    if(nMask & DUEL_RULE_NO_ITEMS) sOut += "no potions, ";
+    if(nMask & DUEL_RULE_NO_CRIT)  sOut += "no crits, ";
+    if(sOut == "") return "honorable";
     return GetStringLeft(sOut, GetStringLength(sOut) - 2);
 }
 

--- a/Honor Duels/Scripts/lib_duel_ev.nss
+++ b/Honor Duels/Scripts/lib_duel_ev.nss
@@ -11,7 +11,7 @@ void DuelHandleSubmitFromConfig(object oPC, int nToken)
     string sTargetName = GetLocalString(oPC, DUEL_LVAR_DRAFT_NAME);
     if(sTargetUuid == "")
     {
-        SendMessageToPC(oPC, "[Pojedynek] Brak celu.");
+        SendMessageToPC(oPC, "[Duel] No target selected.");
         return;
     }
 
@@ -181,7 +181,7 @@ void main()
                 string sVal = JsonGetString(NuiGetBind(oPC, nToken, DUEL_BIND_CH_STAKE_TXT));
                 int nVal = StringToInt(sVal);
                 if(sVal != "" && sVal != "0" && nVal <= 0)
-                    SendMessageToPC(oPC, "[Pojedynek] Stawka musi byc liczba calkowita.");
+                    SendMessageToPC(oPC, "[Duel] Stake must be a whole positive number.");
                 return;
             }
         }

--- a/Honor Duels/Scripts/lib_duel_ev.nss
+++ b/Honor Duels/Scripts/lib_duel_ev.nss
@@ -1,0 +1,261 @@
+#include "lib_duel"
+
+// ----------------------------------------------------------------
+// Honor Duels — NUI event router
+// Handles main window, challenge config, incoming popup, HUD.
+// ----------------------------------------------------------------
+
+void DuelHandleSubmitFromConfig(object oPC, int nToken)
+{
+    string sTargetUuid = GetLocalString(oPC, DUEL_LVAR_DRAFT_TARGET);
+    string sTargetName = GetLocalString(oPC, DUEL_LVAR_DRAFT_NAME);
+    if(sTargetUuid == "")
+    {
+        SendMessageToPC(oPC, "[Pojedynek] Brak celu.");
+        return;
+    }
+
+    int nWin = GetLocalInt(oPC, DUEL_LVAR_DRAFT_WIN);
+    int nRules = GetLocalInt(oPC, DUEL_LVAR_DRAFT_RULES);
+
+    string sStakeStr = JsonGetString(NuiGetBind(oPC, nToken, DUEL_BIND_CH_STAKE_TXT));
+    int nStake = StringToInt(sStakeStr);
+    if(nStake < 0) nStake = 0;
+
+    int nId = DuelSubmitChallenge(oPC, sTargetUuid, sTargetName, nRules, nWin, nStake);
+    if(nId > 0)
+    {
+        NuiDestroy(oPC, nToken);
+        DeleteLocalString(oPC, DUEL_LVAR_DRAFT_TARGET);
+        DeleteLocalString(oPC, DUEL_LVAR_DRAFT_NAME);
+        DeleteLocalInt   (oPC, DUEL_LVAR_DRAFT_RULES);
+        DeleteLocalInt   (oPC, DUEL_LVAR_DRAFT_WIN);
+
+        int nMain = NuiFindWindow(oPC, DUEL_WINDOW);
+        if(nMain != 0) FeedDuelMain(oPC, nMain);
+    }
+}
+
+void DuelToggleWinCondition(object oPC, int nToken, int nWin)
+{
+    SetLocalInt(oPC, DUEL_LVAR_DRAFT_WIN, nWin);
+    NuiSetBind(oPC, nToken, DUEL_BIND_CH_WIN_FB,    JsonBool(nWin == DUEL_WIN_FIRST_BLOOD));
+    NuiSetBind(oPC, nToken, DUEL_BIND_CH_WIN_DEATH, JsonBool(nWin == DUEL_WIN_TO_DEATH));
+    NuiSetBind(oPC, nToken, DUEL_BIND_CH_WIN_YIELD, JsonBool(nWin == DUEL_WIN_TO_YIELD));
+}
+
+void DuelToggleRuleFlag(object oPC, int nToken, int nFlag,
+                        string sBindName, string sButtonId)
+{
+    int nMask = GetLocalInt(oPC, DUEL_LVAR_DRAFT_RULES);
+    int bOn   = JsonGetInt(NuiGetBind(oPC, nToken, sBindName));
+    if(bOn) nMask = nMask | nFlag;
+    else    nMask = nMask & ~nFlag;
+    SetLocalInt(oPC, DUEL_LVAR_DRAFT_RULES, nMask);
+}
+
+// ----------------------------------------------------------------
+// Main entry point
+// ----------------------------------------------------------------
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+
+    int nMain     = NuiFindWindow(oPC, DUEL_WINDOW);
+    int nChallenge= NuiFindWindow(oPC, DUEL_WIN_CHALLENGE);
+    int nIncoming = NuiFindWindow(oPC, DUEL_WIN_INCOMING);
+    int nHud      = NuiFindWindow(oPC, DUEL_WIN_HUD);
+
+    // ---- HUD: yield button ----
+    if(nToken == nHud && nHud != 0)
+    {
+        if(sEvent == EVENT_TYPE_CLICK && sElem == DUEL_BTN_HUD_YIELD)
+            DuelYield(oPC);
+        return;
+    }
+
+    // ---- Incoming challenge popup ----
+    if(nToken == nIncoming && nIncoming != 0)
+    {
+        if(sEvent == EVENT_TYPE_CLICK)
+        {
+            int nDuelId = GetLocalInt(oPC, DUEL_LVAR_INCOMING_ID);
+            if(nDuelId > 0)
+            {
+                if(sElem == DUEL_BTN_INC_ACCEPT)
+                {
+                    NuiDestroy(oPC, nToken);
+                    DeleteLocalInt(oPC, DUEL_LVAR_INCOMING_ID);
+                    DuelAccept(oPC, nDuelId);
+                    return;
+                }
+                if(sElem == DUEL_BTN_INC_DECLINE)
+                {
+                    NuiDestroy(oPC, nToken);
+                    DeleteLocalInt(oPC, DUEL_LVAR_INCOMING_ID);
+                    DuelDecline(oPC, nDuelId);
+                    return;
+                }
+            }
+        }
+        if(sEvent == EVENT_TYPE_CLOSE)
+            DeleteLocalInt(oPC, DUEL_LVAR_INCOMING_ID);
+        return;
+    }
+
+    // ---- Challenge config popup ----
+    if(nToken == nChallenge && nChallenge != 0)
+    {
+        if(sEvent == EVENT_TYPE_CLICK)
+        {
+            if(sElem == DUEL_BTN_CH_SEND)
+            {
+                DuelHandleSubmitFromConfig(oPC, nToken);
+                return;
+            }
+            if(sElem == DUEL_BTN_CH_CANCEL)
+            {
+                NuiDestroy(oPC, nToken);
+                DeleteLocalString(oPC, DUEL_LVAR_DRAFT_TARGET);
+                DeleteLocalString(oPC, DUEL_LVAR_DRAFT_NAME);
+                return;
+            }
+            if(sElem == DUEL_BTN_CH_WIN_FB)
+            { DuelToggleWinCondition(oPC, nToken, DUEL_WIN_FIRST_BLOOD); return; }
+            if(sElem == DUEL_BTN_CH_WIN_DEATH)
+            { DuelToggleWinCondition(oPC, nToken, DUEL_WIN_TO_DEATH);    return; }
+            if(sElem == DUEL_BTN_CH_WIN_YIELD)
+            { DuelToggleWinCondition(oPC, nToken, DUEL_WIN_TO_YIELD);    return; }
+
+            if(sElem == DUEL_BTN_CH_RULE_NOMAGIC)
+            { DuelToggleRuleFlag(oPC, nToken, DUEL_RULE_NO_MAGIC,
+                DUEL_BIND_CH_RULE_NOMAGIC, DUEL_BTN_CH_RULE_NOMAGIC); return; }
+            if(sElem == DUEL_BTN_CH_RULE_NOITEMS)
+            { DuelToggleRuleFlag(oPC, nToken, DUEL_RULE_NO_ITEMS,
+                DUEL_BIND_CH_RULE_NOITEMS, DUEL_BTN_CH_RULE_NOITEMS); return; }
+            if(sElem == DUEL_BTN_CH_RULE_NOCRIT)
+            { DuelToggleRuleFlag(oPC, nToken, DUEL_RULE_NO_CRIT,
+                DUEL_BIND_CH_RULE_NOCRIT, DUEL_BTN_CH_RULE_NOCRIT); return; }
+        }
+
+        if(sEvent == EVENT_TYPE_WATCH)
+        {
+            // Sync rule mask with checkbox state.
+            if(sElem == DUEL_BIND_CH_RULE_NOMAGIC
+            || sElem == DUEL_BIND_CH_RULE_NOITEMS
+            || sElem == DUEL_BIND_CH_RULE_NOCRIT)
+            {
+                int nMask = 0;
+                if(JsonGetInt(NuiGetBind(oPC, nToken, DUEL_BIND_CH_RULE_NOMAGIC)))
+                    nMask = nMask | DUEL_RULE_NO_MAGIC;
+                if(JsonGetInt(NuiGetBind(oPC, nToken, DUEL_BIND_CH_RULE_NOITEMS)))
+                    nMask = nMask | DUEL_RULE_NO_ITEMS;
+                if(JsonGetInt(NuiGetBind(oPC, nToken, DUEL_BIND_CH_RULE_NOCRIT)))
+                    nMask = nMask | DUEL_RULE_NO_CRIT;
+                SetLocalInt(oPC, DUEL_LVAR_DRAFT_RULES, nMask);
+                return;
+            }
+
+            // Win condition radio behavior — only one allowed.
+            if(sElem == DUEL_BIND_CH_WIN_FB
+            || sElem == DUEL_BIND_CH_WIN_DEATH
+            || sElem == DUEL_BIND_CH_WIN_YIELD)
+            {
+                int bFb    = JsonGetInt(NuiGetBind(oPC, nToken, DUEL_BIND_CH_WIN_FB));
+                int bDeath = JsonGetInt(NuiGetBind(oPC, nToken, DUEL_BIND_CH_WIN_DEATH));
+                int bYield = JsonGetInt(NuiGetBind(oPC, nToken, DUEL_BIND_CH_WIN_YIELD));
+                int nWin   = GetLocalInt(oPC, DUEL_LVAR_DRAFT_WIN);
+                if(sElem == DUEL_BIND_CH_WIN_FB    && bFb)    nWin = DUEL_WIN_FIRST_BLOOD;
+                if(sElem == DUEL_BIND_CH_WIN_DEATH && bDeath) nWin = DUEL_WIN_TO_DEATH;
+                if(sElem == DUEL_BIND_CH_WIN_YIELD && bYield) nWin = DUEL_WIN_TO_YIELD;
+                DuelToggleWinCondition(oPC, nToken, nWin);
+                return;
+            }
+
+            if(sElem == DUEL_BIND_CH_STAKE_TXT)
+            {
+                string sVal = JsonGetString(NuiGetBind(oPC, nToken, DUEL_BIND_CH_STAKE_TXT));
+                int nVal = StringToInt(sVal);
+                if(sVal != "" && sVal != "0" && nVal <= 0)
+                    SendMessageToPC(oPC, "[Pojedynek] Stawka musi byc liczba calkowita.");
+                return;
+            }
+        }
+
+        if(sEvent == EVENT_TYPE_CLOSE)
+        {
+            DeleteLocalString(oPC, DUEL_LVAR_DRAFT_TARGET);
+            DeleteLocalString(oPC, DUEL_LVAR_DRAFT_NAME);
+            DeleteLocalInt   (oPC, DUEL_LVAR_DRAFT_RULES);
+            DeleteLocalInt   (oPC, DUEL_LVAR_DRAFT_WIN);
+        }
+        return;
+    }
+
+    // ---- Main window ----
+    if(nToken != nMain || nMain == 0) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalInt(oPC, DUEL_LVAR_VIEW);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == DUEL_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+        if(sElem == DUEL_BTN_CHALLENGE)
+        {
+            DuelStartChallengeTargeting(oPC);
+            return;
+        }
+        if(sElem == DUEL_BTN_TAB_INCOMING)
+        {
+            SetLocalInt(oPC, DUEL_LVAR_VIEW, DUEL_VIEW_INCOMING);
+            FeedDuelMain(oPC, nToken);
+            return;
+        }
+        if(sElem == DUEL_BTN_TAB_HISTORY)
+        {
+            SetLocalInt(oPC, DUEL_LVAR_VIEW, DUEL_VIEW_HISTORY);
+            FeedDuelMain(oPC, nToken);
+            return;
+        }
+        if(sElem == DUEL_BTN_TAB_RANKING)
+        {
+            SetLocalInt(oPC, DUEL_LVAR_VIEW, DUEL_VIEW_RANKING);
+            FeedDuelMain(oPC, nToken);
+            return;
+        }
+    }
+
+    if(sEvent == EVENT_TYPE_MOUSEDOWN && sElem == DUEL_BTN_ROW)
+    {
+        int nIdx  = NuiGetEventArrayIndex();
+        int nView = GetLocalInt(oPC, DUEL_LVAR_VIEW);
+        if(nView != DUEL_VIEW_INCOMING) return;
+
+        json jRows = DuelGetIncoming(GetObjectUUID(oPC));
+        if(nIdx < 0 || nIdx >= JsonGetLength(jRows)) return;
+
+        json jR = JsonArrayGet(jRows, nIdx);
+        int nDuelId   = JsonGetInt   (JsonObjectGet(jR, "id"));
+        string sDir   = JsonGetString(JsonObjectGet(jR, "direction"));
+        if(sDir == "in")
+        {
+            DuelShowIncomingPopup(oPC, nDuelId);
+        }
+        else
+        {
+            DuelCancelOutgoing(oPC, nDuelId);
+        }
+    }
+}

--- a/Honor Duels/Scripts/lib_duel_flow.nss
+++ b/Honor Duels/Scripts/lib_duel_flow.nss
@@ -22,12 +22,12 @@ void DuelBroadcast(string sMsg, object oA, object oB)
     if(GetIsObjectValid(oA))
     {
         FloatingTextStringOnCreature(sMsg, oA, FALSE);
-        SendMessageToPC(oA, "[Pojedynek] " + sMsg);
+        SendMessageToPC(oA, "[Duel] " + sMsg);
     }
     if(GetIsObjectValid(oB))
     {
         FloatingTextStringOnCreature(sMsg, oB, FALSE);
-        SendMessageToPC(oB, "[Pojedynek] " + sMsg);
+        SendMessageToPC(oB, "[Duel] " + sMsg);
     }
 }
 
@@ -36,9 +36,9 @@ void DuelNotifyChallenged(string sChallengedUuid, int nDuelId, string sChallenge
     object oPC = DuelGetPCByUUID(sChallengedUuid);
     if(!GetIsObjectValid(oPC)) return;
 
-    string sMsg = sChallengerName + " rzuca ci wyzwanie. Honor czeka.";
+    string sMsg = sChallengerName + " challenges you. Honor awaits.";
     FloatingTextStringOnCreature(sMsg, oPC, FALSE);
-    SendMessageToPC(oPC, "[Pojedynek] " + sMsg);
+    SendMessageToPC(oPC, "[Duel] " + sMsg);
 
     DelayCommand(0.5, DuelShowIncomingPopup(oPC, nDuelId));
 }
@@ -52,41 +52,41 @@ int DuelSubmitChallenge(object oPC, string sTargetUuid, string sTargetName,
 {
     if(sTargetUuid == "" || sTargetUuid == GetObjectUUID(oPC))
     {
-        SendMessageToPC(oPC, "[Pojedynek] Nieprawidlowy cel.");
+        SendMessageToPC(oPC, "[Duel] Invalid target.");
         return 0;
     }
 
     if(DuelHasActiveBetween(GetObjectUUID(oPC), sTargetUuid))
     {
-        SendMessageToPC(oPC, "[Pojedynek] Macie juz aktywny pojedynek lub wyzwanie.");
+        SendMessageToPC(oPC, "[Duel] You already have an active duel or challenge with that player.");
         return 0;
     }
 
     if(nStake < 0) nStake = 0;
     if(nStake > 0 && GetGold(oPC) < nStake)
     {
-        SendMessageToPC(oPC, "[Pojedynek] Nie masz tyle zlota na stawke.");
+        SendMessageToPC(oPC, "[Duel] Not enough gold for the stake.");
         return 0;
     }
 
     object oTarget = DuelGetPCByUUID(sTargetUuid);
     if(!GetIsObjectValid(oTarget))
     {
-        SendMessageToPC(oPC, "[Pojedynek] Przeciwnik musi byc obecny.");
+        SendMessageToPC(oPC, "[Duel] Opponent must be online.");
         return 0;
     }
 
     int nId = DuelCreate(oPC, oTarget, nRules, nWinCond, nStake);
     if(nId <= 0)
     {
-        SendMessageToPC(oPC, "[Pojedynek] Nie udalo sie utworzyc wyzwania.");
+        SendMessageToPC(oPC, "[Duel] Could not create challenge.");
         return 0;
     }
 
     if(nStake > 0)
         AssignCommand(oPC, TakeGoldFromCreature(nStake, oPC, TRUE));
 
-    SendMessageToPC(oPC, "[Pojedynek] Wyzwanie wyslane do " + sTargetName + ".");
+    SendMessageToPC(oPC, "[Duel] Challenge sent to " + sTargetName + ".");
     DuelNotifyChallenged(sTargetUuid, nId, GetName(oPC));
     return nId;
 }
@@ -102,7 +102,7 @@ void DuelRefundStake(string sUuid, int nGold)
     if(GetIsObjectValid(oPC))
     {
         GiveGoldToCreature(oPC, nGold);
-        SendMessageToPC(oPC, "[Pojedynek] Stawka " + IntToString(nGold) + " zlota zwrocona.");
+        SendMessageToPC(oPC, "[Duel] Stake of " + IntToString(nGold) + " gold refunded.");
     }
     // Offline: gold is forfeit. A real server would queue a refund into Mailbox.
 }
@@ -123,7 +123,7 @@ void DuelDecline(object oPC, int nDuelId)
     int nStake = JsonGetInt(JsonObjectGet(jD, "stake_gold"));
 
     DuelSetOutcome(nDuelId, DUEL_STATUS_DECLINED, "", GetObjectUUID(oPC),
-                   "Odrzucone bez walki.");
+                   "Refused without a fight.");
 
     DuelRefundStake(sChallengerUuid, nStake);
 
@@ -131,7 +131,7 @@ void DuelDecline(object oPC, int nDuelId)
                     DUEL_HONOR_DECLINE, 0, 0, 1, 0, 0);
 
     object oCh = DuelGetPCByUUID(sChallengerUuid);
-    DuelBroadcast("Wyzwanie odrzucone. Honor pochylony nizej niz miecz.",
+    DuelBroadcast("Challenge declined. Honor stooped lower than the blade.",
                   oCh, oPC);
 
     object oRefresh = GetFirstPC();
@@ -152,10 +152,10 @@ void DuelCancelOutgoing(object oPC, int nDuelId)
 
     int nStake = JsonGetInt(JsonObjectGet(jD, "stake_gold"));
     DuelSetOutcome(nDuelId, DUEL_STATUS_CANCELED,
-                   "", "", "Anulowane przez wyzywajacego.");
+                   "", "", "Canceled by the challenger.");
     if(nStake > 0) GiveGoldToCreature(oPC, nStake);
 
-    SendMessageToPC(oPC, "[Pojedynek] Wyzwanie wycofane.");
+    SendMessageToPC(oPC, "[Duel] Challenge withdrawn.");
 
     int nTk = NuiFindWindow(oPC, DUEL_WINDOW);
     if(nTk != 0) FeedDuelMain(oPC, nTk);
@@ -180,15 +180,15 @@ void DuelAccept(object oPC, int nDuelId)
     object oChallenger = DuelGetPCByUUID(sChallengerUuid);
     if(!GetIsObjectValid(oChallenger))
     {
-        SendMessageToPC(oPC, "[Pojedynek] Wyzywajacego juz nie ma w grze.");
-        DuelSetOutcome(nDuelId, DUEL_STATUS_EXPIRED, "", "", "Brak wyzywajacego.");
+        SendMessageToPC(oPC, "[Duel] The challenger is no longer in game.");
+        DuelSetOutcome(nDuelId, DUEL_STATUS_EXPIRED, "", "", "Challenger absent.");
         return;
     }
 
     int nStake = JsonGetInt(JsonObjectGet(jD, "stake_gold"));
     if(nStake > 0 && GetGold(oPC) < nStake)
     {
-        SendMessageToPC(oPC, "[Pojedynek] Nie masz zlota by sprostac stawce.");
+        SendMessageToPC(oPC, "[Duel] Not enough gold to match the stake.");
         return;
     }
     if(nStake > 0)
@@ -202,7 +202,7 @@ void DuelAccept(object oPC, int nDuelId)
         Location(GetArea(oChallenger), vArena, 0.0));
     if(fDist > DUEL_ARENA_RADIUS * 1.5)
     {
-        SendMessageToPC(oPC, "[Pojedynek] Musisz stawic sie w poblizu wyzywajacego.");
+        SendMessageToPC(oPC, "[Duel] You must stand near the challenger.");
         if(nStake > 0) GiveGoldToCreature(oPC, nStake);
         return;
     }
@@ -212,7 +212,7 @@ void DuelAccept(object oPC, int nDuelId)
     SetLocalInt(oPC,         DUEL_LVAR_ACTIVE_DUEL, nDuelId);
     SetLocalInt(oChallenger, DUEL_LVAR_ACTIVE_DUEL, nDuelId);
 
-    DuelBroadcast("Wyzwanie przyjete. Krew rozstrzygnie spor.",
+    DuelBroadcast("Challenge accepted. Blood shall settle the dispute.",
                   oChallenger, oPC);
 
     // Countdown floating text on both
@@ -260,7 +260,7 @@ void DuelBegin(int nDuelId)
     object oB = DuelGetPCByUUID(JsonGetString(JsonObjectGet(jD, "challenged_uuid")));
     if(!GetIsObjectValid(oA) || !GetIsObjectValid(oB))
     {
-        DuelSetOutcome(nDuelId, DUEL_STATUS_EXPIRED, "", "", "Strona opuscila gre.");
+        DuelSetOutcome(nDuelId, DUEL_STATUS_EXPIRED, "", "", "A duelist left the game.");
         return;
     }
 
@@ -268,7 +268,7 @@ void DuelBegin(int nDuelId)
 
     DuelMakeHostile(oA, oB);
 
-    DuelBroadcast("WALKA!", oA, oB);
+    DuelBroadcast("FIGHT!", oA, oB);
 
     CreateDuelHud(oA, nDuelId);
     CreateDuelHud(oB, nDuelId);
@@ -298,7 +298,7 @@ void DuelUpdateHud(object oPC, object oOpp, int nFracSelf, int nFracOpp)
     NuiSetBind(oPC, nTk, DUEL_BIND_HUD_SELF_HP_TIP, JsonString(IntToString(nFracSelf) + "%"));
     NuiSetBind(oPC, nTk, DUEL_BIND_HUD_OPP_HP_TIP,  JsonString(IntToString(nFracOpp) + "%"));
     NuiSetBind(oPC, nTk, DUEL_BIND_HUD_TITLE,
-        JsonString("Pojedynek: " + GetName(oOpp)));
+        JsonString("Duel: " + GetName(oOpp)));
 }
 
 void DuelTick(int nDuelId)
@@ -317,12 +317,12 @@ void DuelTick(int nDuelId)
     // Disconnect / death-by-ragequit handling.
     if(!GetIsObjectValid(oA))
     {
-        DuelEnd(nDuelId, sUuidB, sUuidA, "Wyzywajacy opuscil arene.", FALSE);
+        DuelEnd(nDuelId, sUuidB, sUuidA, "Challenger left the arena.", FALSE);
         return;
     }
     if(!GetIsObjectValid(oB))
     {
-        DuelEnd(nDuelId, sUuidA, sUuidB, "Wyzwany opuscil arene.", FALSE);
+        DuelEnd(nDuelId, sUuidA, sUuidB, "Challenged left the arena.", FALSE);
         return;
     }
 
@@ -330,17 +330,17 @@ void DuelTick(int nDuelId)
     int nDeadB = GetIsDead(oB);
     if(nDeadA && !nDeadB)
     {
-        DuelEnd(nDuelId, sUuidB, sUuidA, "Smiertelny cios.", TRUE);
+        DuelEnd(nDuelId, sUuidB, sUuidA, "Killing blow.", TRUE);
         return;
     }
     if(nDeadB && !nDeadA)
     {
-        DuelEnd(nDuelId, sUuidA, sUuidB, "Smiertelny cios.", TRUE);
+        DuelEnd(nDuelId, sUuidA, sUuidB, "Killing blow.", TRUE);
         return;
     }
     if(nDeadA && nDeadB)
     {
-        DuelEnd(nDuelId, "", "", "Obaj polegli.", FALSE);
+        DuelEnd(nDuelId, "", "", "Both fell.", FALSE);
         return;
     }
 
@@ -354,19 +354,19 @@ void DuelTick(int nDuelId)
         int nThr = FloatToInt(DUEL_FIRST_BLOOD_FRAC * 100.0);
         if(nFracA <= nThr && nFracB > nThr)
         {
-            DuelEnd(nDuelId, sUuidB, sUuidA, "Pierwsza krew.", FALSE);
+            DuelEnd(nDuelId, sUuidB, sUuidA, "First blood.", FALSE);
             return;
         }
         if(nFracB <= nThr && nFracA > nThr)
         {
-            DuelEnd(nDuelId, sUuidA, sUuidB, "Pierwsza krew.", FALSE);
+            DuelEnd(nDuelId, sUuidA, sUuidB, "First blood.", FALSE);
             return;
         }
         if(nFracA <= nThr && nFracB <= nThr)
         {
             string sWin = (nFracA >= nFracB) ? sUuidA : sUuidB;
             string sLos = (nFracA >= nFracB) ? sUuidB : sUuidA;
-            DuelEnd(nDuelId, sWin, sLos, "Obaj zranieni — wygrywa silniejszy.", FALSE);
+            DuelEnd(nDuelId, sWin, sLos, "Both wounded — the stronger prevails.", FALSE);
             return;
         }
     }
@@ -398,20 +398,20 @@ void DuelTick(int nDuelId)
     int nTkA = NuiFindWindow(oA, DUEL_WIN_HUD);
     int nTkB = NuiFindWindow(oB, DUEL_WIN_HUD);
     if(nTkA != 0) NuiSetBind(oA, nTkA, DUEL_BIND_HUD_BOUNDS,
-        JsonString(nOobA > 0 ? "Wracaj na arene! " + IntToString(nOobA) + "/"
+        JsonString(nOobA > 0 ? "Return to the arena! " + IntToString(nOobA) + "/"
             + IntToString(FloatToInt(DUEL_OUT_OF_BOUNDS_TIME)) : ""));
     if(nTkB != 0) NuiSetBind(oB, nTkB, DUEL_BIND_HUD_BOUNDS,
-        JsonString(nOobB > 0 ? "Wracaj na arene! " + IntToString(nOobB) + "/"
+        JsonString(nOobB > 0 ? "Return to the arena! " + IntToString(nOobB) + "/"
             + IntToString(FloatToInt(DUEL_OUT_OF_BOUNDS_TIME)) : ""));
 
     if(IntToFloat(nOobA) >= DUEL_OUT_OF_BOUNDS_TIME)
     {
-        DuelEnd(nDuelId, sUuidB, sUuidA, "Ucieczka z areny.", FALSE);
+        DuelEnd(nDuelId, sUuidB, sUuidA, "Fled the arena.", FALSE);
         return;
     }
     if(IntToFloat(nOobB) >= DUEL_OUT_OF_BOUNDS_TIME)
     {
-        DuelEnd(nDuelId, sUuidA, sUuidB, "Ucieczka z areny.", FALSE);
+        DuelEnd(nDuelId, sUuidA, sUuidB, "Fled the arena.", FALSE);
         return;
     }
 
@@ -437,7 +437,7 @@ void DuelYield(object oPC)
     if(sSelf != sUuidA && sSelf != sUuidB) return;
 
     string sWin = (sSelf == sUuidA) ? sUuidB : sUuidA;
-    DuelEnd(nDuelId, sWin, sSelf, "Poddanie sie.", FALSE);
+    DuelEnd(nDuelId, sWin, sSelf, "Yielded.", FALSE);
 }
 
 // ----------------------------------------------------------------
@@ -477,7 +477,7 @@ void DuelEnd(int nDuelId, string sWinnerUuid, string sLoserUuid, string sNote, i
     DuelHealAndCleanup(oA);
     DuelHealAndCleanup(oB);
 
-    int bForfeit = (sNote == "Poddanie sie." || sNote == "Ucieczka z areny.");
+    int bForfeit = (sNote == "Yielded." || sNote == "Fled the arena.");
 
     string sWinName = (sWinnerUuid == sUuidA) ? sNameA : sNameB;
     string sLosName = (sLoserUuid  == sUuidA) ? sNameA : sNameB;
@@ -499,8 +499,8 @@ void DuelEnd(int nDuelId, string sWinnerUuid, string sLoserUuid, string sNote, i
             if(GetIsObjectValid(oWin))
             {
                 GiveGoldToCreature(oWin, nStake * 2);
-                SendMessageToPC(oWin, "[Pojedynek] Stawka " + IntToString(nStake * 2)
-                    + " zlota do twojej sakiewki.");
+                SendMessageToPC(oWin, "[Duel] Stake of " + IntToString(nStake * 2)
+                    + " gold added to your purse.");
             }
         }
     }
@@ -513,7 +513,7 @@ void DuelEnd(int nDuelId, string sWinnerUuid, string sLoserUuid, string sNote, i
 
     string sMsg = sNote;
     if(sWinnerUuid != "")
-        sMsg += " Zwyciezca: " + sWinName + ".";
+        sMsg += " Victor: " + sWinName + ".";
     DuelBroadcast(sMsg, oA, oB);
 
     object oRefresh = GetFirstPC();

--- a/Honor Duels/Scripts/lib_duel_flow.nss
+++ b/Honor Duels/Scripts/lib_duel_flow.nss
@@ -1,0 +1,526 @@
+#include "lib_duel_def"
+
+// ----------------------------------------------------------------
+// Honor Duels — flow + state machine
+// Triggered from event handlers and timers; no UI building here.
+// ----------------------------------------------------------------
+
+void DuelTick(int nDuelId);
+void DuelBegin(int nDuelId);
+void DuelEnd(int nDuelId, string sWinnerUuid, string sLoserUuid, string sNote, int bKill);
+void CreateDuelHud(object oPC, int nDuelId);
+void DestroyDuelHud(object oPC);
+void FeedDuelMain(object oPC, int nToken);
+void DuelShowIncomingPopup(object oPC, int nDuelId);
+
+// ----------------------------------------------------------------
+// Notifications
+// ----------------------------------------------------------------
+
+void DuelBroadcast(string sMsg, object oA, object oB)
+{
+    if(GetIsObjectValid(oA))
+    {
+        FloatingTextStringOnCreature(sMsg, oA, FALSE);
+        SendMessageToPC(oA, "[Pojedynek] " + sMsg);
+    }
+    if(GetIsObjectValid(oB))
+    {
+        FloatingTextStringOnCreature(sMsg, oB, FALSE);
+        SendMessageToPC(oB, "[Pojedynek] " + sMsg);
+    }
+}
+
+void DuelNotifyChallenged(string sChallengedUuid, int nDuelId, string sChallengerName)
+{
+    object oPC = DuelGetPCByUUID(sChallengedUuid);
+    if(!GetIsObjectValid(oPC)) return;
+
+    string sMsg = sChallengerName + " rzuca ci wyzwanie. Honor czeka.";
+    FloatingTextStringOnCreature(sMsg, oPC, FALSE);
+    SendMessageToPC(oPC, "[Pojedynek] " + sMsg);
+
+    DelayCommand(0.5, DuelShowIncomingPopup(oPC, nDuelId));
+}
+
+// ----------------------------------------------------------------
+// Challenge submission
+// ----------------------------------------------------------------
+
+int DuelSubmitChallenge(object oPC, string sTargetUuid, string sTargetName,
+                        int nRules, int nWinCond, int nStake)
+{
+    if(sTargetUuid == "" || sTargetUuid == GetObjectUUID(oPC))
+    {
+        SendMessageToPC(oPC, "[Pojedynek] Nieprawidlowy cel.");
+        return 0;
+    }
+
+    if(DuelHasActiveBetween(GetObjectUUID(oPC), sTargetUuid))
+    {
+        SendMessageToPC(oPC, "[Pojedynek] Macie juz aktywny pojedynek lub wyzwanie.");
+        return 0;
+    }
+
+    if(nStake < 0) nStake = 0;
+    if(nStake > 0 && GetGold(oPC) < nStake)
+    {
+        SendMessageToPC(oPC, "[Pojedynek] Nie masz tyle zlota na stawke.");
+        return 0;
+    }
+
+    object oTarget = DuelGetPCByUUID(sTargetUuid);
+    if(!GetIsObjectValid(oTarget))
+    {
+        SendMessageToPC(oPC, "[Pojedynek] Przeciwnik musi byc obecny.");
+        return 0;
+    }
+
+    int nId = DuelCreate(oPC, oTarget, nRules, nWinCond, nStake);
+    if(nId <= 0)
+    {
+        SendMessageToPC(oPC, "[Pojedynek] Nie udalo sie utworzyc wyzwania.");
+        return 0;
+    }
+
+    if(nStake > 0)
+        AssignCommand(oPC, TakeGoldFromCreature(nStake, oPC, TRUE));
+
+    SendMessageToPC(oPC, "[Pojedynek] Wyzwanie wyslane do " + sTargetName + ".");
+    DuelNotifyChallenged(sTargetUuid, nId, GetName(oPC));
+    return nId;
+}
+
+// ----------------------------------------------------------------
+// Decline / cancel / expire helpers
+// ----------------------------------------------------------------
+
+void DuelRefundStake(string sUuid, int nGold)
+{
+    if(nGold <= 0) return;
+    object oPC = DuelGetPCByUUID(sUuid);
+    if(GetIsObjectValid(oPC))
+    {
+        GiveGoldToCreature(oPC, nGold);
+        SendMessageToPC(oPC, "[Pojedynek] Stawka " + IntToString(nGold) + " zlota zwrocona.");
+    }
+    // Offline: gold is forfeit. A real server would queue a refund into Mailbox.
+}
+
+void DuelDecline(object oPC, int nDuelId)
+{
+    json jD = DuelGetById(nDuelId);
+    if(JsonGetType(jD) == JSON_TYPE_NULL) return;
+
+    int nStatus = JsonGetInt(JsonObjectGet(jD, "status"));
+    if(nStatus != DUEL_STATUS_PENDING) return;
+
+    string sChallengedUuid = JsonGetString(JsonObjectGet(jD, "challenged_uuid"));
+    if(GetObjectUUID(oPC) != sChallengedUuid) return;
+
+    string sChallengerUuid = JsonGetString(JsonObjectGet(jD, "challenger_uuid"));
+    string sChallengerName = JsonGetString(JsonObjectGet(jD, "challenger_name"));
+    int nStake = JsonGetInt(JsonObjectGet(jD, "stake_gold"));
+
+    DuelSetOutcome(nDuelId, DUEL_STATUS_DECLINED, "", GetObjectUUID(oPC),
+                   "Odrzucone bez walki.");
+
+    DuelRefundStake(sChallengerUuid, nStake);
+
+    DuelAdjustHonor(GetObjectUUID(oPC), GetName(oPC),
+                    DUEL_HONOR_DECLINE, 0, 0, 1, 0, 0);
+
+    object oCh = DuelGetPCByUUID(sChallengerUuid);
+    DuelBroadcast("Wyzwanie odrzucone. Honor pochylony nizej niz miecz.",
+                  oCh, oPC);
+
+    object oRefresh = GetFirstPC();
+    while(GetIsObjectValid(oRefresh))
+    {
+        int nTk = NuiFindWindow(oRefresh, DUEL_WINDOW);
+        if(nTk != 0) FeedDuelMain(oRefresh, nTk);
+        oRefresh = GetNextPC();
+    }
+}
+
+void DuelCancelOutgoing(object oPC, int nDuelId)
+{
+    json jD = DuelGetById(nDuelId);
+    if(JsonGetType(jD) == JSON_TYPE_NULL) return;
+    if(JsonGetInt(JsonObjectGet(jD, "status")) != DUEL_STATUS_PENDING) return;
+    if(JsonGetString(JsonObjectGet(jD, "challenger_uuid")) != GetObjectUUID(oPC)) return;
+
+    int nStake = JsonGetInt(JsonObjectGet(jD, "stake_gold"));
+    DuelSetOutcome(nDuelId, DUEL_STATUS_CANCELED,
+                   "", "", "Anulowane przez wyzywajacego.");
+    if(nStake > 0) GiveGoldToCreature(oPC, nStake);
+
+    SendMessageToPC(oPC, "[Pojedynek] Wyzwanie wycofane.");
+
+    int nTk = NuiFindWindow(oPC, DUEL_WINDOW);
+    if(nTk != 0) FeedDuelMain(oPC, nTk);
+}
+
+// ----------------------------------------------------------------
+// Accept → countdown → begin
+// ----------------------------------------------------------------
+
+void DuelAccept(object oPC, int nDuelId)
+{
+    json jD = DuelGetById(nDuelId);
+    if(JsonGetType(jD) == JSON_TYPE_NULL) return;
+
+    int nStatus = JsonGetInt(JsonObjectGet(jD, "status"));
+    if(nStatus != DUEL_STATUS_PENDING) return;
+
+    string sChallengedUuid = JsonGetString(JsonObjectGet(jD, "challenged_uuid"));
+    if(GetObjectUUID(oPC) != sChallengedUuid) return;
+
+    string sChallengerUuid = JsonGetString(JsonObjectGet(jD, "challenger_uuid"));
+    object oChallenger = DuelGetPCByUUID(sChallengerUuid);
+    if(!GetIsObjectValid(oChallenger))
+    {
+        SendMessageToPC(oPC, "[Pojedynek] Wyzywajacego juz nie ma w grze.");
+        DuelSetOutcome(nDuelId, DUEL_STATUS_EXPIRED, "", "", "Brak wyzywajacego.");
+        return;
+    }
+
+    int nStake = JsonGetInt(JsonObjectGet(jD, "stake_gold"));
+    if(nStake > 0 && GetGold(oPC) < nStake)
+    {
+        SendMessageToPC(oPC, "[Pojedynek] Nie masz zlota by sprostac stawce.");
+        return;
+    }
+    if(nStake > 0)
+        AssignCommand(oPC, TakeGoldFromCreature(nStake, oPC, TRUE));
+
+    // Distance check — must be near the challenger (arena point).
+    float fX = JsonGetFloat(JsonObjectGet(jD, "arena_x"));
+    float fY = JsonGetFloat(JsonObjectGet(jD, "arena_y"));
+    vector vArena = Vector(fX, fY, JsonGetFloat(JsonObjectGet(jD, "arena_z")));
+    float fDist = GetDistanceBetweenLocations(GetLocation(oPC),
+        Location(GetArea(oChallenger), vArena, 0.0));
+    if(fDist > DUEL_ARENA_RADIUS * 1.5)
+    {
+        SendMessageToPC(oPC, "[Pojedynek] Musisz stawic sie w poblizu wyzywajacego.");
+        if(nStake > 0) GiveGoldToCreature(oPC, nStake);
+        return;
+    }
+
+    DuelSetStatus(nDuelId, DUEL_STATUS_ACCEPTED);
+
+    SetLocalInt(oPC,         DUEL_LVAR_ACTIVE_DUEL, nDuelId);
+    SetLocalInt(oChallenger, DUEL_LVAR_ACTIVE_DUEL, nDuelId);
+
+    DuelBroadcast("Wyzwanie przyjete. Krew rozstrzygnie spor.",
+                  oChallenger, oPC);
+
+    // Countdown floating text on both
+    int i;
+    for(i = DUEL_COUNTDOWN_SECONDS; i > 0; i--)
+    {
+        float fT = IntToFloat(DUEL_COUNTDOWN_SECONDS - i);
+        string sCd = IntToString(i) + "...";
+        DelayCommand(fT, FloatingTextStringOnCreature(sCd, oChallenger, FALSE));
+        DelayCommand(fT, FloatingTextStringOnCreature(sCd, oPC, FALSE));
+    }
+    DelayCommand(IntToFloat(DUEL_COUNTDOWN_SECONDS), DuelBegin(nDuelId));
+}
+
+// ----------------------------------------------------------------
+// Begin
+// ----------------------------------------------------------------
+
+void DuelMakeHostile(object oA, object oB)
+{
+    SetIsTemporaryEnemy(oB, oA, FALSE, 0.0);
+    SetIsTemporaryEnemy(oA, oB, FALSE, 0.0);
+    AdjustReputation(oB, oA, -100);
+    AdjustReputation(oA, oB, -100);
+}
+
+void DuelRestoreNeutral(object oA, object oB)
+{
+    if(GetIsObjectValid(oA) && GetIsObjectValid(oB))
+    {
+        SetIsTemporaryNeutral(oB, oA, FALSE, 0.0);
+        SetIsTemporaryNeutral(oA, oB, FALSE, 0.0);
+        AdjustReputation(oB, oA, 100);
+        AdjustReputation(oA, oB, 100);
+    }
+}
+
+void DuelBegin(int nDuelId)
+{
+    json jD = DuelGetById(nDuelId);
+    if(JsonGetType(jD) == JSON_TYPE_NULL) return;
+    if(JsonGetInt(JsonObjectGet(jD, "status")) != DUEL_STATUS_ACCEPTED) return;
+
+    object oA = DuelGetPCByUUID(JsonGetString(JsonObjectGet(jD, "challenger_uuid")));
+    object oB = DuelGetPCByUUID(JsonGetString(JsonObjectGet(jD, "challenged_uuid")));
+    if(!GetIsObjectValid(oA) || !GetIsObjectValid(oB))
+    {
+        DuelSetOutcome(nDuelId, DUEL_STATUS_EXPIRED, "", "", "Strona opuscila gre.");
+        return;
+    }
+
+    DuelSetStatus(nDuelId, DUEL_STATUS_IN_PROGRESS);
+
+    DuelMakeHostile(oA, oB);
+
+    DuelBroadcast("WALKA!", oA, oB);
+
+    CreateDuelHud(oA, nDuelId);
+    CreateDuelHud(oB, nDuelId);
+
+    DelayCommand(IntToFloat(DUEL_TICK_PERIOD), DuelTick(nDuelId));
+}
+
+// ----------------------------------------------------------------
+// Tick: HP / bounds / win condition checks
+// ----------------------------------------------------------------
+
+int DuelHpFraction(object oPC)
+{
+    int nMax = GetMaxHitPoints(oPC);
+    if(nMax <= 0) return 100;
+    int nCur = GetCurrentHitPoints(oPC);
+    if(nCur < 0) nCur = 0;
+    return (nCur * 100) / nMax;
+}
+
+void DuelUpdateHud(object oPC, object oOpp, int nFracSelf, int nFracOpp)
+{
+    int nTk = NuiFindWindow(oPC, DUEL_WIN_HUD);
+    if(nTk == 0) return;
+    NuiSetBind(oPC, nTk, DUEL_BIND_HUD_SELF_HP, JsonFloat(IntToFloat(nFracSelf) / 100.0));
+    NuiSetBind(oPC, nTk, DUEL_BIND_HUD_OPP_HP,  JsonFloat(IntToFloat(nFracOpp) / 100.0));
+    NuiSetBind(oPC, nTk, DUEL_BIND_HUD_SELF_HP_TIP, JsonString(IntToString(nFracSelf) + "%"));
+    NuiSetBind(oPC, nTk, DUEL_BIND_HUD_OPP_HP_TIP,  JsonString(IntToString(nFracOpp) + "%"));
+    NuiSetBind(oPC, nTk, DUEL_BIND_HUD_TITLE,
+        JsonString("Pojedynek: " + GetName(oOpp)));
+}
+
+void DuelTick(int nDuelId)
+{
+    json jD = DuelGetById(nDuelId);
+    if(JsonGetType(jD) == JSON_TYPE_NULL) return;
+    if(JsonGetInt(JsonObjectGet(jD, "status")) != DUEL_STATUS_IN_PROGRESS) return;
+
+    string sUuidA = JsonGetString(JsonObjectGet(jD, "challenger_uuid"));
+    string sUuidB = JsonGetString(JsonObjectGet(jD, "challenged_uuid"));
+    object oA = DuelGetPCByUUID(sUuidA);
+    object oB = DuelGetPCByUUID(sUuidB);
+
+    int nWinCond = JsonGetInt(JsonObjectGet(jD, "win_cond"));
+
+    // Disconnect / death-by-ragequit handling.
+    if(!GetIsObjectValid(oA))
+    {
+        DuelEnd(nDuelId, sUuidB, sUuidA, "Wyzywajacy opuscil arene.", FALSE);
+        return;
+    }
+    if(!GetIsObjectValid(oB))
+    {
+        DuelEnd(nDuelId, sUuidA, sUuidB, "Wyzwany opuscil arene.", FALSE);
+        return;
+    }
+
+    int nDeadA = GetIsDead(oA);
+    int nDeadB = GetIsDead(oB);
+    if(nDeadA && !nDeadB)
+    {
+        DuelEnd(nDuelId, sUuidB, sUuidA, "Smiertelny cios.", TRUE);
+        return;
+    }
+    if(nDeadB && !nDeadA)
+    {
+        DuelEnd(nDuelId, sUuidA, sUuidB, "Smiertelny cios.", TRUE);
+        return;
+    }
+    if(nDeadA && nDeadB)
+    {
+        DuelEnd(nDuelId, "", "", "Obaj polegli.", FALSE);
+        return;
+    }
+
+    int nFracA = DuelHpFraction(oA);
+    int nFracB = DuelHpFraction(oB);
+    DuelUpdateHud(oA, oB, nFracA, nFracB);
+    DuelUpdateHud(oB, oA, nFracB, nFracA);
+
+    if(nWinCond == DUEL_WIN_FIRST_BLOOD)
+    {
+        int nThr = FloatToInt(DUEL_FIRST_BLOOD_FRAC * 100.0);
+        if(nFracA <= nThr && nFracB > nThr)
+        {
+            DuelEnd(nDuelId, sUuidB, sUuidA, "Pierwsza krew.", FALSE);
+            return;
+        }
+        if(nFracB <= nThr && nFracA > nThr)
+        {
+            DuelEnd(nDuelId, sUuidA, sUuidB, "Pierwsza krew.", FALSE);
+            return;
+        }
+        if(nFracA <= nThr && nFracB <= nThr)
+        {
+            string sWin = (nFracA >= nFracB) ? sUuidA : sUuidB;
+            string sLos = (nFracA >= nFracB) ? sUuidB : sUuidA;
+            DuelEnd(nDuelId, sWin, sLos, "Obaj zranieni — wygrywa silniejszy.", FALSE);
+            return;
+        }
+    }
+
+    // Bounds check
+    float fX = JsonGetFloat(JsonObjectGet(jD, "arena_x"));
+    float fY = JsonGetFloat(JsonObjectGet(jD, "arena_y"));
+    float fZ = JsonGetFloat(JsonObjectGet(jD, "arena_z"));
+    string sAreaTag = JsonGetString(JsonObjectGet(jD, "arena_area"));
+    object oArea    = GetObjectByTag(sAreaTag);
+    if(!GetIsObjectValid(oArea)) oArea = GetArea(oA);
+    location lArena = Location(oArea, Vector(fX, fY, fZ), 0.0);
+
+    float fDistA = GetDistanceBetweenLocations(GetLocation(oA), lArena);
+    float fDistB = GetDistanceBetweenLocations(GetLocation(oB), lArena);
+
+    int nOobA = GetLocalInt(oA, DUEL_LVAR_OUT_OF_BOUNDS);
+    int nOobB = GetLocalInt(oB, DUEL_LVAR_OUT_OF_BOUNDS);
+
+    int bAreaA = (GetArea(oA) == oArea);
+    int bAreaB = (GetArea(oB) == oArea);
+
+    if(!bAreaA || fDistA > DUEL_ARENA_RADIUS) nOobA++; else nOobA = 0;
+    if(!bAreaB || fDistB > DUEL_ARENA_RADIUS) nOobB++; else nOobB = 0;
+
+    SetLocalInt(oA, DUEL_LVAR_OUT_OF_BOUNDS, nOobA);
+    SetLocalInt(oB, DUEL_LVAR_OUT_OF_BOUNDS, nOobB);
+
+    int nTkA = NuiFindWindow(oA, DUEL_WIN_HUD);
+    int nTkB = NuiFindWindow(oB, DUEL_WIN_HUD);
+    if(nTkA != 0) NuiSetBind(oA, nTkA, DUEL_BIND_HUD_BOUNDS,
+        JsonString(nOobA > 0 ? "Wracaj na arene! " + IntToString(nOobA) + "/"
+            + IntToString(FloatToInt(DUEL_OUT_OF_BOUNDS_TIME)) : ""));
+    if(nTkB != 0) NuiSetBind(oB, nTkB, DUEL_BIND_HUD_BOUNDS,
+        JsonString(nOobB > 0 ? "Wracaj na arene! " + IntToString(nOobB) + "/"
+            + IntToString(FloatToInt(DUEL_OUT_OF_BOUNDS_TIME)) : ""));
+
+    if(IntToFloat(nOobA) >= DUEL_OUT_OF_BOUNDS_TIME)
+    {
+        DuelEnd(nDuelId, sUuidB, sUuidA, "Ucieczka z areny.", FALSE);
+        return;
+    }
+    if(IntToFloat(nOobB) >= DUEL_OUT_OF_BOUNDS_TIME)
+    {
+        DuelEnd(nDuelId, sUuidA, sUuidB, "Ucieczka z areny.", FALSE);
+        return;
+    }
+
+    DelayCommand(IntToFloat(DUEL_TICK_PERIOD), DuelTick(nDuelId));
+}
+
+// ----------------------------------------------------------------
+// Yield
+// ----------------------------------------------------------------
+
+void DuelYield(object oPC)
+{
+    int nDuelId = GetLocalInt(oPC, DUEL_LVAR_ACTIVE_DUEL);
+    if(nDuelId <= 0) return;
+
+    json jD = DuelGetById(nDuelId);
+    if(JsonGetType(jD) == JSON_TYPE_NULL) return;
+    if(JsonGetInt(JsonObjectGet(jD, "status")) != DUEL_STATUS_IN_PROGRESS) return;
+
+    string sUuidA = JsonGetString(JsonObjectGet(jD, "challenger_uuid"));
+    string sUuidB = JsonGetString(JsonObjectGet(jD, "challenged_uuid"));
+    string sSelf  = GetObjectUUID(oPC);
+    if(sSelf != sUuidA && sSelf != sUuidB) return;
+
+    string sWin = (sSelf == sUuidA) ? sUuidB : sUuidA;
+    DuelEnd(nDuelId, sWin, sSelf, "Poddanie sie.", FALSE);
+}
+
+// ----------------------------------------------------------------
+// End — outcome resolution + honor + stake transfer
+// ----------------------------------------------------------------
+
+void DuelHealAndCleanup(object oPC)
+{
+    if(!GetIsObjectValid(oPC)) return;
+    DeleteLocalInt(oPC, DUEL_LVAR_ACTIVE_DUEL);
+    DeleteLocalInt(oPC, DUEL_LVAR_OUT_OF_BOUNDS);
+    DestroyDuelHud(oPC);
+}
+
+void DuelEnd(int nDuelId, string sWinnerUuid, string sLoserUuid, string sNote, int bKill)
+{
+    json jD = DuelGetById(nDuelId);
+    if(JsonGetType(jD) == JSON_TYPE_NULL) return;
+    int nStatusNow = JsonGetInt(JsonObjectGet(jD, "status"));
+    if(nStatusNow == DUEL_STATUS_COMPLETED) return;
+
+    string sUuidA = JsonGetString(JsonObjectGet(jD, "challenger_uuid"));
+    string sUuidB = JsonGetString(JsonObjectGet(jD, "challenged_uuid"));
+    string sNameA = JsonGetString(JsonObjectGet(jD, "challenger_name"));
+    string sNameB = JsonGetString(JsonObjectGet(jD, "challenged_name"));
+    int nStake    = JsonGetInt   (JsonObjectGet(jD, "stake_gold"));
+    int nWinCond  = JsonGetInt   (JsonObjectGet(jD, "win_cond"));
+
+    object oA = DuelGetPCByUUID(sUuidA);
+    object oB = DuelGetPCByUUID(sUuidB);
+
+    DuelSetOutcome(nDuelId, DUEL_STATUS_COMPLETED, sWinnerUuid, sLoserUuid, sNote);
+
+    if(GetIsObjectValid(oA) && GetIsObjectValid(oB))
+        DuelRestoreNeutral(oA, oB);
+
+    DuelHealAndCleanup(oA);
+    DuelHealAndCleanup(oB);
+
+    int bForfeit = (sNote == "Poddanie sie." || sNote == "Ucieczka z areny.");
+
+    string sWinName = (sWinnerUuid == sUuidA) ? sNameA : sNameB;
+    string sLosName = (sLoserUuid  == sUuidA) ? sNameA : sNameB;
+
+    // Honor distribution
+    if(sWinnerUuid != "")
+    {
+        int nWinDelta = DUEL_HONOR_WIN;
+        if(bKill && nWinCond == DUEL_WIN_TO_DEATH) nWinDelta += DUEL_HONOR_KILL_BONUS;
+        DuelAdjustHonor(sWinnerUuid, sWinName, nWinDelta, 1, 0, 0, 0, bKill ? 1 : 0);
+
+        int nLoseDelta = bForfeit ? DUEL_HONOR_FORFEIT : DUEL_HONOR_LOSE;
+        DuelAdjustHonor(sLoserUuid, sLosName, nLoseDelta, 0, 1, 0, bForfeit ? 1 : 0, 0);
+
+        // Stake: winner takes both halves.
+        if(nStake > 0)
+        {
+            object oWin = DuelGetPCByUUID(sWinnerUuid);
+            if(GetIsObjectValid(oWin))
+            {
+                GiveGoldToCreature(oWin, nStake * 2);
+                SendMessageToPC(oWin, "[Pojedynek] Stawka " + IntToString(nStake * 2)
+                    + " zlota do twojej sakiewki.");
+            }
+        }
+    }
+    else
+    {
+        // No winner (mutual death) — stakes refunded.
+        DuelRefundStake(sUuidA, nStake);
+        DuelRefundStake(sUuidB, nStake);
+    }
+
+    string sMsg = sNote;
+    if(sWinnerUuid != "")
+        sMsg += " Zwyciezca: " + sWinName + ".";
+    DuelBroadcast(sMsg, oA, oB);
+
+    object oRefresh = GetFirstPC();
+    while(GetIsObjectValid(oRefresh))
+    {
+        int nTk = NuiFindWindow(oRefresh, DUEL_WINDOW);
+        if(nTk != 0) FeedDuelMain(oRefresh, nTk);
+        oRefresh = GetNextPC();
+    }
+}

--- a/Honor Duels/Scripts/lib_duel_hud.nss
+++ b/Honor Duels/Scripts/lib_duel_hud.nss
@@ -24,14 +24,14 @@ void CreateDuelHud(object oPC, int nDuelId)
         JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
     jTitle = NuiHeight(jTitle, fLblH);
 
-    json jOppLbl = NuiLabel(JsonString("Przeciwnik"),
+    json jOppLbl = NuiLabel(JsonString("Opponent"),
         JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
     jOppLbl = NuiHeight(jOppLbl, fLblH);
     json jOppBar = NuiProgress(NuiBind(DUEL_BIND_HUD_OPP_HP));
     jOppBar = NuiTooltip(jOppBar, NuiBind(DUEL_BIND_HUD_OPP_HP_TIP));
     jOppBar = NuiHeight(jOppBar, fBarH);
 
-    json jSelfLbl = NuiLabel(JsonString("Ty"),
+    json jSelfLbl = NuiLabel(JsonString("You"),
         JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
     jSelfLbl = NuiHeight(jSelfLbl, fLblH);
     json jSelfBar = NuiProgress(NuiBind(DUEL_BIND_HUD_SELF_HP));
@@ -43,7 +43,7 @@ void CreateDuelHud(object oPC, int nDuelId)
     jBounds = NuiHeight(jBounds, fLblH);
     jBounds = NuiStyleForegroundColor(jBounds, NuiColor(220, 60, 60));
 
-    json jYield = NuiButton(JsonString("Poddaj sie"));
+    json jYield = NuiButton(JsonString("Yield"));
     jYield = NuiId(jYield, DUEL_BTN_HUD_YIELD);
     jYield = NuiHeight(jYield, fBtnH);
 
@@ -59,7 +59,7 @@ void CreateDuelHud(object oPC, int nDuelId)
     json jRoot = NuiCol(jCol);
 
     json jNui = NuiWindow(jRoot,
-        JsonString("Pojedynek"),
+        JsonString("Duel"),
         NuiBind(DUEL_BIND_HUD_GEOM),
         JsonBool(FALSE),  // resizable
         JsonBool(FALSE),  // collapsed
@@ -71,7 +71,7 @@ void CreateDuelHud(object oPC, int nDuelId)
 
     NuiSetBind(oPC, nTk, DUEL_BIND_HUD_GEOM,
         NuiRect(20.0, 60.0, fW, fH));
-    NuiSetBind(oPC, nTk, DUEL_BIND_HUD_TITLE,    JsonString("Pojedynek"));
+    NuiSetBind(oPC, nTk, DUEL_BIND_HUD_TITLE,    JsonString("Duel"));
     NuiSetBind(oPC, nTk, DUEL_BIND_HUD_OPP_HP,   JsonFloat(1.0));
     NuiSetBind(oPC, nTk, DUEL_BIND_HUD_SELF_HP,  JsonFloat(1.0));
     NuiSetBind(oPC, nTk, DUEL_BIND_HUD_OPP_HP_TIP,  JsonString("100%"));
@@ -119,11 +119,11 @@ void DuelShowIncomingPopup(object oPC, int nDuelId)
         JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
     jStake = NuiHeight(jStake, fLblH);
 
-    json jAccept = NuiButton(JsonString("Przyjmij"));
+    json jAccept = NuiButton(JsonString("Accept"));
     jAccept = NuiId(jAccept, DUEL_BTN_INC_ACCEPT);
     jAccept = NuiHeight(jAccept, fBtnH);
 
-    json jDecline = NuiButton(JsonString("Odrzuc"));
+    json jDecline = NuiButton(JsonString("Decline"));
     jDecline = NuiId(jDecline, DUEL_BTN_INC_DECLINE);
     jDecline = NuiHeight(jDecline, fBtnH);
 
@@ -142,7 +142,7 @@ void DuelShowIncomingPopup(object oPC, int nDuelId)
     json jRoot = NuiCol(jCol);
 
     json jNui = NuiWindow(jRoot,
-        JsonString("Wyzwanie"),
+        JsonString("Challenge"),
         NuiRect(-1.0, -1.0, fW, fH),
         JsonBool(FALSE),
         JsonBool(FALSE),
@@ -153,15 +153,15 @@ void DuelShowIncomingPopup(object oPC, int nDuelId)
     int nTk = NuiCreate(oPC, jNui, DUEL_WIN_INCOMING, DUEL_EV_SCRIPT);
 
     NuiSetBind(oPC, nTk, DUEL_BIND_INC_TITLE,
-        JsonString(sName + " rzuca ci wyzwanie."));
+        JsonString(sName + " challenges you."));
     NuiSetBind(oPC, nTk, DUEL_BIND_INC_WIN,
-        JsonString("Warunek zwyciestwa: " + DuelWinConditionToString(nWinCond)));
+        JsonString("Win condition: " + DuelWinConditionToString(nWinCond)));
     NuiSetBind(oPC, nTk, DUEL_BIND_INC_RULES,
-        JsonString("Reguly: " + DuelRulesToString(nRules)));
+        JsonString("Rules: " + DuelRulesToString(nRules)));
     NuiSetBind(oPC, nTk, DUEL_BIND_INC_STAKE,
         JsonString(nStake > 0
-            ? "Stawka: " + IntToString(nStake) + " zlota (musisz dolozyc tyle samo)"
-            : "Stawka: brak"));
+            ? "Stake: " + IntToString(nStake) + " gold (you must match it)"
+            : "Stake: none"));
 }
 
 // ----------------------------------------------------------------
@@ -189,31 +189,31 @@ void DuelShowChallengeConfig(object oPC, string sTargetUuid, string sTargetName)
     jTarget = NuiHeight(jTarget, fLblH);
 
     // Win condition group
-    json jWinLbl = NuiLabel(JsonString("Warunek zwyciestwa:"),
+    json jWinLbl = NuiLabel(JsonString("Win condition:"),
         JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
     jWinLbl = NuiHeight(jWinLbl, fLblH);
 
-    json jWinFb = NuiCheck(JsonString("Pierwsza krew"), NuiBind(DUEL_BIND_CH_WIN_FB));
+    json jWinFb = NuiCheck(JsonString("First blood"), NuiBind(DUEL_BIND_CH_WIN_FB));
     jWinFb = NuiId(jWinFb, DUEL_BTN_CH_WIN_FB);
-    json jWinDeath = NuiCheck(JsonString("Na smierc"), NuiBind(DUEL_BIND_CH_WIN_DEATH));
+    json jWinDeath = NuiCheck(JsonString("To the death"), NuiBind(DUEL_BIND_CH_WIN_DEATH));
     jWinDeath = NuiId(jWinDeath, DUEL_BTN_CH_WIN_DEATH);
-    json jWinYield = NuiCheck(JsonString("Do poddania"), NuiBind(DUEL_BIND_CH_WIN_YIELD));
+    json jWinYield = NuiCheck(JsonString("Until yield"), NuiBind(DUEL_BIND_CH_WIN_YIELD));
     jWinYield = NuiId(jWinYield, DUEL_BTN_CH_WIN_YIELD);
 
     // Rules group
-    json jRulesLbl = NuiLabel(JsonString("Reguly:"),
+    json jRulesLbl = NuiLabel(JsonString("Rules:"),
         JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
     jRulesLbl = NuiHeight(jRulesLbl, fLblH);
 
-    json jR1 = NuiCheck(JsonString("Bez magii"), NuiBind(DUEL_BIND_CH_RULE_NOMAGIC));
+    json jR1 = NuiCheck(JsonString("No magic"), NuiBind(DUEL_BIND_CH_RULE_NOMAGIC));
     jR1 = NuiId(jR1, DUEL_BTN_CH_RULE_NOMAGIC);
-    json jR2 = NuiCheck(JsonString("Bez mikstur i zwojow"), NuiBind(DUEL_BIND_CH_RULE_NOITEMS));
+    json jR2 = NuiCheck(JsonString("No potions or scrolls"), NuiBind(DUEL_BIND_CH_RULE_NOITEMS));
     jR2 = NuiId(jR2, DUEL_BTN_CH_RULE_NOITEMS);
-    json jR3 = NuiCheck(JsonString("Bez krytykow"), NuiBind(DUEL_BIND_CH_RULE_NOCRIT));
+    json jR3 = NuiCheck(JsonString("No crits"), NuiBind(DUEL_BIND_CH_RULE_NOCRIT));
     jR3 = NuiId(jR3, DUEL_BTN_CH_RULE_NOCRIT);
 
     // Stake
-    json jStakeLbl = NuiLabel(JsonString("Stawka (zloto):"),
+    json jStakeLbl = NuiLabel(JsonString("Stake (gold):"),
         JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
     jStakeLbl = NuiHeight(jStakeLbl, fLblH);
 
@@ -221,12 +221,12 @@ void DuelShowChallengeConfig(object oPC, string sTargetUuid, string sTargetName)
     jStake = NuiHeight(jStake, fLblH);
 
     // Buttons
-    json jSend = NuiButton(JsonString("Rzuc rekawice"));
+    json jSend = NuiButton(JsonString("Throw down the gauntlet"));
     jSend = NuiId(jSend, DUEL_BTN_CH_SEND);
     jSend = NuiEnabled(jSend, NuiBind(DUEL_BIND_CH_SEND_ENA));
     jSend = NuiHeight(jSend, fBtnH);
 
-    json jCancel = NuiButton(JsonString("Anuluj"));
+    json jCancel = NuiButton(JsonString("Cancel"));
     jCancel = NuiId(jCancel, DUEL_BTN_CH_CANCEL);
     jCancel = NuiHeight(jCancel, fBtnH);
 
@@ -252,7 +252,7 @@ void DuelShowChallengeConfig(object oPC, string sTargetUuid, string sTargetName)
     json jRoot = NuiCol(jCol);
 
     json jNui = NuiWindow(jRoot,
-        JsonString("Wyzwanie na pojedynek"),
+        JsonString("Challenge to a duel"),
         NuiRect(-1.0, -1.0, fW, fH),
         JsonBool(FALSE), JsonBool(FALSE),
         JsonBool(TRUE),  JsonBool(FALSE), JsonBool(TRUE));
@@ -260,7 +260,7 @@ void DuelShowChallengeConfig(object oPC, string sTargetUuid, string sTargetName)
     int nTk = NuiCreate(oPC, jNui, DUEL_WIN_CHALLENGE, DUEL_EV_SCRIPT);
 
     NuiSetBind(oPC, nTk, DUEL_BIND_CH_TARGET_LBL,
-        JsonString("Wyzywasz: " + sTargetName));
+        JsonString("Challenging: " + sTargetName));
     NuiSetBind(oPC, nTk, DUEL_BIND_CH_WIN_FB,        JsonBool(TRUE));
     NuiSetBind(oPC, nTk, DUEL_BIND_CH_WIN_DEATH,     JsonBool(FALSE));
     NuiSetBind(oPC, nTk, DUEL_BIND_CH_WIN_YIELD,     JsonBool(FALSE));

--- a/Honor Duels/Scripts/lib_duel_hud.nss
+++ b/Honor Duels/Scripts/lib_duel_hud.nss
@@ -1,0 +1,272 @@
+#include "lib_duel_def"
+
+// ----------------------------------------------------------------
+// Honor Duels — overlay HUD (active duel) + popups
+// ----------------------------------------------------------------
+
+void DestroyDuelHud(object oPC)
+{
+    int nTk = NuiFindWindow(oPC, DUEL_WIN_HUD);
+    if(nTk != 0) NuiDestroy(oPC, nTk);
+}
+
+void CreateDuelHud(object oPC, int nDuelId)
+{
+    DestroyDuelHud(oPC);
+
+    float fW = GetNuiScaleDimension(oPC, DUEL_HUD_W);
+    float fH = GetNuiScaleDimension(oPC, DUEL_HUD_H);
+    float fBarH = GetNuiScaleDimension(oPC, 18.0);
+    float fLblH = GetNuiScaleDimension(oPC, 22.0);
+    float fBtnH = GetNuiScaleDimension(oPC, 28.0);
+
+    json jTitle = NuiLabel(NuiBind(DUEL_BIND_HUD_TITLE),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitle = NuiHeight(jTitle, fLblH);
+
+    json jOppLbl = NuiLabel(JsonString("Przeciwnik"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jOppLbl = NuiHeight(jOppLbl, fLblH);
+    json jOppBar = NuiProgress(NuiBind(DUEL_BIND_HUD_OPP_HP));
+    jOppBar = NuiTooltip(jOppBar, NuiBind(DUEL_BIND_HUD_OPP_HP_TIP));
+    jOppBar = NuiHeight(jOppBar, fBarH);
+
+    json jSelfLbl = NuiLabel(JsonString("Ty"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jSelfLbl = NuiHeight(jSelfLbl, fLblH);
+    json jSelfBar = NuiProgress(NuiBind(DUEL_BIND_HUD_SELF_HP));
+    jSelfBar = NuiTooltip(jSelfBar, NuiBind(DUEL_BIND_HUD_SELF_HP_TIP));
+    jSelfBar = NuiHeight(jSelfBar, fBarH);
+
+    json jBounds = NuiLabel(NuiBind(DUEL_BIND_HUD_BOUNDS),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jBounds = NuiHeight(jBounds, fLblH);
+    jBounds = NuiStyleForegroundColor(jBounds, NuiColor(220, 60, 60));
+
+    json jYield = NuiButton(JsonString("Poddaj sie"));
+    jYield = NuiId(jYield, DUEL_BTN_HUD_YIELD);
+    jYield = NuiHeight(jYield, fBtnH);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jTitle);
+    jCol = JsonArrayInsert(jCol, jOppLbl);
+    jCol = JsonArrayInsert(jCol, jOppBar);
+    jCol = JsonArrayInsert(jCol, jSelfLbl);
+    jCol = JsonArrayInsert(jCol, jSelfBar);
+    jCol = JsonArrayInsert(jCol, jBounds);
+    jCol = JsonArrayInsert(jCol, jYield);
+
+    json jRoot = NuiCol(jCol);
+
+    json jNui = NuiWindow(jRoot,
+        JsonString("Pojedynek"),
+        NuiBind(DUEL_BIND_HUD_GEOM),
+        JsonBool(FALSE),  // resizable
+        JsonBool(FALSE),  // collapsed
+        JsonBool(FALSE),  // closable — only via duel end
+        JsonBool(FALSE),  // transparent
+        JsonBool(TRUE));  // border
+
+    int nTk = NuiCreate(oPC, jNui, DUEL_WIN_HUD, DUEL_EV_SCRIPT);
+
+    NuiSetBind(oPC, nTk, DUEL_BIND_HUD_GEOM,
+        NuiRect(20.0, 60.0, fW, fH));
+    NuiSetBind(oPC, nTk, DUEL_BIND_HUD_TITLE,    JsonString("Pojedynek"));
+    NuiSetBind(oPC, nTk, DUEL_BIND_HUD_OPP_HP,   JsonFloat(1.0));
+    NuiSetBind(oPC, nTk, DUEL_BIND_HUD_SELF_HP,  JsonFloat(1.0));
+    NuiSetBind(oPC, nTk, DUEL_BIND_HUD_OPP_HP_TIP,  JsonString("100%"));
+    NuiSetBind(oPC, nTk, DUEL_BIND_HUD_SELF_HP_TIP, JsonString("100%"));
+    NuiSetBind(oPC, nTk, DUEL_BIND_HUD_BOUNDS,   JsonString(""));
+}
+
+// ----------------------------------------------------------------
+// Incoming challenge popup (target sees this)
+// ----------------------------------------------------------------
+
+void DuelShowIncomingPopup(object oPC, int nDuelId)
+{
+    int nExisting = NuiFindWindow(oPC, DUEL_WIN_INCOMING);
+    if(nExisting != 0) NuiDestroy(oPC, nExisting);
+
+    json jD = DuelGetById(nDuelId);
+    if(JsonGetType(jD) == JSON_TYPE_NULL) return;
+
+    SetLocalInt(oPC, DUEL_LVAR_INCOMING_ID, nDuelId);
+
+    string sName  = JsonGetString(JsonObjectGet(jD, "challenger_name"));
+    int nRules    = JsonGetInt   (JsonObjectGet(jD, "rules_mask"));
+    int nWinCond  = JsonGetInt   (JsonObjectGet(jD, "win_cond"));
+    int nStake    = JsonGetInt   (JsonObjectGet(jD, "stake_gold"));
+
+    float fW = GetNuiScaleDimension(oPC, DUEL_INCOMING_W);
+    float fH = GetNuiScaleDimension(oPC, DUEL_INCOMING_H);
+    float fLblH = GetNuiScaleDimension(oPC, 24.0);
+    float fBtnH = GetNuiScaleDimension(oPC, 32.0);
+
+    json jTitle = NuiLabel(NuiBind(DUEL_BIND_INC_TITLE),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitle = NuiHeight(jTitle, fLblH);
+
+    json jWin = NuiLabel(NuiBind(DUEL_BIND_INC_WIN),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jWin = NuiHeight(jWin, fLblH);
+
+    json jRules = NuiLabel(NuiBind(DUEL_BIND_INC_RULES),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRules = NuiHeight(jRules, fLblH);
+
+    json jStake = NuiLabel(NuiBind(DUEL_BIND_INC_STAKE),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jStake = NuiHeight(jStake, fLblH);
+
+    json jAccept = NuiButton(JsonString("Przyjmij"));
+    jAccept = NuiId(jAccept, DUEL_BTN_INC_ACCEPT);
+    jAccept = NuiHeight(jAccept, fBtnH);
+
+    json jDecline = NuiButton(JsonString("Odrzuc"));
+    jDecline = NuiId(jDecline, DUEL_BTN_INC_DECLINE);
+    jDecline = NuiHeight(jDecline, fBtnH);
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, jAccept);
+    jBtnRow = JsonArrayInsert(jBtnRow, jDecline);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jTitle);
+    jCol = JsonArrayInsert(jCol, jWin);
+    jCol = JsonArrayInsert(jCol, jRules);
+    jCol = JsonArrayInsert(jCol, jStake);
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+
+    json jRoot = NuiCol(jCol);
+
+    json jNui = NuiWindow(jRoot,
+        JsonString("Wyzwanie"),
+        NuiRect(-1.0, -1.0, fW, fH),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE),
+        JsonBool(TRUE));
+
+    int nTk = NuiCreate(oPC, jNui, DUEL_WIN_INCOMING, DUEL_EV_SCRIPT);
+
+    NuiSetBind(oPC, nTk, DUEL_BIND_INC_TITLE,
+        JsonString(sName + " rzuca ci wyzwanie."));
+    NuiSetBind(oPC, nTk, DUEL_BIND_INC_WIN,
+        JsonString("Warunek zwyciestwa: " + DuelWinConditionToString(nWinCond)));
+    NuiSetBind(oPC, nTk, DUEL_BIND_INC_RULES,
+        JsonString("Reguly: " + DuelRulesToString(nRules)));
+    NuiSetBind(oPC, nTk, DUEL_BIND_INC_STAKE,
+        JsonString(nStake > 0
+            ? "Stawka: " + IntToString(nStake) + " zlota (musisz dolozyc tyle samo)"
+            : "Stawka: brak"));
+}
+
+// ----------------------------------------------------------------
+// Challenge config popup (challenger fills before sending)
+// ----------------------------------------------------------------
+
+void DuelShowChallengeConfig(object oPC, string sTargetUuid, string sTargetName)
+{
+    int nExisting = NuiFindWindow(oPC, DUEL_WIN_CHALLENGE);
+    if(nExisting != 0) NuiDestroy(oPC, nExisting);
+
+    SetLocalString(oPC, DUEL_LVAR_DRAFT_TARGET, sTargetUuid);
+    SetLocalString(oPC, DUEL_LVAR_DRAFT_NAME,   sTargetName);
+    SetLocalInt   (oPC, DUEL_LVAR_DRAFT_RULES,  0);
+    SetLocalInt   (oPC, DUEL_LVAR_DRAFT_WIN,    DUEL_WIN_FIRST_BLOOD);
+    SetLocalInt   (oPC, DUEL_LVAR_DRAFT_STAKE,  0);
+
+    float fW = GetNuiScaleDimension(oPC, DUEL_CHALLENGE_W);
+    float fH = GetNuiScaleDimension(oPC, DUEL_CHALLENGE_H);
+    float fLblH = GetNuiScaleDimension(oPC, 22.0);
+    float fBtnH = GetNuiScaleDimension(oPC, 28.0);
+
+    json jTarget = NuiLabel(NuiBind(DUEL_BIND_CH_TARGET_LBL),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jTarget = NuiHeight(jTarget, fLblH);
+
+    // Win condition group
+    json jWinLbl = NuiLabel(JsonString("Warunek zwyciestwa:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jWinLbl = NuiHeight(jWinLbl, fLblH);
+
+    json jWinFb = NuiCheck(JsonString("Pierwsza krew"), NuiBind(DUEL_BIND_CH_WIN_FB));
+    jWinFb = NuiId(jWinFb, DUEL_BTN_CH_WIN_FB);
+    json jWinDeath = NuiCheck(JsonString("Na smierc"), NuiBind(DUEL_BIND_CH_WIN_DEATH));
+    jWinDeath = NuiId(jWinDeath, DUEL_BTN_CH_WIN_DEATH);
+    json jWinYield = NuiCheck(JsonString("Do poddania"), NuiBind(DUEL_BIND_CH_WIN_YIELD));
+    jWinYield = NuiId(jWinYield, DUEL_BTN_CH_WIN_YIELD);
+
+    // Rules group
+    json jRulesLbl = NuiLabel(JsonString("Reguly:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRulesLbl = NuiHeight(jRulesLbl, fLblH);
+
+    json jR1 = NuiCheck(JsonString("Bez magii"), NuiBind(DUEL_BIND_CH_RULE_NOMAGIC));
+    jR1 = NuiId(jR1, DUEL_BTN_CH_RULE_NOMAGIC);
+    json jR2 = NuiCheck(JsonString("Bez mikstur i zwojow"), NuiBind(DUEL_BIND_CH_RULE_NOITEMS));
+    jR2 = NuiId(jR2, DUEL_BTN_CH_RULE_NOITEMS);
+    json jR3 = NuiCheck(JsonString("Bez krytykow"), NuiBind(DUEL_BIND_CH_RULE_NOCRIT));
+    jR3 = NuiId(jR3, DUEL_BTN_CH_RULE_NOCRIT);
+
+    // Stake
+    json jStakeLbl = NuiLabel(JsonString("Stawka (zloto):"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jStakeLbl = NuiHeight(jStakeLbl, fLblH);
+
+    json jStake = NuiTextEdit(JsonString("0"), NuiBind(DUEL_BIND_CH_STAKE_TXT), 8, FALSE);
+    jStake = NuiHeight(jStake, fLblH);
+
+    // Buttons
+    json jSend = NuiButton(JsonString("Rzuc rekawice"));
+    jSend = NuiId(jSend, DUEL_BTN_CH_SEND);
+    jSend = NuiEnabled(jSend, NuiBind(DUEL_BIND_CH_SEND_ENA));
+    jSend = NuiHeight(jSend, fBtnH);
+
+    json jCancel = NuiButton(JsonString("Anuluj"));
+    jCancel = NuiId(jCancel, DUEL_BTN_CH_CANCEL);
+    jCancel = NuiHeight(jCancel, fBtnH);
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, jSend);
+    jBtnRow = JsonArrayInsert(jBtnRow, jCancel);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jTarget);
+    jCol = JsonArrayInsert(jCol, jWinLbl);
+    jCol = JsonArrayInsert(jCol, jWinFb);
+    jCol = JsonArrayInsert(jCol, jWinDeath);
+    jCol = JsonArrayInsert(jCol, jWinYield);
+    jCol = JsonArrayInsert(jCol, jRulesLbl);
+    jCol = JsonArrayInsert(jCol, jR1);
+    jCol = JsonArrayInsert(jCol, jR2);
+    jCol = JsonArrayInsert(jCol, jR3);
+    jCol = JsonArrayInsert(jCol, jStakeLbl);
+    jCol = JsonArrayInsert(jCol, jStake);
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+
+    json jRoot = NuiCol(jCol);
+
+    json jNui = NuiWindow(jRoot,
+        JsonString("Wyzwanie na pojedynek"),
+        NuiRect(-1.0, -1.0, fW, fH),
+        JsonBool(FALSE), JsonBool(FALSE),
+        JsonBool(TRUE),  JsonBool(FALSE), JsonBool(TRUE));
+
+    int nTk = NuiCreate(oPC, jNui, DUEL_WIN_CHALLENGE, DUEL_EV_SCRIPT);
+
+    NuiSetBind(oPC, nTk, DUEL_BIND_CH_TARGET_LBL,
+        JsonString("Wyzywasz: " + sTargetName));
+    NuiSetBind(oPC, nTk, DUEL_BIND_CH_WIN_FB,        JsonBool(TRUE));
+    NuiSetBind(oPC, nTk, DUEL_BIND_CH_WIN_DEATH,     JsonBool(FALSE));
+    NuiSetBind(oPC, nTk, DUEL_BIND_CH_WIN_YIELD,     JsonBool(FALSE));
+    NuiSetBind(oPC, nTk, DUEL_BIND_CH_RULE_NOMAGIC,  JsonBool(FALSE));
+    NuiSetBind(oPC, nTk, DUEL_BIND_CH_RULE_NOITEMS,  JsonBool(FALSE));
+    NuiSetBind(oPC, nTk, DUEL_BIND_CH_RULE_NOCRIT,   JsonBool(FALSE));
+    NuiSetBind(oPC, nTk, DUEL_BIND_CH_STAKE_TXT,     JsonString("0"));
+    NuiSetBind(oPC, nTk, DUEL_BIND_CH_SEND_ENA,      JsonBool(TRUE));
+}

--- a/Honor Duels/Scripts/lib_duel_ui.nss
+++ b/Honor Duels/Scripts/lib_duel_ui.nss
@@ -56,7 +56,7 @@ void CreateDuelMainWindow(object oPC)
         JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
     jTitle = NuiHeight(jTitle, fBtnH);
 
-    json jClose = NuiButton(JsonString("Zamknij"));
+    json jClose = NuiButton(JsonString("Close"));
     jClose = NuiId(jClose, DUEL_BTN_CLOSE);
     jClose = NuiWidth(jClose, GetNuiScaleDimension(oPC, 90.0));
     jClose = NuiHeight(jClose, fBtnH);
@@ -80,22 +80,22 @@ void CreateDuelMainWindow(object oPC)
     jStatRow = JsonArrayInsert(jStatRow, jRecord);
 
     // -- Challenge button --
-    json jChallenge = NuiButton(JsonString("Rzuc rekawice (wybierz cel)"));
+    json jChallenge = NuiButton(JsonString("Throw down the gauntlet (select target)"));
     jChallenge = NuiId(jChallenge, DUEL_BTN_CHALLENGE);
     jChallenge = NuiHeight(jChallenge, fBtnH);
 
     // -- Tabs --
-    json jTabInc = NuiButton(JsonString("Wyzwania"));
+    json jTabInc = NuiButton(JsonString("Challenges"));
     jTabInc = NuiId(jTabInc, DUEL_BTN_TAB_INCOMING);
     jTabInc = NuiEncouraged(jTabInc, NuiBind(DUEL_BIND_TAB_INCOMING_ENC));
     jTabInc = NuiHeight(jTabInc, fBtnH);
 
-    json jTabHis = NuiButton(JsonString("Historia"));
+    json jTabHis = NuiButton(JsonString("History"));
     jTabHis = NuiId(jTabHis, DUEL_BTN_TAB_HISTORY);
     jTabHis = NuiEncouraged(jTabHis, NuiBind(DUEL_BIND_TAB_HISTORY_ENC));
     jTabHis = NuiHeight(jTabHis, fBtnH);
 
-    json jTabRnk = NuiButton(JsonString("Ranking honoru"));
+    json jTabRnk = NuiButton(JsonString("Honor ranking"));
     jTabRnk = NuiId(jTabRnk, DUEL_BTN_TAB_RANKING);
     jTabRnk = NuiEncouraged(jTabRnk, NuiBind(DUEL_BIND_TAB_RANKING_ENC));
     jTabRnk = NuiHeight(jTabRnk, fBtnH);
@@ -134,11 +134,11 @@ void CreateDuelMainWindow(object oPC)
     int nTk = NuiCreate(oPC, jNui, DUEL_WINDOW, DUEL_EV_SCRIPT);
 
     NuiSetBind(oPC, nTk, WINDOW_TITLE,
-        JsonString("Honorowe Pojedynki"));
+        JsonString("Honor Duels"));
     NuiSetBind(oPC, nTk, WINDOW_GEOMETRY,
         NuiRect(-1.0, -1.0, fW, fH));
     NuiSetBind(oPC, nTk, DUEL_BIND_TITLE,
-        JsonString("Honorowe Pojedynki"));
+        JsonString("Honor Duels"));
 
     FeedDuelMain(oPC, nTk);
 }
@@ -177,14 +177,14 @@ void FeedDuelIncoming(object oPC, int nToken)
         int nStake    = JsonGetInt   (JsonObjectGet(jR, "stake_gold"));
         int nStatus   = JsonGetInt   (JsonObjectGet(jR, "status"));
 
-        string sPrefix = (sDir == "in") ? "Od: " : "Do: ";
-        string sStatus = (nStatus == DUEL_STATUS_PENDING) ? "[oczekuje]" : "[przyjete]";
+        string sPrefix = (sDir == "in") ? "From: " : "To: ";
+        string sStatus = (nStatus == DUEL_STATUS_PENDING) ? "[pending]" : "[accepted]";
 
         jPrim  = JsonArrayInsert(jPrim, JsonString(sPrefix + sName + " " + sStatus));
         jSec   = JsonArrayInsert(jSec,
             JsonString(DuelWinConditionToString(nWin) + " | " + DuelRulesToString(nRules)));
         jRight = JsonArrayInsert(jRight,
-            JsonString(nStake > 0 ? IntToString(nStake) + " zl" : "—"));
+            JsonString(nStake > 0 ? IntToString(nStake) + " gp" : "—"));
 
         json jColor = (sDir == "in") ? NuiColor(220, 200, 120) : NuiColor(150, 150, 200);
         jCol   = JsonArrayInsert(jCol, jColor);
@@ -194,7 +194,7 @@ void FeedDuelIncoming(object oPC, int nToken)
 
     NuiSetBind(oPC, nToken, DUEL_BIND_EMPTY_VIS, JsonBool(nCnt == 0));
     NuiSetBind(oPC, nToken, DUEL_BIND_EMPTY_TXT,
-        JsonString("Zadnych aktywnych wyzwan. Rzuc rekawice komus z dobrych dlonia mieczem."));
+        JsonString("No active challenges. Throw down the gauntlet to a worthy blade."));
 }
 
 void FeedDuelHistory(object oPC, int nToken)
@@ -226,27 +226,27 @@ void FeedDuelHistory(object oPC, int nToken)
         json jColor;
         if(nStatus == DUEL_STATUS_COMPLETED && sWn == sUuid)
         {
-            sLine = "Zwyciestwo nad " + sOpp;
+            sLine = "Victory over " + sOpp;
             jColor = NuiColor(120, 220, 120);
         }
         else if(nStatus == DUEL_STATUS_COMPLETED)
         {
-            sLine = "Porazka z " + sOpp;
+            sLine = "Defeat by " + sOpp;
             jColor = NuiColor(220, 120, 120);
         }
         else if(nStatus == DUEL_STATUS_DECLINED)
         {
-            sLine = "Odrzucone z " + sOpp;
+            sLine = "Declined with " + sOpp;
             jColor = NuiColor(170, 170, 170);
         }
         else if(nStatus == DUEL_STATUS_CANCELED)
         {
-            sLine = "Anulowane z " + sOpp;
+            sLine = "Canceled with " + sOpp;
             jColor = NuiColor(170, 170, 170);
         }
         else
         {
-            sLine = "Wygaslo z " + sOpp;
+            sLine = "Expired with " + sOpp;
             jColor = NuiColor(170, 170, 170);
         }
 
@@ -262,7 +262,7 @@ void FeedDuelHistory(object oPC, int nToken)
 
     NuiSetBind(oPC, nToken, DUEL_BIND_EMPTY_VIS, JsonBool(nCnt == 0));
     NuiSetBind(oPC, nToken, DUEL_BIND_EMPTY_TXT,
-        JsonString("Brak zapisanych pojedynkow. Twoja karta honoru jest jeszcze pusta."));
+        JsonString("No recorded duels. Your honor ledger is still blank."));
 }
 
 void FeedDuelRanking(object oPC, int nToken)
@@ -288,8 +288,8 @@ void FeedDuelRanking(object oPC, int nToken)
         jPrim = JsonArrayInsert(jPrim,
             JsonString(IntToString(i + 1) + ". " + sName));
         jSec  = JsonArrayInsert(jSec,
-            JsonString("W: " + IntToString(nWins) + " | P: " + IntToString(nLosses)
-                + " | Glowy: " + IntToString(nKills)));
+            JsonString("W: " + IntToString(nWins) + " | L: " + IntToString(nLosses)
+                + " | Kills: " + IntToString(nKills)));
         jRight= JsonArrayInsert(jRight,
             JsonString("Honor " + IntToString(nHonor)));
 
@@ -305,7 +305,7 @@ void FeedDuelRanking(object oPC, int nToken)
 
     NuiSetBind(oPC, nToken, DUEL_BIND_EMPTY_VIS, JsonBool(nCnt == 0));
     NuiSetBind(oPC, nToken, DUEL_BIND_EMPTY_TXT,
-        JsonString("Nikt jeszcze nie skrzyzowal mieczy."));
+        JsonString("No one has yet crossed swords."));
 }
 
 void FeedDuelMain(object oPC, int nToken)
@@ -324,8 +324,8 @@ void FeedDuelMain(object oPC, int nToken)
     NuiSetBind(oPC, nToken, DUEL_BIND_HONOR_LBL,
         JsonString("Honor: " + IntToString(nHonor)));
     NuiSetBind(oPC, nToken, DUEL_BIND_RECORD_LBL,
-        JsonString("W: " + IntToString(nWins) + " / P: " + IntToString(nLosses)
-            + " / Glowy: " + IntToString(nKills)));
+        JsonString("W: " + IntToString(nWins) + " / L: " + IntToString(nLosses)
+            + " / Kills: " + IntToString(nKills)));
 
     int nView = GetLocalInt(oPC, DUEL_LVAR_VIEW);
     NuiSetBind(oPC, nToken, DUEL_BIND_TAB_INCOMING_ENC, JsonBool(nView == DUEL_VIEW_INCOMING));

--- a/Honor Duels/Scripts/lib_duel_ui.nss
+++ b/Honor Duels/Scripts/lib_duel_ui.nss
@@ -1,0 +1,338 @@
+#include "lib_duel_def"
+
+void FeedDuelMain(object oPC, int nToken);
+
+// ----------------------------------------------------------------
+// Honor Duels — main window (challenge + tabs: incoming/history/ranking)
+// ----------------------------------------------------------------
+
+json BuildDuelRowCell(object oPC)
+{
+    float fH = GetNuiScaleDimension(oPC, 26.0);
+    float fRightW = GetNuiScaleDimension(oPC, 110.0);
+
+    json jPrim = NuiLabel(NuiBind(DUEL_BIND_ROW_PRIMARY),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jPrim = NuiStyleForegroundColor(jPrim, NuiBind(DUEL_BIND_ROW_COLOR));
+
+    json jSec = NuiLabel(NuiBind(DUEL_BIND_ROW_SECONDARY),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jSec = NuiStyleForegroundColor(jSec, NuiBind(DUEL_BIND_ROW_COLOR));
+
+    json jRight = NuiLabel(NuiBind(DUEL_BIND_ROW_RIGHT),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRight = NuiWidth(jRight, fRightW);
+    jRight = NuiStyleForegroundColor(jRight, NuiBind(DUEL_BIND_ROW_COLOR));
+
+    json jRow = JsonArray();
+    jRow = JsonArrayInsert(jRow, jPrim);
+    jRow = JsonArrayInsert(jRow, jSec);
+    jRow = JsonArrayInsert(jRow, jRight);
+
+    json jCell = NuiGroup(NuiRow(jRow), TRUE, NUI_SCROLLBARS_NONE);
+    jCell = NuiId(jCell, DUEL_BTN_ROW);
+    jCell = NuiHeight(jCell, fH);
+    return jCell;
+}
+
+void CreateDuelMainWindow(object oPC)
+{
+    int nExisting = NuiFindWindow(oPC, DUEL_WINDOW);
+    if(nExisting != 0)
+    {
+        FeedDuelMain(oPC, nExisting);
+        return;
+    }
+
+    SetLocalInt(oPC, DUEL_LVAR_VIEW, DUEL_VIEW_INCOMING);
+
+    float fW = GetNuiScaleDimension(oPC, DUEL_W);
+    float fH = GetNuiScaleDimension(oPC, DUEL_H);
+    float fBtnH = GetNuiScaleDimension(oPC, 30.0);
+    float fLblH = GetNuiScaleDimension(oPC, 22.0);
+
+    // -- Top: title + close --
+    json jTitle = NuiLabel(NuiBind(DUEL_BIND_TITLE),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitle = NuiHeight(jTitle, fBtnH);
+
+    json jClose = NuiButton(JsonString("Zamknij"));
+    jClose = NuiId(jClose, DUEL_BTN_CLOSE);
+    jClose = NuiWidth(jClose, GetNuiScaleDimension(oPC, 90.0));
+    jClose = NuiHeight(jClose, fBtnH);
+
+    json jTopRow = JsonArray();
+    jTopRow = JsonArrayInsert(jTopRow, jTitle);
+    jTopRow = JsonArrayInsert(jTopRow, jClose);
+
+    // -- Honor / record line --
+    json jHonor = NuiLabel(NuiBind(DUEL_BIND_HONOR_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jHonor = NuiStyleForegroundColor(jHonor, GetNuiColorNwnGold());
+    jHonor = NuiHeight(jHonor, fLblH);
+
+    json jRecord = NuiLabel(NuiBind(DUEL_BIND_RECORD_LBL),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRecord = NuiHeight(jRecord, fLblH);
+
+    json jStatRow = JsonArray();
+    jStatRow = JsonArrayInsert(jStatRow, jHonor);
+    jStatRow = JsonArrayInsert(jStatRow, jRecord);
+
+    // -- Challenge button --
+    json jChallenge = NuiButton(JsonString("Rzuc rekawice (wybierz cel)"));
+    jChallenge = NuiId(jChallenge, DUEL_BTN_CHALLENGE);
+    jChallenge = NuiHeight(jChallenge, fBtnH);
+
+    // -- Tabs --
+    json jTabInc = NuiButton(JsonString("Wyzwania"));
+    jTabInc = NuiId(jTabInc, DUEL_BTN_TAB_INCOMING);
+    jTabInc = NuiEncouraged(jTabInc, NuiBind(DUEL_BIND_TAB_INCOMING_ENC));
+    jTabInc = NuiHeight(jTabInc, fBtnH);
+
+    json jTabHis = NuiButton(JsonString("Historia"));
+    jTabHis = NuiId(jTabHis, DUEL_BTN_TAB_HISTORY);
+    jTabHis = NuiEncouraged(jTabHis, NuiBind(DUEL_BIND_TAB_HISTORY_ENC));
+    jTabHis = NuiHeight(jTabHis, fBtnH);
+
+    json jTabRnk = NuiButton(JsonString("Ranking honoru"));
+    jTabRnk = NuiId(jTabRnk, DUEL_BTN_TAB_RANKING);
+    jTabRnk = NuiEncouraged(jTabRnk, NuiBind(DUEL_BIND_TAB_RANKING_ENC));
+    jTabRnk = NuiHeight(jTabRnk, fBtnH);
+
+    json jTabRow = JsonArray();
+    jTabRow = JsonArrayInsert(jTabRow, jTabInc);
+    jTabRow = JsonArrayInsert(jTabRow, jTabHis);
+    jTabRow = JsonArrayInsert(jTabRow, jTabRnk);
+
+    // -- List --
+    json jList = NuiList(JsonArrayInsert(JsonArray(), BuildDuelRowCell(oPC)),
+        GetNuiScaleDimension(oPC, 28.0));
+
+    // -- Empty placeholder (only visible when list empty) --
+    json jEmpty = NuiLabel(NuiBind(DUEL_BIND_EMPTY_TXT),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jEmpty = NuiVisible(jEmpty, NuiBind(DUEL_BIND_EMPTY_VIS));
+    jEmpty = NuiHeight(jEmpty, GetNuiScaleDimension(oPC, 60.0));
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(jTopRow));
+    jCol = JsonArrayInsert(jCol, NuiRow(jStatRow));
+    jCol = JsonArrayInsert(jCol, jChallenge);
+    jCol = JsonArrayInsert(jCol, NuiRow(jTabRow));
+    jCol = JsonArrayInsert(jCol, jEmpty);
+    jCol = JsonArrayInsert(jCol, jList);
+
+    json jRoot = NuiCol(jCol);
+
+    json jNui = NuiWindow(jRoot,
+        NuiBind(WINDOW_TITLE),
+        NuiBind(WINDOW_GEOMETRY),
+        JsonBool(FALSE), JsonBool(FALSE),
+        JsonBool(TRUE),  JsonBool(FALSE), JsonBool(TRUE));
+
+    int nTk = NuiCreate(oPC, jNui, DUEL_WINDOW, DUEL_EV_SCRIPT);
+
+    NuiSetBind(oPC, nTk, WINDOW_TITLE,
+        JsonString("Honorowe Pojedynki"));
+    NuiSetBind(oPC, nTk, WINDOW_GEOMETRY,
+        NuiRect(-1.0, -1.0, fW, fH));
+    NuiSetBind(oPC, nTk, DUEL_BIND_TITLE,
+        JsonString("Honorowe Pojedynki"));
+
+    FeedDuelMain(oPC, nTk);
+}
+
+// ----------------------------------------------------------------
+// Feed: re-populates the list bindings based on selected view
+// ----------------------------------------------------------------
+
+void DuelFeedRows(object oPC, int nToken,
+                  json jPrimary, json jSecondary, json jRight, json jColors)
+{
+    NuiSetBind(oPC, nToken, DUEL_BIND_ROW_PRIMARY,   jPrimary);
+    NuiSetBind(oPC, nToken, DUEL_BIND_ROW_SECONDARY, jSecondary);
+    NuiSetBind(oPC, nToken, DUEL_BIND_ROW_RIGHT,     jRight);
+    NuiSetBind(oPC, nToken, DUEL_BIND_ROW_COLOR,     jColors);
+}
+
+void FeedDuelIncoming(object oPC, int nToken)
+{
+    json jRows = DuelGetIncoming(GetObjectUUID(oPC));
+    int nCnt = JsonGetLength(jRows);
+
+    json jPrim = JsonArray();
+    json jSec  = JsonArray();
+    json jRight= JsonArray();
+    json jCol  = JsonArray();
+
+    int i;
+    for(i = 0; i < nCnt; i++)
+    {
+        json jR = JsonArrayGet(jRows, i);
+        string sDir   = JsonGetString(JsonObjectGet(jR, "direction"));
+        string sName  = JsonGetString(JsonObjectGet(jR, "challenger_name"));
+        int nWin      = JsonGetInt   (JsonObjectGet(jR, "win_cond"));
+        int nRules    = JsonGetInt   (JsonObjectGet(jR, "rules_mask"));
+        int nStake    = JsonGetInt   (JsonObjectGet(jR, "stake_gold"));
+        int nStatus   = JsonGetInt   (JsonObjectGet(jR, "status"));
+
+        string sPrefix = (sDir == "in") ? "Od: " : "Do: ";
+        string sStatus = (nStatus == DUEL_STATUS_PENDING) ? "[oczekuje]" : "[przyjete]";
+
+        jPrim  = JsonArrayInsert(jPrim, JsonString(sPrefix + sName + " " + sStatus));
+        jSec   = JsonArrayInsert(jSec,
+            JsonString(DuelWinConditionToString(nWin) + " | " + DuelRulesToString(nRules)));
+        jRight = JsonArrayInsert(jRight,
+            JsonString(nStake > 0 ? IntToString(nStake) + " zl" : "—"));
+
+        json jColor = (sDir == "in") ? NuiColor(220, 200, 120) : NuiColor(150, 150, 200);
+        jCol   = JsonArrayInsert(jCol, jColor);
+    }
+
+    DuelFeedRows(oPC, nToken, jPrim, jSec, jRight, jCol);
+
+    NuiSetBind(oPC, nToken, DUEL_BIND_EMPTY_VIS, JsonBool(nCnt == 0));
+    NuiSetBind(oPC, nToken, DUEL_BIND_EMPTY_TXT,
+        JsonString("Zadnych aktywnych wyzwan. Rzuc rekawice komus z dobrych dlonia mieczem."));
+}
+
+void FeedDuelHistory(object oPC, int nToken)
+{
+    string sUuid = GetObjectUUID(oPC);
+    json jRows = DuelGetHistory(sUuid, DUEL_HISTORY_LIMIT);
+    int nCnt = JsonGetLength(jRows);
+
+    json jPrim = JsonArray();
+    json jSec  = JsonArray();
+    json jRight= JsonArray();
+    json jCol  = JsonArray();
+
+    int i;
+    for(i = 0; i < nCnt; i++)
+    {
+        json jR = JsonArrayGet(jRows, i);
+        string sCu = JsonGetString(JsonObjectGet(jR, "challenger_uuid"));
+        string sCn = JsonGetString(JsonObjectGet(jR, "challenger_name"));
+        string sDn = JsonGetString(JsonObjectGet(jR, "challenged_name"));
+        string sWn = JsonGetString(JsonObjectGet(jR, "winner_uuid"));
+        int nStatus = JsonGetInt(JsonObjectGet(jR, "status"));
+        int nWinC   = JsonGetInt(JsonObjectGet(jR, "win_cond"));
+        int nDate   = JsonGetInt(JsonObjectGet(jR, "completed_at"));
+        string sNote= JsonGetString(JsonObjectGet(jR, "outcome_note"));
+
+        string sOpp = (sCu == sUuid) ? sDn : sCn;
+        string sLine = "";
+        json jColor;
+        if(nStatus == DUEL_STATUS_COMPLETED && sWn == sUuid)
+        {
+            sLine = "Zwyciestwo nad " + sOpp;
+            jColor = NuiColor(120, 220, 120);
+        }
+        else if(nStatus == DUEL_STATUS_COMPLETED)
+        {
+            sLine = "Porazka z " + sOpp;
+            jColor = NuiColor(220, 120, 120);
+        }
+        else if(nStatus == DUEL_STATUS_DECLINED)
+        {
+            sLine = "Odrzucone z " + sOpp;
+            jColor = NuiColor(170, 170, 170);
+        }
+        else if(nStatus == DUEL_STATUS_CANCELED)
+        {
+            sLine = "Anulowane z " + sOpp;
+            jColor = NuiColor(170, 170, 170);
+        }
+        else
+        {
+            sLine = "Wygaslo z " + sOpp;
+            jColor = NuiColor(170, 170, 170);
+        }
+
+        jPrim  = JsonArrayInsert(jPrim, JsonString(sLine));
+        jSec   = JsonArrayInsert(jSec,
+            JsonString(DuelWinConditionToString(nWinC) + (sNote != "" ? " | " + sNote : "")));
+        jRight = JsonArrayInsert(jRight,
+            JsonString(DuelFormatDateSQL(nDate)));
+        jCol   = JsonArrayInsert(jCol, jColor);
+    }
+
+    DuelFeedRows(oPC, nToken, jPrim, jSec, jRight, jCol);
+
+    NuiSetBind(oPC, nToken, DUEL_BIND_EMPTY_VIS, JsonBool(nCnt == 0));
+    NuiSetBind(oPC, nToken, DUEL_BIND_EMPTY_TXT,
+        JsonString("Brak zapisanych pojedynkow. Twoja karta honoru jest jeszcze pusta."));
+}
+
+void FeedDuelRanking(object oPC, int nToken)
+{
+    json jRows = DuelGetRanking(DUEL_RANKING_LIMIT);
+    int nCnt = JsonGetLength(jRows);
+
+    json jPrim = JsonArray();
+    json jSec  = JsonArray();
+    json jRight= JsonArray();
+    json jCol  = JsonArray();
+
+    int i;
+    for(i = 0; i < nCnt; i++)
+    {
+        json jR = JsonArrayGet(jRows, i);
+        string sName = JsonGetString(JsonObjectGet(jR, "char_name"));
+        int nHonor   = JsonGetInt   (JsonObjectGet(jR, "honor"));
+        int nWins    = JsonGetInt   (JsonObjectGet(jR, "wins"));
+        int nLosses  = JsonGetInt   (JsonObjectGet(jR, "losses"));
+        int nKills   = JsonGetInt   (JsonObjectGet(jR, "kills"));
+
+        jPrim = JsonArrayInsert(jPrim,
+            JsonString(IntToString(i + 1) + ". " + sName));
+        jSec  = JsonArrayInsert(jSec,
+            JsonString("W: " + IntToString(nWins) + " | P: " + IntToString(nLosses)
+                + " | Glowy: " + IntToString(nKills)));
+        jRight= JsonArrayInsert(jRight,
+            JsonString("Honor " + IntToString(nHonor)));
+
+        json jColor;
+        if(i == 0)      jColor = NuiColor(255, 215, 0);
+        else if(i == 1) jColor = NuiColor(192, 192, 192);
+        else if(i == 2) jColor = NuiColor(205, 127, 50);
+        else            jColor = NuiColor(220, 220, 220);
+        jCol  = JsonArrayInsert(jCol, jColor);
+    }
+
+    DuelFeedRows(oPC, nToken, jPrim, jSec, jRight, jCol);
+
+    NuiSetBind(oPC, nToken, DUEL_BIND_EMPTY_VIS, JsonBool(nCnt == 0));
+    NuiSetBind(oPC, nToken, DUEL_BIND_EMPTY_TXT,
+        JsonString("Nikt jeszcze nie skrzyzowal mieczy."));
+}
+
+void FeedDuelMain(object oPC, int nToken)
+{
+    string sUuid = GetObjectUUID(oPC);
+    json jH = DuelGetHonorRow(sUuid);
+    int nHonor = 0, nWins = 0, nLosses = 0, nKills = 0;
+    if(JsonGetType(jH) != JSON_TYPE_NULL)
+    {
+        nHonor  = JsonGetInt(JsonObjectGet(jH, "honor"));
+        nWins   = JsonGetInt(JsonObjectGet(jH, "wins"));
+        nLosses = JsonGetInt(JsonObjectGet(jH, "losses"));
+        nKills  = JsonGetInt(JsonObjectGet(jH, "kills"));
+    }
+
+    NuiSetBind(oPC, nToken, DUEL_BIND_HONOR_LBL,
+        JsonString("Honor: " + IntToString(nHonor)));
+    NuiSetBind(oPC, nToken, DUEL_BIND_RECORD_LBL,
+        JsonString("W: " + IntToString(nWins) + " / P: " + IntToString(nLosses)
+            + " / Glowy: " + IntToString(nKills)));
+
+    int nView = GetLocalInt(oPC, DUEL_LVAR_VIEW);
+    NuiSetBind(oPC, nToken, DUEL_BIND_TAB_INCOMING_ENC, JsonBool(nView == DUEL_VIEW_INCOMING));
+    NuiSetBind(oPC, nToken, DUEL_BIND_TAB_HISTORY_ENC,  JsonBool(nView == DUEL_VIEW_HISTORY));
+    NuiSetBind(oPC, nToken, DUEL_BIND_TAB_RANKING_ENC,  JsonBool(nView == DUEL_VIEW_RANKING));
+
+    if(nView == DUEL_VIEW_INCOMING)      FeedDuelIncoming(oPC, nToken);
+    else if(nView == DUEL_VIEW_HISTORY)  FeedDuelHistory (oPC, nToken);
+    else                                 FeedDuelRanking (oPC, nToken);
+}

--- a/Honor Duels/Scripts/lib_nui.nss
+++ b/Honor Duels/Scripts/lib_nui.nss
@@ -51,7 +51,7 @@ const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
 const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
 const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
 
-// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — scales widget dimensions by player's GUI scale
 float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
 {
     int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
@@ -76,7 +76,7 @@ json GetNuiColorNwnGold()
     return NuiColor(185, 150, 100);
 }
 
-// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+// NuiAddInfoRow() — returns a row with an info button (?) to attach to a title row
 json NuiAddInfoRow()
 {
     float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
@@ -85,7 +85,7 @@ json NuiAddInfoRow()
     json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
     jButton = NuiWidth(jButton, fButtonWidth);
     jButton = NuiHeight(jButton, fButtonHeight);
-    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jButton = NuiTooltip(jButton, JsonString("Click for more information."));
     jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
     jRow = JsonArrayInsert(jRow, jButton);
     jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
@@ -103,6 +103,6 @@ json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffse
     return JsonArrayInsert(jImageList, jImageInfo);
 }
 
-// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// CreateWindowInfo(oPC, sStatment) — opens an info window (500x400) with text and a Close button
 // Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
 void CreateWindowInfo(object oPC, string sStatment);

--- a/Honor Duels/Scripts/lib_nui.nss
+++ b/Honor Duels/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Honor Duels/Scripts/lib_nui_utility.nss
+++ b/Honor Duels/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Honor Duels/Scripts/sql_duel.nss
+++ b/Honor Duels/Scripts/sql_duel.nss
@@ -1,0 +1,339 @@
+// ----------------------------------------------------------------
+// Honor Duels — persistence layer (SQLite via NWNX, campaign-scope)
+// ----------------------------------------------------------------
+
+const string DUEL_DB = "duel";
+
+void DuelCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign(DUEL_DB,
+        "CREATE TABLE IF NOT EXISTS duels ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "challenger_uuid TEXT NOT NULL, "
+        "challenger_name TEXT DEFAULT '', "
+        "challenged_uuid TEXT NOT NULL, "
+        "challenged_name TEXT DEFAULT '', "
+        "rules_mask INTEGER DEFAULT 0, "
+        "win_cond INTEGER DEFAULT 0, "
+        "stake_gold INTEGER DEFAULT 0, "
+        "status INTEGER DEFAULT 0, "
+        "winner_uuid TEXT DEFAULT '', "
+        "loser_uuid TEXT DEFAULT '', "
+        "outcome_note TEXT DEFAULT '', "
+        "arena_x REAL DEFAULT 0, "
+        "arena_y REAL DEFAULT 0, "
+        "arena_z REAL DEFAULT 0, "
+        "arena_area TEXT DEFAULT '', "
+        "created_at INTEGER DEFAULT 0, "
+        "completed_at INTEGER DEFAULT 0)");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign(DUEL_DB,
+        "CREATE TABLE IF NOT EXISTS duel_honor ("
+        "uuid TEXT PRIMARY KEY, "
+        "char_name TEXT DEFAULT '', "
+        "honor INTEGER DEFAULT 0, "
+        "wins INTEGER DEFAULT 0, "
+        "losses INTEGER DEFAULT 0, "
+        "declined INTEGER DEFAULT 0, "
+        "forfeits INTEGER DEFAULT 0, "
+        "kills INTEGER DEFAULT 0, "
+        "last_seen INTEGER DEFAULT 0)");
+    SqlStep(q);
+}
+
+void DuelRegisterHonor(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign(DUEL_DB,
+        "INSERT OR IGNORE INTO duel_honor (uuid, char_name, last_seen) "
+        "VALUES (@uuid, @name, strftime('%s','now'))");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindString(q, "@name", GetName(oPC));
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign(DUEL_DB,
+        "UPDATE duel_honor SET char_name = @name, last_seen = strftime('%s','now') WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindString(q, "@name", GetName(oPC));
+    SqlStep(q);
+}
+
+int DuelGetHonor(string sUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign(DUEL_DB,
+        "SELECT honor FROM duel_honor WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", sUuid);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+json DuelGetHonorRow(string sUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign(DUEL_DB,
+        "SELECT char_name, honor, wins, losses, declined, forfeits, kills "
+        "FROM duel_honor WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", sUuid);
+    if(!SqlStep(q)) return JsonNull();
+    json j = JsonObject();
+    j = JsonObjectSet(j, "char_name", JsonString(SqlGetString(q, 0)));
+    j = JsonObjectSet(j, "honor",     JsonInt   (SqlGetInt   (q, 1)));
+    j = JsonObjectSet(j, "wins",      JsonInt   (SqlGetInt   (q, 2)));
+    j = JsonObjectSet(j, "losses",    JsonInt   (SqlGetInt   (q, 3)));
+    j = JsonObjectSet(j, "declined",  JsonInt   (SqlGetInt   (q, 4)));
+    j = JsonObjectSet(j, "forfeits",  JsonInt   (SqlGetInt   (q, 5)));
+    j = JsonObjectSet(j, "kills",     JsonInt   (SqlGetInt   (q, 6)));
+    return j;
+}
+
+void DuelAdjustHonor(string sUuid, string sName, int nDelta,
+                     int bWin, int bLoss, int bDecline, int bForfeit, int bKill)
+{
+    // Ensure row exists.
+    sqlquery qIns = SqlPrepareQueryCampaign(DUEL_DB,
+        "INSERT OR IGNORE INTO duel_honor (uuid, char_name) VALUES (@uuid, @name)");
+    SqlBindString(qIns, "@uuid", sUuid);
+    SqlBindString(qIns, "@name", sName);
+    SqlStep(qIns);
+
+    sqlquery q = SqlPrepareQueryCampaign(DUEL_DB,
+        "UPDATE duel_honor SET "
+        "honor = honor + @delta, "
+        "wins = wins + @w, "
+        "losses = losses + @l, "
+        "declined = declined + @d, "
+        "forfeits = forfeits + @f, "
+        "kills = kills + @k, "
+        "char_name = @name "
+        "WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid",  sUuid);
+    SqlBindString(q, "@name",  sName);
+    SqlBindInt   (q, "@delta", nDelta);
+    SqlBindInt   (q, "@w",     bWin);
+    SqlBindInt   (q, "@l",     bLoss);
+    SqlBindInt   (q, "@d",     bDecline);
+    SqlBindInt   (q, "@f",     bForfeit);
+    SqlBindInt   (q, "@k",     bKill);
+    SqlStep(q);
+}
+
+// ----------------------------------------------------------------
+// Duel CRUD
+// ----------------------------------------------------------------
+
+int DuelCreate(object oChallenger, object oChallenged,
+               int nRules, int nWinCond, int nStake)
+{
+    location lLoc = GetLocation(oChallenger);
+    vector vPos  = GetPositionFromLocation(lLoc);
+
+    sqlquery q = SqlPrepareQueryCampaign(DUEL_DB,
+        "INSERT INTO duels (challenger_uuid, challenger_name, challenged_uuid, challenged_name, "
+        "rules_mask, win_cond, stake_gold, status, arena_x, arena_y, arena_z, arena_area, created_at) "
+        "VALUES (@cu, @cn, @du, @dn, @r, @w, @s, 0, @x, @y, @z, @area, strftime('%s','now'))");
+    SqlBindString(q, "@cu",   GetObjectUUID(oChallenger));
+    SqlBindString(q, "@cn",   GetName(oChallenger));
+    SqlBindString(q, "@du",   GetObjectUUID(oChallenged));
+    SqlBindString(q, "@dn",   GetName(oChallenged));
+    SqlBindInt   (q, "@r",    nRules);
+    SqlBindInt   (q, "@w",    nWinCond);
+    SqlBindInt   (q, "@s",    nStake);
+    SqlBindFloat (q, "@x",    vPos.x);
+    SqlBindFloat (q, "@y",    vPos.y);
+    SqlBindFloat (q, "@z",    vPos.z);
+    SqlBindString(q, "@area", GetTag(GetAreaFromLocation(lLoc)));
+    SqlStep(q);
+
+    sqlquery qId = SqlPrepareQueryCampaign(DUEL_DB, "SELECT last_insert_rowid()");
+    if(SqlStep(qId)) return SqlGetInt(qId, 0);
+    return 0;
+}
+
+json DuelGetById(int nId)
+{
+    sqlquery q = SqlPrepareQueryCampaign(DUEL_DB,
+        "SELECT id, challenger_uuid, challenger_name, challenged_uuid, challenged_name, "
+        "rules_mask, win_cond, stake_gold, status, winner_uuid, loser_uuid, outcome_note, "
+        "arena_x, arena_y, arena_z, arena_area, created_at, completed_at "
+        "FROM duels WHERE id = @id");
+    SqlBindInt(q, "@id", nId);
+    if(!SqlStep(q)) return JsonNull();
+
+    json j = JsonObject();
+    j = JsonObjectSet(j, "id",              JsonInt   (SqlGetInt   (q,  0)));
+    j = JsonObjectSet(j, "challenger_uuid", JsonString(SqlGetString(q,  1)));
+    j = JsonObjectSet(j, "challenger_name", JsonString(SqlGetString(q,  2)));
+    j = JsonObjectSet(j, "challenged_uuid", JsonString(SqlGetString(q,  3)));
+    j = JsonObjectSet(j, "challenged_name", JsonString(SqlGetString(q,  4)));
+    j = JsonObjectSet(j, "rules_mask",      JsonInt   (SqlGetInt   (q,  5)));
+    j = JsonObjectSet(j, "win_cond",        JsonInt   (SqlGetInt   (q,  6)));
+    j = JsonObjectSet(j, "stake_gold",      JsonInt   (SqlGetInt   (q,  7)));
+    j = JsonObjectSet(j, "status",          JsonInt   (SqlGetInt   (q,  8)));
+    j = JsonObjectSet(j, "winner_uuid",     JsonString(SqlGetString(q,  9)));
+    j = JsonObjectSet(j, "loser_uuid",      JsonString(SqlGetString(q, 10)));
+    j = JsonObjectSet(j, "outcome_note",    JsonString(SqlGetString(q, 11)));
+    j = JsonObjectSet(j, "arena_x",         JsonFloat (SqlGetFloat (q, 12)));
+    j = JsonObjectSet(j, "arena_y",         JsonFloat (SqlGetFloat (q, 13)));
+    j = JsonObjectSet(j, "arena_z",         JsonFloat (SqlGetFloat (q, 14)));
+    j = JsonObjectSet(j, "arena_area",      JsonString(SqlGetString(q, 15)));
+    j = JsonObjectSet(j, "created_at",      JsonInt   (SqlGetInt   (q, 16)));
+    j = JsonObjectSet(j, "completed_at",    JsonInt   (SqlGetInt   (q, 17)));
+    return j;
+}
+
+void DuelSetStatus(int nId, int nStatus)
+{
+    sqlquery q = SqlPrepareQueryCampaign(DUEL_DB,
+        "UPDATE duels SET status = @s WHERE id = @id");
+    SqlBindInt(q, "@s",  nStatus);
+    SqlBindInt(q, "@id", nId);
+    SqlStep(q);
+}
+
+void DuelSetOutcome(int nId, int nStatus, string sWinnerUuid, string sLoserUuid, string sNote)
+{
+    sqlquery q = SqlPrepareQueryCampaign(DUEL_DB,
+        "UPDATE duels SET status = @s, winner_uuid = @w, loser_uuid = @l, "
+        "outcome_note = @n, completed_at = strftime('%s','now') WHERE id = @id");
+    SqlBindInt   (q, "@s",  nStatus);
+    SqlBindString(q, "@w",  sWinnerUuid);
+    SqlBindString(q, "@l",  sLoserUuid);
+    SqlBindString(q, "@n",  sNote);
+    SqlBindInt   (q, "@id", nId);
+    SqlStep(q);
+}
+
+void DuelExpireOld(int nTtlSeconds)
+{
+    sqlquery q = SqlPrepareQueryCampaign(DUEL_DB,
+        "UPDATE duels SET status = 5, completed_at = strftime('%s','now') "
+        "WHERE status = 0 AND created_at < strftime('%s','now') - @ttl");
+    SqlBindInt(q, "@ttl", nTtlSeconds);
+    SqlStep(q);
+}
+
+int DuelHasActiveBetween(string sA, string sB)
+{
+    sqlquery q = SqlPrepareQueryCampaign(DUEL_DB,
+        "SELECT COUNT(*) FROM duels WHERE status IN (0,1,2) AND "
+        "((challenger_uuid = @a AND challenged_uuid = @b) OR "
+        " (challenger_uuid = @b AND challenged_uuid = @a))");
+    SqlBindString(q, "@a", sA);
+    SqlBindString(q, "@b", sB);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+int DuelHasAnyActive(string sUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign(DUEL_DB,
+        "SELECT id FROM duels WHERE status IN (1,2) AND "
+        "(challenger_uuid = @u OR challenged_uuid = @u) LIMIT 1");
+    SqlBindString(q, "@u", sUuid);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// Returns array of pending challenges TO this PC: [{id, challenger_name, rules_mask, win_cond, stake_gold, created_at}, ...]
+json DuelGetIncoming(string sUuid)
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign(DUEL_DB,
+        "SELECT id, challenger_name, challenger_uuid, rules_mask, win_cond, stake_gold, created_at, status "
+        "FROM duels WHERE status IN (0,1) AND challenged_uuid = @u ORDER BY created_at DESC");
+    SqlBindString(q, "@u", sUuid);
+    while(SqlStep(q))
+    {
+        json j = JsonObject();
+        j = JsonObjectSet(j, "id",               JsonInt   (SqlGetInt   (q, 0)));
+        j = JsonObjectSet(j, "challenger_name",  JsonString(SqlGetString(q, 1)));
+        j = JsonObjectSet(j, "challenger_uuid",  JsonString(SqlGetString(q, 2)));
+        j = JsonObjectSet(j, "rules_mask",       JsonInt   (SqlGetInt   (q, 3)));
+        j = JsonObjectSet(j, "win_cond",         JsonInt   (SqlGetInt   (q, 4)));
+        j = JsonObjectSet(j, "stake_gold",       JsonInt   (SqlGetInt   (q, 5)));
+        j = JsonObjectSet(j, "created_at",       JsonInt   (SqlGetInt   (q, 6)));
+        j = JsonObjectSet(j, "status",           JsonInt   (SqlGetInt   (q, 7)));
+        j = JsonObjectSet(j, "direction",        JsonString("in"));
+        jRows = JsonArrayInsert(jRows, j);
+    }
+
+    // Also include outgoing pending challenges so the user can cancel them.
+    q = SqlPrepareQueryCampaign(DUEL_DB,
+        "SELECT id, challenged_name, challenged_uuid, rules_mask, win_cond, stake_gold, created_at, status "
+        "FROM duels WHERE status = 0 AND challenger_uuid = @u ORDER BY created_at DESC");
+    SqlBindString(q, "@u", sUuid);
+    while(SqlStep(q))
+    {
+        json j = JsonObject();
+        j = JsonObjectSet(j, "id",               JsonInt   (SqlGetInt   (q, 0)));
+        j = JsonObjectSet(j, "challenger_name",  JsonString(SqlGetString(q, 1)));
+        j = JsonObjectSet(j, "challenger_uuid",  JsonString(SqlGetString(q, 2)));
+        j = JsonObjectSet(j, "rules_mask",       JsonInt   (SqlGetInt   (q, 3)));
+        j = JsonObjectSet(j, "win_cond",         JsonInt   (SqlGetInt   (q, 4)));
+        j = JsonObjectSet(j, "stake_gold",       JsonInt   (SqlGetInt   (q, 5)));
+        j = JsonObjectSet(j, "created_at",       JsonInt   (SqlGetInt   (q, 6)));
+        j = JsonObjectSet(j, "status",           JsonInt   (SqlGetInt   (q, 7)));
+        j = JsonObjectSet(j, "direction",        JsonString("out"));
+        jRows = JsonArrayInsert(jRows, j);
+    }
+    return jRows;
+}
+
+json DuelGetHistory(string sUuid, int nLimit)
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign(DUEL_DB,
+        "SELECT id, challenger_uuid, challenger_name, challenged_uuid, challenged_name, "
+        "winner_uuid, status, win_cond, rules_mask, stake_gold, completed_at, outcome_note "
+        "FROM duels WHERE status IN (3,4,5,6) AND "
+        "(challenger_uuid = @u OR challenged_uuid = @u) "
+        "ORDER BY COALESCE(completed_at, created_at) DESC LIMIT @lim");
+    SqlBindString(q, "@u",   sUuid);
+    SqlBindInt   (q, "@lim", nLimit);
+    while(SqlStep(q))
+    {
+        json j = JsonObject();
+        j = JsonObjectSet(j, "id",              JsonInt   (SqlGetInt   (q,  0)));
+        j = JsonObjectSet(j, "challenger_uuid", JsonString(SqlGetString(q,  1)));
+        j = JsonObjectSet(j, "challenger_name", JsonString(SqlGetString(q,  2)));
+        j = JsonObjectSet(j, "challenged_uuid", JsonString(SqlGetString(q,  3)));
+        j = JsonObjectSet(j, "challenged_name", JsonString(SqlGetString(q,  4)));
+        j = JsonObjectSet(j, "winner_uuid",     JsonString(SqlGetString(q,  5)));
+        j = JsonObjectSet(j, "status",          JsonInt   (SqlGetInt   (q,  6)));
+        j = JsonObjectSet(j, "win_cond",        JsonInt   (SqlGetInt   (q,  7)));
+        j = JsonObjectSet(j, "rules_mask",      JsonInt   (SqlGetInt   (q,  8)));
+        j = JsonObjectSet(j, "stake_gold",      JsonInt   (SqlGetInt   (q,  9)));
+        j = JsonObjectSet(j, "completed_at",    JsonInt   (SqlGetInt   (q, 10)));
+        j = JsonObjectSet(j, "outcome_note",    JsonString(SqlGetString(q, 11)));
+        jRows = JsonArrayInsert(jRows, j);
+    }
+    return jRows;
+}
+
+json DuelGetRanking(int nLimit)
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign(DUEL_DB,
+        "SELECT char_name, honor, wins, losses, kills FROM duel_honor "
+        "WHERE wins + losses + forfeits > 0 ORDER BY honor DESC, wins DESC LIMIT @lim");
+    SqlBindInt(q, "@lim", nLimit);
+    while(SqlStep(q))
+    {
+        json j = JsonObject();
+        j = JsonObjectSet(j, "char_name", JsonString(SqlGetString(q, 0)));
+        j = JsonObjectSet(j, "honor",     JsonInt   (SqlGetInt   (q, 1)));
+        j = JsonObjectSet(j, "wins",      JsonInt   (SqlGetInt   (q, 2)));
+        j = JsonObjectSet(j, "losses",    JsonInt   (SqlGetInt   (q, 3)));
+        j = JsonObjectSet(j, "kills",     JsonInt   (SqlGetInt   (q, 4)));
+        jRows = JsonArrayInsert(jRows, j);
+    }
+    return jRows;
+}
+
+string DuelFormatDateSQL(int nUnix)
+{
+    sqlquery q = SqlPrepareQueryCampaign(DUEL_DB,
+        "SELECT strftime('%d.%m %H:%M', @ts, 'unixepoch')");
+    SqlBindInt(q, "@ts", nUnix);
+    if(SqlStep(q)) return SqlGetString(q, 0);
+    return "";
+}

--- a/Honor Duels/Scripts/sys_on_enter.nss
+++ b/Honor Duels/Scripts/sys_on_enter.nss
@@ -1,0 +1,18 @@
+#include "lib_duel"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC)) return;
+
+    DuelRegisterHonor(oPC);
+    DuelExpireOld(DUEL_PENDING_TTL);
+
+    json jIn = DuelGetIncoming(GetObjectUUID(oPC));
+    int nCnt = JsonGetLength(jIn);
+    if(nCnt > 0)
+    {
+        SendMessageToPC(oPC, "[Pojedynek] Czeka na ciebie "
+            + IntToString(nCnt) + " wyzwan(ie). Sprawdz tablice honoru.");
+    }
+}

--- a/Honor Duels/Scripts/sys_on_enter.nss
+++ b/Honor Duels/Scripts/sys_on_enter.nss
@@ -12,7 +12,7 @@ void main()
     int nCnt = JsonGetLength(jIn);
     if(nCnt > 0)
     {
-        SendMessageToPC(oPC, "[Pojedynek] Czeka na ciebie "
-            + IntToString(nCnt) + " wyzwan(ie). Sprawdz tablice honoru.");
+        SendMessageToPC(oPC, "[Duel] You have "
+            + IntToString(nCnt) + " pending challenge(s). Visit the honor board.");
     }
 }

--- a/Honor Duels/Scripts/sys_on_load.nss
+++ b/Honor Duels/Scripts/sys_on_load.nss
@@ -1,0 +1,7 @@
+#include "lib_duel"
+
+void main()
+{
+    DuelCreateTables();
+    DuelExpireOld(DUEL_PENDING_TTL);
+}

--- a/Honor Duels/Scripts/sys_on_target.nss
+++ b/Honor Duels/Scripts/sys_on_target.nss
@@ -1,0 +1,13 @@
+#include "lib_duel"
+
+void main()
+{
+    object oPC = GetLastPlayerToSelectTarget();
+    if(!GetIsPC(oPC)) return;
+
+    if(NuiFindWindow(oPC, DUEL_WINDOW) != 0
+       || GetLocalInt(oPC, DUEL_LVAR_DRAFT_TARGET) == 0)
+    {
+        DuelOnPlayerTarget(oPC);
+    }
+}

--- a/Honor Duels/Scripts/test_duel.nss
+++ b/Honor Duels/Scripts/test_duel.nss
@@ -1,0 +1,8 @@
+#include "lib_duel"
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+    CreateDuelMainWindow(oPC);
+}


### PR DESCRIPTION
## What it does

PvP honor-duel system — formal challenge with configurable rules and gold stakes, popup on the challenged side, bounded arena, in-duel HUD with HP bars, and an honor ranking. Persistence is in SQLite (campaign-scope, database `duel`).

## Mechanics

- **Honor board** (placeable -> NUI) with 3 tabs: Challenges (incoming + your outgoing), History (last 20), Honor ranking (top 10).
- **Challenge**: targeting mode -> config popup (win condition: first blood / to the death / until yield; rules: no magic / no potions / no crits; gold stake).
- **Acceptance**: popup on the challenged side describing the rules. Accepting takes the matching stake and starts a 5-second countdown. Decline -> honor penalty + stake refund to the challenger.
- **Duel**: temporary hostility (`SetIsTemporaryEnemy`), HUD with both HP bars, 1s tick checking HP / arena bounds (10m) / win condition.
- **First blood** = HP <50%, **to the death** = `GetIsDead`, **until yield** = Yield button in the HUD.
- **Forfeit** on fleeing the arena (>6s outside the radius) or yielding.
- **Honor**: +10 win, -3 loss, -15 decline, -25 forfeit, +5 bonus on a death-duel kill.
- **Stake**: winner takes both halves; mutual death = refund.

## Files

13 files, ~2.4k LOC of NWScript:

| File | LOC | Role |
|---|---:|---|
| `lib_duel_def.nss` | 240 | Constants, statuses, rules, layout, formatters. |
| `sql_duel.nss` | 339 | Schema (`duels` + `duel_honor`) + CRUD + ranking + history + expire. |
| `lib_duel_flow.nss` | 526 | State machine: submit / accept / decline / begin / tick / yield / end + honor and stake distribution. |
| `lib_duel_ui.nss` | 338 | Main window with 3 tabs, color-coded list rows. |
| `lib_duel_hud.nss` | 272 | Active-duel HUD + incoming-challenge popup + challenge-config popup. |
| `lib_duel_ev.nss` | 261 | NUI event router for all 4 windows. |
| `lib_duel.nss` | 38 | Public facade (`#include` + targeting helper). |
| `sys_on_load.nss` | 7 | Schema init + expire stale challenges. |
| `sys_on_enter.nss` | 18 | Honor-table registration + pending-challenge notification. |
| `sys_on_target.nss` | 13 | Targeting -> challenge config popup. |
| `test_duel.nss` | 8 | OnUsed entry point for the honor-board placeable. |
| `lib_nui.nss` + `lib_nui_utility.nss` | 206 | NUI helper layer (copied from Mailbox so the module is self-contained). |

## Dependencies

- **NWN:EE** (NUI + JSON API).
- **SQL** campaign-scope (database `duel`) — built into NWN:EE, no extra packages.
- **NWNX**: none.

## How to integrate in an existing module

Wire the hooks in your module's event scripts:

```nwscript
// OnModuleLoad
ExecuteScript("sys_on_load", OBJECT_SELF);

// OnClientEnter
ExecuteScript("sys_on_enter", OBJECT_SELF);

// OnPlayerTarget
ExecuteScript("sys_on_target", OBJECT_SELF);
```

On a placeable acting as the honor board / banner / town notice (OnUsed):

```nwscript
#include "lib_duel"
void main()
{
    object oPC = GetLastUsedBy();
    if(!GetIsPC(oPC)) return;
    CreateDuelMainWindow(oPC);
}
```

If you already use `OnPlayerTarget` for another module (Mailbox, Spell Macro), merge the dispatch logic via your own router.

Full description in `Honor Duels/INTEGRATION.md`.

## Intentionally omitted

- **Rule enforcement** (no_magic / no_items / no_crit) — persisted and displayed but not enforced. Requires `OnSpellCastAt` / `OnUseItem` / crit-roll hooks. Significant refactor outside MVP scope.
- **Seconds / witnesses**.
- **Salute animations** (bow, sword salute) — risk of conflict with combat readiness.
- **PvP zone** (blocking other players from interfering) — for a real server, via `OnPhysicalAttacked`.
- **Stake refund for offline players** — currently lost; ideally via Mailbox.
- **HAK** with main-window background art and an honor-board icon.