### PR TITLE
feat: Sanity (Szaleństwo)

### DIFF
--- a/Sanity/INTEGRATION.md
+++ b/Sanity/INTEGRATION.md
@@ -1,0 +1,82 @@
+# Sanity — Integration Guide
+
+## Wymagane hooki modułu
+
+Podłącz skrypty do odpowiednich zdarzeń modułu w Toolset / skrypcie init:
+
+| Zdarzenie modułu | Skrypt |
+|---|---|
+| OnModuleLoad | `sys_on_load` |
+| OnClientEnter | `sys_on_enter` |
+| OnHeartbeat | `sys_on_heartbeat` |
+| OnPlayerRest | `sys_on_rest` |
+| OnNUIEvent | `lib_san_ev` |
+| OnActivateItem *(opcjonalne)* | wywołaj `SanOnActivateItem(oPC, oItem)` |
+
+Jeśli masz już własne skrypty na tych zdarzeniach, dodaj wywołania inline:
+
+```nss
+// przykład — istniejący sys_on_enter.nss:
+#include "lib_san"
+// ... twój kod ...
+SanOnPlayerEnter(GetEnteringObject());
+```
+
+## Zależności
+
+- **NWN:EE 8193.36+** — wymaga NUI (TagEffect, SqlPrepareQueryCampaign).
+- **NWNX**: nie jest wymagane.
+- **Hak**: żaden — moduł nie używa własnych zasobów graficznych.
+
+## Baza danych
+
+Kampania SQLite `"sanity"` (pliki `sanity.db` w katalogu serwera).
+Tabele tworzone automatycznie przy starcie modułu (idempotentne `CREATE TABLE IF NOT EXISTS`).
+
+## Demo — szybki test w Toolset
+
+1. Dodaj placeable z tagiem `san_mirror`, OnUsed → `test_san`.
+2. Dodaj placeable z tagiem `san_altar_dark`, OnUsed → `test_san`.
+3. Dodaj placeable z tagiem `san_font_holy`, OnUsed → `test_san`.
+4. Uruchom moduł. Kliknij **Lustro** — otworzy okno "Stan Psychiczny".
+5. Kliknij **Czarny Ołtarz** kilkakrotnie — obserwuj spadek wartości i efekty.
+6. Kliknij **Święte Źródło** — odbudowa.
+7. Testuj **Medytuj** (przycisk w oknie; cooldown 120 s).
+
+## Przeklęte obszary
+
+Aby oznaczyć obszar jako strefę horroru (pasywna utrata co ~3 min):
+
+```nss
+SetLocalInt(oArea, "SAN_HORROR_AREA", 1);
+```
+
+Można ustawić w OnEnter obszaru lub przez Toolset → Properties → Variables.
+
+## Stała konfiguracja (lib_san_def.nss)
+
+| Stała | Domyślnie | Opis |
+|---|---|---|
+| `SAN_THR_UNEASE` | 75 | Próg "Niepokój" |
+| `SAN_THR_HORROR` | 50 | Próg "Groza" |
+| `SAN_THR_MADNESS` | 25 | Próg "Obłęd" |
+| `SAN_THR_INSANITY` | 10 | Próg "Szaleństwo" |
+| `SAN_COOLDOWN_MEDITATE` | 120 | Cooldown medytacji (sekundy) |
+| `SAN_GAIN_REST` | 15 | Odbudowa po odpoczynku |
+| `SAN_GAIN_MEDITATE` | 5 | Odbudowa przez medytację |
+| `SAN_GAIN_HOLY` | 10 | Odbudowa przez święconą wodę |
+| `SAN_LOSS_UNDEAD` | 3 | Utrata przy nieumarłych |
+| `SAN_LOSS_NEAR_DEATH` | 5 | Utrata przy bliskiej śmierci |
+| `SAN_LOSS_ALLY_DEATH` | 8 | Utrata przy śmierci sojusznika |
+
+## Święcona woda
+
+Przedmiot z tagiem `san_holy_water`. Wywołaj `SanOnActivateItem(oPC, oItem)`
+z hooka `OnActivateItem` — item zostaje zniszczony po użyciu.
+
+## Co celowo pominięto
+
+- **Brak pliku .mod** — środowisko kompilacji NWN nie jest dostępne; patrz sekcja Demo powyżej.
+- **Brak obsługi śmierci sojusznika jako hooka** — `SanOnAllyDeath` jest zaimplementowane w `lib_san.nss`; builder sam podłącza je do zdarzenia śmierci creatury (`OnDeath`) lub `OnPlayerDeath`.
+- **Brak widgetów "szumu wizualnego"** (nakładki DrawList na ekran) — wymagałoby dedykowanego haka graficznego.
+- **Brak ikonki notyfikacji (tray)** — intencjonalnie; informacja przekazywana przez floating text i wiadomość systemową.

--- a/Sanity/Scripts/lib_nui.nss
+++ b/Sanity/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Sanity/Scripts/lib_nui_utility.nss
+++ b/Sanity/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Sanity/Scripts/lib_san.nss
+++ b/Sanity/Scripts/lib_san.nss
@@ -1,0 +1,442 @@
+// lib_san.nss — UI construction, game-logic triggers, and effect management
+//   for the Sanity module.
+
+#include "lib_san_def"
+
+// ================================================================
+// Effect management
+// ================================================================
+
+// Removes every active effect on oPC that carries SAN_EFFECT_TAG.
+void SanRemoveEffects(object oPC)
+{
+    effect eEff = GetFirstEffect(oPC);
+    while(GetIsEffectValid(eEff))
+    {
+        effect eNext = GetNextEffect(oPC);
+        if(GetEffectTag(eEff) == SAN_EFFECT_TAG)
+            RemoveEffect(oPC, eEff);
+        eEff = eNext;
+    }
+}
+
+// Recalculates and re-applies all permanent sanity debuffs from scratch.
+void SanApplyEffects(object oPC)
+{
+    SanRemoveEffects(oPC);
+    int nSan = SanGetSanity(oPC);
+    if(nSan >= SAN_THR_UNEASE) return;
+
+    // Accumulate penalties per threshold crossed.
+    int nWis = 0;
+    int nInt = 0;
+
+    if(nSan < SAN_THR_UNEASE)   nWis += 2;
+    if(nSan < SAN_THR_HORROR)   nWis += 2;
+    if(nSan < SAN_THR_MADNESS)  { nWis += 2; nInt += 4; }
+    if(nSan < SAN_THR_INSANITY) { nWis += 4; nInt += 4; }
+
+    if(nWis > 0)
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+            TagEffect(EffectAbilityDecrease(ABILITY_WISDOM,       nWis), SAN_EFFECT_TAG), oPC);
+    if(nInt > 0)
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+            TagEffect(EffectAbilityDecrease(ABILITY_INTELLIGENCE, nInt), SAN_EFFECT_TAG), oPC);
+}
+
+// Checks whether the threshold level changed and, if so, re-applies effects
+// and notifies the player.  Avoids redundant effect churn on every tick.
+void SanSyncEffects(object oPC)
+{
+    int nSan  = SanGetSanity(oPC);
+    int nLvl  = SanThresholdLevel(nSan);
+    int nLast = GetLocalInt(oPC, SAN_LVAR_SYNC_LVL);
+    if(nLvl == nLast) return;
+
+    SetLocalInt(oPC, SAN_LVAR_SYNC_LVL, nLvl);
+    SanApplyEffects(oPC);
+    SendMessageToPC(oPC, SanThresholdMessage(nLvl));
+    FloatingTextStringOnCreature(SanThresholdMessage(nLvl), oPC, FALSE);
+}
+
+// ================================================================
+// Random episodic effects  (called on every heartbeat tick)
+// ================================================================
+
+void SanApplyRandomEffect(object oPC)
+{
+    int nSan = SanGetSanity(oPC);
+    if(nSan >= SAN_THR_HORROR) return;   // episodes only below GROZA
+
+    int nRoll = Random(100);
+
+    if(nSan < SAN_THR_INSANITY && nRoll < 5)
+    {
+        // Brief paralysis — the mind short-circuits entirely.
+        ApplyEffectToObject(DURATION_TYPE_TEMPORARY, EffectParalyze(), oPC, 3.0);
+        FloatingTextStringOnCreature("Twój umysł zapada w otchłań obłędu...", oPC, FALSE);
+        return;
+    }
+    if(nSan < SAN_THR_MADNESS && nRoll < 12)
+    {
+        // Hallucinations blot out vision.
+        ApplyEffectToObject(DURATION_TYPE_TEMPORARY, EffectBlindness(), oPC, 5.0);
+        FloatingTextStringOnCreature("Halucynacje zamazują twój wzrok...", oPC, FALSE);
+        return;
+    }
+    if(nRoll < 18)
+    {
+        // Irrational terror seizes the mind.
+        ApplyEffectToObject(DURATION_TYPE_TEMPORARY, EffectFear(), oPC, 6.0);
+        FloatingTextStringOnCreature("Opanowuje cię irracjonalny terror...", oPC, FALSE);
+    }
+}
+
+// ================================================================
+// Sanity-loss triggers
+// ================================================================
+
+// Checks whether an undead creature is within 10 metres and drains sanity.
+void SanCheckUndead(object oPC)
+{
+    object oUndead = GetNearestCreature(
+        CREATURE_TYPE_RACIAL_TYPE, RACIAL_TYPE_UNDEAD, oPC, 1,
+        CREATURE_TYPE_IS_ALIVE, TRUE);
+    if(!GetIsObjectValid(oUndead)) return;
+    if(GetDistanceBetween(oPC, oUndead) > 10.0) return;
+
+    int nNew = SanAdjust(oPC, -SAN_LOSS_UNDEAD, "Obecność nieumarłych");
+    if(nNew >= 0) SanSyncEffects(oPC);
+}
+
+// Drains sanity when the PC is near death (HP < 10 % of max).
+void SanCheckNearDeath(object oPC)
+{
+    int nCurrent = GetCurrentHitPoints(oPC);
+    int nMax     = GetMaxHitPoints(oPC);
+    if(nMax <= 0 || nCurrent * 10 >= nMax) return;
+
+    int nNew = SanAdjust(oPC, -SAN_LOSS_NEAR_DEATH, "Bliskość śmierci");
+    if(nNew >= 0) SanSyncEffects(oPC);
+}
+
+// Drains sanity when the PC stands in an area tagged as a horror zone.
+// Builders mark an area by setting its local integer SAN_HORROR_AREA = 1.
+void SanCheckHorrorArea(object oPC)
+{
+    if(!GetLocalInt(GetArea(oPC), SAN_AREA_HORROR)) return;
+
+    int nNew = SanAdjust(oPC, -SAN_LOSS_HORROR_AREA, "Przeklęte miejsce");
+    if(nNew >= 0) SanSyncEffects(oPC);
+}
+
+// Drains sanity when a PC ally dies in the same area.
+// Call this from the module's OnPlayerDeath hook (or a creature OnDeath).
+void SanOnAllyDeath(object oPC, object oDeceased)
+{
+    if(!GetIsPC(oPC) || GetIsDead(oPC)) return;
+    if(GetArea(oPC) != GetArea(oDeceased)) return;
+    if(oPC == oDeceased) return;
+
+    int nNew = SanAdjust(oPC, -SAN_LOSS_ALLY_DEATH, "Śmierć sojusznika");
+    if(nNew >= 0) SanSyncEffects(oPC);
+}
+
+// Restores sanity via holy water (call from OnActivateItem).
+void SanOnActivateItem(object oPC, object oItem)
+{
+    if(GetTag(oItem) != SAN_ITEM_TAG_HOLY) return;
+    int nSan = SanGetSanity(oPC);
+    if(nSan >= SAN_MAX)
+    {
+        SendMessageToPC(oPC, "[Szaleństwo] Twój umysł jest już spokojny.");
+        return;
+    }
+    SanAdjust(oPC, SAN_GAIN_HOLY, "Święcona woda");
+    SanSyncEffects(oPC);
+    SendMessageToPC(oPC, "[Szaleństwo] Święcona woda koi twój umysł.");
+    FloatingTextStringOnCreature("Pieczęć grozy słabnie...", oPC, FALSE);
+    DestroyObject(oItem);
+}
+
+// ================================================================
+// NUI — window construction
+// ================================================================
+
+json SanBuildWindow(object oPC)
+{
+    float fBtnH   = GetNuiScaleDimension(oPC,  32.0);
+    float fBarH   = GetNuiScaleDimension(oPC,  26.0);
+    float fSmallH = GetNuiScaleDimension(oPC,  22.0);
+    float fFlavorH= GetNuiScaleDimension(oPC,  56.0);
+    float fMedH   = GetNuiScaleDimension(oPC,  36.0);
+    float fCloseW = GetNuiScaleDimension(oPC,  36.0);
+
+    // ── Title row ──────────────────────────────────────────────
+    json jTitleLbl = NuiLabel(
+        JsonString("Stan Psychiczny"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitleLbl = NuiHeight(jTitleLbl, fBtnH);
+
+    json jCloseBtn = NuiButton(JsonString("X"));
+    jCloseBtn = NuiId    (jCloseBtn, SAN_BTN_CLOSE);
+    jCloseBtn = NuiWidth (jCloseBtn, fCloseW);
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jTitleArr = JsonArray();
+    jTitleArr = JsonArrayInsert(jTitleArr, jTitleLbl);
+    jTitleArr = JsonArrayInsert(jTitleArr, jCloseBtn);
+
+    // ── Status label  (colored, e.g. "GROZA") ─────────────────
+    json jStatusLbl = NuiLabel(
+        NuiBind(SAN_BIND_STATUS_LBL),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jStatusLbl = NuiStyleForegroundColor(jStatusLbl, NuiBind(SAN_BIND_STATUS_COL));
+    jStatusLbl = NuiHeight(jStatusLbl, fBtnH);
+
+    // ── Sanity progress bar ────────────────────────────────────
+    json jBar = NuiProgress(NuiBind(SAN_BIND_BAR_VAL));
+    jBar = NuiStyleForegroundColor(jBar, NuiBind(SAN_BIND_BAR_COL));
+    jBar = NuiHeight(jBar, fBarH);
+
+    // ── Numeric value "73 / 100" ──────────────────────────────
+    json jValueLbl = NuiLabel(
+        NuiBind(SAN_BIND_VALUE_TXT),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jValueLbl = NuiHeight(jValueLbl, fSmallH);
+
+    // ── Flavor text ────────────────────────────────────────────
+    json jFlavor = NuiLabel(
+        NuiBind(SAN_BIND_FLAVOR_TXT),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jFlavor = NuiHeight(jFlavor, fFlavorH);
+
+    // ── Event log header ───────────────────────────────────────
+    json jLogHeader = NuiLabel(
+        JsonString("Ostatnie zdarzenia:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jLogHeader = NuiHeight(jLogHeader, fSmallH);
+
+    // ── Event log list  (scrollable, SAN_EVENT_LOG_MAX rows) ──
+    json jEvtLbl = NuiLabel(
+        NuiBind(SAN_BIND_EVT_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jEvtLbl = NuiStyleForegroundColor(jEvtLbl, NuiBind(SAN_BIND_EVT_COL));
+
+    json jEvtRowArr = JsonArray();
+    jEvtRowArr = JsonArrayInsert(jEvtRowArr, jEvtLbl);
+    json jEvtList = NuiList(
+        NuiRow(jEvtRowArr),
+        NuiBind(SAN_BIND_EVT_COUNT),
+        fSmallH);
+
+    // ── Meditate button ────────────────────────────────────────
+    json jMedBtn = NuiButton(JsonString("Medytuj  (+" + IntToString(SAN_GAIN_MEDITATE) + ")"));
+    jMedBtn = NuiId     (jMedBtn, SAN_BTN_MEDITATE);
+    jMedBtn = NuiEnabled(jMedBtn, NuiBind(SAN_BIND_MED_ENA));
+    jMedBtn = NuiTooltip(jMedBtn, NuiBind(SAN_BIND_MED_TIP));
+    jMedBtn = NuiHeight (jMedBtn, fMedH);
+
+    // ── Assemble column ────────────────────────────────────────
+    json jCol = JsonArray();
+
+    jCol = JsonArrayInsert(jCol, NuiRow(jTitleArr));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jStatusLbl)));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jBar)));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jValueLbl)));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jFlavor)));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jLogHeader)));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jEvtList)));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jMedBtn)));
+
+    return NuiWindow(
+        NuiCol(jCol),
+        JsonString("Stan Psychiczny"),
+        NuiBind(SAN_WIN_GEOM),
+        JsonBool(FALSE),  // not resizable
+        JsonBool(FALSE),  // not collapsed
+        JsonBool(TRUE),   // closable
+        JsonBool(FALSE),  // not transparent
+        JsonBool(TRUE));  // has border
+}
+
+// ================================================================
+// NUI — data feed
+// ================================================================
+
+void SanFeedWindow(object oPC, int nToken)
+{
+    int nSan = SanGetSanity(oPC);
+
+    NuiSetBind(oPC, nToken, SAN_BIND_STATUS_LBL, JsonString(SanStatusText(nSan)));
+    NuiSetBind(oPC, nToken, SAN_BIND_STATUS_COL, SanBarColor(nSan));
+    NuiSetBind(oPC, nToken, SAN_BIND_BAR_VAL,    JsonFloat((nSan * 1.0) / SAN_MAX));
+    NuiSetBind(oPC, nToken, SAN_BIND_BAR_COL,    SanBarColor(nSan));
+    NuiSetBind(oPC, nToken, SAN_BIND_VALUE_TXT,
+        JsonString(IntToString(nSan) + " / " + IntToString(SAN_MAX)));
+    NuiSetBind(oPC, nToken, SAN_BIND_FLAVOR_TXT, JsonString(SanFlavorText(nSan)));
+
+    // ── Event log ──────────────────────────────────────────────
+    json jEvents = SanGetRecentEvents(oPC, SAN_EVENT_LOG_MAX);
+    int  nCount  = JsonGetLength(jEvents);
+    json jLabels = JsonArray();
+    json jColors = JsonArray();
+
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json   jEv     = JsonArrayGet(jEvents, i);
+        int    nDelta  = JsonGetInt   (JsonObjectGet(jEv, "delta"));
+        string sReason = JsonGetString(JsonObjectGet(jEv, "reason"));
+        string sPrefix = (nDelta >= 0) ? "+" : "";
+
+        jLabels = JsonArrayInsert(jLabels,
+            JsonString(sPrefix + IntToString(nDelta) + "   " + sReason));
+        jColors = JsonArrayInsert(jColors,
+            (nDelta >= 0) ? NuiColor(80, 200, 80, 255) : NuiColor(200, 80, 80, 255));
+    }
+    // Pad empty rows so the list height stays stable.
+    for(i = nCount; i < SAN_EVENT_LOG_MAX; i++)
+    {
+        jLabels = JsonArrayInsert(jLabels, JsonString(""));
+        jColors = JsonArrayInsert(jColors, NuiColor(80, 80, 80, 255));
+    }
+    NuiSetBind(oPC, nToken, SAN_BIND_EVT_COUNT, JsonInt(nCount > 0 ? nCount : 1));
+    NuiSetBind(oPC, nToken, SAN_BIND_EVT_LBL,   jLabels);
+    NuiSetBind(oPC, nToken, SAN_BIND_EVT_COL,   jColors);
+
+    // ── Meditate button ────────────────────────────────────────
+    int bCanMed = SanCanMeditate(oPC, SAN_COOLDOWN_MEDITATE) && (nSan < SAN_MAX);
+    NuiSetBind(oPC, nToken, SAN_BIND_MED_ENA, JsonBool(bCanMed));
+    NuiSetBind(oPC, nToken, SAN_BIND_MED_TIP,
+        JsonString(bCanMed
+            ? "Usiądź w ciszy i uspokój umysł."
+            : "Musisz poczekać przed następną medytacją."));
+}
+
+// ================================================================
+// NUI — open / create
+// ================================================================
+
+void SanOpen(object oPC)
+{
+    SanEnsureChar(oPC);
+
+    int nToken = NuiFindWindow(oPC, SAN_WINDOW);
+    if(nToken != 0)
+    {
+        SanFeedWindow(oPC, nToken);
+        return;
+    }
+
+    json jWindow = SanBuildWindow(oPC);
+    nToken = NuiCreate(oPC, jWindow, SAN_WINDOW);
+
+    // Centre the window on screen.
+    float fSW = IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH));
+    float fSH = IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT));
+    float fW  = GetNuiScaleDimension(oPC, SAN_W);
+    float fH  = GetNuiScaleDimension(oPC, SAN_H);
+    NuiSetBind(oPC, nToken, SAN_WIN_GEOM,
+        NuiRect((fSW - fW) * 0.5, (fSH - fH) * 0.5, fW, fH));
+
+    SanFeedWindow(oPC, nToken);
+}
+
+// ================================================================
+// Meditate action  (called from event handler on button click)
+// ================================================================
+
+void SanHandleMeditate(object oPC, int nToken)
+{
+    if(!SanCanMeditate(oPC, SAN_COOLDOWN_MEDITATE))
+    {
+        SendMessageToPC(oPC, "[Szaleństwo] Nie możesz jeszcze medytować.");
+        return;
+    }
+    int nSan = SanGetSanity(oPC);
+    if(nSan >= SAN_MAX)
+    {
+        SendMessageToPC(oPC, "[Szaleństwo] Twój umysł jest już spokojny.");
+        return;
+    }
+
+    SanAdjust(oPC, SAN_GAIN_MEDITATE, "Medytacja");
+    SanRecordMeditate(oPC);
+    SanSyncEffects(oPC);
+
+    FloatingTextStringOnCreature("Cisza koi twój niespokojny umysł...", oPC, FALSE);
+    SanFeedWindow(oPC, nToken);
+}
+
+// ================================================================
+// Registration  (call on module Enter)
+// ================================================================
+
+void SanOnPlayerEnter(object oPC)
+{
+    SanEnsureChar(oPC);
+    SanSyncEffects(oPC);    // re-apply effects after relog
+
+    int nSan = SanGetSanity(oPC);
+    if(nSan < SAN_THR_UNEASE)
+    {
+        SendMessageToPC(oPC, "[Szaleństwo] Twój stan psychiczny: "
+            + SanStatusText(nSan) + " (" + IntToString(nSan) + "/" + IntToString(SAN_MAX) + ")");
+    }
+}
+
+// ================================================================
+// Rest recovery  (call from module OnPlayerRest hook)
+// ================================================================
+
+void SanOnPlayerRest(object oPC)
+{
+    int nSan = SanGetSanity(oPC);
+    if(nSan >= SAN_MAX) return;
+
+    SanAdjust(oPC, SAN_GAIN_REST, "Odpoczynek");
+    SanSyncEffects(oPC);
+    FloatingTextStringOnCreature("Spokojny sen łagodzi pieczęć szaleństwa...", oPC, FALSE);
+
+    int nToken = NuiFindWindow(oPC, SAN_WINDOW);
+    if(nToken != 0) SanFeedWindow(oPC, nToken);
+}
+
+// ================================================================
+// Heartbeat dispatcher  (call from module OnHeartbeat)
+// ================================================================
+
+void SanHeartbeatTick()
+{
+    int nTick = GetLocalInt(GetModule(), SAN_LVAR_TICK) + 1;
+    SetLocalInt(GetModule(), SAN_LVAR_TICK, nTick);
+
+    int bUndead = (nTick % SAN_TICK_UNDEAD     == 0);
+    int bDeath  = (nTick % SAN_TICK_NEAR_DEATH == 0);
+    int bHorror = (nTick % SAN_TICK_HORROR_AREA== 0);
+
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        if(!GetIsDead(oPC))
+        {
+            if(bUndead) SanCheckUndead(oPC);
+            if(bDeath)  SanCheckNearDeath(oPC);
+            if(bHorror) SanCheckHorrorArea(oPC);
+            SanApplyRandomEffect(oPC);
+
+            // Refresh open window once per undead-check cycle.
+            if(bUndead)
+            {
+                int nToken = NuiFindWindow(oPC, SAN_WINDOW);
+                if(nToken != 0) SanFeedWindow(oPC, nToken);
+            }
+        }
+        oPC = GetNextPC();
+    }
+}

--- a/Sanity/Scripts/lib_san_def.nss
+++ b/Sanity/Scripts/lib_san_def.nss
@@ -1,0 +1,168 @@
+// lib_san_def.nss — constants, bind/button IDs, and lightweight helpers
+//   for the Sanity module.
+
+#include "lib_nui"
+#include "sql_san"
+
+// Forward declarations for functions defined in lib_san.nss.
+void SanOpen(object oPC);
+void SanFeedWindow(object oPC, int nToken);
+void SanApplyEffects(object oPC);
+void SanSyncEffects(object oPC);
+
+// ----------------------------------------------------------------
+// Window / script identifiers
+// ----------------------------------------------------------------
+
+const string SAN_WINDOW    = "SAN_WINDOW";
+const string SAN_EV_SCRIPT = "lib_san_ev";
+const string SAN_WIN_GEOM  = "san_win_geom";
+
+// ----------------------------------------------------------------
+// Sanity thresholds  (exclusive lower bounds)
+// ----------------------------------------------------------------
+
+const int SAN_THR_UNEASE   = 75;   // [75, 100] — SPOKOJNY
+const int SAN_THR_HORROR   = 50;   // [50,  74] — NIEPOKÓJ
+const int SAN_THR_MADNESS  = 25;   // [25,  49] — GROZA
+const int SAN_THR_INSANITY = 10;   // [10,  24] — OBŁĘD
+                                   // [ 0,   9] — SZALEŃSTWO
+
+// ----------------------------------------------------------------
+// Delta values for each trigger
+// ----------------------------------------------------------------
+
+const int SAN_LOSS_UNDEAD     =  3;
+const int SAN_LOSS_NEAR_DEATH =  5;
+const int SAN_LOSS_HORROR_AREA=  2;
+const int SAN_LOSS_ALLY_DEATH =  8;
+
+const int SAN_GAIN_REST      = 15;
+const int SAN_GAIN_MEDITATE  =  5;
+const int SAN_GAIN_HOLY      = 10;
+
+// ----------------------------------------------------------------
+// Cooldowns  (seconds)
+// ----------------------------------------------------------------
+
+const int SAN_COOLDOWN_MEDITATE  = 120;
+
+// Heartbeat-tick cadence: module OnHeartbeat fires every 6 s.
+// We keep a global tick counter and gate checks by modulus.
+const int SAN_TICK_UNDEAD     = 10;   //  60 s
+const int SAN_TICK_NEAR_DEATH = 20;   // 120 s
+const int SAN_TICK_HORROR_AREA= 30;   // 180 s
+const int SAN_TICK_RAND_FX    =  1;   // every heartbeat, probability-gated
+
+// ----------------------------------------------------------------
+// Local variable names  (on PC object)
+// ----------------------------------------------------------------
+
+const string SAN_LVAR_SYNC_LVL = "SAN_SYNC_LVL";   // last applied effect level
+
+// ----------------------------------------------------------------
+// Tag for holy-water item that restores sanity
+// ----------------------------------------------------------------
+
+const string SAN_ITEM_TAG_HOLY = "san_holy_water";
+
+// Tag applied to every SAN effect so they can be found and removed.
+const string SAN_EFFECT_TAG    = "SAN_EFFECT";
+
+// Local variable on Module for heartbeat counter
+const string SAN_LVAR_TICK     = "SAN_TICK";
+
+// Local variable on Area to mark it as a horror zone
+const string SAN_AREA_HORROR   = "SAN_HORROR_AREA";
+
+// ----------------------------------------------------------------
+// NUI bind names
+// ----------------------------------------------------------------
+
+const string SAN_BIND_STATUS_LBL = "san_status_lbl";
+const string SAN_BIND_STATUS_COL = "san_status_col";
+const string SAN_BIND_VALUE_TXT  = "san_value_txt";
+const string SAN_BIND_BAR_VAL    = "san_bar_val";
+const string SAN_BIND_BAR_COL    = "san_bar_col";
+const string SAN_BIND_FLAVOR_TXT = "san_flavor";
+const string SAN_BIND_EVT_LBL    = "san_evt_lbl";
+const string SAN_BIND_EVT_COL    = "san_evt_col";
+const string SAN_BIND_EVT_COUNT  = "san_evt_cnt";
+const string SAN_BIND_MED_ENA    = "san_med_ena";
+const string SAN_BIND_MED_TIP    = "san_med_tip";
+
+// ----------------------------------------------------------------
+// Button IDs
+// ----------------------------------------------------------------
+
+const string SAN_BTN_CLOSE    = "san_btn_close";
+const string SAN_BTN_MEDITATE = "san_btn_meditate";
+
+// ----------------------------------------------------------------
+// Layout dimensions  (unscaled; scaled via GetNuiScaleDimension)
+// ----------------------------------------------------------------
+
+const float SAN_W = 380.0;
+const float SAN_H = 440.0;
+
+// ----------------------------------------------------------------
+// Inline helpers
+// ----------------------------------------------------------------
+
+// Returns a NUI color JSON appropriate for the current sanity level.
+json SanBarColor(int nSan)
+{
+    if(nSan >= SAN_THR_UNEASE)   return NuiColor( 80, 200,  80, 255);  // green
+    if(nSan >= SAN_THR_HORROR)   return NuiColor(220, 200,  50, 255);  // yellow
+    if(nSan >= SAN_THR_MADNESS)  return NuiColor(220, 120,  30, 255);  // orange
+    if(nSan >= SAN_THR_INSANITY) return NuiColor(200,  60,  60, 255);  // red
+    return                              NuiColor(160,  30, 160, 255);  // deep purple
+}
+
+// Short label displayed prominently in the UI.
+string SanStatusText(int nSan)
+{
+    if(nSan >= SAN_THR_UNEASE)   return "SPOKOJNY";
+    if(nSan >= SAN_THR_HORROR)   return "NIEPOKÓJ";
+    if(nSan >= SAN_THR_MADNESS)  return "GROZA";
+    if(nSan >= SAN_THR_INSANITY) return "OBŁĘD";
+    return                              "SZALEŃSTWO";
+}
+
+// Two-line flavor text shown below the bar.
+string SanFlavorText(int nSan)
+{
+    if(nSan >= SAN_THR_UNEASE)
+        return "Twój umysł jest trzeźwy.\nCienie nie mają nad tobą władzy.";
+    if(nSan >= SAN_THR_HORROR)
+        return "Coś drąży w ciemności twego umysłu.\nSny nie przynoszą ukojenia.";
+    if(nSan >= SAN_THR_MADNESS)
+        return "Groza zlewa się z rzeczywistością.\nWidzisz rzeczy, które nie powinny istnieć.";
+    if(nSan >= SAN_THR_INSANITY)
+        return "Krzyki wypełniają głowę.\nNie wiesz już, co jest prawdziwe, a co ułudą.";
+    return "Umysł pęka pod ciężarem obłędu.\nSzaleństwo jest jedyną prawdą.";
+}
+
+// Encodes the current sanity into one of 5 levels (0-4) used to detect
+// threshold crossings without comparing full integer values.
+int SanThresholdLevel(int nSan)
+{
+    if(nSan >= SAN_THR_UNEASE)   return 0;
+    if(nSan >= SAN_THR_HORROR)   return 1;
+    if(nSan >= SAN_THR_MADNESS)  return 2;
+    if(nSan >= SAN_THR_INSANITY) return 3;
+    return 4;
+}
+
+// Notification sent to PC when crossing a threshold.
+string SanThresholdMessage(int nLevel)
+{
+    switch(nLevel)
+    {
+        case 1: return "[Szaleństwo] Niepokój zaczyna gryzć od środka. Twój wzrok jest cięższy.";
+        case 2: return "[Szaleństwo] Groza przesącza się przez myśli. Wizje zacierają rzeczywistość.";
+        case 3: return "[Szaleństwo] Obłąkanie rozdziera umysł. Nie kontrolujesz własnych myśli.";
+        case 4: return "[Szaleństwo] Szaleństwo całkowicie cię pochłania. Jesteś złamany.";
+    }
+    return "[Szaleństwo] Spokój powraca. Cienie cofają się.";
+}

--- a/Sanity/Scripts/lib_san_ev.nss
+++ b/Sanity/Scripts/lib_san_ev.nss
@@ -1,0 +1,42 @@
+// lib_san_ev.nss — NUI event handler for the Sanity module.
+//   Assign this script to the module's OnNUIEvent hook.
+
+#include "lib_san"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+
+    // Only process events for our window.
+    if(nToken != NuiFindWindow(oPC, SAN_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_OPEN)
+    {
+        SanFeedWindow(oPC, nToken);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        // Nothing to clean up — all state is in SQL.
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == SAN_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        if(sElem == SAN_BTN_MEDITATE)
+        {
+            SanHandleMeditate(oPC, nToken);
+            return;
+        }
+    }
+}

--- a/Sanity/Scripts/sql_san.nss
+++ b/Sanity/Scripts/sql_san.nss
@@ -1,0 +1,131 @@
+// sql_san.nss — SQLite schema and data access for the Sanity module.
+
+const string SAN_DB            = "sanity";
+const int    SAN_MAX           = 100;
+const int    SAN_EVENT_LOG_MAX = 8;    // rows kept in recent-events display
+
+void SanCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign(SAN_DB,
+        "CREATE TABLE IF NOT EXISTS san_chars ("
+        "  uuid           TEXT PRIMARY KEY,"
+        "  sanity         INTEGER NOT NULL DEFAULT 100,"
+        "  last_meditate  INTEGER NOT NULL DEFAULT 0,"
+        "  last_seen      INTEGER NOT NULL DEFAULT 0"
+        ")");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign(SAN_DB,
+        "CREATE TABLE IF NOT EXISTS san_events ("
+        "  id     INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "  uuid   TEXT    NOT NULL,"
+        "  delta  INTEGER NOT NULL,"
+        "  reason TEXT    NOT NULL DEFAULT '',"
+        "  ts     INTEGER NOT NULL DEFAULT (strftime('%s','now'))"
+        ")");
+    SqlStep(q);
+}
+
+void SanEnsureChar(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign(SAN_DB,
+        "INSERT OR IGNORE INTO san_chars (uuid, sanity, last_meditate, last_seen)"
+        " VALUES (@uuid, 100, 0, strftime('%s','now'))");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+int SanGetSanity(object oPC)
+{
+    SanEnsureChar(oPC);
+    sqlquery q = SqlPrepareQueryCampaign(SAN_DB,
+        "SELECT sanity FROM san_chars WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return SAN_MAX;
+}
+
+void SanSetSanity(object oPC, int nValue)
+{
+    if(nValue < 0)       nValue = 0;
+    if(nValue > SAN_MAX) nValue = SAN_MAX;
+    sqlquery q = SqlPrepareQueryCampaign(SAN_DB,
+        "UPDATE san_chars SET sanity = @san, last_seen = strftime('%s','now')"
+        " WHERE uuid = @uuid");
+    SqlBindInt   (q, "@san",  nValue);
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+// Returns 1 if the meditate cooldown has elapsed.
+int SanCanMeditate(object oPC, int nCooldownSecs)
+{
+    SanEnsureChar(oPC);
+    sqlquery q = SqlPrepareQueryCampaign(SAN_DB,
+        "SELECT CASE WHEN strftime('%s','now') - last_meditate >= @cd THEN 1 ELSE 0 END"
+        " FROM san_chars WHERE uuid = @uuid");
+    SqlBindInt   (q, "@cd",   nCooldownSecs);
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 1;
+}
+
+void SanRecordMeditate(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign(SAN_DB,
+        "UPDATE san_chars SET last_meditate = strftime('%s','now') WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+void SanLogEvent(object oPC, int nDelta, string sReason)
+{
+    sqlquery q = SqlPrepareQueryCampaign(SAN_DB,
+        "INSERT INTO san_events (uuid, delta, reason) VALUES (@uuid, @delta, @reason)");
+    SqlBindString(q, "@uuid",   GetObjectUUID(oPC));
+    SqlBindInt   (q, "@delta",  nDelta);
+    SqlBindString(q, "@reason", sReason);
+    SqlStep(q);
+
+    // Trim to last 50 rows per character to prevent unbounded growth.
+    q = SqlPrepareQueryCampaign(SAN_DB,
+        "DELETE FROM san_events WHERE uuid = @uuid AND id NOT IN"
+        " (SELECT id FROM san_events WHERE uuid = @uuid ORDER BY id DESC LIMIT 50)");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+// Returns JsonArray of {delta, reason, ts}, newest first, up to nLimit entries.
+json SanGetRecentEvents(object oPC, int nLimit)
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign(SAN_DB,
+        "SELECT delta, reason, ts FROM san_events"
+        " WHERE uuid = @uuid ORDER BY id DESC LIMIT @lim");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@lim",  nLimit);
+    while(SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "delta",  JsonInt   (SqlGetInt   (q, 0)));
+        jRow = JsonObjectSet(jRow, "reason", JsonString(SqlGetString(q, 1)));
+        jRow = JsonObjectSet(jRow, "ts",     JsonInt   (SqlGetInt   (q, 2)));
+        jRows = JsonArrayInsert(jRows, jRow);
+    }
+    return jRows;
+}
+
+// Adjusts sanity by nDelta, logs the event, and returns the new value.
+// Returns -1 if the value did not change (already at boundary).
+int SanAdjust(object oPC, int nDelta, string sReason)
+{
+    SanEnsureChar(oPC);
+    int nOld = SanGetSanity(oPC);
+    int nNew = nOld + nDelta;
+    if(nNew < 0)       nNew = 0;
+    if(nNew > SAN_MAX) nNew = SAN_MAX;
+    if(nNew == nOld)   return -1;
+    SanSetSanity(oPC, nNew);
+    SanLogEvent(oPC, nNew - nOld, sReason);
+    return nNew;
+}

--- a/Sanity/Scripts/sys_on_enter.nss
+++ b/Sanity/Scripts/sys_on_enter.nss
@@ -1,0 +1,13 @@
+// sys_on_enter.nss — module OnClientEnter hook.
+//   Registers the character, restores persistent effects, and gives a
+//   sanity-status reminder when their mind is already troubled.
+
+#include "lib_san"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC) || GetIsDM(oPC)) return;
+
+    SanOnPlayerEnter(oPC);
+}

--- a/Sanity/Scripts/sys_on_heartbeat.nss
+++ b/Sanity/Scripts/sys_on_heartbeat.nss
@@ -1,0 +1,9 @@
+// sys_on_heartbeat.nss — module OnHeartbeat hook.
+//   Runs every 6 seconds; dispatches sanity checks at configured cadences.
+
+#include "lib_san"
+
+void main()
+{
+    SanHeartbeatTick();
+}

--- a/Sanity/Scripts/sys_on_load.nss
+++ b/Sanity/Scripts/sys_on_load.nss
@@ -1,0 +1,9 @@
+// sys_on_load.nss — module OnModuleLoad hook.
+//   Creates database tables. Safe to run multiple times (idempotent).
+
+#include "lib_san_def"
+
+void main()
+{
+    SanCreateTables();
+}

--- a/Sanity/Scripts/sys_on_rest.nss
+++ b/Sanity/Scripts/sys_on_rest.nss
@@ -1,0 +1,13 @@
+// sys_on_rest.nss — module OnPlayerRest hook  (REST_EVENTTYPE_REST_FINISHED).
+//   Restores a portion of sanity after a completed rest.
+
+#include "lib_san"
+
+void main()
+{
+    object oPC = GetLastPCRested();
+    if(!GetIsPC(oPC)) return;
+    if(GetLastRestEventType() != REST_EVENTTYPE_REST_FINISHED) return;
+
+    SanOnPlayerRest(oPC);
+}

--- a/Sanity/Scripts/test_san.nss
+++ b/Sanity/Scripts/test_san.nss
@@ -1,0 +1,55 @@
+// test_san.nss — OnUsed script for the demo placeable.
+//   Place a placeable (tag: "san_mirror") in the test module and assign
+//   this script to its OnUsed event.  Using it opens the Sanity window.
+//   A second placeable (tag: "san_altar_dark") can be used to simulate
+//   a horror-area sanity drain for testing without a live heartbeat.
+
+#include "lib_san"
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    string sTag = GetTag(OBJECT_SELF);
+
+    if(sTag == "san_mirror")
+    {
+        SanOpen(oPC);
+        return;
+    }
+
+    if(sTag == "san_altar_dark")
+    {
+        // Simulate a horror-zone drain — useful for QA.
+        int nNew = SanAdjust(oPC, -SAN_LOSS_HORROR_AREA * 5,
+            "Czarny ołtarz wysysa twoją wolę");
+        if(nNew >= 0) SanSyncEffects(oPC);
+
+        FloatingTextStringOnCreature(
+            "Czarny ołtarz pulsuje złowrogą mocą...", oPC, FALSE);
+
+        int nToken = NuiFindWindow(oPC, SAN_WINDOW);
+        if(nToken != 0) SanFeedWindow(oPC, nToken);
+        return;
+    }
+
+    if(sTag == "san_font_holy")
+    {
+        // Simulate holy-water recovery — useful for QA.
+        int nSan = SanGetSanity(oPC);
+        if(nSan >= SAN_MAX)
+        {
+            SendMessageToPC(oPC, "[Szaleństwo] Twój umysł jest już spokojny.");
+            return;
+        }
+        SanAdjust(oPC, SAN_GAIN_HOLY, "Święte źródło");
+        SanSyncEffects(oPC);
+        FloatingTextStringOnCreature(
+            "Święta woda spływa spokojnie przez twój umysł...", oPC, FALSE);
+
+        int nToken = NuiFindWindow(oPC, SAN_WINDOW);
+        if(nToken != 0) SanFeedWindow(oPC, nToken);
+        return;
+    }
+}


### PR DESCRIPTION
## Co to robi

Moduł **Sanity** śledzi zdrowie psychiczne każdej postaci na skali 0–100, zapisuje dane w SQLite i wyświetla stan w oknie NUI z dynamicznym paskiem kolorowym, tekstem klimatycznym oraz historią ostatnich zdarzeń. Wraz z pogarszaniem się stanu pojawiają się progressywne kary statystyk i losowe efekty (strach, ślepota, paraliż).

## Mechanika

| Zakres | Stan | Kary WIS / INT | Efekty epizodyczne |
|--------|------|----------------|--------------------|
| 75–100 | SPOKOJNY | — | — |
| 50–74 | NIEPOKÓJ | −2 WIS | — |
| 25–49 | GROZA | −4 WIS | 18 % szansa na strach / HB |
| 10–24 | OBŁĘD | −6 WIS, −4 INT | + 12 % ślepota |
| 0–9 | SZALEŃSTWO | −10 WIS, −8 INT | + 5 % paraliż (3 s) |

**Utrata sanity:**
- Obecność nieumarłych w promieniu 10 m (−3, co ~60 s)
- Bliskość śmierci (HP < 10 % max) (−5, co ~120 s)
- Przeklęte obszary oznaczone zmienną `SAN_HORROR_AREA=1` (−2, co ~180 s)
- Śmierć sojusznika w tym samym obszarze (−8, jednorazowo)

**Odbudowa:**
- Medytacja przez UI (przycisk, +5, cooldown 120 s, SQLite-persistent)
- Odpoczynek (REST_EVENTTYPE_REST_FINISHED, +15)
- Przedmiot `san_holy_water` aktywowany przez gracza (+10, item niszczony)

Efekty debuff są tagowane (`SAN_EFFECT_TAG`) i wymieniane tylko przy przekroczeniu progu (brak churn'u co heartbeat).

## Pliki

```
Sanity/
  Scripts/
    sql_san.nss          — schemat SQLite, CRUD, cooldown medytacji
    lib_san_def.nss      — stałe, bind/button IDs, SanBarColor/SanStatusText/SanFlavorText
    lib_san.nss          — NUI (SanBuildWindow/SanFeedWindow/SanOpen),
                           silnik efektów, triggery utraty/odbudowy,
                           SanHeartbeatTick (dyspozytor)
    lib_san_ev.nss       — handler NUI OnNUIEvent
    sys_on_load.nss      — OnModuleLoad: SanCreateTables()
    sys_on_enter.nss     — OnClientEnter: rejestracja + przywrócenie efektów
    sys_on_heartbeat.nss — OnHeartbeat: SanHeartbeatTick()
    sys_on_rest.nss      — OnPlayerRest: SanOnPlayerRest()
    test_san.nss         — OnUsed na 3 placea demowych (lustro / ołtarz / źródło)
    lib_nui.nss          — skopiowane z Mailbox (bez zmian)
    lib_nui_utility.nss  — skopiowane z Mailbox (bez zmian)
  INTEGRATION.md         — instrukcja podpięcia hooków i konfiguracji
```

## Zależności (NWNX? SQL?)

- **NWNX**: **nie wymagane**.
- **SQLite**: kampania `"sanity"` (`san_chars`, `san_events`). Tabele tworzone automatycznie.
- **NWN:EE 8193.36+**: wymaga `TagEffect`, `SqlPrepareQueryCampaign`, NUI.

## Jak włączyć w istniejącym module

1. Skopiuj folder `Sanity/Scripts/` do skryptów modułu.
2. Podłącz hooki (szczegóły w `INTEGRATION.md`):
   - `OnModuleLoad` → `sys_on_load`
   - `OnClientEnter` → `sys_on_enter`
   - `OnHeartbeat` → `sys_on_heartbeat`
   - `OnPlayerRest` → `sys_on_rest`
   - `OnNUIEvent` → `lib_san_ev`
3. Opcjonalnie dodaj wywołanie `SanOnActivateItem(oPC, oItem)` w `OnActivateItem`.
4. Oznacz obszary horroru: `SetLocalInt(oArea, "SAN_HORROR_AREA", 1)`.

## Co celowo pominięto

- Plik `.mod` — środowisko kompilacji NWN niedostępne; zamiast tego `INTEGRATION.md`.
- Hook `OnPlayerDeath` / śmierć sojusznika — `SanOnAllyDeath()` jest zaimplementowane w `lib_san.nss`; builder podpina je samodzielnie do zdarzenia śmierci odpowiedniej creatury.
- Graficzne nakładki szumu (DrawList overlay na cały ekran) — wymagałyby dedykowanego haka graficznego poza zakresem tego modułu.
- Ikona tray notifikacji — informacja przekazywana przez floating text + `SendMessageToPC`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GJXiDaw5T1BtiPc2RkjMJH)_