### PR TITLE
feat: Pracownia Alchemiczna

### DIFF
--- a/Alchemy/INTEGRATION.md
+++ b/Alchemy/INTEGRATION.md
@@ -1,0 +1,87 @@
+# Pracownia Alchemiczna — Integracja
+
+## Opis modułu
+
+Pracownia Alchemiczna to system craftingowy oparty na NUI. Gracz podchodzi do
+stołu alchemicznego, wybiera przepis z listy i klika **Destyluj**. System pobiera
+trzy składniki z ekwipunku, wykonuje rzut Wiedza Magiczna + premia INT vs DC
+przepisu, po czym:
+
+- **Sukces** → aplikuje efekt bezpośrednio na gracza (Heal, Haste, STR+4, itp.)
+- **Porażka** → składniki przepadają, brak efektu
+- **Krytyczna porażka (rzut 1)** → składniki przepadają + 1d6+2 obrażeń od kwasowych oparów
+- **Krytyczny sukces (total ≥ DC+10 lub rzut 20)** → efekt aplikowany dwukrotnie
+
+## Wymagane hooki w istniejącym module
+
+| Zdarzenie | Skrypt | Uwaga |
+|---|---|---|
+| OnModuleLoad | `sys_on_load` | Ustawia NUI event handler |
+| OnClientEnter | `sys_on_enter` | Inicjuje tabelę SQL + starter recipes |
+| OnAcquireItem | `sys_on_acquire` | Wykrywa zwoje receptur |
+| OnNuiEvent | `lib_alch_ev` | Obsługa kliknięć w UI |
+
+Jeśli moduł ma już własne skrypty dla tych zdarzeń, dodaj wywołania przez
+`ExecuteScript("sys_on_load_alch", OBJECT_SELF)` lub scal ręcznie.
+
+## Wymagane assety w hak/module
+
+### Składniki (OBJECT_TYPE_ITEM)
+
+Utwórz przedmioty z poniższymi resrefs. Mogą to być zwykłe ikony ziół/fiolek.
+
+| Resref | Polska nazwa | Sugerowana ikona |
+|---|---|---|
+| `alch_piolun` | Piołun | it_herb/fiolka zielona |
+| `alch_kosciol` | Kość Trupna | it_bone01 |
+| `alch_krew_n` | Krew Nocna | it_vial02 |
+| `alch_grzyb` | Czarny Grzyb | it_herb01 |
+| `alch_rtec` | Rtęć | it_vial01 |
+| `alch_olej` | Tłuszcz Szczurzy | it_oil01 |
+| `alch_oko` | Oko Sowy | it_eye01 |
+| `alch_kwiat` | Kwiat Bladej Damy | it_herb02 |
+| `alch_krew_o` | Krew Ogra | it_vial03 |
+| `alch_zelaz` | Pył Żelazny | it_gem01 |
+
+### Zwoje receptur
+
+Utwórz przedmioty z poniższymi **tagami** (tag, nie resref) aby gracze mogli
+odblokowywać przepisy 2–8:
+
+| Tag | Odblokowuje |
+|---|---|
+| `ALCH_REC_2` | Wywar Pancerza Krwi (DC 14) |
+| `ALCH_REC_3` | Eliksir Siły Ogra (DC 16) |
+| `ALCH_REC_4` | Wywar Cieni (DC 16) |
+| `ALCH_REC_5` | Odwar Odporności (DC 18) |
+| `ALCH_REC_6` | Eliksir Szybkości (DC 18) |
+| `ALCH_REC_7` | Wywar Ostrza (DC 20) |
+| `ALCH_REC_8` | Nalewka Czarnego Serca (DC 22) |
+
+### Stół alchemiczny (placeable)
+
+Utwórz placeable z tagiem `alch_bench` i skryptem `test_alch` na zdarzeniu
+**OnUsed**.
+
+## Brak NWNX
+
+Moduł działa wyłącznie na standardowym NWScript + NUI. Brak zależności od NWNX.
+
+## Testy
+
+1. Wejdź do modułu jako PC.
+2. Kliknij stół `alch_bench` — dostaniesz składniki testowe + zwój receptury 2.
+3. Podnieś zwój — zobaczysz komunikat odblokowania i lista w UI się odświeży.
+4. Kliknij stół ponownie, wybierz "Nalewka Gojąca", kliknij "Destyluj".
+5. Sprawdź komunikaty rzutu i efekt HP.
+
+## Co celowo pominięto
+
+- **Animacja destylacji** — efekt VFX na stole nie jest aplikowany; można dodać
+  `ApplyEffectAtLocation(DURATION_TYPE_INSTANT, EffectVisualEffect(VFX_FNF_SMOKE_PUFF), GetLocation(oPC))`.
+- **Sklep ze składnikami** — intencjonalnie nie dostarczono NPC handlarza; to
+  decyzja projektanta świata.
+- **Trwałe efekty** — wszystkie efekty są tymczasowe; "permanentna" alchemia
+  wymagałaby osobnego systemu ekwipunku.
+- **Multiplayer race condition** — brak locka na składnikach między sprawdzeniem
+  a ich zdjęciem (minimalne ryzyko w praktyce przy lokalnym inventory).

--- a/Alchemy/Scripts/lib_alch.nss
+++ b/Alchemy/Scripts/lib_alch.nss
@@ -1,0 +1,556 @@
+// lib_alch.nss
+// NUI window builder, feed functions and brewing logic for the Alchemy Workshop.
+#include "lib_alch_def"
+
+// ----------------------------------------------------------------
+// NUI layout helpers (local; mirrors lib_nui.nss conventions)
+// ----------------------------------------------------------------
+
+float AlchScale(object oPC, float fDim, float fMax = 1.5)
+{
+    int nScale = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fS   = IntToFloat(nScale) / 100.0;
+    if(fS > fMax) fS = fMax;
+    return fDim / fS;
+}
+
+json AlchColor(int r, int g, int b)
+{
+    return NuiColor(r, g, b);
+}
+
+json AlchColorGold()  { return NuiColor(185, 150, 100); }
+json AlchColorGreen() { return NuiColor( 80, 200,  80); }
+json AlchColorRed()   { return NuiColor(220,  60,  60); }
+json AlchColorGray()  { return NuiColor(100, 100, 100); }
+
+json AlchSpacer(object oPC, float fH)
+{
+    json jItems = JsonArray();
+    jItems = JsonArrayInsert(jItems, NuiHeight(NuiSpacer(), AlchScale(oPC, fH)));
+    return NuiRow(jItems);
+}
+
+// ----------------------------------------------------------------
+// Recipe list cell template (used by NuiList)
+// ----------------------------------------------------------------
+
+json AlchBuildRecipeCell(object oPC)
+{
+    float fLblH = AlchScale(oPC, 24.0);
+
+    json jName = NuiLabel(
+        NuiBind(ALCH_BIND_REC_NAME),
+        JsonInt(NUI_HALIGN_LEFT),
+        JsonInt(NUI_VALIGN_MIDDLE)
+    );
+    jName = NuiHeight(jName, fLblH);
+    jName = NuiStyleForegroundColor(jName, NuiBind(ALCH_BIND_REC_COLOR));
+
+    json jRow = JsonArray();
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), AlchScale(oPC, 6.0)));
+    jRow = JsonArrayInsert(jRow, jName);
+
+    json jCell = NuiGroup(NuiRow(jRow), TRUE, NUI_SCROLLBARS_NONE);
+    jCell = NuiId(jCell, ALCH_BTN_ROW);
+    jCell = NuiEncouraged(jCell, NuiBind(ALCH_BIND_REC_ENC));
+
+    json jTmpl = JsonArray();
+    jTmpl = JsonArrayInsert(jTmpl, NuiListTemplateCell(jCell, 0.0, TRUE));
+    return jTmpl;
+}
+
+// ----------------------------------------------------------------
+// Ingredient row helper (inside detail panel)
+// ----------------------------------------------------------------
+
+json AlchBuildIngRow(object oPC, string sNameBind, string sHaveBind, string sColBind)
+{
+    float fH    = AlchScale(oPC, 20.0);
+    float fNameW= AlchScale(oPC, 200.0);
+    float fHaveW= AlchScale(oPC, 100.0);
+
+    json jName = NuiLabel(
+        NuiBind(sNameBind),
+        JsonInt(NUI_HALIGN_LEFT),
+        JsonInt(NUI_VALIGN_MIDDLE)
+    );
+    jName = NuiWidth(jName, fNameW);
+    jName = NuiHeight(jName, fH);
+
+    json jHave = NuiLabel(
+        NuiBind(sHaveBind),
+        JsonInt(NUI_HALIGN_RIGHT),
+        JsonInt(NUI_VALIGN_MIDDLE)
+    );
+    jHave = NuiWidth(jHave, fHaveW);
+    jHave = NuiHeight(jHave, fH);
+    jHave = NuiStyleForegroundColor(jHave, NuiBind(sColBind));
+
+    json jRow = JsonArray();
+    jRow = JsonArrayInsert(jRow, jName);
+    jRow = JsonArrayInsert(jRow, NuiSpacer());
+    jRow = JsonArrayInsert(jRow, jHave);
+    return NuiRow(jRow);
+}
+
+// ----------------------------------------------------------------
+// Detail panel (right side)
+// ----------------------------------------------------------------
+
+json AlchBuildDetailPanel(object oPC)
+{
+    float fTitleH = AlchScale(oPC, 22.0);
+    float fDescH  = AlchScale(oPC, 80.0);
+    float fFlavH  = AlchScale(oPC, 44.0);
+    float fLblH   = AlchScale(oPC, 20.0);
+    float fBtnH   = AlchScale(oPC, 32.0);
+    float fBtnW   = AlchScale(oPC, 200.0);
+    float fPad    = AlchScale(oPC, 8.0);
+
+    // --- Recipe title ---
+    json jTitle = NuiLabel(
+        NuiBind(ALCH_BIND_DET_NAME),
+        JsonInt(NUI_HALIGN_CENTER),
+        JsonInt(NUI_VALIGN_MIDDLE)
+    );
+    jTitle = NuiHeight(jTitle, fTitleH);
+    jTitle = NuiStyleForegroundColor(jTitle, AlchColorGold());
+
+    // --- "Locked" overlay label ---
+    json jLocked = NuiLabel(
+        NuiBind(ALCH_BIND_LOCKED_LBL),
+        JsonInt(NUI_HALIGN_CENTER),
+        JsonInt(NUI_VALIGN_MIDDLE)
+    );
+    jLocked = NuiHeight(jLocked, fLblH);
+    jLocked = NuiStyleForegroundColor(jLocked, AlchColorRed());
+    jLocked = NuiVisible(jLocked, NuiBind(ALCH_BIND_LOCKED_VIS));
+
+    // --- Effect description ---
+    json jDesc = NuiText(NuiBind(ALCH_BIND_DET_DESC), FALSE);
+    jDesc = NuiHeight(jDesc, fDescH);
+
+    // --- Flavor text ---
+    json jFlav = NuiText(NuiBind(ALCH_BIND_DET_FLAV), FALSE);
+    jFlav = NuiHeight(jFlav, fFlavH);
+    jFlav = NuiStyleForegroundColor(jFlav, AlchColor(160, 130, 90));
+
+    // --- Ingredient section header ---
+    json jIngHdr = NuiLabel(
+        JsonString("Składniki:"),
+        JsonInt(NUI_HALIGN_LEFT),
+        JsonInt(NUI_VALIGN_MIDDLE)
+    );
+    jIngHdr = NuiHeight(jIngHdr, fLblH);
+    jIngHdr = NuiStyleForegroundColor(jIngHdr, AlchColorGold());
+
+    // --- DC and skill labels ---
+    json jDc = NuiLabel(
+        NuiBind(ALCH_BIND_DC_LBL),
+        JsonInt(NUI_HALIGN_LEFT),
+        JsonInt(NUI_VALIGN_MIDDLE)
+    );
+    jDc = NuiHeight(jDc, fLblH);
+
+    json jSkill = NuiLabel(
+        NuiBind(ALCH_BIND_SKILL_LBL),
+        JsonInt(NUI_HALIGN_LEFT),
+        JsonInt(NUI_VALIGN_MIDDLE)
+    );
+    jSkill = NuiHeight(jSkill, fLblH);
+
+    // --- Brew button ---
+    json jBrew = NuiId(NuiButton(JsonString("Destyluj")), ALCH_BTN_BREW);
+    jBrew = NuiEnabled(jBrew, NuiBind(ALCH_BIND_BREW_EN));
+    jBrew = NuiWidth(jBrew, fBtnW);
+    jBrew = NuiHeight(jBrew, fBtnH);
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jBrew);
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+
+    // --- Assemble column ---
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jTitle);
+    jCol = JsonArrayInsert(jCol, jLocked);
+    jCol = JsonArrayInsert(jCol, AlchSpacer(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, jDesc);
+    jCol = JsonArrayInsert(jCol, jFlav);
+    jCol = JsonArrayInsert(jCol, AlchSpacer(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, jIngHdr);
+    jCol = JsonArrayInsert(jCol, AlchBuildIngRow(oPC, ALCH_BIND_ING1_NAME, ALCH_BIND_ING1_HAVE, ALCH_BIND_ING1_COL));
+    jCol = JsonArrayInsert(jCol, AlchBuildIngRow(oPC, ALCH_BIND_ING2_NAME, ALCH_BIND_ING2_HAVE, ALCH_BIND_ING2_COL));
+    jCol = JsonArrayInsert(jCol, AlchBuildIngRow(oPC, ALCH_BIND_ING3_NAME, ALCH_BIND_ING3_HAVE, ALCH_BIND_ING3_COL));
+    jCol = JsonArrayInsert(jCol, AlchSpacer(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, jDc);
+    jCol = JsonArrayInsert(jCol, jSkill);
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+    jCol = JsonArrayInsert(jCol, AlchSpacer(oPC, 8.0));
+
+    return NuiGroup(NuiCol(jCol), TRUE, NUI_SCROLLBARS_AUTO);
+}
+
+// ----------------------------------------------------------------
+// Full window layout
+// ----------------------------------------------------------------
+
+json AlchBuildWindow(object oPC)
+{
+    float fRowH  = AlchScale(oPC, 28.0);
+    float fListH = AlchScale(oPC, ALCH_WIN_H - 80.0);
+    float fListW = AlchScale(oPC, 210.0);
+    float fPad   = AlchScale(oPC, 10.0);
+    float fBtnH  = AlchScale(oPC, 24.0);
+    float fBtnW  = AlchScale(oPC, 80.0);
+
+    // --- Left: recipe list ---
+    json jList = NuiList(AlchBuildRecipeCell(oPC), NuiBind(ALCH_BIND_REC_COUNT), fRowH);
+    jList = NuiHeight(jList, fListH);
+    jList = NuiWidth(jList, fListW);
+
+    // --- Right: detail panel ---
+    json jDetail = AlchBuildDetailPanel(oPC);
+    jDetail = NuiHeight(jDetail, fListH);
+
+    // --- Close button row ---
+    json jClose = NuiId(NuiButton(JsonString("Zamknij")), ALCH_BTN_CLOSE);
+    jClose = NuiWidth(jClose, fBtnW);
+    jClose = NuiHeight(jClose, fBtnH);
+
+    json jCloseRow = JsonArray();
+    jCloseRow = JsonArrayInsert(jCloseRow, NuiSpacer());
+    jCloseRow = JsonArrayInsert(jCloseRow, jClose);
+
+    // --- Content row (list + detail) ---
+    json jContent = JsonArray();
+    jContent = JsonArrayInsert(jContent, jList);
+    jContent = JsonArrayInsert(jContent, NuiWidth(NuiSpacer(), fPad));
+    jContent = JsonArrayInsert(jContent, jDetail);
+
+    // --- Outer column ---
+    json jOuter = JsonArray();
+    jOuter = JsonArrayInsert(jOuter, AlchSpacer(oPC, 4.0));
+    jOuter = JsonArrayInsert(jOuter, NuiRow(jContent));
+    jOuter = JsonArrayInsert(jOuter, NuiRow(jCloseRow));
+    jOuter = JsonArrayInsert(jOuter, AlchSpacer(oPC, 4.0));
+
+    json jRoot = NuiCol(jOuter);
+
+    float fW = AlchScale(oPC, ALCH_WIN_W);
+    float fH = AlchScale(oPC, ALCH_WIN_H);
+
+    return NuiWindow(
+        jRoot,
+        JsonString("Pracownia Alchemiczna"),
+        NuiBind(ALCH_WINDOW + "_geom"),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE),
+        JsonBool(TRUE)
+    );
+}
+
+// ----------------------------------------------------------------
+// Feed recipe list
+// ----------------------------------------------------------------
+
+void FeedRecipeList(object oPC, int nToken)
+{
+    int nSel = GetLocalInt(oPC, ALCH_LVAR_SEL_IDX);
+
+    json jNames  = JsonArray();
+    json jEncs   = JsonArray();
+    json jColors = JsonArray();
+
+    int i;
+    for(i = 0; i < ALCH_RECIPE_COUNT; i++)
+    {
+        int bKnown = AlchHasRecipe(oPC, i);
+        string sName = bKnown ? AlchGetRecipeName(i) : "??? Nieznany Przepis ???";
+
+        jNames  = JsonArrayInsert(jNames,  JsonString(sName));
+        jEncs   = JsonArrayInsert(jEncs,   JsonBool(i == nSel));
+        jColors = JsonArrayInsert(jColors, bKnown ? AlchColorGold() : AlchColorGray());
+    }
+
+    NuiSetBind(oPC, nToken, ALCH_BIND_REC_NAME,  jNames);
+    NuiSetBind(oPC, nToken, ALCH_BIND_REC_ENC,   jEncs);
+    NuiSetBind(oPC, nToken, ALCH_BIND_REC_COLOR, jColors);
+    NuiSetBind(oPC, nToken, ALCH_BIND_REC_COUNT, JsonInt(ALCH_RECIPE_COUNT));
+}
+
+// ----------------------------------------------------------------
+// Feed detail panel for selected recipe
+// ----------------------------------------------------------------
+
+void FeedDetailPanel(object oPC, int nToken, int nIdx)
+{
+    if(nIdx < 0 || nIdx >= ALCH_RECIPE_COUNT)
+    {
+        NuiSetBind(oPC, nToken, ALCH_BIND_DET_NAME,  JsonString("— Wybierz przepis —"));
+        NuiSetBind(oPC, nToken, ALCH_BIND_DET_DESC,  JsonString(""));
+        NuiSetBind(oPC, nToken, ALCH_BIND_DET_FLAV,  JsonString(""));
+        NuiSetBind(oPC, nToken, ALCH_BIND_ING1_NAME, JsonString(""));
+        NuiSetBind(oPC, nToken, ALCH_BIND_ING2_NAME, JsonString(""));
+        NuiSetBind(oPC, nToken, ALCH_BIND_ING3_NAME, JsonString(""));
+        NuiSetBind(oPC, nToken, ALCH_BIND_ING1_HAVE, JsonString(""));
+        NuiSetBind(oPC, nToken, ALCH_BIND_ING2_HAVE, JsonString(""));
+        NuiSetBind(oPC, nToken, ALCH_BIND_ING3_HAVE, JsonString(""));
+        NuiSetBind(oPC, nToken, ALCH_BIND_ING1_COL,  AlchColorGray());
+        NuiSetBind(oPC, nToken, ALCH_BIND_ING2_COL,  AlchColorGray());
+        NuiSetBind(oPC, nToken, ALCH_BIND_ING3_COL,  AlchColorGray());
+        NuiSetBind(oPC, nToken, ALCH_BIND_DC_LBL,    JsonString(""));
+        NuiSetBind(oPC, nToken, ALCH_BIND_SKILL_LBL, JsonString(""));
+        NuiSetBind(oPC, nToken, ALCH_BIND_BREW_EN,   JsonBool(FALSE));
+        NuiSetBind(oPC, nToken, ALCH_BIND_LOCKED_LBL,JsonString(""));
+        NuiSetBind(oPC, nToken, ALCH_BIND_LOCKED_VIS,JsonBool(FALSE));
+        return;
+    }
+
+    int bKnown = AlchHasRecipe(oPC, nIdx);
+
+    NuiSetBind(oPC, nToken, ALCH_BIND_DET_NAME, JsonString(AlchGetRecipeName(nIdx)));
+    NuiSetBind(oPC, nToken, ALCH_BIND_LOCKED_LBL,
+        JsonString(bKnown ? "" : "[ Przepis Zablokowany — Szukaj Zwoju Receptury ]"));
+    NuiSetBind(oPC, nToken, ALCH_BIND_LOCKED_VIS, JsonBool(!bKnown));
+
+    if(!bKnown)
+    {
+        NuiSetBind(oPC, nToken, ALCH_BIND_DET_DESC,  JsonString("Ten przepis jest ci nieznany."));
+        NuiSetBind(oPC, nToken, ALCH_BIND_DET_FLAV,  JsonString(""));
+        NuiSetBind(oPC, nToken, ALCH_BIND_ING1_NAME, JsonString("???"));
+        NuiSetBind(oPC, nToken, ALCH_BIND_ING2_NAME, JsonString("???"));
+        NuiSetBind(oPC, nToken, ALCH_BIND_ING3_NAME, JsonString("???"));
+        NuiSetBind(oPC, nToken, ALCH_BIND_ING1_HAVE, JsonString(""));
+        NuiSetBind(oPC, nToken, ALCH_BIND_ING2_HAVE, JsonString(""));
+        NuiSetBind(oPC, nToken, ALCH_BIND_ING3_HAVE, JsonString(""));
+        NuiSetBind(oPC, nToken, ALCH_BIND_ING1_COL,  AlchColorGray());
+        NuiSetBind(oPC, nToken, ALCH_BIND_ING2_COL,  AlchColorGray());
+        NuiSetBind(oPC, nToken, ALCH_BIND_ING3_COL,  AlchColorGray());
+        NuiSetBind(oPC, nToken, ALCH_BIND_DC_LBL,    JsonString(""));
+        NuiSetBind(oPC, nToken, ALCH_BIND_SKILL_LBL, JsonString(""));
+        NuiSetBind(oPC, nToken, ALCH_BIND_BREW_EN,   JsonBool(FALSE));
+        return;
+    }
+
+    string sIng1 = AlchGetRecipeIng1(nIdx);
+    string sIng2 = AlchGetRecipeIng2(nIdx);
+    string sIng3 = AlchGetRecipeIng3(nIdx);
+
+    int nHave1 = AlchCountIngredient(oPC, sIng1);
+    int nHave2 = AlchCountIngredient(oPC, sIng2);
+    int nHave3 = AlchCountIngredient(oPC, sIng3);
+
+    int bHaveAll = (nHave1 >= 1) && (nHave2 >= 1) && (nHave3 >= 1);
+
+    NuiSetBind(oPC, nToken, ALCH_BIND_DET_DESC, JsonString(AlchGetRecipeDesc(nIdx)));
+    NuiSetBind(oPC, nToken, ALCH_BIND_DET_FLAV, JsonString(AlchGetRecipeFlavor(nIdx)));
+
+    NuiSetBind(oPC, nToken, ALCH_BIND_ING1_NAME, JsonString(AlchGetIngredientName(sIng1)));
+    NuiSetBind(oPC, nToken, ALCH_BIND_ING2_NAME, JsonString(AlchGetIngredientName(sIng2)));
+    NuiSetBind(oPC, nToken, ALCH_BIND_ING3_NAME, JsonString(AlchGetIngredientName(sIng3)));
+
+    NuiSetBind(oPC, nToken, ALCH_BIND_ING1_HAVE, JsonString("masz: " + IntToString(nHave1)));
+    NuiSetBind(oPC, nToken, ALCH_BIND_ING2_HAVE, JsonString("masz: " + IntToString(nHave2)));
+    NuiSetBind(oPC, nToken, ALCH_BIND_ING3_HAVE, JsonString("masz: " + IntToString(nHave3)));
+
+    NuiSetBind(oPC, nToken, ALCH_BIND_ING1_COL, nHave1 >= 1 ? AlchColorGreen() : AlchColorRed());
+    NuiSetBind(oPC, nToken, ALCH_BIND_ING2_COL, nHave2 >= 1 ? AlchColorGreen() : AlchColorRed());
+    NuiSetBind(oPC, nToken, ALCH_BIND_ING3_COL, nHave3 >= 1 ? AlchColorGreen() : AlchColorRed());
+
+    int nDC     = AlchGetRecipeDC(nIdx);
+    int nBonus  = AlchGetCraftBonus(oPC);
+    NuiSetBind(oPC, nToken, ALCH_BIND_DC_LBL,    JsonString("Trudność: DC " + IntToString(nDC)));
+    NuiSetBind(oPC, nToken, ALCH_BIND_SKILL_LBL,
+        JsonString("Twój bonus: +" + IntToString(nBonus) + " (Wiedza Magiczna + INT)"));
+
+    NuiSetBind(oPC, nToken, ALCH_BIND_BREW_EN, JsonBool(bHaveAll));
+}
+
+// ----------------------------------------------------------------
+// Open window
+// ----------------------------------------------------------------
+
+void AlchOpenWindow(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, ALCH_WINDOW);
+    if(nToken != 0)
+    {
+        // Refresh data and bring to front
+        FeedRecipeList(oPC, nToken);
+        int nSel = GetLocalInt(oPC, ALCH_LVAR_SEL_IDX);
+        FeedDetailPanel(oPC, nToken, nSel);
+        return;
+    }
+
+    SetLocalInt(oPC, ALCH_LVAR_SEL_IDX, -1);
+
+    nToken = NuiCreate(oPC, AlchBuildWindow(oPC), ALCH_WINDOW);
+    if(nToken == 0) return;
+
+    float fW = AlchScale(oPC, ALCH_WIN_W);
+    float fH = AlchScale(oPC, ALCH_WIN_H);
+    NuiSetBind(oPC, nToken, ALCH_WINDOW + "_geom",
+        NuiRect(50.0, 100.0, fW, fH));
+
+    FeedRecipeList(oPC, nToken);
+    FeedDetailPanel(oPC, nToken, -1);
+
+    SetEventScript(oPC, EVENT_SCRIPT_MODULE_ON_NUI_EVENT, ALCH_EV_SCRIPT);
+}
+
+// ----------------------------------------------------------------
+// Brew — apply effect and consume ingredients
+// ----------------------------------------------------------------
+
+void AlchApplyEffect(object oPC, int nRecipeId)
+{
+    float fMin5  = 300.0;
+    float fMin3  = 180.0;
+    float fMin2  = 120.0;
+    float fRound = 6.0;
+
+    switch(nRecipeId)
+    {
+        case 0:
+            // Nalewka Gojąca — instant heal 15 HP
+            ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectHeal(15), oPC);
+            SendMessageToPC(oPC, "[Alchemia] Rana zastyga. Ciepło zalewa pierś.");
+            break;
+
+        case 1:
+            // Odwar Mrocznego Wzroku — Ultravision + Spot +10 for 3min
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY, EffectUltravision(),                      oPC, fMin3);
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY, EffectSkillIncrease(SKILL_SPOT, 10),      oPC, fMin3);
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY, EffectSkillIncrease(SKILL_LISTEN, 5),     oPC, fMin3);
+            SendMessageToPC(oPC, "[Alchemia] Ciemność ustępuje. Widzisz każdy cień przez 3 minuty.");
+            break;
+
+        case 2:
+            // Wywar Pancerza Krwi — AC +4 enchantment for 5min
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                EffectACIncrease(4, AC_ARMOUR_ENCHANTMENT_BONUS), oPC, fMin5);
+            SendMessageToPC(oPC, "[Alchemia] Skóra twardnieje niczym żelazo. +4 do KP przez 5 minut.");
+            break;
+
+        case 3:
+            // Eliksir Siły Ogra — STR +4 for 5min
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                EffectAbilityIncrease(ABILITY_STRENGTH, 4), oPC, fMin5);
+            SendMessageToPC(oPC, "[Alchemia] Mięśnie nabrzmiewają. Siła +4 przez 5 minut.");
+            break;
+
+        case 4:
+            // Wywar Cieni — Concealment 20% for 3min
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                EffectConcealment(20, MISS_CHANCE_TYPE_NORMAL), oPC, fMin3);
+            SendMessageToPC(oPC, "[Alchemia] Kontury ciała rozmywają się w cieniu. 20%% zasłony przez 3 minuty.");
+            break;
+
+        case 5:
+            // Odwar Odporności — all saves +2 for 5min
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                EffectSavingThrowIncrease(SAVING_THROW_ALL, 2, SAVING_THROW_TYPE_ALL), oPC, fMin5);
+            SendMessageToPC(oPC, "[Alchemia] Wewnętrzna tarcza wzniesiona. Rzuty obronne +2 przez 5 minut.");
+            break;
+
+        case 6:
+            // Eliksir Szybkości — Haste for 3 rounds (18s)
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY, EffectHaste(), oPC, fRound * 3.0);
+            SendMessageToPC(oPC, "[Alchemia] Rtęć śpiewa w żyłach. Haste przez 3 rundy.");
+            break;
+
+        case 7:
+            // Wywar Ostrza — attack bonus +3 for 5min
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                EffectAttackIncrease(3, ATTACK_BONUS_MISC), oPC, fMin5);
+            SendMessageToPC(oPC, "[Alchemia] Ręka prowadzi broń pewniej. Premia do ataku +3 przez 5 minut.");
+            break;
+
+        case 8:
+            // Nalewka Czarnego Serca — Regenerate 2HP/6s for 5min
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY, EffectRegenerate(2, 6.0), oPC, fMin5);
+            SendMessageToPC(oPC, "[Alchemia] Ciemne ciepło pełznie przez żyły. Regeneracja 2 PŻ / rundę przez 5 minut.");
+            break;
+
+        default: break;
+    }
+}
+
+void AlchBrew(object oPC, int nToken, int nRecipeId)
+{
+    if(!AlchHasRecipe(oPC, nRecipeId))
+    {
+        SendMessageToPC(oPC, "[Alchemia] Nie znasz tego przepisu.");
+        return;
+    }
+
+    string sIng1 = AlchGetRecipeIng1(nRecipeId);
+    string sIng2 = AlchGetRecipeIng2(nRecipeId);
+    string sIng3 = AlchGetRecipeIng3(nRecipeId);
+
+    if(AlchCountIngredient(oPC, sIng1) < 1 ||
+       AlchCountIngredient(oPC, sIng2) < 1 ||
+       AlchCountIngredient(oPC, sIng3) < 1)
+    {
+        SendMessageToPC(oPC, "[Alchemia] Brakuje składników.");
+        FeedDetailPanel(oPC, nToken, nRecipeId);
+        return;
+    }
+
+    int nDC    = AlchGetRecipeDC(nRecipeId);
+    int nBonus = AlchGetCraftBonus(oPC);
+    int nRoll  = d20(1);
+    int nTotal = nRoll + nBonus;
+
+    // Always consume ingredients
+    AlchTakeIngredient(oPC, sIng1);
+    AlchTakeIngredient(oPC, sIng2);
+    AlchTakeIngredient(oPC, sIng3);
+
+    if(nRoll == 1 || (nTotal < nDC && nRoll != 20))
+    {
+        // Failure — ingredients wasted
+        string sMsg = "[Alchemia] Destylacja nieudana (rzut: "
+            + IntToString(nRoll) + "+" + IntToString(nBonus)
+            + "=" + IntToString(nTotal) + " vs DC " + IntToString(nDC)
+            + "). Składniki zmarnowane.";
+        SendMessageToPC(oPC, sMsg);
+
+        // Critical fumble on natural 1: HP penalty from fume inhalation
+        if(nRoll == 1)
+        {
+            int nFumeDmg = d6(1) + 2;
+            ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectDamage(nFumeDmg, DAMAGE_TYPE_ACID), oPC);
+            SendMessageToPC(oPC, "[Alchemia] Opary alchemiczne atakują gardło! Obrażenia: "
+                + IntToString(nFumeDmg) + ".");
+        }
+    }
+    else
+    {
+        // Success
+        int bCritSuccess = (nTotal >= nDC + 10 || nRoll == 20);
+
+        string sMsg = "[Alchemia] Destylacja udana (rzut: "
+            + IntToString(nRoll) + "+" + IntToString(nBonus)
+            + "=" + IntToString(nTotal) + " vs DC " + IntToString(nDC) + ").";
+        if(bCritSuccess) sMsg += " Mistrzostwo!";
+        SendMessageToPC(oPC, sMsg);
+
+        AlchApplyEffect(oPC, nRecipeId);
+
+        // Critical success: apply effect a second time (double potency)
+        if(bCritSuccess)
+        {
+            AlchApplyEffect(oPC, nRecipeId);
+            SendMessageToPC(oPC, "[Alchemia] Podwójne działanie mikstury!");
+        }
+    }
+
+    FeedDetailPanel(oPC, nToken, nRecipeId);
+    FeedRecipeList(oPC, nToken);
+}

--- a/Alchemy/Scripts/lib_alch_def.nss
+++ b/Alchemy/Scripts/lib_alch_def.nss
@@ -1,0 +1,277 @@
+// lib_alch_def.nss
+// Constants, recipe metadata and helpers for the Alchemy Workshop module.
+#include "nw_inc_nui"
+#include "sql_alch"
+
+// ----------------------------------------------------------------
+// Forward declarations
+// ----------------------------------------------------------------
+void FeedRecipeList(object oPC, int nToken);
+void FeedDetailPanel(object oPC, int nToken, int nIdx);
+
+// ----------------------------------------------------------------
+// Window / event
+// ----------------------------------------------------------------
+const string ALCH_WINDOW    = "ALCH_WINDOW";
+const string ALCH_EV_SCRIPT = "lib_alch_ev";
+
+const float ALCH_WIN_W = 700.0;
+const float ALCH_WIN_H = 500.0;
+
+// ----------------------------------------------------------------
+// Bind names — recipe list
+// ----------------------------------------------------------------
+const string ALCH_BIND_REC_NAME  = "alch_rec_name";
+const string ALCH_BIND_REC_ENC   = "alch_rec_enc";
+const string ALCH_BIND_REC_COLOR = "alch_rec_color";
+const string ALCH_BIND_REC_COUNT = "alch_rec_count";
+
+// ----------------------------------------------------------------
+// Bind names — detail panel
+// ----------------------------------------------------------------
+const string ALCH_BIND_DET_NAME  = "alch_det_name";
+const string ALCH_BIND_DET_DESC  = "alch_det_desc";
+const string ALCH_BIND_DET_FLAV  = "alch_det_flav";
+
+const string ALCH_BIND_ING1_NAME = "alch_ing1_name";
+const string ALCH_BIND_ING2_NAME = "alch_ing2_name";
+const string ALCH_BIND_ING3_NAME = "alch_ing3_name";
+const string ALCH_BIND_ING1_HAVE = "alch_ing1_have";
+const string ALCH_BIND_ING2_HAVE = "alch_ing2_have";
+const string ALCH_BIND_ING3_HAVE = "alch_ing3_have";
+const string ALCH_BIND_ING1_COL  = "alch_ing1_col";
+const string ALCH_BIND_ING2_COL  = "alch_ing2_col";
+const string ALCH_BIND_ING3_COL  = "alch_ing3_col";
+
+const string ALCH_BIND_DC_LBL    = "alch_dc_lbl";
+const string ALCH_BIND_SKILL_LBL = "alch_skill_lbl";
+const string ALCH_BIND_BREW_EN   = "alch_brew_en";
+const string ALCH_BIND_LOCKED_LBL= "alch_locked_lbl";
+const string ALCH_BIND_LOCKED_VIS= "alch_locked_vis";
+
+// ----------------------------------------------------------------
+// Buttons
+// ----------------------------------------------------------------
+const string ALCH_BTN_CLOSE = "alch_btn_x";
+const string ALCH_BTN_ROW   = "alch_btn_row";
+const string ALCH_BTN_BREW  = "alch_btn_brew";
+
+// ----------------------------------------------------------------
+// PC local variables
+// ----------------------------------------------------------------
+const string ALCH_LVAR_SEL_IDX = "ALCH_SEL_IDX";   // int, -1 = none
+
+// ----------------------------------------------------------------
+// Ingredient resrefs — add items with these resrefs to your hak
+// ----------------------------------------------------------------
+const string ALCH_ING_PIOLUN  = "alch_piolun";     // Piołun (wormwood)
+const string ALCH_ING_KOSCIOL = "alch_kosciol";    // Kość Trupna (bone meal)
+const string ALCH_ING_KREW_N  = "alch_krew_n";     // Krew Nocna (night blood)
+const string ALCH_ING_GRZYB   = "alch_grzyb";      // Czarny Grzyb (black mushroom)
+const string ALCH_ING_RTEC    = "alch_rtec";        // Rtęć (mercury)
+const string ALCH_ING_OLEJ    = "alch_olej";        // Tłuszcz Szczurzy (rat fat)
+const string ALCH_ING_OKO     = "alch_oko";         // Oko Sowy (owl eye)
+const string ALCH_ING_KWIAT   = "alch_kwiat";       // Kwiat Bladej Damy (pale lady flower)
+const string ALCH_ING_KREW_O  = "alch_krew_o";     // Krew Ogra (ogre blood)
+const string ALCH_ING_ZELAZ   = "alch_zelaz";       // Pył Żelazny (iron dust)
+
+// ----------------------------------------------------------------
+// Recipe scroll tags — picking up ALCH_REC_N unlocks recipe N
+// ----------------------------------------------------------------
+const string ALCH_REC_TAG_PREFIX = "ALCH_REC_";
+
+// ----------------------------------------------------------------
+// Recipe count
+// ----------------------------------------------------------------
+const int ALCH_RECIPE_COUNT = 9;
+
+// Recipes 0 and 1 are known by default; others require recipe scrolls.
+const int ALCH_STARTER_A = 0;
+const int ALCH_STARTER_B = 1;
+
+// ----------------------------------------------------------------
+// Recipe accessors — switch-based to avoid global arrays in NWScript
+// ----------------------------------------------------------------
+
+string AlchGetRecipeName(int nId)
+{
+    switch(nId)
+    {
+        case 0: return "Nalewka Gojąca";
+        case 1: return "Odwar Mrocznego Wzroku";
+        case 2: return "Wywar Pancerza Krwi";
+        case 3: return "Eliksir Siły Ogra";
+        case 4: return "Wywar Cieni";
+        case 5: return "Odwar Odporności";
+        case 6: return "Eliksir Szybkości";
+        case 7: return "Wywar Ostrza";
+        case 8: return "Nalewka Czarnego Serca";
+    }
+    return "Nieznany Wywar";
+}
+
+string AlchGetRecipeDesc(int nId)
+{
+    switch(nId)
+    {
+        case 0: return "Leczy 15 punktów ran. Prosta, niezawodna mikstura.";
+        case 1: return "Ultrawzrok przez 3 minuty. Widzisz w ciemności i dostrzegasz ukryte.";
+        case 2: return "Pancerz magiczny +4 do KP przez 5 minut. Skóra twardnieje jak kamień.";
+        case 3: return "Siła +4 przez 5 minut. Mięśnie nabrzmiewają jak u ogra.";
+        case 4: return "Niewidzialność przez 2 minuty. Wtapiasz się w cień.";
+        case 5: return "Odporność na rzuty obronne +2 przez 5 minut. Wewnętrzna tarcza.";
+        case 6: return "Przyśpieszenie (Haste) przez 18 sekund. Każda żyła płonie.";
+        case 7: return "Premia do ataku +3 przez 5 minut. Ręka prowadzi broń pewniej.";
+        case 8: return "Regeneracja 2 PŻ / rundę przez 5 minut. Ciało naprawia samo siebie.";
+    }
+    return "";
+}
+
+string AlchGetRecipeFlavor(int nId)
+{
+    switch(nId)
+    {
+        case 0: return "„Smakuje jak ziemia i rdza, ale ból odpływa szybko."";
+        case 1: return "„Po wypiciu źrenice rozszerzają się niczym u kota — widzisz każdy cień."";
+        case 2: return "„Skóra błyszczy przez chwilę srebrno, zanim efekt znika pod tkanią."";
+        case 3: return "„Zapach krwi ogra nie znika przez kilka godzin. Warto."";
+        case 4: return "„Ciało staje się nieokreślone. Nawet własne dłonie wydają się mgliste."";
+        case 5: return "„Gorzkie i metaliczne. Chroni, lecz smak zostaje długo."";
+        case 6: return "„Rtęć śpiewa w żyłach. Ruszasz się zanim zdążysz pomyśleć."";
+        case 7: return "„Ręka unosi się sama ku rękojeści. Instynkt staje się ostrym ostrzem."";
+        case 8: return "„Serce bije wolno, lecz równo. Rany zaciskają się jak usta milczące."";
+    }
+    return "";
+}
+
+int AlchGetRecipeDC(int nId)
+{
+    switch(nId)
+    {
+        case 0: return 12;
+        case 1: return 14;
+        case 2: return 14;
+        case 3: return 16;
+        case 4: return 16;
+        case 5: return 18;
+        case 6: return 18;
+        case 7: return 20;
+        case 8: return 22;
+    }
+    return 15;
+}
+
+string AlchGetRecipeIng1(int nId)
+{
+    switch(nId)
+    {
+        case 0: return ALCH_ING_PIOLUN;
+        case 1: return ALCH_ING_GRZYB;
+        case 2: return ALCH_ING_ZELAZ;
+        case 3: return ALCH_ING_KREW_O;
+        case 4: return ALCH_ING_OKO;
+        case 5: return ALCH_ING_RTEC;
+        case 6: return ALCH_ING_RTEC;
+        case 7: return ALCH_ING_KREW_O;
+        case 8: return ALCH_ING_GRZYB;
+    }
+    return "";
+}
+
+string AlchGetRecipeIng2(int nId)
+{
+    switch(nId)
+    {
+        case 0: return ALCH_ING_KOSCIOL;
+        case 1: return ALCH_ING_OKO;
+        case 2: return ALCH_ING_OLEJ;
+        case 3: return ALCH_ING_ZELAZ;
+        case 4: return ALCH_ING_GRZYB;
+        case 5: return ALCH_ING_KWIAT;
+        case 6: return ALCH_ING_KWIAT;
+        case 7: return ALCH_ING_ZELAZ;
+        case 8: return ALCH_ING_KREW_N;
+    }
+    return "";
+}
+
+string AlchGetRecipeIng3(int nId)
+{
+    switch(nId)
+    {
+        case 0: return ALCH_ING_KREW_N;
+        case 1: return ALCH_ING_RTEC;
+        case 2: return ALCH_ING_KOSCIOL;
+        case 3: return ALCH_ING_OLEJ;
+        case 4: return ALCH_ING_KOSCIOL;
+        case 5: return ALCH_ING_KOSCIOL;
+        case 6: return ALCH_ING_OLEJ;
+        case 7: return ALCH_ING_OLEJ;
+        case 8: return ALCH_ING_KWIAT;
+    }
+    return "";
+}
+
+// Polish display name for each ingredient resref
+string AlchGetIngredientName(string sResRef)
+{
+    if(sResRef == ALCH_ING_PIOLUN)  return "Piołun";
+    if(sResRef == ALCH_ING_KOSCIOL) return "Kość Trupna";
+    if(sResRef == ALCH_ING_KREW_N)  return "Krew Nocna";
+    if(sResRef == ALCH_ING_GRZYB)   return "Czarny Grzyb";
+    if(sResRef == ALCH_ING_RTEC)    return "Rtęć";
+    if(sResRef == ALCH_ING_OLEJ)    return "Tłuszcz Szczurzy";
+    if(sResRef == ALCH_ING_OKO)     return "Oko Sowy";
+    if(sResRef == ALCH_ING_KWIAT)   return "Kwiat Bladej Damy";
+    if(sResRef == ALCH_ING_KREW_O)  return "Krew Ogra";
+    if(sResRef == ALCH_ING_ZELAZ)   return "Pył Żelazny";
+    return sResRef;
+}
+
+// ----------------------------------------------------------------
+// Inventory helpers
+// ----------------------------------------------------------------
+
+// Count total stack size of items matching sResRef in PC inventory
+int AlchCountIngredient(object oPC, string sResRef)
+{
+    int nCount = 0;
+    object oItem = GetFirstItemInInventory(oPC);
+    while(GetIsObjectValid(oItem))
+    {
+        if(GetResRef(oItem) == sResRef)
+            nCount += GetItemStackSize(oItem);
+        oItem = GetNextItemInInventory(oPC);
+    }
+    return nCount;
+}
+
+// Remove exactly one unit of sResRef from PC inventory (reduces stack or destroys)
+void AlchTakeIngredient(object oPC, string sResRef)
+{
+    object oItem = GetFirstItemInInventory(oPC);
+    while(GetIsObjectValid(oItem))
+    {
+        if(GetResRef(oItem) == sResRef)
+        {
+            int nStack = GetItemStackSize(oItem);
+            if(nStack > 1)
+                SetItemStackSize(oItem, nStack - 1);
+            else
+                DestroyObject(oItem);
+            return;
+        }
+        oItem = GetNextItemInInventory(oPC);
+    }
+}
+
+// ----------------------------------------------------------------
+// Craft skill bonus: Spellcraft rank + INT modifier
+// ----------------------------------------------------------------
+int AlchGetCraftBonus(object oPC)
+{
+    int nSkill = GetSkillRank(SKILL_SPELLCRAFT, oPC);
+    int nInt   = GetAbilityScore(oPC, ABILITY_INTELLIGENCE);
+    int nMod   = (nInt - 10) / 2;
+    return nSkill + nMod;
+}

--- a/Alchemy/Scripts/lib_alch_ev.nss
+++ b/Alchemy/Scripts/lib_alch_ev.nss
@@ -1,0 +1,67 @@
+// lib_alch_ev.nss
+// NUI event handler for the Alchemy Workshop window.
+// Set as the module OnNuiEvent script (see sys_on_load.nss).
+#include "lib_alch"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    if(nToken != NuiFindWindow(oPC, ALCH_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalInt(oPC, ALCH_LVAR_SEL_IDX);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == ALCH_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        if(sElem == ALCH_BTN_BREW)
+        {
+            int nSel = GetLocalInt(oPC, ALCH_LVAR_SEL_IDX);
+            if(nSel >= 0)
+                AlchBrew(oPC, nToken, nSel);
+            return;
+        }
+    }
+
+    if(sEvent == EVENT_TYPE_MOUSEDOWN && sElem == ALCH_BTN_ROW)
+    {
+        if(nIdx < 0 || nIdx >= ALCH_RECIPE_COUNT) return;
+
+        // De-encourage previously selected row
+        int nPrev = GetLocalInt(oPC, ALCH_LVAR_SEL_IDX);
+        if(nPrev >= 0)
+        {
+            json jEncs = NuiGetBind(oPC, nToken, ALCH_BIND_REC_ENC);
+            if(JsonGetType(jEncs) == JSON_TYPE_ARRAY && nPrev < JsonGetLength(jEncs))
+            {
+                jEncs = JsonArraySet(jEncs, nPrev, JsonBool(FALSE));
+                NuiSetBind(oPC, nToken, ALCH_BIND_REC_ENC, jEncs);
+            }
+        }
+
+        // Encourage new row
+        SetLocalInt(oPC, ALCH_LVAR_SEL_IDX, nIdx);
+        json jEncs = NuiGetBind(oPC, nToken, ALCH_BIND_REC_ENC);
+        if(JsonGetType(jEncs) == JSON_TYPE_ARRAY && nIdx < JsonGetLength(jEncs))
+        {
+            jEncs = JsonArraySet(jEncs, nIdx, JsonBool(TRUE));
+            NuiSetBind(oPC, nToken, ALCH_BIND_REC_ENC, jEncs);
+        }
+
+        FeedDetailPanel(oPC, nToken, nIdx);
+        return;
+    }
+}

--- a/Alchemy/Scripts/sql_alch.nss
+++ b/Alchemy/Scripts/sql_alch.nss
@@ -1,0 +1,65 @@
+// sql_alch.nss
+// SQLite schema and CRUD for per-character recipe knowledge.
+// Uses SqlPrepareQueryObject (per-PC) for recipe data.
+// Campaign DB stores nothing; all data lives on the PC object
+// so it travels with the character across server restarts.
+
+// ----------------------------------------------------------------
+// Schema
+// ----------------------------------------------------------------
+
+void AlchInitTables(object oPC)
+{
+    // Idempotent: safe to call on every login
+    sqlquery q = SqlPrepareQueryObject(oPC,
+        "CREATE TABLE IF NOT EXISTS alch_recipes ("
+        "  recipe_id   INTEGER NOT NULL,"
+        "  unlocked_at INTEGER NOT NULL DEFAULT 0,"
+        "  PRIMARY KEY (recipe_id)"
+        ");"
+    );
+    SqlStep(q);
+}
+
+// ----------------------------------------------------------------
+// Recipe knowledge
+// ----------------------------------------------------------------
+
+int AlchHasRecipe(object oPC, int nRecipeId)
+{
+    sqlquery q = SqlPrepareQueryObject(oPC,
+        "SELECT 1 FROM alch_recipes WHERE recipe_id = @id;"
+    );
+    SqlBindInt(q, "@id", nRecipeId);
+    return SqlStep(q) ? 1 : 0;
+}
+
+void AlchUnlockRecipe(object oPC, int nRecipeId)
+{
+    sqlquery q = SqlPrepareQueryObject(oPC,
+        "INSERT OR IGNORE INTO alch_recipes (recipe_id, unlocked_at)"
+        " VALUES (@id, @now);"
+    );
+    SqlBindInt(q, "@id",  nRecipeId);
+    SqlBindInt(q, "@now", GetCalendarDay() * 86400 + GetTimeHour() * 3600);
+    SqlStep(q);
+}
+
+// Returns a JsonArray of integer recipe IDs the PC knows
+json AlchGetUnlockedRecipes(object oPC)
+{
+    sqlquery q = SqlPrepareQueryObject(oPC,
+        "SELECT recipe_id FROM alch_recipes ORDER BY recipe_id;"
+    );
+    json jResult = JsonArray();
+    while(SqlStep(q))
+        jResult = JsonArrayInsert(jResult, JsonInt(SqlGetInt(q, 0)));
+    return jResult;
+}
+
+// Grants the two starter recipes (0 = Nalewka Gojąca, 1 = Odwar Mrocznego Wzroku)
+void AlchGrantStarterRecipes(object oPC)
+{
+    AlchUnlockRecipe(oPC, 0);
+    AlchUnlockRecipe(oPC, 1);
+}

--- a/Alchemy/Scripts/sys_on_acquire.nss
+++ b/Alchemy/Scripts/sys_on_acquire.nss
@@ -1,0 +1,43 @@
+// sys_on_acquire.nss
+// Module OnAcquireItem — detects recipe scrolls and unlocks the matching recipe.
+// Recipe scroll tags follow the pattern ALCH_REC_N where N is the recipe ID (0–8).
+#include "lib_alch_def"
+
+void main()
+{
+    object oItem = GetModuleItemAcquired();
+    object oPC   = GetModuleItemAcquiredBy();
+
+    if(!GetIsPC(oPC) || !GetIsObjectValid(oItem)) return;
+
+    string sTag = GetTag(oItem);
+
+    // Fast-reject: must start with ALCH_REC_
+    if(GetStringLeft(sTag, GetStringLength(ALCH_REC_TAG_PREFIX)) != ALCH_REC_TAG_PREFIX)
+        return;
+
+    string sSuffix = GetStringRight(sTag,
+        GetStringLength(sTag) - GetStringLength(ALCH_REC_TAG_PREFIX));
+    int nId = StringToInt(sSuffix);
+
+    if(nId < 0 || nId >= ALCH_RECIPE_COUNT) return;
+
+    if(AlchHasRecipe(oPC, nId))
+    {
+        SendMessageToPC(oPC, "[Alchemia] Znasz już ten przepis. Zwój rozsypuje się w pył.");
+        DestroyObject(oItem);
+        return;
+    }
+
+    AlchUnlockRecipe(oPC, nId);
+    SendMessageToPC(oPC,
+        "[Alchemia] Nauczyłeś się nowego przepisu: " + AlchGetRecipeName(nId) + "!");
+
+    // Refresh open window if PC has it open
+    int nToken = NuiFindWindow(oPC, ALCH_WINDOW);
+    if(nToken != 0)
+        FeedRecipeList(oPC, nToken);
+
+    // Consume scroll with a short delay so engine finishes the acquire event
+    DestroyObject(oItem, 0.1);
+}

--- a/Alchemy/Scripts/sys_on_enter.nss
+++ b/Alchemy/Scripts/sys_on_enter.nss
@@ -1,0 +1,12 @@
+// sys_on_enter.nss
+// Module OnClientEnter — initialise per-PC recipe table and grant starter recipes.
+#include "lib_alch_def"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC) || GetIsDMPossessed(oPC)) return;
+
+    AlchInitTables(oPC);
+    AlchGrantStarterRecipes(oPC);
+}

--- a/Alchemy/Scripts/sys_on_load.nss
+++ b/Alchemy/Scripts/sys_on_load.nss
@@ -1,0 +1,10 @@
+// sys_on_load.nss
+// Module OnModuleLoad — no persistent tables needed at module scope;
+// per-PC tables are created on first enter (sys_on_enter.nss).
+// Sets the module NUI event script so lib_alch_ev.nss receives events.
+#include "lib_alch_def"
+
+void main()
+{
+    SetEventScript(GetModule(), EVENT_SCRIPT_MODULE_ON_NUI_EVENT, ALCH_EV_SCRIPT);
+}

--- a/Alchemy/Scripts/test_alch.nss
+++ b/Alchemy/Scripts/test_alch.nss
@@ -1,0 +1,55 @@
+// test_alch.nss
+// OnUsed script for a demo placeable (tag: alch_bench).
+// Opens the Alchemy Workshop window for the activating PC.
+// Also hands out one set of starter ingredients and one recipe scroll
+// on the first interaction so the demo can be run immediately.
+#include "lib_alch"
+
+const string ALCH_TEST_GIVEN = "ALCH_TEST_GIVEN";
+
+void GiveTestIngredients(object oPC)
+{
+    // One of each ingredient for the two starter recipes:
+    // Starter 0 (Nalewka Gojąca):        PIOLUN + KOSCIOL + KREW_N
+    // Starter 1 (Odwar Mrocznego Wzroku): GRZYB  + OKO    + RTEC
+    int i;
+    for(i = 0; i < 6; i++)
+    {
+        string sRef;
+        switch(i)
+        {
+            case 0: sRef = ALCH_ING_PIOLUN;  break;
+            case 1: sRef = ALCH_ING_KOSCIOL; break;
+            case 2: sRef = ALCH_ING_KREW_N;  break;
+            case 3: sRef = ALCH_ING_GRZYB;   break;
+            case 4: sRef = ALCH_ING_OKO;     break;
+            case 5: sRef = ALCH_ING_RTEC;    break;
+            default: sRef = ""; break;
+        }
+        if(sRef != "")
+            CreateItemOnObject(sRef, oPC);
+    }
+
+    // One recipe scroll for recipe 2 (Wywar Pancerza Krwi) — demonstrates discovery
+    // Tag must match ALCH_REC_2 so sys_on_acquire.nss picks it up
+    CreateItemOnObject("alch_rec_2", oPC);
+
+    SendMessageToPC(oPC,
+        "[Alchemia — Demo] Otrzymałeś składniki testowe i zwój receptury 'Wywar Pancerza Krwi'.");
+    SendMessageToPC(oPC,
+        "[Alchemia — Demo] Podnieś zwój, by odblokować przepis, a potem otwórz stół alchemiczny.");
+}
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    if(!GetLocalInt(oPC, ALCH_TEST_GIVEN))
+    {
+        SetLocalInt(oPC, ALCH_TEST_GIVEN, 1);
+        GiveTestIngredients(oPC);
+    }
+
+    AlchOpenWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

System craftingowy z NUI pozwalający graczom wytwarzać ciemno-fantastyczne eliksiry na stole alchemicznym. Gracz wybiera przepis z listy, sprawdza stan składników i klika **Destyluj** — system wykonuje rzut umiejętności, aplikuje efekt i rozlicza surowce.

## Mechanika

- **9 przepisów** w klimacie Gothic/Planescape: Nalewka Gojąca, Odwar Mrocznego Wzroku, Wywar Pancerza Krwi, Eliksir Siły Ogra, Wywar Cieni, Odwar Odporności, Eliksir Szybkości, Wywar Ostrza, Nalewka Czarnego Serca.
- **Rzut destylacji**: d20 + Wiedza Magiczna + premia INT vs DC 12–22 (rośnie z rzadkością przepisu). Sukces → efekt na PC. Porażka → składniki przepadają. Krytyczna porażka (nat. 1) → dodatkowo 1d6+2 obrażeń od oparów kwasowych. Krytyczny sukces (total ≥ DC+10 lub nat. 20) → efekt podwójny.
- **Odblokowanie przepisów**: dwa przepisy znane od startu; pozostałe 7 wymaga znalezienia i podniesienia zwojów receptury (tagi `ALCH_REC_2`…`ALCH_REC_8`). Podniesienie niszczy zwój i utrwala wiedzę w SQLite.
- **Persystencja**: baza per-PC (`SqlPrepareQueryObject`) — wiedza przepisów wędruje z postacią przez restarty serwera.
- **UI NUI**: lewa lista z kolorowym rozróżnieniem znany/zablokowany + zachęcenie zaznaczonego wiersza; prawy panel z opisem efektu, tekstem klimatycznym, stanem składników (zielony = masz, czerwony = brakuje), wskaźnikiem DC i bonusu gracza oraz przyciskiem Destyluj.

## Pliki

| Plik | Rola |
|---|---|
| `Alchemy/Scripts/lib_alch_def.nss` | Stałe, bindy NUI, metadane 9 przepisów (name/desc/flavor/DC/ing), helpery inventory |
| `Alchemy/Scripts/sql_alch.nss` | Schemat SQLite + CRUD (AlchInitTables, AlchHasRecipe, AlchUnlockRecipe, AlchGrantStarterRecipes) |
| `Alchemy/Scripts/lib_alch.nss` | Builder okna NUI, FeedRecipeList, FeedDetailPanel, AlchApplyEffect, AlchBrew |
| `Alchemy/Scripts/lib_alch_ev.nss` | Handler NUI — switch po NuiGetEventType(), dispatch CLOSE/CLICK/MOUSEDOWN |
| `Alchemy/Scripts/sys_on_load.nss` | OnModuleLoad — ustawia NUI event handler |
| `Alchemy/Scripts/sys_on_enter.nss` | OnClientEnter — init tabel + starter recipes |
| `Alchemy/Scripts/sys_on_acquire.nss` | OnAcquireItem — detekcja zwojów ALCH_REC_N, odblokowanie, zniszczenie |
| `Alchemy/Scripts/test_alch.nss` | OnUsed na placeable alch_bench — rozdaje składniki testowe i otwiera UI |
| `Alchemy/INTEGRATION.md` | Tabela hooków, lista wymaganych assetów hak, opis testu |

## Zależności (NWNX? SQL?)

- **SQL**: `SqlPrepareQueryObject` (per-PC, NWN:EE built-in) — brak NWNX.
- **NWNX**: brak zależności.
- **NWN:EE**: wymaga silnika Beamdog Enhanced Edition (NUI + SQLite API).

## Jak włączyć w istniejącym module

1. Dodaj wywołanie `ExecuteScript("sys_on_load", GetModule())` w module OnModuleLoad (lub scal skrypt).
2. Dodaj wywołanie `ExecuteScript("sys_on_enter", OBJECT_SELF)` w module OnClientEnter.
3. Dodaj wywołanie `ExecuteScript("sys_on_acquire", OBJECT_SELF)` w module OnAcquireItem.
4. Utwórz 10 rodzajów składników (resrefs `alch_piolun`…`alch_zelaz`) i stół (`alch_bench`, OnUsed → `test_alch`).
5. Opcjonalnie: utwórz zwoje receptur z tagami `ALCH_REC_2`…`ALCH_REC_8` i rozłóż w świecie.

## Co celowo pominięto

- **Animacja VFX** na stole — można dodać `EffectVisualEffect(VFX_FNF_SMOKE_PUFF)`.
- **Tworzenie przedmiotów** (potion items) — efekty aplikowane bezpośrednio, co eliminuje zależność od assetów hak i upraszcza demo.
- **Sklep ze składnikami** — decyzja projektanta świata.
- **Multiplayer race condition** na składnikach — minimalne ryzyko przy lokalnym inventory.
- **Plik .mod** — brak narzędzi do pakowania .mod w tym środowisku; zastąpiony przez INTEGRATION.md.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nf9tufSd2FrDp5X7DQCg6q)_