### PR TITLE
feat: Master &amp; Apprentice

### DIFF
--- a/Master Apprentice/Scripts/lib_ma.nss
+++ b/Master Apprentice/Scripts/lib_ma.nss
@@ -1,0 +1,463 @@
+#include "lib_ma_def"
+
+void FeedMaWindow(object oPC, int nToken);
+void MaShowProposal(object oPC, string sFromUuid, string sFromName);
+void MaApplyApprenticeBonuses(object oApprentice);
+void MaRemoveApprenticeBonuses(object oApprentice);
+
+// ----------------------------------------------------------------
+// Skill bonus application
+// ----------------------------------------------------------------
+
+void MaRemoveApprenticeBonuses(object oPC)
+{
+    if(!GetIsObjectValid(oPC)) return;
+    effect e = GetFirstEffect(oPC);
+    while(GetIsEffectValid(e))
+    {
+        if(GetEffectTag(e) == MA_EFFECT_TAG)
+            RemoveEffect(oPC, e);
+        e = GetNextEffect(oPC);
+    }
+}
+
+void MaApplyApprenticeBonuses(object oApprentice)
+{
+    MaRemoveApprenticeBonuses(oApprentice);
+    string sMasterUuid = MaGetMasterUuid(GetObjectUUID(oApprentice));
+    if(sMasterUuid == "") return;
+    object oMaster = MaGetPCByUUID(sMasterUuid);
+    if(!GetIsObjectValid(oMaster)) return; // applied next time both are online together
+
+    int nSkill;
+    int nGranted = 0;
+    for(nSkill = 0; nSkill <= MA_MAX_SKILL_INDEX; nSkill++)
+    {
+        int nMasterRank = GetSkillRank(nSkill, oMaster, TRUE);
+        if(nMasterRank >= MA_SKILL_THRESHOLD)
+        {
+            effect eBonus = EffectSkillIncrease(nSkill, MA_SKILL_BONUS);
+            eBonus = TagEffect(eBonus, MA_EFFECT_TAG);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, eBonus, oApprentice);
+            nGranted++;
+        }
+    }
+
+    if(nGranted > 0)
+        SendMessageToPC(oApprentice, "[Mentor] Bond with " + GetName(oMaster)
+            + " grants +" + IntToString(MA_SKILL_BONUS) + " to "
+            + IntToString(nGranted) + " skill(s).");
+}
+
+// ----------------------------------------------------------------
+// Bond lifecycle
+// ----------------------------------------------------------------
+
+int MaProposeApprenticeship(object oMaster, object oCandidate)
+{
+    if(oMaster == oCandidate)
+    {
+        SendMessageToPC(oMaster, "[Mentor] You cannot apprentice yourself.");
+        return 0;
+    }
+    if(!GetIsPC(oCandidate))
+    {
+        SendMessageToPC(oMaster, "[Mentor] Only living players can be apprenticed.");
+        return 0;
+    }
+    if(GetDistanceBetween(oMaster, oCandidate) > MA_PROPOSAL_DISTANCE)
+    {
+        SendMessageToPC(oMaster, "[Mentor] Stand closer to the candidate.");
+        return 0;
+    }
+    if(MaCountActiveApprentices(GetObjectUUID(oMaster)) >= MA_MAX_APPRENTICES)
+    {
+        SendMessageToPC(oMaster, "[Mentor] You already mentor the maximum number of apprentices.");
+        return 0;
+    }
+    if(MaHasMaster(GetObjectUUID(oCandidate)))
+    {
+        SendMessageToPC(oMaster, "[Mentor] " + GetName(oCandidate) + " is already bound to a master.");
+        return 0;
+    }
+    if(GetHitDice(oCandidate) >= GetHitDice(oMaster))
+    {
+        SendMessageToPC(oMaster, "[Mentor] Master must be of higher level than apprentice.");
+        return 0;
+    }
+
+    SetLocalString(oCandidate, MA_LVAR_PROPOSAL_FROM, GetObjectUUID(oMaster));
+    SetLocalString(oCandidate, MA_LVAR_PROPOSAL_NAME, GetName(oMaster));
+    MaShowProposal(oCandidate, GetObjectUUID(oMaster), GetName(oMaster));
+    SendMessageToPC(oMaster, "[Mentor] Offer extended to " + GetName(oCandidate) + ".");
+    return 1;
+}
+
+void MaAcceptProposal(object oApprentice)
+{
+    string sMasterUuid = GetLocalString(oApprentice, MA_LVAR_PROPOSAL_FROM);
+    if(sMasterUuid == "") return;
+
+    object oMaster = MaGetPCByUUID(sMasterUuid);
+    if(!GetIsObjectValid(oMaster))
+    {
+        SendMessageToPC(oApprentice, "[Mentor] The master is no longer here.");
+        DeleteLocalString(oApprentice, MA_LVAR_PROPOSAL_FROM);
+        DeleteLocalString(oApprentice, MA_LVAR_PROPOSAL_NAME);
+        return;
+    }
+    // Re-validate (state could have changed during the popup).
+    if(MaCountActiveApprentices(sMasterUuid) >= MA_MAX_APPRENTICES
+       || MaHasMaster(GetObjectUUID(oApprentice)))
+    {
+        SendMessageToPC(oApprentice, "[Mentor] The bond can no longer be formed.");
+        return;
+    }
+
+    int nId = MaCreateBond(oMaster, oApprentice);
+    if(nId <= 0) return;
+
+    DeleteLocalString(oApprentice, MA_LVAR_PROPOSAL_FROM);
+    DeleteLocalString(oApprentice, MA_LVAR_PROPOSAL_NAME);
+
+    FloatingTextStringOnCreature(GetName(oMaster) + " takes "
+        + GetName(oApprentice) + " as apprentice.", oMaster, FALSE);
+    FloatingTextStringOnCreature(GetName(oApprentice) + " accepts "
+        + GetName(oMaster) + " as master.", oApprentice, FALSE);
+    SendMessageToPC(oMaster,     "[Mentor] " + GetName(oApprentice) + " is now your apprentice.");
+    SendMessageToPC(oApprentice, "[Mentor] " + GetName(oMaster)     + " is now your master.");
+
+    MaApplyApprenticeBonuses(oApprentice);
+
+    int nMTk = NuiFindWindow(oMaster, MA_WINDOW);
+    if(nMTk != 0) FeedMaWindow(oMaster, nMTk);
+    int nATk = NuiFindWindow(oApprentice, MA_WINDOW);
+    if(nATk != 0) FeedMaWindow(oApprentice, nATk);
+}
+
+void MaDeclineProposal(object oApprentice)
+{
+    string sMasterUuid = GetLocalString(oApprentice, MA_LVAR_PROPOSAL_FROM);
+    string sMasterName = GetLocalString(oApprentice, MA_LVAR_PROPOSAL_NAME);
+    DeleteLocalString(oApprentice, MA_LVAR_PROPOSAL_FROM);
+    DeleteLocalString(oApprentice, MA_LVAR_PROPOSAL_NAME);
+    object oMaster = MaGetPCByUUID(sMasterUuid);
+    if(GetIsObjectValid(oMaster))
+        SendMessageToPC(oMaster, "[Mentor] " + GetName(oApprentice)
+            + " refuses your offer.");
+    SendMessageToPC(oApprentice, "[Mentor] You declined " + sMasterName + "'s offer.");
+}
+
+void MaDismissApprentice(object oMaster, int nBondId, string sReason)
+{
+    MaBreakBond(nBondId, sReason);
+
+    SendMessageToPC(oMaster, "[Mentor] Bond dissolved.");
+
+    // If apprentice is online, clean up bonuses.
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        if(MaGetActiveBondIdForApprentice(GetObjectUUID(oPC)) == 0)
+            MaRemoveApprenticeBonuses(oPC);
+        oPC = GetNextPC();
+    }
+
+    int nTk = NuiFindWindow(oMaster, MA_WINDOW);
+    if(nTk != 0) FeedMaWindow(oMaster, nTk);
+}
+
+void MaLeaveMaster(object oApprentice)
+{
+    string sMasterUuid = MaGetMasterUuid(GetObjectUUID(oApprentice));
+    if(sMasterUuid == "") return;
+
+    MaBreakBondByApprentice(GetObjectUUID(oApprentice), "Apprentice left the bond.");
+    MaRemoveApprenticeBonuses(oApprentice);
+
+    object oMaster = MaGetPCByUUID(sMasterUuid);
+    if(GetIsObjectValid(oMaster))
+    {
+        SendMessageToPC(oMaster, "[Mentor] " + GetName(oApprentice)
+            + " has left the bond.");
+        int nMTk = NuiFindWindow(oMaster, MA_WINDOW);
+        if(nMTk != 0) FeedMaWindow(oMaster, nMTk);
+    }
+    SendMessageToPC(oApprentice, "[Mentor] You walk your own path now.");
+
+    int nATk = NuiFindWindow(oApprentice, MA_WINDOW);
+    if(nATk != 0) FeedMaWindow(oApprentice, nATk);
+}
+
+// ----------------------------------------------------------------
+// Level-up XP transfer (called from sys_on_levelup)
+// ----------------------------------------------------------------
+
+void MaOnApprenticeLevelUp(object oApprentice, int nNewLevel)
+{
+    int nBondId = MaGetActiveBondIdForApprentice(GetObjectUUID(oApprentice));
+    if(nBondId <= 0) return;
+
+    string sMasterUuid = MaGetMasterUuid(GetObjectUUID(oApprentice));
+    object oMaster = MaGetPCByUUID(sMasterUuid);
+    if(!GetIsObjectValid(oMaster)) return;
+
+    // Reaching the master's level breaks the bond automatically.
+    if(nNewLevel >= GetHitDice(oMaster))
+    {
+        MaBreakBond(nBondId, "Apprentice reached master's level.");
+        MaRemoveApprenticeBonuses(oApprentice);
+        SendMessageToPC(oMaster,
+            "[Mentor] Apprentice " + GetName(oApprentice) + " has matched your level. The bond is dissolved.");
+        SendMessageToPC(oApprentice,
+            "[Mentor] You have matched your master's level. The bond is dissolved.");
+        return;
+    }
+
+    int nXpGain = MA_MASTER_XP_PER_LEVEL * nNewLevel;
+    GiveXPToCreature(oMaster, nXpGain);
+    MaAddSharedXp(nBondId, nXpGain);
+    SendMessageToPC(oMaster,
+        "[Mentor] " + GetName(oApprentice) + " advanced to level "
+        + IntToString(nNewLevel) + ". You receive " + IntToString(nXpGain) + " XP.");
+}
+
+// ----------------------------------------------------------------
+// UI
+// ----------------------------------------------------------------
+
+json BuildMaRowCell(object oPC)
+{
+    float fH = GetNuiScaleDimension(oPC, 26.0);
+    json jName = NuiLabel(NuiBind(MA_BIND_ROW_NAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jName = NuiStyleForegroundColor(jName, NuiBind(MA_BIND_ROW_COLOR));
+
+    json jInfo = NuiLabel(NuiBind(MA_BIND_ROW_INFO),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jInfo = NuiWidth(jInfo, GetNuiScaleDimension(oPC, 220.0));
+    jInfo = NuiStyleForegroundColor(jInfo, NuiBind(MA_BIND_ROW_COLOR));
+
+    json jRow = JsonArray();
+    jRow = JsonArrayInsert(jRow, jName);
+    jRow = JsonArrayInsert(jRow, jInfo);
+    json jCell = NuiGroup(NuiRow(jRow), TRUE, NUI_SCROLLBARS_NONE);
+    jCell = NuiId(jCell, MA_BTN_ROW);
+    jCell = NuiHeight(jCell, fH);
+    return jCell;
+}
+
+void CreateMaWindow(object oPC)
+{
+    int nExisting = NuiFindWindow(oPC, MA_WINDOW);
+    if(nExisting != 0) { FeedMaWindow(oPC, nExisting); return; }
+
+    float fW = GetNuiScaleDimension(oPC, MA_W);
+    float fH = GetNuiScaleDimension(oPC, MA_H);
+    float fBtnH = GetNuiScaleDimension(oPC, 30.0);
+    float fLblH = GetNuiScaleDimension(oPC, 22.0);
+
+    json jTitle = NuiLabel(NuiBind(MA_BIND_TITLE),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitle = NuiHeight(jTitle, fBtnH);
+    json jClose = NuiId(NuiButton(JsonString("Close")), MA_BTN_CLOSE);
+    jClose = NuiWidth(jClose, GetNuiScaleDimension(oPC, 90.0));
+    jClose = NuiHeight(jClose, fBtnH);
+
+    json jTopRow = JsonArray();
+    jTopRow = JsonArrayInsert(jTopRow, jTitle);
+    jTopRow = JsonArrayInsert(jTopRow, jClose);
+
+    json jMaster = NuiLabel(NuiBind(MA_BIND_MASTER_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jMaster = NuiStyleForegroundColor(jMaster, GetNuiColorNwnGold());
+    jMaster = NuiHeight(jMaster, fLblH);
+
+    json jBonus = NuiLabel(NuiBind(MA_BIND_BONUS_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jBonus = NuiHeight(jBonus, fLblH);
+
+    json jLeave = NuiId(NuiButton(JsonString("Leave master")), MA_BTN_LEAVE);
+    jLeave = NuiVisible(jLeave, NuiBind(MA_BIND_LEAVE_VIS));
+    jLeave = NuiHeight(jLeave, fBtnH);
+
+    json jSection = NuiLabel(NuiBind(MA_BIND_SECTION_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jSection = NuiStyleForegroundColor(jSection, GetNuiColorNwnGold());
+    jSection = NuiHeight(jSection, fLblH);
+
+    json jTake = NuiId(NuiButton(JsonString("Take apprentice (select target)")), MA_BTN_TAKE_APPRENTICE);
+    jTake = NuiEnabled(jTake, NuiBind(MA_BIND_TAKE_ENA));
+    jTake = NuiHeight(jTake, fBtnH);
+
+    json jEmpty = NuiLabel(NuiBind(MA_BIND_EMPTY_TXT),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jEmpty = NuiVisible(jEmpty, NuiBind(MA_BIND_EMPTY_VIS));
+    jEmpty = NuiHeight(jEmpty, GetNuiScaleDimension(oPC, 50.0));
+
+    json jList = NuiList(JsonArrayInsert(JsonArray(), BuildMaRowCell(oPC)),
+        GetNuiScaleDimension(oPC, 28.0));
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(jTopRow));
+    jCol = JsonArrayInsert(jCol, jMaster);
+    jCol = JsonArrayInsert(jCol, jBonus);
+    jCol = JsonArrayInsert(jCol, jLeave);
+    jCol = JsonArrayInsert(jCol, jSection);
+    jCol = JsonArrayInsert(jCol, jTake);
+    jCol = JsonArrayInsert(jCol, jEmpty);
+    jCol = JsonArrayInsert(jCol, jList);
+
+    json jRoot = NuiCol(jCol);
+
+    json jNui = NuiWindow(jRoot,
+        NuiBind(WINDOW_TITLE), NuiBind(WINDOW_GEOMETRY),
+        JsonBool(FALSE), JsonBool(FALSE),
+        JsonBool(TRUE),  JsonBool(FALSE), JsonBool(TRUE));
+
+    int nTk = NuiCreate(oPC, jNui, MA_WINDOW, MA_EV_SCRIPT);
+    NuiSetBind(oPC, nTk, WINDOW_TITLE, JsonString("Master & Apprentice"));
+    NuiSetBind(oPC, nTk, WINDOW_GEOMETRY, NuiRect(-1.0, -1.0, fW, fH));
+    NuiSetBind(oPC, nTk, MA_BIND_TITLE,   JsonString("Bonds of Mentorship"));
+
+    FeedMaWindow(oPC, nTk);
+}
+
+void FeedMaWindow(object oPC, int nToken)
+{
+    string sUuid = GetObjectUUID(oPC);
+
+    // -- "I am apprentice" section --
+    int nHasMaster = MaHasMaster(sUuid);
+    if(nHasMaster)
+    {
+        string sMasterName = MaGetMasterName(sUuid);
+        NuiSetBind(oPC, nToken, MA_BIND_MASTER_LBL,
+            JsonString("Your master: " + sMasterName));
+
+        // Count bonus skills currently active.
+        int nBonusCount = 0;
+        effect e = GetFirstEffect(oPC);
+        while(GetIsEffectValid(e))
+        {
+            if(GetEffectTag(e) == MA_EFFECT_TAG) nBonusCount++;
+            e = GetNextEffect(oPC);
+        }
+        NuiSetBind(oPC, nToken, MA_BIND_BONUS_LBL,
+            JsonString("Skill bonuses inherited: " + IntToString(nBonusCount)));
+        NuiSetBind(oPC, nToken, MA_BIND_LEAVE_VIS, JsonBool(TRUE));
+    }
+    else
+    {
+        NuiSetBind(oPC, nToken, MA_BIND_MASTER_LBL, JsonString("You have no master."));
+        NuiSetBind(oPC, nToken, MA_BIND_BONUS_LBL,  JsonString(""));
+        NuiSetBind(oPC, nToken, MA_BIND_LEAVE_VIS,  JsonBool(FALSE));
+    }
+
+    // -- "I am master" section --
+    int nApprenticeCount = MaCountActiveApprentices(sUuid);
+    NuiSetBind(oPC, nToken, MA_BIND_SECTION_LBL,
+        JsonString("Your apprentices (" + IntToString(nApprenticeCount)
+        + "/" + IntToString(MA_MAX_APPRENTICES) + ")"));
+    NuiSetBind(oPC, nToken, MA_BIND_TAKE_ENA,
+        JsonBool(nApprenticeCount < MA_MAX_APPRENTICES));
+
+    json jApps = MaGetApprentices(sUuid);
+    int nCnt = JsonGetLength(jApps);
+
+    json jNames = JsonArray();
+    json jInfos = JsonArray();
+    json jColors = JsonArray();
+    int i;
+    for(i = 0; i < nCnt; i++)
+    {
+        json jR = JsonArrayGet(jApps, i);
+        string sName = JsonGetString(JsonObjectGet(jR, "name"));
+        int nXp = JsonGetInt(JsonObjectGet(jR, "xp_shared_total"));
+        jNames  = JsonArrayInsert(jNames,  JsonString(sName));
+        jInfos  = JsonArrayInsert(jInfos,  JsonString("Shared XP: "
+            + IntToString(nXp) + " (click to dismiss)"));
+        jColors = JsonArrayInsert(jColors, NuiColor(220, 200, 120));
+    }
+    NuiSetBind(oPC, nToken, MA_BIND_ROW_NAME,  jNames);
+    NuiSetBind(oPC, nToken, MA_BIND_ROW_INFO,  jInfos);
+    NuiSetBind(oPC, nToken, MA_BIND_ROW_COLOR, jColors);
+
+    NuiSetBind(oPC, nToken, MA_BIND_EMPTY_VIS, JsonBool(nCnt == 0));
+    NuiSetBind(oPC, nToken, MA_BIND_EMPTY_TXT,
+        JsonString("No apprentices. Stand near a candidate and offer the bond."));
+}
+
+// ----------------------------------------------------------------
+// Proposal popup (target sees this)
+// ----------------------------------------------------------------
+
+void MaShowProposal(object oPC, string sFromUuid, string sFromName)
+{
+    int nExisting = NuiFindWindow(oPC, MA_WIN_PROPOSAL);
+    if(nExisting != 0) NuiDestroy(oPC, nExisting);
+
+    float fW = GetNuiScaleDimension(oPC, MA_PROP_W);
+    float fH = GetNuiScaleDimension(oPC, MA_PROP_H);
+    float fLblH = GetNuiScaleDimension(oPC, 24.0);
+    float fBtnH = GetNuiScaleDimension(oPC, 32.0);
+
+    json jTitle = NuiLabel(NuiBind(MA_BIND_PROP_TITLE),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitle = NuiHeight(jTitle, fLblH);
+    json jDetail = NuiLabel(NuiBind(MA_BIND_PROP_DETAIL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jDetail = NuiHeight(jDetail, fLblH);
+
+    json jAccept  = NuiHeight(NuiId(NuiButton(JsonString("Accept")),  MA_BTN_PROP_ACCEPT),  fBtnH);
+    json jDecline = NuiHeight(NuiId(NuiButton(JsonString("Decline")), MA_BTN_PROP_DECLINE), fBtnH);
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, jAccept);
+    jBtnRow = JsonArrayInsert(jBtnRow, jDecline);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jTitle);
+    jCol = JsonArrayInsert(jCol, jDetail);
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+
+    json jNui = NuiWindow(NuiCol(jCol),
+        JsonString("Master's Offer"),
+        NuiRect(-1.0, -1.0, fW, fH),
+        JsonBool(FALSE), JsonBool(FALSE),
+        JsonBool(TRUE),  JsonBool(FALSE), JsonBool(TRUE));
+    int nTk = NuiCreate(oPC, jNui, MA_WIN_PROPOSAL, MA_EV_SCRIPT);
+
+    NuiSetBind(oPC, nTk, MA_BIND_PROP_TITLE,
+        JsonString(sFromName + " offers to take you as apprentice."));
+    NuiSetBind(oPC, nTk, MA_BIND_PROP_DETAIL,
+        JsonString("Bond grants +" + IntToString(MA_SKILL_BONUS)
+            + " to skills your master excels at; "
+            + "your level-ups feed XP back to your master."));
+}
+
+// ----------------------------------------------------------------
+// Targeting helper (called from sys_on_target)
+// ----------------------------------------------------------------
+
+void MaStartTakeApprentice(object oMaster)
+{
+    if(MaCountActiveApprentices(GetObjectUUID(oMaster)) >= MA_MAX_APPRENTICES)
+    {
+        SendMessageToPC(oMaster, "[Mentor] Already at apprentice limit.");
+        return;
+    }
+    SendMessageToPC(oMaster, "[Mentor] Select a player to apprentice.");
+    EnterTargetingMode(oMaster, OBJECT_TYPE_CREATURE);
+}
+
+void MaOnPlayerTarget(object oMaster)
+{
+    object oCandidate = GetTargetingModeSelectedObject();
+    if(!GetIsObjectValid(oCandidate))
+    {
+        SendMessageToPC(oMaster, "[Mentor] Selection canceled.");
+        return;
+    }
+    MaProposeApprenticeship(oMaster, oCandidate);
+}

--- a/Master Apprentice/Scripts/lib_ma_def.nss
+++ b/Master Apprentice/Scripts/lib_ma_def.nss
@@ -1,0 +1,85 @@
+#include "lib_nui"
+#include "sql_ma"
+
+// ----------------------------------------------------------------
+// Master & Apprentice
+// ----------------------------------------------------------------
+// PvP-friendly mentorship system:
+//   - One PC may be Master to up to MA_MAX_APPRENTICES.
+//   - One PC may have at most one Master at a time.
+//   - On apprentice level-up the Master receives MA_MASTER_XP_PER_LEVEL
+//     * <new_level> bonus XP (capped to apprentice's level <= master's).
+//   - Apprentice gains MA_SKILL_BONUS to every skill the Master has at
+//     rank >= MA_SKILL_THRESHOLD. Bonuses re-apply on login.
+//
+// Hooks:
+//   OnModuleLoad     -> sys_on_load    (init schema)
+//   OnPlayerLevelUp  -> sys_on_levelup (XP transfer to master)
+//   OnClientEnter    -> sys_on_enter   (reapply skill bonuses)
+//   OnPlayerTarget   -> sys_on_target  (apprentice selection)
+//
+// Open the panel from a placeable's OnUsed:
+//   #include "lib_ma"
+//   void main() { CreateMaWindow(GetLastUsedBy()); }
+// ----------------------------------------------------------------
+
+const string MA_WINDOW           = "MA_WINDOW";
+const string MA_WIN_PROPOSAL     = "MA_WIN_PROPOSAL";
+const string MA_EV_SCRIPT        = "lib_ma_ev";
+
+// Tunables
+const int   MA_MAX_APPRENTICES   = 3;
+const int   MA_MASTER_XP_PER_LEVEL = 200;   // master gets this * apprentice_new_level
+const int   MA_SKILL_BONUS       = 2;       // bonus ranks granted to apprentice
+const int   MA_SKILL_THRESHOLD   = 5;       // master must have at least this rank to grant
+const int   MA_MAX_SKILL_INDEX   = 27;      // standard NWN skill range (0..27)
+const float MA_PROPOSAL_DISTANCE = 6.0;     // meters
+
+// Effect tag for granted skill bonuses (so we can remove cleanly)
+const string MA_EFFECT_TAG       = "MA_APPRENTICE_BONUS";
+
+// LVARs on PC
+const string MA_LVAR_PROPOSAL_FROM   = "MA_PROPOSAL_FROM_UUID";
+const string MA_LVAR_PROPOSAL_NAME   = "MA_PROPOSAL_FROM_NAME";
+
+// Bind names
+const string MA_BIND_TITLE           = "ma_title";
+const string MA_BIND_MASTER_LBL      = "ma_master_lbl";
+const string MA_BIND_BONUS_LBL       = "ma_bonus_lbl";
+const string MA_BIND_LEAVE_VIS       = "ma_leave_vis";
+const string MA_BIND_TAKE_ENA        = "ma_take_ena";
+const string MA_BIND_SECTION_LBL     = "ma_section_lbl";
+const string MA_BIND_ROW_NAME        = "ma_row_name";
+const string MA_BIND_ROW_INFO        = "ma_row_info";
+const string MA_BIND_ROW_COLOR       = "ma_row_color";
+const string MA_BIND_EMPTY_VIS       = "ma_empty_vis";
+const string MA_BIND_EMPTY_TXT       = "ma_empty_txt";
+// Proposal popup
+const string MA_BIND_PROP_TITLE      = "ma_prop_title";
+const string MA_BIND_PROP_DETAIL     = "ma_prop_detail";
+
+// Button IDs
+const string MA_BTN_CLOSE            = "ma_btn_close";
+const string MA_BTN_TAKE_APPRENTICE  = "ma_btn_take";
+const string MA_BTN_LEAVE            = "ma_btn_leave";
+const string MA_BTN_ROW              = "ma_btn_row";   // dismiss apprentice row
+const string MA_BTN_PROP_ACCEPT      = "ma_btn_prop_accept";
+const string MA_BTN_PROP_DECLINE     = "ma_btn_prop_decline";
+
+// Layout
+const float MA_W = 560.0;
+const float MA_H = 460.0;
+const float MA_PROP_W = 420.0;
+const float MA_PROP_H = 220.0;
+
+object MaGetPCByUUID(string sUuid)
+{
+    if(sUuid == "") return OBJECT_INVALID;
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        if(GetObjectUUID(oPC) == sUuid) return oPC;
+        oPC = GetNextPC();
+    }
+    return OBJECT_INVALID;
+}

--- a/Master Apprentice/Scripts/lib_ma_ev.nss
+++ b/Master Apprentice/Scripts/lib_ma_ev.nss
@@ -1,0 +1,72 @@
+#include "lib_ma"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    int nMain     = NuiFindWindow(oPC, MA_WINDOW);
+    int nProposal = NuiFindWindow(oPC, MA_WIN_PROPOSAL);
+
+    // ---- Proposal popup ----
+    if(nToken == nProposal && nProposal != 0)
+    {
+        if(sEvent == EVENT_TYPE_CLICK)
+        {
+            if(sElem == MA_BTN_PROP_ACCEPT)
+            {
+                NuiDestroy(oPC, nToken);
+                MaAcceptProposal(oPC);
+                return;
+            }
+            if(sElem == MA_BTN_PROP_DECLINE)
+            {
+                NuiDestroy(oPC, nToken);
+                MaDeclineProposal(oPC);
+                return;
+            }
+        }
+        if(sEvent == EVENT_TYPE_CLOSE)
+        {
+            // Closing without choosing = decline.
+            if(GetLocalString(oPC, MA_LVAR_PROPOSAL_FROM) != "")
+                MaDeclineProposal(oPC);
+        }
+        return;
+    }
+
+    // ---- Main window ----
+    if(nToken != nMain || nMain == 0) return;
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == MA_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+        if(sElem == MA_BTN_TAKE_APPRENTICE)
+        {
+            MaStartTakeApprentice(oPC);
+            return;
+        }
+        if(sElem == MA_BTN_LEAVE)
+        {
+            MaLeaveMaster(oPC);
+            return;
+        }
+    }
+
+    if(sEvent == EVENT_TYPE_MOUSEDOWN && sElem == MA_BTN_ROW)
+    {
+        // Row click in apprentice list => dismiss that apprentice.
+        json jApps = MaGetApprentices(GetObjectUUID(oPC));
+        if(nIdx < 0 || nIdx >= JsonGetLength(jApps)) return;
+        json jR = JsonArrayGet(jApps, nIdx);
+        int nBondId = JsonGetInt(JsonObjectGet(jR, "id"));
+        MaDismissApprentice(oPC, nBondId, "Master dismissed apprentice.");
+    }
+}

--- a/Master Apprentice/Scripts/lib_nui.nss
+++ b/Master Apprentice/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Master Apprentice/Scripts/lib_nui_utility.nss
+++ b/Master Apprentice/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Master Apprentice/Scripts/sql_ma.nss
+++ b/Master Apprentice/Scripts/sql_ma.nss
@@ -1,0 +1,155 @@
+// Master & Apprentice — persistence (campaign DB "ma")
+
+const string MA_DB = "ma";
+
+void MaCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign(MA_DB,
+        "CREATE TABLE IF NOT EXISTS ma_bonds ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "master_uuid TEXT NOT NULL, "
+        "master_name TEXT DEFAULT '', "
+        "apprentice_uuid TEXT NOT NULL, "
+        "apprentice_name TEXT DEFAULT '', "
+        "created_at INTEGER DEFAULT 0, "
+        "broken_at INTEGER DEFAULT 0, "
+        "broken_reason TEXT DEFAULT '', "
+        "xp_shared_total INTEGER DEFAULT 0)");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign(MA_DB,
+        "CREATE INDEX IF NOT EXISTS idx_ma_master "
+        "ON ma_bonds(master_uuid, broken_at)");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign(MA_DB,
+        "CREATE INDEX IF NOT EXISTS idx_ma_apprentice "
+        "ON ma_bonds(apprentice_uuid, broken_at)");
+    SqlStep(q);
+}
+
+int MaCountActiveApprentices(string sMasterUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign(MA_DB,
+        "SELECT COUNT(*) FROM ma_bonds "
+        "WHERE master_uuid = @u AND broken_at = 0");
+    SqlBindString(q, "@u", sMasterUuid);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+int MaHasMaster(string sApprenticeUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign(MA_DB,
+        "SELECT COUNT(*) FROM ma_bonds "
+        "WHERE apprentice_uuid = @u AND broken_at = 0");
+    SqlBindString(q, "@u", sApprenticeUuid);
+    if(SqlStep(q)) return SqlGetInt(q, 0) > 0;
+    return 0;
+}
+
+string MaGetMasterUuid(string sApprenticeUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign(MA_DB,
+        "SELECT master_uuid FROM ma_bonds "
+        "WHERE apprentice_uuid = @u AND broken_at = 0 LIMIT 1");
+    SqlBindString(q, "@u", sApprenticeUuid);
+    if(SqlStep(q)) return SqlGetString(q, 0);
+    return "";
+}
+
+string MaGetMasterName(string sApprenticeUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign(MA_DB,
+        "SELECT master_name FROM ma_bonds "
+        "WHERE apprentice_uuid = @u AND broken_at = 0 LIMIT 1");
+    SqlBindString(q, "@u", sApprenticeUuid);
+    if(SqlStep(q)) return SqlGetString(q, 0);
+    return "";
+}
+
+int MaCreateBond(object oMaster, object oApprentice)
+{
+    sqlquery q = SqlPrepareQueryCampaign(MA_DB,
+        "INSERT INTO ma_bonds (master_uuid, master_name, apprentice_uuid, apprentice_name, created_at) "
+        "VALUES (@mu, @mn, @au, @an, strftime('%s','now'))");
+    SqlBindString(q, "@mu", GetObjectUUID(oMaster));
+    SqlBindString(q, "@mn", GetName(oMaster));
+    SqlBindString(q, "@au", GetObjectUUID(oApprentice));
+    SqlBindString(q, "@an", GetName(oApprentice));
+    SqlStep(q);
+    sqlquery qId = SqlPrepareQueryCampaign(MA_DB, "SELECT last_insert_rowid()");
+    if(SqlStep(qId)) return SqlGetInt(qId, 0);
+    return 0;
+}
+
+void MaBreakBond(int nId, string sReason)
+{
+    sqlquery q = SqlPrepareQueryCampaign(MA_DB,
+        "UPDATE ma_bonds SET broken_at = strftime('%s','now'), broken_reason = @r "
+        "WHERE id = @id AND broken_at = 0");
+    SqlBindString(q, "@r", sReason);
+    SqlBindInt   (q, "@id", nId);
+    SqlStep(q);
+}
+
+void MaBreakBondByApprentice(string sApprenticeUuid, string sReason)
+{
+    sqlquery q = SqlPrepareQueryCampaign(MA_DB,
+        "UPDATE ma_bonds SET broken_at = strftime('%s','now'), broken_reason = @r "
+        "WHERE apprentice_uuid = @u AND broken_at = 0");
+    SqlBindString(q, "@r", sReason);
+    SqlBindString(q, "@u", sApprenticeUuid);
+    SqlStep(q);
+}
+
+void MaAddSharedXp(int nId, int nDelta)
+{
+    sqlquery q = SqlPrepareQueryCampaign(MA_DB,
+        "UPDATE ma_bonds SET xp_shared_total = xp_shared_total + @d WHERE id = @id");
+    SqlBindInt(q, "@d",  nDelta);
+    SqlBindInt(q, "@id", nId);
+    SqlStep(q);
+}
+
+int MaGetActiveBondId(string sMasterUuid, string sApprenticeUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign(MA_DB,
+        "SELECT id FROM ma_bonds WHERE master_uuid = @m AND apprentice_uuid = @a "
+        "AND broken_at = 0 LIMIT 1");
+    SqlBindString(q, "@m", sMasterUuid);
+    SqlBindString(q, "@a", sApprenticeUuid);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// Returns array of {id, apprentice_uuid, apprentice_name, xp_shared_total, created_at}
+json MaGetApprentices(string sMasterUuid)
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign(MA_DB,
+        "SELECT id, apprentice_uuid, apprentice_name, xp_shared_total, created_at "
+        "FROM ma_bonds WHERE master_uuid = @u AND broken_at = 0 "
+        "ORDER BY created_at ASC");
+    SqlBindString(q, "@u", sMasterUuid);
+    while(SqlStep(q))
+    {
+        json j = JsonObject();
+        j = JsonObjectSet(j, "id",              JsonInt   (SqlGetInt   (q, 0)));
+        j = JsonObjectSet(j, "uuid",            JsonString(SqlGetString(q, 1)));
+        j = JsonObjectSet(j, "name",            JsonString(SqlGetString(q, 2)));
+        j = JsonObjectSet(j, "xp_shared_total", JsonInt   (SqlGetInt   (q, 3)));
+        j = JsonObjectSet(j, "created_at",      JsonInt   (SqlGetInt   (q, 4)));
+        jRows = JsonArrayInsert(jRows, j);
+    }
+    return jRows;
+}
+
+int MaGetActiveBondIdForApprentice(string sApprenticeUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign(MA_DB,
+        "SELECT id FROM ma_bonds WHERE apprentice_uuid = @u AND broken_at = 0 LIMIT 1");
+    SqlBindString(q, "@u", sApprenticeUuid);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}

--- a/Master Apprentice/Scripts/sys_on_enter.nss
+++ b/Master Apprentice/Scripts/sys_on_enter.nss
@@ -1,0 +1,13 @@
+#include "lib_ma"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC)) return;
+
+    // Reapply skill bonuses if the apprentice still has an active master.
+    if(MaHasMaster(GetObjectUUID(oPC)))
+        MaApplyApprenticeBonuses(oPC);
+    else
+        MaRemoveApprenticeBonuses(oPC);
+}

--- a/Master Apprentice/Scripts/sys_on_levelup.nss
+++ b/Master Apprentice/Scripts/sys_on_levelup.nss
@@ -1,0 +1,10 @@
+#include "lib_ma"
+
+void main()
+{
+    object oPC = GetPCLevellingUp();
+    if(!GetIsPC(oPC)) return;
+
+    int nNewLevel = GetHitDice(oPC);
+    MaOnApprenticeLevelUp(oPC, nNewLevel);
+}

--- a/Master Apprentice/Scripts/sys_on_load.nss
+++ b/Master Apprentice/Scripts/sys_on_load.nss
@@ -1,0 +1,6 @@
+#include "lib_ma"
+
+void main()
+{
+    MaCreateTables();
+}

--- a/Master Apprentice/Scripts/sys_on_target.nss
+++ b/Master Apprentice/Scripts/sys_on_target.nss
@@ -1,0 +1,9 @@
+#include "lib_ma"
+
+void main()
+{
+    object oPC = GetLastPlayerToSelectTarget();
+    if(!GetIsPC(oPC)) return;
+    if(NuiFindWindow(oPC, MA_WINDOW) != 0)
+        MaOnPlayerTarget(oPC);
+}

--- a/Master Apprentice/Scripts/test_ma.nss
+++ b/Master Apprentice/Scripts/test_ma.nss
@@ -1,0 +1,8 @@
+#include "lib_ma"
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+    CreateMaWindow(oPC);
+}


### PR DESCRIPTION
## What it does

PvP-friendly mentorship system. A higher-level player can take up to **3 apprentices**; the apprentice gains a passive skill bonus inherited from the master, and the master earns XP whenever the apprentice levels up. The bond is consensual on both sides and dissolves automatically when the apprentice reaches the master's level.

## Mechanics

- **Single NUI window** with two sections: "I am apprentice" (your master + inherited bonuses + Leave button) and "I am master" (apprentice list with shared XP + Take button).
- **Proposal flow**: master clicks `Take apprentice (select target)` -> targeting mode -> picks a PC -> popup appears on candidate -> Accept/Decline.
- **Validation**: max 3 apprentices per master, 1 master per apprentice, master must be higher level, both within 6m for the proposal.
- **Skill bonus**: +2 ranks to every skill where master rank >= 5. Applied on bond creation and on `OnClientEnter`. Removed cleanly via tagged effect on bond break.
- **XP transfer**: on apprentice level-up, master receives `200 * new_level` XP and the running total is logged in the bond row.
- **Auto-dissolve**: when apprentice's level matches master's, the bond breaks (notice sent to both).
- **Persistence**: SQLite (`ma` campaign DB), single `ma_bonds` table.

## Files

11 files, ~1k LOC (~700 module + ~200 NUI helpers + ~100 hooks):

| File | LOC | Role |
|---|---:|---|
| `lib_ma_def.nss` | 85 | Constants, integration header, helper. |
| `sql_ma.nss` | 155 | Campaign schema (`ma_bonds`) + CRUD. |
| `lib_ma.nss` | 463 | UI + bond lifecycle + skill-bonus apply/remove + level-up handler. |
| `lib_ma_ev.nss` | 72 | NUI event router for main + proposal popup. |
| `sys_on_load.nss` | 6 | Schema init. |
| `sys_on_enter.nss` | 13 | Reapply skill bonuses on login. |
| `sys_on_target.nss` | 9 | Apprentice targeting dispatcher. |
| `sys_on_levelup.nss` | 10 | XP transfer to master + auto-dissolve. |
| `test_ma.nss` | 8 | OnUsed entry point. |
| `lib_nui.nss` + `lib_nui_utility.nss` | 206 | NUI helpers (copied from Mailbox). |

## Dependencies

- **NWN:EE** (NUI + JSON API + campaign SQLite).
- **NWNX**: none.

## How to integrate

In your module's event scripts:

```nwscript
// OnModuleLoad
ExecuteScript("sys_on_load", OBJECT_SELF);

// OnClientEnter
ExecuteScript("sys_on_enter", OBJECT_SELF);

// OnPlayerTarget
ExecuteScript("sys_on_target", OBJECT_SELF);

// OnPlayerLevelUp
ExecuteScript("sys_on_levelup", OBJECT_SELF);
```

On a placeable (e.g. mentor's lectern, training dummy, mage college sign-up):

```nwscript
#include "lib_ma"
void main()
{
    object oPC = GetLastUsedBy();
    if(!GetIsPC(oPC)) return;
    CreateMaWindow(oPC);
}
```

If you already use any of these `sys_on_*` hooks, merge by calling each handler conditionally.

Full integration details are in the header of `lib_ma_def.nss`.

## Intentionally omitted

- **Multi-skill weighting**: bonus is a flat +2 to every qualifying skill; no scaling with master's rank.
- **Betrayal mechanic**: no special penalty if apprentice/master attacks the other.
- **XP cap on master**: master XP can theoretically exceed natural progression; cap left to server policy.
- **Refund of skill bonuses on master logout**: bonuses persist on the apprentice as effects until login refresh.
- **HAK with mentor placeable model and icon**.

## Scope

Tighter than Honor Duels by design — single NUI window, ~700 LOC of module code, one campaign table. Built to fit the daily-routine reliability budget.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CoNsmEmyocr7Hkn8XyELhZ)_