### PR TITLE
feat: Prayer &amp; Miracles

### DIFF
--- a/Prayer Miracles/Scripts/lib_nui.nss
+++ b/Prayer Miracles/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Prayer Miracles/Scripts/lib_nui_utility.nss
+++ b/Prayer Miracles/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Prayer Miracles/Scripts/lib_pr.nss
+++ b/Prayer Miracles/Scripts/lib_pr.nss
@@ -1,0 +1,466 @@
+#include "lib_pr_def"
+
+void FeedPrWindow(object oPC, int nToken);
+void PrShowDeitySelector(object oPC);
+
+// ----------------------------------------------------------------
+// Cooldown helpers
+// ----------------------------------------------------------------
+
+int PrCooldownRemaining(object oPC, int nMiracle)
+{
+    int nReady = GetLocalInt(oPC, PR_LVAR_CD_PREFIX + IntToString(nMiracle));
+    int nNow   = PrGetNowSeconds();
+    if(nNow >= nReady) return 0;
+    return nReady - nNow;
+}
+
+void PrSetCooldown(object oPC, int nMiracle)
+{
+    int nNow = PrGetNowSeconds();
+    SetLocalInt(oPC, PR_LVAR_CD_PREFIX + IntToString(nMiracle),
+                nNow + PrMiracleCooldownS(nMiracle));
+}
+
+string PrFormatCooldown(int nSecs)
+{
+    if(nSecs <= 0) return "";
+    int nMin = nSecs / 60;
+    int nSec = nSecs % 60;
+    if(nMin > 0) return IntToString(nMin) + "m " + IntToString(nSec) + "s";
+    return IntToString(nSec) + "s";
+}
+
+// ----------------------------------------------------------------
+// Pray
+// ----------------------------------------------------------------
+
+void PrPray(object oPC)
+{
+    string sUuid = GetObjectUUID(oPC);
+    if(PrGetDeity(sUuid) == PR_DEITY_NONE)
+    {
+        SendMessageToPC(oPC, "[Prayer] Choose a deity before you pray.");
+        return;
+    }
+
+    int nNow  = PrGetNowSeconds();
+    int nLast = PrGetLastPrayedAt(sUuid);
+    if(nLast > 0 && nNow - nLast < PR_PRAY_COOLDOWN_S)
+    {
+        int nLeft = PR_PRAY_COOLDOWN_S - (nNow - nLast);
+        SendMessageToPC(oPC, "[Prayer] Your prayer is too fresh. Wait "
+            + PrFormatCooldown(nLeft) + ".");
+        return;
+    }
+
+    PrAdjustFavor(sUuid, PR_PRAY_FAVOR_GAIN, PR_FAVOR_MIN, PR_FAVOR_MAX);
+    PrMarkPrayed(sUuid);
+
+    int nDeity = PrGetDeity(sUuid);
+    string sName = PrDeityName(nDeity);
+    FloatingTextStringOnCreature("You whisper a prayer to " + sName + ".",
+        oPC, FALSE);
+    SendMessageToPC(oPC, "[Prayer] Favor with " + sName + " grows by "
+        + IntToString(PR_PRAY_FAVOR_GAIN) + ".");
+
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectVisualEffect(VFX_IMP_DIVINE_STRIKE_HOLY), oPC);
+
+    int nTk = NuiFindWindow(oPC, PR_WINDOW);
+    if(nTk != 0) FeedPrWindow(oPC, nTk);
+}
+
+// ----------------------------------------------------------------
+// Miracle effects
+// ----------------------------------------------------------------
+
+void PrApplyHeal(object oPC)
+{
+    effect eHeal = EffectHeal(25);
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, eHeal, oPC);
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectVisualEffect(VFX_IMP_HEALING_M), oPC);
+}
+
+void PrApplyBless(object oPC)
+{
+    location lLoc = GetLocation(oPC);
+    object oTarget = GetFirstObjectInShape(SHAPE_SPHERE, 10.0, lLoc);
+    while(GetIsObjectValid(oTarget))
+    {
+        if(GetIsPC(oTarget) && !GetIsEnemy(oTarget, oPC))
+        {
+            effect eAtk = EffectAttackIncrease(2);
+            effect eSav = EffectSavingThrowIncrease(SAVING_THROW_ALL, 2);
+            effect eLink = EffectLinkEffects(eAtk, eSav);
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eLink, oTarget, 60.0);
+            ApplyEffectToObject(DURATION_TYPE_INSTANT,
+                EffectVisualEffect(VFX_IMP_HEAD_HOLY), oTarget);
+        }
+        oTarget = GetNextObjectInShape(SHAPE_SPHERE, 10.0, lLoc);
+    }
+}
+
+void PrApplySmite(object oPC, object oEnemy)
+{
+    if(!GetIsObjectValid(oEnemy) || oEnemy == oPC) return;
+    int nDmg = d6(3);
+    effect eDmg = EffectDamage(nDmg, DAMAGE_TYPE_DIVINE);
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, eDmg, oEnemy);
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectVisualEffect(VFX_IMP_DIVINE_STRIKE_HOLY), oEnemy);
+    SendMessageToPC(oPC, "[Prayer] Smite strikes for " + IntToString(nDmg) + ".");
+}
+
+void PrApplySanctuary(object oPC)
+{
+    effect eSanc = EffectSanctuary(20);
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eSanc, oPC, 18.0);
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectVisualEffect(VFX_IMP_SANCTUARY), oPC);
+}
+
+void PrApplyRaise(object oPC, object oTarget)
+{
+    if(!GetIsObjectValid(oTarget) || !GetIsPC(oTarget) || !GetIsDead(oTarget))
+    {
+        SendMessageToPC(oPC, "[Prayer] Target must be a slain ally.");
+        return;
+    }
+    effect eRaise = EffectResurrection();
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, eRaise, oTarget);
+    int nQuarter = GetMaxHitPoints(oTarget) / 4;
+    if(nQuarter < 1) nQuarter = 1;
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectHeal(nQuarter), oTarget);
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectVisualEffect(VFX_IMP_RAISE_DEAD), oTarget);
+}
+
+// ----------------------------------------------------------------
+// Cast a miracle (validation + effect application)
+// ----------------------------------------------------------------
+
+int PrTryCastMiracle(object oPC, int nMiracle, object oTarget)
+{
+    string sUuid = GetObjectUUID(oPC);
+    int nDeity   = PrGetDeity(sUuid);
+    if(nDeity == PR_DEITY_NONE)
+    {
+        SendMessageToPC(oPC, "[Prayer] You serve no deity.");
+        return FALSE;
+    }
+    int nFavor = PrGetFavor(sUuid);
+    if(nFavor < PrMiracleFavorReq(nMiracle))
+    {
+        SendMessageToPC(oPC, "[Prayer] Insufficient favor for "
+            + PrMiracleName(nMiracle) + " (need "
+            + IntToString(PrMiracleFavorReq(nMiracle)) + ").");
+        return FALSE;
+    }
+    int nCd = PrCooldownRemaining(oPC, nMiracle);
+    if(nCd > 0)
+    {
+        SendMessageToPC(oPC, "[Prayer] " + PrMiracleName(nMiracle)
+            + " is on cooldown (" + PrFormatCooldown(nCd) + ").");
+        return FALSE;
+    }
+
+    switch(nMiracle)
+    {
+        case PR_MIRACLE_HEAL:      PrApplyHeal(oPC);                 break;
+        case PR_MIRACLE_BLESS:     PrApplyBless(oPC);                break;
+        case PR_MIRACLE_SMITE:     PrApplySmite(oPC, oTarget);       break;
+        case PR_MIRACLE_SANCTUARY: PrApplySanctuary(oPC);            break;
+        case PR_MIRACLE_RAISE:     PrApplyRaise(oPC, oTarget);       break;
+        default: return FALSE;
+    }
+
+    PrAdjustFavor(sUuid, -PrMiracleFavorCost(nMiracle), PR_FAVOR_MIN, PR_FAVOR_MAX);
+    PrSetCooldown(oPC, nMiracle);
+    PrIncMiraclesCast(sUuid);
+
+    SendMessageToPC(oPC, "[Prayer] " + PrMiracleName(nMiracle) + " invoked.");
+
+    int nTk = NuiFindWindow(oPC, PR_WINDOW);
+    if(nTk != 0) FeedPrWindow(oPC, nTk);
+    return TRUE;
+}
+
+void PrStartMiracleTargeting(object oPC, int nMiracle)
+{
+    SetLocalInt(oPC, PR_LVAR_PENDING_TARGET, nMiracle + 1);  // +1 so 0 means "none"
+    SendMessageToPC(oPC, "[Prayer] Select a target for "
+        + PrMiracleName(nMiracle) + ".");
+    EnterTargetingMode(oPC, OBJECT_TYPE_CREATURE);
+}
+
+void PrOnPlayerTarget(object oPC)
+{
+    int nMir = GetLocalInt(oPC, PR_LVAR_PENDING_TARGET) - 1;
+    DeleteLocalInt(oPC, PR_LVAR_PENDING_TARGET);
+    if(nMir < 0) return;
+
+    object oTarget = GetTargetingModeSelectedObject();
+    if(!GetIsObjectValid(oTarget))
+    {
+        SendMessageToPC(oPC, "[Prayer] Targeting canceled.");
+        return;
+    }
+    PrTryCastMiracle(oPC, nMir, oTarget);
+}
+
+// ----------------------------------------------------------------
+// UI — main window
+// ----------------------------------------------------------------
+
+json BuildPrMiracleRow(object oPC)
+{
+    float fH = GetNuiScaleDimension(oPC, 32.0);
+
+    json jName = NuiLabel(NuiBind(PR_BIND_MIR_NAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jName = NuiWidth(jName, GetNuiScaleDimension(oPC, 160.0));
+    jName = NuiStyleForegroundColor(jName, NuiBind(PR_BIND_MIR_COLOR));
+
+    json jDesc = NuiLabel(NuiBind(PR_BIND_MIR_DESC),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jDesc = NuiStyleForegroundColor(jDesc, NuiBind(PR_BIND_MIR_COLOR));
+
+    json jBtn = NuiButton(NuiBind(PR_BIND_MIR_BTN));
+    jBtn = NuiId(jBtn, PR_BTN_MIRACLE);
+    jBtn = NuiEnabled(jBtn, NuiBind(PR_BIND_MIR_BTN_ENA));
+    jBtn = NuiWidth(jBtn, GetNuiScaleDimension(oPC, 110.0));
+
+    json jRow = JsonArray();
+    jRow = JsonArrayInsert(jRow, jName);
+    jRow = JsonArrayInsert(jRow, jDesc);
+    jRow = JsonArrayInsert(jRow, jBtn);
+    json jCell = NuiGroup(NuiRow(jRow), TRUE, NUI_SCROLLBARS_NONE);
+    jCell = NuiHeight(jCell, fH);
+    return jCell;
+}
+
+void CreatePrWindow(object oPC)
+{
+    int nExisting = NuiFindWindow(oPC, PR_WINDOW);
+    if(nExisting != 0) { FeedPrWindow(oPC, nExisting); return; }
+
+    PrEnsureRow(oPC);
+
+    float fW = GetNuiScaleDimension(oPC, PR_W);
+    float fH = GetNuiScaleDimension(oPC, PR_H);
+    float fBtnH = GetNuiScaleDimension(oPC, 30.0);
+    float fLblH = GetNuiScaleDimension(oPC, 22.0);
+
+    json jTitle = NuiLabel(NuiBind(PR_BIND_TITLE),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitle = NuiHeight(jTitle, fBtnH);
+    json jClose = NuiId(NuiButton(JsonString("Close")), PR_BTN_CLOSE);
+    jClose = NuiWidth(jClose, GetNuiScaleDimension(oPC, 90.0));
+    jClose = NuiHeight(jClose, fBtnH);
+    json jTopRow = JsonArray();
+    jTopRow = JsonArrayInsert(jTopRow, jTitle);
+    jTopRow = JsonArrayInsert(jTopRow, jClose);
+
+    json jDeity = NuiLabel(NuiBind(PR_BIND_DEITY_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jDeity = NuiStyleForegroundColor(jDeity, GetNuiColorNwnGold());
+    jDeity = NuiHeight(jDeity, fLblH);
+
+    json jFavor = NuiLabel(NuiBind(PR_BIND_FAVOR_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jFavor = NuiHeight(jFavor, fLblH);
+
+    json jRank = NuiLabel(NuiBind(PR_BIND_RANK_LBL),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRank = NuiHeight(jRank, fLblH);
+
+    json jStatRow = JsonArray();
+    jStatRow = JsonArrayInsert(jStatRow, jFavor);
+    jStatRow = JsonArrayInsert(jStatRow, jRank);
+
+    json jPray = NuiId(NuiButton(JsonString("Pray (gain favor)")), PR_BTN_PRAY);
+    jPray = NuiEnabled(jPray, NuiBind(PR_BIND_PRAY_ENA));
+    jPray = NuiTooltip(jPray, NuiBind(PR_BIND_PRAY_TIP));
+    jPray = NuiHeight(jPray, fBtnH);
+
+    json jChange = NuiId(NuiButton(JsonString("Choose / change deity")), PR_BTN_CHANGE_DEITY);
+    jChange = NuiHeight(jChange, fBtnH);
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, jPray);
+    jBtnRow = JsonArrayInsert(jBtnRow, jChange);
+
+    json jList = NuiList(JsonArrayInsert(JsonArray(), BuildPrMiracleRow(oPC)),
+        GetNuiScaleDimension(oPC, 36.0));
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(jTopRow));
+    jCol = JsonArrayInsert(jCol, jDeity);
+    jCol = JsonArrayInsert(jCol, NuiRow(jStatRow));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+    jCol = JsonArrayInsert(jCol, jList);
+
+    json jNui = NuiWindow(NuiCol(jCol),
+        NuiBind(WINDOW_TITLE), NuiBind(WINDOW_GEOMETRY),
+        JsonBool(FALSE), JsonBool(FALSE),
+        JsonBool(TRUE),  JsonBool(FALSE), JsonBool(TRUE));
+
+    int nTk = NuiCreate(oPC, jNui, PR_WINDOW, PR_EV_SCRIPT);
+    NuiSetBind(oPC, nTk, WINDOW_TITLE, JsonString("Prayer & Miracles"));
+    NuiSetBind(oPC, nTk, WINDOW_GEOMETRY, NuiRect(-1.0, -1.0, fW, fH));
+    NuiSetBind(oPC, nTk, PR_BIND_TITLE, JsonString("Altar of Devotion"));
+
+    FeedPrWindow(oPC, nTk);
+}
+
+void FeedPrWindow(object oPC, int nToken)
+{
+    string sUuid = GetObjectUUID(oPC);
+    int nDeity = PrGetDeity(sUuid);
+    int nFavor = PrGetFavor(sUuid);
+
+    if(nDeity == PR_DEITY_NONE)
+    {
+        NuiSetBind(oPC, nToken, PR_BIND_DEITY_LBL,
+            JsonString("Devoted to: nobody yet"));
+    }
+    else
+    {
+        NuiSetBind(oPC, nToken, PR_BIND_DEITY_LBL,
+            JsonString("Devoted to: " + PrDeityName(nDeity)
+                + " — " + PrDeityDomain(nDeity)));
+    }
+
+    NuiSetBind(oPC, nToken, PR_BIND_FAVOR_LBL,
+        JsonString("Favor: " + IntToString(nFavor)));
+    NuiSetBind(oPC, nToken, PR_BIND_RANK_LBL,
+        JsonString(PrFavorRank(nFavor)));
+
+    int nNow = PrGetNowSeconds();
+    int nLast = PrGetLastPrayedAt(sUuid);
+    int nWait = (nLast == 0) ? 0
+        : (nNow - nLast >= PR_PRAY_COOLDOWN_S ? 0 : PR_PRAY_COOLDOWN_S - (nNow - nLast));
+    int bCanPray = (nDeity != PR_DEITY_NONE) && (nWait == 0);
+    NuiSetBind(oPC, nToken, PR_BIND_PRAY_ENA, JsonBool(bCanPray));
+    NuiSetBind(oPC, nToken, PR_BIND_PRAY_TIP,
+        JsonString(nWait > 0
+            ? "Available in " + PrFormatCooldown(nWait)
+            : "Speak the words and gain " + IntToString(PR_PRAY_FAVOR_GAIN) + " favor."));
+
+    json jName = JsonArray();
+    json jDesc = JsonArray();
+    json jBtn  = JsonArray();
+    json jEna  = JsonArray();
+    json jColor= JsonArray();
+
+    int i;
+    for(i = 0; i < PR_MIRACLE_COUNT; i++)
+    {
+        int nReq  = PrMiracleFavorReq(i);
+        int nCost = PrMiracleFavorCost(i);
+        int nCd   = PrCooldownRemaining(oPC, i);
+        int bUnlocked = (nFavor >= nReq) && (nDeity != PR_DEITY_NONE);
+        int bReady    = bUnlocked && (nCd == 0);
+
+        jName = JsonArrayInsert(jName, JsonString(PrMiracleName(i)));
+        jDesc = JsonArrayInsert(jDesc,
+            JsonString(PrMiracleDescription(i) + " [need " + IntToString(nReq)
+                + ", -" + IntToString(nCost) + " favor]"));
+
+        string sBtn;
+        if(!bUnlocked)      sBtn = "Locked";
+        else if(nCd > 0)    sBtn = PrFormatCooldown(nCd);
+        else                sBtn = "Invoke";
+        jBtn  = JsonArrayInsert(jBtn,  JsonString(sBtn));
+        jEna  = JsonArrayInsert(jEna,  JsonBool(bReady));
+        jColor= JsonArrayInsert(jColor,
+            bUnlocked ? NuiColor(220, 200, 120) : NuiColor(140, 140, 140));
+    }
+    NuiSetBind(oPC, nToken, PR_BIND_MIR_NAME,    jName);
+    NuiSetBind(oPC, nToken, PR_BIND_MIR_DESC,    jDesc);
+    NuiSetBind(oPC, nToken, PR_BIND_MIR_BTN,     jBtn);
+    NuiSetBind(oPC, nToken, PR_BIND_MIR_BTN_ENA, jEna);
+    NuiSetBind(oPC, nToken, PR_BIND_MIR_COLOR,   jColor);
+}
+
+// ----------------------------------------------------------------
+// Deity selector popup
+// ----------------------------------------------------------------
+
+void PrShowDeitySelector(object oPC)
+{
+    int nExisting = NuiFindWindow(oPC, PR_WIN_DEITY);
+    if(nExisting != 0) NuiDestroy(oPC, nExisting);
+
+    float fW = GetNuiScaleDimension(oPC, PR_DEITY_W);
+    float fH = GetNuiScaleDimension(oPC, PR_DEITY_H);
+    float fRowH = GetNuiScaleDimension(oPC, 28.0);
+
+    json jLbl = NuiLabel(NuiBind(PR_BIND_DEITY_ROW_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jLbl = NuiWidth(jLbl, GetNuiScaleDimension(oPC, 130.0));
+
+    json jDesc = NuiLabel(NuiBind(PR_BIND_DEITY_ROW_DESC),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+
+    json jRowCell = NuiGroup(NuiRow(JsonArrayInsert(JsonArrayInsert(JsonArray(),
+        jLbl), jDesc)), TRUE, NUI_SCROLLBARS_NONE);
+    jRowCell = NuiId(jRowCell, PR_BTN_DEITY_ROW);
+    jRowCell = NuiHeight(jRowCell, fRowH);
+
+    json jList = NuiList(JsonArrayInsert(JsonArray(), jRowCell), fRowH);
+
+    json jHdr = NuiLabel(JsonString("Choose your deity (click a row):"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jHdr = NuiHeight(jHdr, GetNuiScaleDimension(oPC, 24.0));
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jHdr);
+    jCol = JsonArrayInsert(jCol, jList);
+
+    json jNui = NuiWindow(NuiCol(jCol),
+        JsonString("Pantheon"),
+        NuiRect(-1.0, -1.0, fW, fH),
+        JsonBool(FALSE), JsonBool(FALSE),
+        JsonBool(TRUE),  JsonBool(FALSE), JsonBool(TRUE));
+    int nTk = NuiCreate(oPC, jNui, PR_WIN_DEITY, PR_EV_SCRIPT);
+
+    json jLabels = JsonArray();
+    json jDescs  = JsonArray();
+    int i;
+    for(i = 0; i < PR_DEITY_COUNT; i++)
+    {
+        jLabels = JsonArrayInsert(jLabels, JsonString(PrDeityName(i)));
+        jDescs  = JsonArrayInsert(jDescs,  JsonString(PrDeityDomain(i)));
+    }
+    NuiSetBind(oPC, nTk, PR_BIND_DEITY_ROW_LBL,  jLabels);
+    NuiSetBind(oPC, nTk, PR_BIND_DEITY_ROW_DESC, jDescs);
+}
+
+void PrSelectDeity(object oPC, int nDeityId)
+{
+    if(nDeityId < 0 || nDeityId >= PR_DEITY_COUNT) return;
+    string sUuid = GetObjectUUID(oPC);
+    int nCurrent = PrGetDeity(sUuid);
+    if(nCurrent == nDeityId)
+    {
+        SendMessageToPC(oPC, "[Prayer] You already serve " + PrDeityName(nDeityId) + ".");
+        return;
+    }
+    if(nCurrent != PR_DEITY_NONE)
+    {
+        // Switching gods costs all favor and applies disfavor.
+        PrAdjustFavor(sUuid, -PrGetFavor(sUuid) - 25, PR_FAVOR_MIN, PR_FAVOR_MAX);
+        SendMessageToPC(oPC, "[Prayer] Forsaking " + PrDeityName(nCurrent)
+            + " — favor lost, disfavor incurred.");
+    }
+    PrSetDeity(sUuid, nDeityId);
+    SendMessageToPC(oPC, "[Prayer] You devote yourself to " + PrDeityName(nDeityId) + ".");
+
+    int nMain = NuiFindWindow(oPC, PR_WINDOW);
+    if(nMain != 0) FeedPrWindow(oPC, nMain);
+    int nSel = NuiFindWindow(oPC, PR_WIN_DEITY);
+    if(nSel != 0) NuiDestroy(oPC, nSel);
+}

--- a/Prayer Miracles/Scripts/lib_pr_def.nss
+++ b/Prayer Miracles/Scripts/lib_pr_def.nss
@@ -1,0 +1,194 @@
+#include "lib_nui"
+#include "sql_pr"
+
+// ----------------------------------------------------------------
+// Prayer & Miracles
+// ----------------------------------------------------------------
+// Devotion to one of five deities, daily prayer to build favor,
+// and miracles unlocked at favor thresholds. Each miracle costs
+// favor and has its own cooldown.
+//
+// Pantheon (id):
+//   0 — Lumis    (Light & Dawn)
+//   1 — Mortis   (Death & Rest)
+//   2 — Bellator (War & Honor)
+//   3 — Tenebris (Shadows & Secrets)
+//   4 — Sylva    (Wilds & Beasts)
+//
+// Miracles (favor threshold / cooldown / favor cost):
+//   0 — Heal      (10 / 5 min  / -2)   restores 25 HP to caster
+//   1 — Bless     (25 / 10 min / -3)   +2 attack & saves, party in 10m, 60s
+//   2 — Smite     (25 / 5 min  / -3)   3d6 divine damage to target
+//   3 — Sanctuary (50 / 20 min / -5)   immunity to attacks for 18s
+//   4 — Raise     (75 / 60 min / -10)  raise target dead PC at 25% HP
+//
+// Hooks:
+//   OnModuleLoad  -> sys_on_load   (init schema)
+//   OnClientEnter -> sys_on_enter  (register devotion row)
+//   OnPlayerTarget -> sys_on_target (Smite/Raise targeting)
+//
+// Open the panel from a placeable's OnUsed:
+//   #include "lib_pr"
+//   void main() { CreatePrWindow(GetLastUsedBy()); }
+// ----------------------------------------------------------------
+
+const string PR_WINDOW              = "PR_WINDOW";
+const string PR_WIN_DEITY           = "PR_WIN_DEITY";
+const string PR_EV_SCRIPT           = "lib_pr_ev";
+
+// Tunables
+const int   PR_PRAY_COOLDOWN_S      = 3600;   // 1 IRL hour between prayers
+const int   PR_PRAY_FAVOR_GAIN      = 5;
+const int   PR_FAVOR_MIN            = -100;
+const int   PR_FAVOR_MAX            = 100;
+
+const int   PR_DEITY_NONE           = -1;
+const int   PR_DEITY_COUNT          = 5;
+
+// Miracle indices
+const int   PR_MIRACLE_HEAL         = 0;
+const int   PR_MIRACLE_BLESS        = 1;
+const int   PR_MIRACLE_SMITE        = 2;
+const int   PR_MIRACLE_SANCTUARY    = 3;
+const int   PR_MIRACLE_RAISE        = 4;
+const int   PR_MIRACLE_COUNT        = 5;
+
+// LVAR prefixes (cooldown timestamps per miracle)
+const string PR_LVAR_CD_PREFIX      = "PR_CD_";          // + IntToString(idx)
+const string PR_LVAR_PENDING_TARGET = "PR_TARGET_MIR";   // miracle id awaiting OnPlayerTarget
+
+// Bind names
+const string PR_BIND_TITLE          = "pr_title";
+const string PR_BIND_DEITY_LBL      = "pr_deity_lbl";
+const string PR_BIND_FAVOR_LBL      = "pr_favor_lbl";
+const string PR_BIND_RANK_LBL       = "pr_rank_lbl";
+const string PR_BIND_PRAY_ENA       = "pr_pray_ena";
+const string PR_BIND_PRAY_TIP       = "pr_pray_tip";
+const string PR_BIND_MIR_NAME       = "pr_mir_name";
+const string PR_BIND_MIR_DESC       = "pr_mir_desc";
+const string PR_BIND_MIR_BTN        = "pr_mir_btn";       // label per row
+const string PR_BIND_MIR_BTN_ENA    = "pr_mir_btn_ena";
+const string PR_BIND_MIR_COLOR      = "pr_mir_color";
+const string PR_BIND_DEITY_ROW_LBL  = "pr_d_row_lbl";
+const string PR_BIND_DEITY_ROW_DESC = "pr_d_row_desc";
+
+// Button IDs
+const string PR_BTN_CLOSE           = "pr_btn_close";
+const string PR_BTN_PRAY            = "pr_btn_pray";
+const string PR_BTN_CHANGE_DEITY    = "pr_btn_change";
+const string PR_BTN_MIRACLE         = "pr_btn_mir";       // row click in list
+const string PR_BTN_DEITY_ROW       = "pr_btn_d_row";     // deity selection row
+
+// Layout
+const float PR_W = 600.0;
+const float PR_H = 500.0;
+const float PR_DEITY_W = 480.0;
+const float PR_DEITY_H = 360.0;
+
+// ---- Static data accessors ----
+
+string PrDeityName(int nDeity)
+{
+    switch(nDeity)
+    {
+        case 0: return "Lumis";
+        case 1: return "Mortis";
+        case 2: return "Bellator";
+        case 3: return "Tenebris";
+        case 4: return "Sylva";
+    }
+    return "—";
+}
+
+string PrDeityDomain(int nDeity)
+{
+    switch(nDeity)
+    {
+        case 0: return "Light and Dawn";
+        case 1: return "Death and Rest";
+        case 2: return "War and Honor";
+        case 3: return "Shadows and Secrets";
+        case 4: return "Wilds and Beasts";
+    }
+    return "";
+}
+
+string PrMiracleName(int n)
+{
+    switch(n)
+    {
+        case PR_MIRACLE_HEAL:      return "Heal Wounds";
+        case PR_MIRACLE_BLESS:     return "Bless Companions";
+        case PR_MIRACLE_SMITE:     return "Divine Smite";
+        case PR_MIRACLE_SANCTUARY: return "Sanctuary";
+        case PR_MIRACLE_RAISE:     return "Raise the Fallen";
+    }
+    return "?";
+}
+
+int PrMiracleFavorReq(int n)
+{
+    switch(n)
+    {
+        case PR_MIRACLE_HEAL:      return 10;
+        case PR_MIRACLE_BLESS:     return 25;
+        case PR_MIRACLE_SMITE:     return 25;
+        case PR_MIRACLE_SANCTUARY: return 50;
+        case PR_MIRACLE_RAISE:     return 75;
+    }
+    return 999;
+}
+
+int PrMiracleFavorCost(int n)
+{
+    switch(n)
+    {
+        case PR_MIRACLE_HEAL:      return 2;
+        case PR_MIRACLE_BLESS:     return 3;
+        case PR_MIRACLE_SMITE:     return 3;
+        case PR_MIRACLE_SANCTUARY: return 5;
+        case PR_MIRACLE_RAISE:     return 10;
+    }
+    return 999;
+}
+
+int PrMiracleCooldownS(int n)
+{
+    switch(n)
+    {
+        case PR_MIRACLE_HEAL:      return 300;
+        case PR_MIRACLE_BLESS:     return 600;
+        case PR_MIRACLE_SMITE:     return 300;
+        case PR_MIRACLE_SANCTUARY: return 1200;
+        case PR_MIRACLE_RAISE:     return 3600;
+    }
+    return 0;
+}
+
+int PrMiracleNeedsTarget(int n)
+{
+    return (n == PR_MIRACLE_SMITE || n == PR_MIRACLE_RAISE);
+}
+
+string PrMiracleDescription(int n)
+{
+    switch(n)
+    {
+        case PR_MIRACLE_HEAL:      return "Restore 25 HP to yourself.";
+        case PR_MIRACLE_BLESS:     return "+2 attack and saves to allies within 10m for 60s.";
+        case PR_MIRACLE_SMITE:     return "3d6 divine damage to a target enemy.";
+        case PR_MIRACLE_SANCTUARY: return "Become immune to all attacks for 18s.";
+        case PR_MIRACLE_RAISE:     return "Raise a slain ally at 25% HP.";
+    }
+    return "";
+}
+
+string PrFavorRank(int nFavor)
+{
+    if(nFavor <= -75) return "Excommunicated";
+    if(nFavor <= -25) return "Disfavored";
+    if(nFavor <    25) return "Acolyte";
+    if(nFavor <    50) return "Devoted";
+    if(nFavor <    75) return "Blessed";
+    return "Chosen";
+}

--- a/Prayer Miracles/Scripts/lib_pr_ev.nss
+++ b/Prayer Miracles/Scripts/lib_pr_ev.nss
@@ -1,0 +1,56 @@
+#include "lib_pr"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    int nMain  = NuiFindWindow(oPC, PR_WINDOW);
+    int nDeity = NuiFindWindow(oPC, PR_WIN_DEITY);
+
+    // ---- Deity selector ----
+    if(nToken == nDeity && nDeity != 0)
+    {
+        if(sEvent == EVENT_TYPE_MOUSEDOWN && sElem == PR_BTN_DEITY_ROW)
+        {
+            if(nIdx >= 0 && nIdx < PR_DEITY_COUNT)
+                PrSelectDeity(oPC, nIdx);
+        }
+        return;
+    }
+
+    // ---- Main window ----
+    if(nToken != nMain || nMain == 0) return;
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == PR_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+        if(sElem == PR_BTN_PRAY)
+        {
+            PrPray(oPC);
+            return;
+        }
+        if(sElem == PR_BTN_CHANGE_DEITY)
+        {
+            PrShowDeitySelector(oPC);
+            return;
+        }
+        if(sElem == PR_BTN_MIRACLE)
+        {
+            // Click came from a per-row button — index identifies the miracle.
+            if(nIdx < 0 || nIdx >= PR_MIRACLE_COUNT) return;
+            if(PrMiracleNeedsTarget(nIdx))
+                PrStartMiracleTargeting(oPC, nIdx);
+            else
+                PrTryCastMiracle(oPC, nIdx, OBJECT_INVALID);
+            return;
+        }
+    }
+}

--- a/Prayer Miracles/Scripts/sql_pr.nss
+++ b/Prayer Miracles/Scripts/sql_pr.nss
@@ -1,0 +1,107 @@
+// Prayer & Miracles — persistence (campaign DB "pr")
+
+const string PR_DB = "pr";
+
+void PrCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign(PR_DB,
+        "CREATE TABLE IF NOT EXISTS pr_devotion ("
+        "uuid TEXT PRIMARY KEY, "
+        "char_name TEXT DEFAULT '', "
+        "deity_id INTEGER DEFAULT -1, "
+        "favor INTEGER DEFAULT 0, "
+        "last_prayed_at INTEGER DEFAULT 0, "
+        "miracles_cast INTEGER DEFAULT 0, "
+        "created_at INTEGER DEFAULT 0)");
+    SqlStep(q);
+}
+
+void PrEnsureRow(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign(PR_DB,
+        "INSERT OR IGNORE INTO pr_devotion (uuid, char_name, created_at) "
+        "VALUES (@u, @n, strftime('%s','now'))");
+    SqlBindString(q, "@u", GetObjectUUID(oPC));
+    SqlBindString(q, "@n", GetName(oPC));
+    SqlStep(q);
+}
+
+int PrGetDeity(string sUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign(PR_DB,
+        "SELECT deity_id FROM pr_devotion WHERE uuid = @u");
+    SqlBindString(q, "@u", sUuid);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return -1;
+}
+
+int PrGetFavor(string sUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign(PR_DB,
+        "SELECT favor FROM pr_devotion WHERE uuid = @u");
+    SqlBindString(q, "@u", sUuid);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+int PrGetLastPrayedAt(string sUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign(PR_DB,
+        "SELECT last_prayed_at FROM pr_devotion WHERE uuid = @u");
+    SqlBindString(q, "@u", sUuid);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+int PrGetNowSeconds()
+{
+    sqlquery q = SqlPrepareQueryCampaign(PR_DB,
+        "SELECT CAST(strftime('%s','now') AS INTEGER)");
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+void PrSetDeity(string sUuid, int nDeity)
+{
+    sqlquery q = SqlPrepareQueryCampaign(PR_DB,
+        "UPDATE pr_devotion SET deity_id = @d WHERE uuid = @u");
+    SqlBindInt   (q, "@d", nDeity);
+    SqlBindString(q, "@u", sUuid);
+    SqlStep(q);
+}
+
+void PrAdjustFavor(string sUuid, int nDelta, int nMin, int nMax)
+{
+    sqlquery q = SqlPrepareQueryCampaign(PR_DB,
+        "UPDATE pr_devotion SET favor = MAX(@lo, MIN(@hi, favor + @d)) WHERE uuid = @u");
+    SqlBindInt   (q, "@lo", nMin);
+    SqlBindInt   (q, "@hi", nMax);
+    SqlBindInt   (q, "@d",  nDelta);
+    SqlBindString(q, "@u",  sUuid);
+    SqlStep(q);
+}
+
+void PrMarkPrayed(string sUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign(PR_DB,
+        "UPDATE pr_devotion SET last_prayed_at = strftime('%s','now') WHERE uuid = @u");
+    SqlBindString(q, "@u", sUuid);
+    SqlStep(q);
+}
+
+void PrIncMiraclesCast(string sUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign(PR_DB,
+        "UPDATE pr_devotion SET miracles_cast = miracles_cast + 1 WHERE uuid = @u");
+    SqlBindString(q, "@u", sUuid);
+    SqlStep(q);
+}
+
+int PrGetMiraclesCast(string sUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign(PR_DB,
+        "SELECT miracles_cast FROM pr_devotion WHERE uuid = @u");
+    SqlBindString(q, "@u", sUuid);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}

--- a/Prayer Miracles/Scripts/sys_on_enter.nss
+++ b/Prayer Miracles/Scripts/sys_on_enter.nss
@@ -1,0 +1,8 @@
+#include "lib_pr"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC)) return;
+    PrEnsureRow(oPC);
+}

--- a/Prayer Miracles/Scripts/sys_on_load.nss
+++ b/Prayer Miracles/Scripts/sys_on_load.nss
@@ -1,0 +1,6 @@
+#include "lib_pr"
+
+void main()
+{
+    PrCreateTables();
+}

--- a/Prayer Miracles/Scripts/sys_on_target.nss
+++ b/Prayer Miracles/Scripts/sys_on_target.nss
@@ -1,0 +1,9 @@
+#include "lib_pr"
+
+void main()
+{
+    object oPC = GetLastPlayerToSelectTarget();
+    if(!GetIsPC(oPC)) return;
+    if(GetLocalInt(oPC, PR_LVAR_PENDING_TARGET) > 0)
+        PrOnPlayerTarget(oPC);
+}

--- a/Prayer Miracles/Scripts/test_pr.nss
+++ b/Prayer Miracles/Scripts/test_pr.nss
@@ -1,0 +1,8 @@
+#include "lib_pr"
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+    CreatePrWindow(oPC);
+}


### PR DESCRIPTION
## What it does

Devotion system: a player picks one of five deities, prays at an altar to build **favor**, and uses that favor to invoke five **miracles** with varying favor cost and cooldown. Switching deities forfeits all favor and stains the player with disfavor.

## Mechanics

- **Pantheon (5 deities)**: Lumis (Light/Dawn), Mortis (Death/Rest), Bellator (War/Honor), Tenebris (Shadows/Secrets), Sylva (Wilds/Beasts). Pure flavor for now — same miracle pool for all.
- **Pray**: +5 favor, 1 IRL hour cooldown. Visual `VFX_IMP_DIVINE_STRIKE_HOLY` on success.
- **Favor range**: -100..+100. Ranks: Excommunicated / Disfavored / Acolyte / Devoted / Blessed / Chosen.
- **Switching deity**: forfeit all favor + automatic -25 disfavor.
- **Miracles** (favor req / cost / cooldown):
  - **Heal Wounds** (10 / -2 / 5 min) — +25 HP to caster
  - **Bless Companions** (25 / -3 / 10 min) — +2 attack & saves to allies in 10m for 60s
  - **Divine Smite** (25 / -3 / 5 min) — 3d6 divine damage to target (needs targeting)
  - **Sanctuary** (50 / -5 / 20 min) — 18s of attack immunity
  - **Raise the Fallen** (75 / -10 / 60 min) — resurrect target ally at 25% HP (needs targeting)
- **Single NUI window**: deity + favor/rank header, Pray + Change-deity buttons, miracle list with per-row Invoke buttons (locked / cooldown timer / Invoke).
- **Deity selector**: secondary popup with 5-row list, click to commit.
- **Persistence**: SQLite (`pr` campaign DB), single `pr_devotion` table.
- **Cooldowns**: stored as LVAR timestamps on the PC (`PR_CD_<idx>`), so they persist across the session.

## Files

10 files, ~1k LOC (~860 module + ~200 NUI helpers):

| File | LOC | Role |
|---|---:|---|
| `lib_pr_def.nss` | 194 | Constants + integration header + deity/miracle static data. |
| `sql_pr.nss` | 107 | Campaign schema (`pr_devotion`) + CRUD. |
| `lib_pr.nss` | 466 | UI + prayer + miracle effects + targeting flow. |
| `lib_pr_ev.nss` | 56 | NUI event router for main + deity selector. |
| `sys_on_load.nss` | 6 | Schema init. |
| `sys_on_enter.nss` | 8 | Ensure devotion row exists on login. |
| `sys_on_target.nss` | 9 | Targeting dispatcher (Smite / Raise). |
| `test_pr.nss` | 8 | Altar OnUsed entry point. |
| `lib_nui.nss` + `lib_nui_utility.nss` | 206 | NUI helpers (copied from Mailbox). |

## Dependencies

- **NWN:EE** (NUI + JSON + campaign SQLite).
- **NWNX**: none.

## How to integrate

```nwscript
// OnModuleLoad
ExecuteScript("sys_on_load", OBJECT_SELF);

// OnClientEnter
ExecuteScript("sys_on_enter", OBJECT_SELF);

// OnPlayerTarget
ExecuteScript("sys_on_target", OBJECT_SELF);
```

On an altar / shrine placeable (OnUsed):

```nwscript
#include "lib_pr"
void main()
{
    object oPC = GetLastUsedBy();
    if(!GetIsPC(oPC)) return;
    CreatePrWindow(oPC);
}
```

If you already use `OnPlayerTarget`, merge handlers conditionally (the Prayer module signals targeting via `PR_LVAR_PENDING_TARGET` LVAR).

Full integration details in the header of `lib_pr_def.nss`.

## Intentionally omitted

- **Per-deity unique miracles** — all five share the same miracle pool. Easy to specialize later by branching on `PrGetDeity` in `PrTryCastMiracle`.
- **Sin tracking / confession** — no automatic favor loss for "evil" actions. Server logic could call `PrAdjustFavor` from quest/event scripts.
- **Donation as favor source** — only prayer. Could add a "donate gold" button.
- **Pilgrimage integration** — separate module candidate, would feed favor on completion.
- **Persistent miracle cooldowns across logout** — cooldowns are LVARs, lost on logout (acceptable trade-off; SQL-backed cooldowns possible later).
- **HAK with altar model and miracle icons**.

## Scope

Same tight budget as Master & Apprentice — single window, ~860 LOC of module code, one SQL table.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CoNsmEmyocr7Hkn8XyELhZ)_