### PR TITLE
feat: Alchemy — System Alchemii

### DIFF
--- a/Alchemy/INTEGRATION.md
+++ b/Alchemy/INTEGRATION.md
@@ -1,0 +1,120 @@
+# Alchemy — Instrukcja integracji
+
+## Opis
+
+System alchemii pozwala graczom odkrywać i warzyć mikstury przy stole alchemika.
+Każda postać posiada własną listę poznanych przepisów (persystowaną w SQLite).
+Warzenie nieznanej kombinacji niszczy składniki i może zakończyć się wybuchem;
+trafienie w nieznany przepis odkrywa go i nagradza bonusowym XP.
+
+## Hooki modułu
+
+| Zdarzenie modułu      | Skrypt                          |
+|-----------------------|---------------------------------|
+| OnModuleLoad          | `sys_on_load.nss`               |
+| OnClientEnter         | `sys_on_enter.nss`              |
+| OnPlayerTarget        | `sys_on_target.nss`             |
+
+> Jeśli moduł ma już własne skrypty dla tych zdarzeń, dodaj wywołania
+> funkcji alchemy na końcu istniejących skryptów:
+>
+> ```nss
+> // w OnModuleLoad:
+> AlchCreateTables();
+>
+> // w OnClientEnter:
+> if(GetIsPC(GetEnteringObject())) {
+>     int nKnown = AlchGetKnownCount(GetEnteringObject());
+>     // ... opcjonalna wiadomość
+> }
+>
+> // w OnPlayerTarget:
+> object oPC = GetLastPlayerToSelectTarget();
+> if(GetIsPC(oPC) && NuiFindWindow(oPC, ALCH_WINDOW) != 0
+> && GetLocalInt(oPC, ALCH_LVAR_TARGETING) > 0)
+>     AlchHandleTargeting(oPC);
+> ```
+
+## Placeable — stół alchemika
+
+1. Umieść dowolny placeable z tag `alchemy_bench` (lub innym).
+2. Ustaw jego skrypt OnUsed na `test_alch`.
+3. W produkcyjnym module zastąp `test_alch` własnym skryptem, który:
+   - Sprawdza odległość gracza od stołu (opcjonalnie).
+   - Sprawdza umiejętność Craft Alchemy (opcjonalnie).
+   - Woła `AlchOpenWindow(oPC)`.
+
+## HAK / zasoby
+
+Moduł wymaga następujących resrefów w HAK-u lub module:
+
+### Składniki (resrefy = tagi itemów)
+
+| Tag / resref              | Opis                          |
+|---------------------------|-------------------------------|
+| `alch_herb_glasswort`     | Ziele głogu                   |
+| `alch_herb_elfwood`       | Łzy elfiego drzewa            |
+| `alch_herb_bloodmoss`     | Krwawy mech                   |
+| `alch_herb_archangel`     | Ziele Archanioła              |
+| `alch_mineral_bezoar`     | Kamień bezoarowy              |
+| `alch_herb_nightshade`    | Czarny bez                    |
+| `alch_fat_shadowcat`      | Tłuszcz kota cienia           |
+| `alch_herb_firecoral`     | Ognisty koral                 |
+| `alch_mineral_sulfur`     | Siarka                        |
+| `alch_fat_salamander`     | Tłuszcz salamandry            |
+| `alch_gland_viper`        | Gruczoł jadowy żmii           |
+| `alch_herb_cowparsley`    | Krowi pasternak               |
+| `alch_gland_sparrowheart` | Serce wróbla                  |
+| `alch_herb_colibrina`     | Ziele kolibrzycy              |
+| `alch_mineral_quartz`     | Kryształ kwarcu               |
+| `alch_clay_deep`          | Glina z Głębinowych Kopalni   |
+| `alch_oil_stone`          | Olej kamienny                 |
+| `alch_herb_deathcap`      | Śmiertelna czapeczka          |
+| `alch_blood_unholy`       | Krew nieświęta                |
+| `alch_mineral_ashbone`    | Proch z kości                 |
+| `alch_blood_witch`        | Krew wiedźmy                  |
+| `alch_shroom_shadow`      | Grzyb Cienia                  |
+| `alch_dust_rune`          | Pył z rozgniecionej runy      |
+
+### Rezultaty (resrefy itemów wytwarzanych)
+
+| Resref                | Przepis                        |
+|-----------------------|--------------------------------|
+| `alch_pot_heal_s`     | Eliksir Uzdrowienia            |
+| `alch_pot_heal_l`     | Wielki Eliksir Uzdrowienia     |
+| `alch_pot_antidote`   | Antidotum                      |
+| `alch_oil_shadow`     | Olej Cienia                    |
+| `alch_pot_fireres`    | Napar z Ognistego Korzenia     |
+| `alch_oil_poison`     | Trucizna Ostrza                |
+| `alch_pot_speed`      | Esencja Przyspieszenia         |
+| `alch_pot_stone`      | Wywar z Kamiennej Skóry        |
+| `alch_pot_death`      | Nektar Umarłych                |
+| `alch_pot_witch`      | Krew Czarownicy                |
+
+Wszystkie itemy składnikowe i wynikowe muszą posiadać tagi identyczne z resrefami
+(lub resrefy muszą być dostępne przez `CreateItemOnObject`). Rekomendowane:
+stworzenie itemów w toolsecie z tymi resrefami i dodanie ich do HAK-u.
+
+## Baza danych
+
+Używa SQLite campaign database `"alchemy"` (plik `alchemy.sqlite` w katalogu serwera).
+Tabela `alch_known` jest tworzona automatycznie przy `sys_on_load`.
+Brak zależności od NWNX — używa wyłącznie natywnych funkcji `SqlPrepareQueryCampaign`.
+
+## NWNX
+
+Brak wymagań NWNX. Moduł działa na czystym NWN:EE.
+
+## Jak nauczyć gracza przepisu z zewnętrznego skryptu
+
+```nss
+#include "sql_alch"
+AlchLearnRecipe(oPC, ALCH_RCP_HEAL_MINOR);   // lub dowolne ID z lib_alch_def
+```
+
+## Celowo pominięto
+
+- Grafika tła okna (brak `alch_bg` w bindach) — łatwo dodać DrawList jak w Mailbox.
+- Poziomy umiejętności alchemii (można dodać sprawdzenie GetSkillRank w AlchBrew).
+- Receptury dynamiczne / definiowane przez DM w runtime (wymagałoby dodatkowej tabeli SQL).
+- System jakości (szansa na wytworzenie wersji wyższej/niższej jakości).

--- a/Alchemy/Scripts/lib_alch.nss
+++ b/Alchemy/Scripts/lib_alch.nss
@@ -1,0 +1,516 @@
+#include "lib_alch_def"
+#include "sql_alch"
+
+// ----------------------------------------------------------------
+// Internal helpers
+// ----------------------------------------------------------------
+
+json _AlchColorNormal()  { return NuiColor(220, 200, 160, 255); }
+json _AlchColorKnown()   { return NuiColor(160, 220, 160, 255); }
+json _AlchColorUnknown() { return NuiColor(120, 120, 120, 255); }
+json _AlchColorSelected(){ return NuiColor(255, 210,  80, 255); }
+json _AlchColorSuccess()  { return NuiColor(100, 220, 100, 255); }
+json _AlchColorFail()     { return NuiColor(220,  80,  80, 255); }
+json _AlchColorDiscover() { return NuiColor(180, 140, 255, 255); }
+
+int AlchAnySlotFilled(object oPC)
+{
+    return (GetLocalString(oPC, ALCH_LVAR_SLOT1) != ""
+         || GetLocalString(oPC, ALCH_LVAR_SLOT2) != ""
+         || GetLocalString(oPC, ALCH_LVAR_SLOT3) != "");
+}
+
+void AlchClearAllSlots(object oPC)
+{
+    DeleteLocalString(oPC, ALCH_LVAR_SLOT1);
+    DeleteLocalString(oPC, ALCH_LVAR_SLOT2);
+    DeleteLocalString(oPC, ALCH_LVAR_SLOT3);
+    DeleteLocalObject(oPC, ALCH_LVAR_SLOT1_OBJ);
+    DeleteLocalObject(oPC, ALCH_LVAR_SLOT2_OBJ);
+    DeleteLocalObject(oPC, ALCH_LVAR_SLOT3_OBJ);
+}
+
+// ----------------------------------------------------------------
+// NUI layout builders
+// ----------------------------------------------------------------
+
+// Left panel: recipe list with 10 scrollable rows + brief ingredient preview
+json _AlchBuildRecipePanel(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 28.0);
+    float fDescH = GetNuiScaleDimension(oPC, 80.0);
+    float fPanW  = GetNuiScaleDimension(oPC, 300.0);
+
+    // Header label
+    json jHeader = NuiLabel(JsonString("Znane Przepisy"),
+                            JsonInt(NUI_HALIGN_CENTER),
+                            JsonInt(NUI_VALIGN_MIDDLE));
+    jHeader = NuiHeight(jHeader, GetNuiScaleDimension(oPC, 26.0));
+
+    // Recipe list rows
+    json jRows = JsonArray();
+    int i;
+    for(i = 0; i < ALCH_RCP_ROWS; i++)
+    {
+        json jBtn = NuiButton(NuiBind(ALCH_BIND_RCP_LABEL + IntToString(i)));
+        jBtn = NuiId(jBtn, ALCH_BTN_RCP_ROW + IntToString(i));
+        jBtn = NuiEnabled(jBtn, NuiBind(ALCH_BIND_RCP_ENA + IntToString(i)));
+        jBtn = NuiHeight(jBtn, fBtnH);
+        jBtn = NuiStyleForegroundColor(jBtn, NuiBind(ALCH_BIND_RCP_COLOR + IntToString(i)));
+        jRows = JsonArrayInsert(jRows, jBtn);
+    }
+
+    json jList = NuiColumn(jRows);
+    json jListScroll = NuiScrollbars(jList, JsonInt(NUI_SCROLLBARS_Y));
+
+    // Selected recipe detail
+    json jDescLbl = NuiLabel(NuiBind(ALCH_BIND_RCP_DESC),
+                             JsonInt(NUI_HALIGN_LEFT),
+                             JsonInt(NUI_VALIGN_TOP));
+    jDescLbl = NuiHeight(jDescLbl, fDescH);
+
+    json jColItems = JsonArray();
+    jColItems = JsonArrayInsert(jColItems, jHeader);
+    jColItems = JsonArrayInsert(jColItems, jListScroll);
+    jColItems = JsonArrayInsert(jColItems, NuiSpacer());
+    jColItems = JsonArrayInsert(jColItems, jDescLbl);
+
+    json jCol = NuiColumn(jColItems);
+    jCol = NuiWidth(jCol, fPanW);
+    return jCol;
+}
+
+// Right panel: recipe details + 3 ingredient slots + brew button + result log
+json _AlchBuildWorkbenchPanel(object oPC)
+{
+    float fBtnH   = GetNuiScaleDimension(oPC, 34.0);
+    float fSlotH  = GetNuiScaleDimension(oPC, 36.0);
+    float fResH   = GetNuiScaleDimension(oPC, 50.0);
+
+    // Selected recipe name + difficulty
+    json jRcpName = NuiLabel(NuiBind(ALCH_BIND_RCP_NAME),
+                              JsonInt(NUI_HALIGN_LEFT),
+                              JsonInt(NUI_VALIGN_MIDDLE));
+    jRcpName = NuiHeight(jRcpName, GetNuiScaleDimension(oPC, 26.0));
+
+    json jDiffLbl = NuiLabel(NuiBind(ALCH_BIND_RCP_DIFF),
+                              JsonInt(NUI_HALIGN_RIGHT),
+                              JsonInt(NUI_VALIGN_MIDDLE));
+    jDiffLbl = NuiHeight(jDiffLbl, GetNuiScaleDimension(oPC, 26.0));
+    jDiffLbl = NuiWidth(jDiffLbl, GetNuiScaleDimension(oPC, 120.0));
+
+    json jNameRow = JsonArray();
+    jNameRow = JsonArrayInsert(jNameRow, jRcpName);
+    jNameRow = JsonArrayInsert(jNameRow, jDiffLbl);
+
+    // Ingredient labels for selected recipe
+    json jIngrHeader = NuiLabel(JsonString("Wymagane składniki:"),
+                                 JsonInt(NUI_HALIGN_LEFT),
+                                 JsonInt(NUI_VALIGN_MIDDLE));
+    jIngrHeader = NuiHeight(jIngrHeader, GetNuiScaleDimension(oPC, 20.0));
+
+    json jIngr1 = NuiLabel(NuiBind(ALCH_BIND_RCP_INGR1),
+                            JsonInt(NUI_HALIGN_LEFT),
+                            JsonInt(NUI_VALIGN_MIDDLE));
+    jIngr1 = NuiHeight(jIngr1, GetNuiScaleDimension(oPC, 18.0));
+
+    json jIngr2 = NuiLabel(NuiBind(ALCH_BIND_RCP_INGR2),
+                            JsonInt(NUI_HALIGN_LEFT),
+                            JsonInt(NUI_VALIGN_MIDDLE));
+    jIngr2 = NuiHeight(jIngr2, GetNuiScaleDimension(oPC, 18.0));
+
+    json jIngr3 = NuiLabel(NuiBind(ALCH_BIND_RCP_INGR3),
+                            JsonInt(NUI_HALIGN_LEFT),
+                            JsonInt(NUI_VALIGN_MIDDLE));
+    jIngr3 = NuiHeight(jIngr3, GetNuiScaleDimension(oPC, 18.0));
+
+    // Separator label
+    json jSlotHeader = NuiLabel(JsonString("Warzelnia — wrzuć składniki:"),
+                                 JsonInt(NUI_HALIGN_LEFT),
+                                 JsonInt(NUI_VALIGN_MIDDLE));
+    jSlotHeader = NuiHeight(jSlotHeader, GetNuiScaleDimension(oPC, 22.0));
+
+    // 3 ingredient slots, each: [pick button] [clear button]
+    float fClearW = GetNuiScaleDimension(oPC, 28.0);
+    json jSlots = JsonArray();
+    int s;
+    for(s = 1; s <= 3; s++)
+    {
+        string sSuf = IntToString(s);
+
+        json jPickBtn = NuiButton(NuiBind(ALCH_BIND_SLOT_LBL + sSuf));
+        jPickBtn = NuiId(jPickBtn, ALCH_BTN_SLOT + sSuf);
+        jPickBtn = NuiHeight(jPickBtn, fSlotH);
+        jPickBtn = NuiStyleForegroundColor(jPickBtn, NuiBind(ALCH_BIND_SLOT_CLR + sSuf));
+
+        json jClearBtn = NuiButton(JsonString("X"));
+        jClearBtn = NuiId(jClearBtn, ALCH_BTN_SLOT_CLR + sSuf);
+        jClearBtn = NuiWidth(jClearBtn, fClearW);
+        jClearBtn = NuiHeight(jClearBtn, fSlotH);
+
+        json jSlotRow = JsonArray();
+        jSlotRow = JsonArrayInsert(jSlotRow, jPickBtn);
+        jSlotRow = JsonArrayInsert(jSlotRow, jClearBtn);
+
+        jSlots = JsonArrayInsert(jSlots, NuiRow(jSlotRow));
+    }
+
+    json jSlotCol = NuiColumn(jSlots);
+
+    // Brew button
+    json jBrewBtn = NuiButton(JsonString("Warzyć"));
+    jBrewBtn = NuiId(jBrewBtn, ALCH_BTN_BREW);
+    jBrewBtn = NuiEnabled(jBrewBtn, NuiBind(ALCH_BIND_BREW_ENA));
+    jBrewBtn = NuiHeight(jBrewBtn, fBtnH);
+
+    // Result label
+    json jResultLbl = NuiLabel(NuiBind(ALCH_BIND_RESULT_LBL),
+                                JsonInt(NUI_HALIGN_LEFT),
+                                JsonInt(NUI_VALIGN_TOP));
+    jResultLbl = NuiHeight(jResultLbl, fResH);
+    jResultLbl = NuiStyleForegroundColor(jResultLbl, NuiBind(ALCH_BIND_RESULT_COL));
+
+    json jColItems = JsonArray();
+    jColItems = JsonArrayInsert(jColItems, NuiRow(jNameRow));
+    jColItems = JsonArrayInsert(jColItems, jIngrHeader);
+    jColItems = JsonArrayInsert(jColItems, jIngr1);
+    jColItems = JsonArrayInsert(jColItems, jIngr2);
+    jColItems = JsonArrayInsert(jColItems, jIngr3);
+    jColItems = JsonArrayInsert(jColItems, NuiSpacer());
+    jColItems = JsonArrayInsert(jColItems, jSlotHeader);
+    jColItems = JsonArrayInsert(jColItems, jSlotCol);
+    jColItems = JsonArrayInsert(jColItems, NuiSpacer());
+    jColItems = JsonArrayInsert(jColItems, jBrewBtn);
+    jColItems = JsonArrayInsert(jColItems, jResultLbl);
+
+    return NuiColumn(jColItems);
+}
+
+// Full window layout
+json _AlchBuildLayout(object oPC)
+{
+    json jLeft  = _AlchBuildRecipePanel(oPC);
+    json jRight = _AlchBuildWorkbenchPanel(oPC);
+
+    json jMainRow = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jLeft);
+    jMainRow = JsonArrayInsert(jMainRow, NuiSpacer());
+    jMainRow = JsonArrayInsert(jMainRow, jRight);
+
+    // Close button in a top bar
+    json jCloseBtn = NuiButton(JsonString("Zamknij"));
+    jCloseBtn = NuiId(jCloseBtn, ALCH_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, GetNuiScaleDimension(oPC, 80.0));
+    jCloseBtn = NuiHeight(jCloseBtn, GetNuiScaleDimension(oPC, 26.0));
+
+    json jTitleLbl = NuiLabel(JsonString("Stół Alchemiczny"),
+                               JsonInt(NUI_HALIGN_LEFT),
+                               JsonInt(NUI_VALIGN_MIDDLE));
+    jTitleLbl = NuiHeight(jTitleLbl, GetNuiScaleDimension(oPC, 26.0));
+
+    json jTopBar = JsonArray();
+    jTopBar = JsonArrayInsert(jTopBar, jTitleLbl);
+    jTopBar = JsonArrayInsert(jTopBar, jCloseBtn);
+
+    json jRoot = JsonArray();
+    jRoot = JsonArrayInsert(jRoot, NuiRow(jTopBar));
+    jRoot = JsonArrayInsert(jRoot, NuiRow(jMainRow));
+
+    return NuiColumn(jRoot);
+}
+
+// ----------------------------------------------------------------
+// Open window
+// ----------------------------------------------------------------
+
+void AlchOpenWindow(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, ALCH_WINDOW);
+    if(nToken != 0)
+    {
+        // Window already open — just refresh binds (layout is immutable without NuiGroup swap)
+        AlchFeedRecipeList(oPC, nToken);
+        AlchFeedSlotLabels(oPC, nToken);
+        return;
+    }
+
+    float fW = GetNuiScaleDimension(oPC, ALCH_W);
+    float fH = GetNuiScaleDimension(oPC, ALCH_H);
+
+    json jGeom = NuiRect(
+        (GetNuiScaleDimension(oPC, 1920.0) - fW) / 2.0,
+        (GetNuiScaleDimension(oPC, 1080.0) - fH) / 2.0,
+        fW, fH);
+
+    json jWin = NuiWindow(
+        _AlchBuildLayout(oPC),
+        JsonString("Stół Alchemiczny"),
+        NuiBind(ALCH_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE),
+        JsonBool(TRUE));
+
+    nToken = NuiCreate(oPC, jWin, ALCH_WINDOW);
+    NuiSetEventScript(oPC, nToken, ALCH_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, ALCH_WIN_GEOM, jGeom);
+
+    SetLocalInt(oPC, ALCH_LVAR_SEL_RCP, -1);
+    AlchClearAllSlots(oPC);
+    AlchFeedRecipeList(oPC, nToken);
+    AlchFeedSlotLabels(oPC, nToken);
+    AlchFeedRecipeInfo(oPC, nToken, -1);
+}
+
+// ----------------------------------------------------------------
+// Feed functions
+// ----------------------------------------------------------------
+
+void AlchFeedRecipeList(object oPC, int nToken)
+{
+    int nSel = GetLocalInt(oPC, ALCH_LVAR_SEL_RCP);
+    int i;
+    for(i = 0; i < ALCH_RCP_ROWS; i++)
+    {
+        string sSuf = IntToString(i);
+        if(i >= ALCH_RECIPE_COUNT)
+        {
+            NuiSetBind(oPC, nToken, ALCH_BIND_RCP_LABEL + sSuf, JsonString(""));
+            NuiSetBind(oPC, nToken, ALCH_BIND_RCP_ENA   + sSuf, JsonBool(FALSE));
+            NuiSetBind(oPC, nToken, ALCH_BIND_RCP_COLOR + sSuf, _AlchColorUnknown());
+            continue;
+        }
+
+        int nKnown = AlchIsRecipeKnown(oPC, i);
+        string sLabel = nKnown ? AlchGetRecipeName(i) : "??? (nieznany)";
+        json jColor   = (i == nSel)
+                            ? _AlchColorSelected()
+                            : (nKnown ? _AlchColorKnown() : _AlchColorUnknown());
+
+        NuiSetBind(oPC, nToken, ALCH_BIND_RCP_LABEL + sSuf, JsonString(sLabel));
+        NuiSetBind(oPC, nToken, ALCH_BIND_RCP_ENA   + sSuf, JsonBool(nKnown));
+        NuiSetBind(oPC, nToken, ALCH_BIND_RCP_COLOR + sSuf, jColor);
+    }
+}
+
+void AlchFeedSlotLabels(object oPC, int nToken)
+{
+    string sTag;
+    string sLbl;
+    json jColor;
+
+    sTag   = GetLocalString(oPC, ALCH_LVAR_SLOT1);
+    sLbl   = (sTag != "") ? sTag : "[ Pusty slot 1 ]";
+    jColor = (sTag != "") ? _AlchColorKnown() : _AlchColorNormal();
+    NuiSetBind(oPC, nToken, ALCH_BIND_SLOT_LBL + "1", JsonString(sLbl));
+    NuiSetBind(oPC, nToken, ALCH_BIND_SLOT_CLR + "1", jColor);
+
+    sTag   = GetLocalString(oPC, ALCH_LVAR_SLOT2);
+    sLbl   = (sTag != "") ? sTag : "[ Pusty slot 2 ]";
+    jColor = (sTag != "") ? _AlchColorKnown() : _AlchColorNormal();
+    NuiSetBind(oPC, nToken, ALCH_BIND_SLOT_LBL + "2", JsonString(sLbl));
+    NuiSetBind(oPC, nToken, ALCH_BIND_SLOT_CLR + "2", jColor);
+
+    sTag   = GetLocalString(oPC, ALCH_LVAR_SLOT3);
+    sLbl   = (sTag != "") ? sTag : "[ Pusty slot 3 ]";
+    jColor = (sTag != "") ? _AlchColorKnown() : _AlchColorNormal();
+    NuiSetBind(oPC, nToken, ALCH_BIND_SLOT_LBL + "3", JsonString(sLbl));
+    NuiSetBind(oPC, nToken, ALCH_BIND_SLOT_CLR + "3", jColor);
+
+    NuiSetBind(oPC, nToken, ALCH_BIND_BREW_ENA, JsonBool(AlchAnySlotFilled(oPC)));
+}
+
+void AlchFeedRecipeInfo(object oPC, int nToken, int nRecipeId)
+{
+    if(nRecipeId < 0)
+    {
+        NuiSetBind(oPC, nToken, ALCH_BIND_RCP_NAME,  JsonString("— wybierz przepis —"));
+        NuiSetBind(oPC, nToken, ALCH_BIND_RCP_DESC,  JsonString(""));
+        NuiSetBind(oPC, nToken, ALCH_BIND_RCP_INGR1, JsonString(""));
+        NuiSetBind(oPC, nToken, ALCH_BIND_RCP_INGR2, JsonString(""));
+        NuiSetBind(oPC, nToken, ALCH_BIND_RCP_INGR3, JsonString(""));
+        NuiSetBind(oPC, nToken, ALCH_BIND_RCP_DIFF,  JsonString(""));
+        return;
+    }
+
+    NuiSetBind(oPC, nToken, ALCH_BIND_RCP_NAME,
+        JsonString(AlchGetRecipeName(nRecipeId)));
+    NuiSetBind(oPC, nToken, ALCH_BIND_RCP_DESC,
+        JsonString(AlchGetRecipeDesc(nRecipeId)));
+    NuiSetBind(oPC, nToken, ALCH_BIND_RCP_INGR1,
+        JsonString("  1. " + AlchGetRecipeIngrLabel(nRecipeId, 1)));
+    NuiSetBind(oPC, nToken, ALCH_BIND_RCP_INGR2,
+        JsonString("  2. " + AlchGetRecipeIngrLabel(nRecipeId, 2)));
+    NuiSetBind(oPC, nToken, ALCH_BIND_RCP_INGR3,
+        JsonString("  3. " + AlchGetRecipeIngrLabel(nRecipeId, 3)));
+    NuiSetBind(oPC, nToken, ALCH_BIND_RCP_DIFF,
+        JsonString("Trudność: " + AlchDifficultyLabel(AlchGetRecipeDifficulty(nRecipeId))));
+
+    NuiSetBind(oPC, nToken, ALCH_BIND_RESULT_LBL, JsonString(""));
+}
+
+// ----------------------------------------------------------------
+// Brewing
+// ----------------------------------------------------------------
+
+void AlchBrew(object oPC, int nToken)
+{
+    string sTag1 = GetLocalString(oPC, ALCH_LVAR_SLOT1);
+    string sTag2 = GetLocalString(oPC, ALCH_LVAR_SLOT2);
+    string sTag3 = GetLocalString(oPC, ALCH_LVAR_SLOT3);
+
+    if(sTag1 == "" && sTag2 == "" && sTag3 == "")
+    {
+        NuiSetBind(oPC, nToken, ALCH_BIND_RESULT_LBL,
+            JsonString("Warzelnia jest pusta. Wrzuć składniki."));
+        NuiSetBind(oPC, nToken, ALCH_BIND_RESULT_COL, _AlchColorFail());
+        return;
+    }
+
+    string sSig = AlchBuildSignature(sTag1, sTag2, sTag3);
+    int nRecipeId = AlchFindRecipeBySignature(sSig);
+
+    // Consume slot items from inventory
+    object oItem1 = GetLocalObject(oPC, ALCH_LVAR_SLOT1_OBJ);
+    object oItem2 = GetLocalObject(oPC, ALCH_LVAR_SLOT2_OBJ);
+    object oItem3 = GetLocalObject(oPC, ALCH_LVAR_SLOT3_OBJ);
+
+    if(sTag1 != "" && !GetIsObjectValid(oItem1))
+    {
+        NuiSetBind(oPC, nToken, ALCH_BIND_RESULT_LBL,
+            JsonString("Nie znaleziono składnika w ekwipunku. Odśwież sloty."));
+        NuiSetBind(oPC, nToken, ALCH_BIND_RESULT_COL, _AlchColorFail());
+        return;
+    }
+    if(sTag2 != "" && !GetIsObjectValid(oItem2))
+    {
+        NuiSetBind(oPC, nToken, ALCH_BIND_RESULT_LBL,
+            JsonString("Nie znaleziono składnika w ekwipunku. Odśwież sloty."));
+        NuiSetBind(oPC, nToken, ALCH_BIND_RESULT_COL, _AlchColorFail());
+        return;
+    }
+    if(sTag3 != "" && !GetIsObjectValid(oItem3))
+    {
+        NuiSetBind(oPC, nToken, ALCH_BIND_RESULT_LBL,
+            JsonString("Nie znaleziono składnika w ekwipunku. Odśwież sloty."));
+        NuiSetBind(oPC, nToken, ALCH_BIND_RESULT_COL, _AlchColorFail());
+        return;
+    }
+
+    // Destroy ingredients regardless of outcome
+    if(GetIsObjectValid(oItem1)) DestroyObject(oItem1);
+    if(GetIsObjectValid(oItem2)) DestroyObject(oItem2);
+    if(GetIsObjectValid(oItem3)) DestroyObject(oItem3);
+    AlchClearAllSlots(oPC);
+    AlchFeedSlotLabels(oPC, nToken);
+
+    if(nRecipeId < 0)
+    {
+        // Unknown combination — 30% chance of acid splash
+        int nExplode = (Random(100) < 30);
+        if(nExplode)
+        {
+            ApplyEffectToObject(DURATION_TYPE_INSTANT,
+                EffectDamage(d6(2), DAMAGE_TYPE_ACID), oPC);
+            NuiSetBind(oPC, nToken, ALCH_BIND_RESULT_LBL,
+                JsonString("BUCH! Niestabilna mieszanina wybuchła kwasem. Składniki zniszczone."));
+            NuiSetBind(oPC, nToken, ALCH_BIND_RESULT_COL, _AlchColorFail());
+            FloatingTextStringOnCreature(
+                "Niestabilna mieszanina wybucha kwasem!", oPC, FALSE);
+        }
+        else
+        {
+            NuiSetBind(oPC, nToken, ALCH_BIND_RESULT_LBL,
+                JsonString("Połączenie nic nie dało. Składniki uległy rozkładowi."));
+            NuiSetBind(oPC, nToken, ALCH_BIND_RESULT_COL, _AlchColorFail());
+        }
+        return;
+    }
+
+    int nKnewBefore = AlchIsRecipeKnown(oPC, nRecipeId);
+
+    if(!nKnewBefore)
+    {
+        // Discovery: learn recipe, bonus XP
+        AlchLearnRecipe(oPC, nRecipeId);
+        GiveXPToCreature(oPC, ALCH_XP_DISCOVER);
+        NuiSetBind(oPC, nToken, ALCH_BIND_RESULT_LBL,
+            JsonString("Odkryto nowy przepis: " + AlchGetRecipeName(nRecipeId)
+                     + "! Zdobyto " + IntToString(ALCH_XP_DISCOVER) + " PD."));
+        NuiSetBind(oPC, nToken, ALCH_BIND_RESULT_COL, _AlchColorDiscover());
+        FloatingTextStringOnCreature(
+            "Odkryto przepis: " + AlchGetRecipeName(nRecipeId) + "!", oPC, FALSE);
+        AlchFeedRecipeList(oPC, nToken);
+    }
+
+    // Create result item
+    string sResref = AlchGetRecipeResultResref(nRecipeId);
+    object oResult = CreateItemOnObject(sResref, oPC);
+
+    if(!GetIsObjectValid(oResult))
+    {
+        // Resref not found — still award discovery, notify DM
+        SendMessageToAllDMs("[Alchemy] Brak resref: " + sResref
+                          + " dla przepisu " + IntToString(nRecipeId));
+        if(!nKnewBefore) return;
+        NuiSetBind(oPC, nToken, ALCH_BIND_RESULT_LBL,
+            JsonString("Warzenie zakończone, lecz rezultat wyparował. Skontaktuj się z DM."));
+        NuiSetBind(oPC, nToken, ALCH_BIND_RESULT_COL, _AlchColorFail());
+        return;
+    }
+
+    AlchIncrementBrewCount(oPC, nRecipeId);
+    GiveXPToCreature(oPC, ALCH_XP_BREW_BASE * AlchGetRecipeDifficulty(nRecipeId));
+
+    if(nKnewBefore)
+    {
+        NuiSetBind(oPC, nToken, ALCH_BIND_RESULT_LBL,
+            JsonString("Uwarzono: " + GetName(oResult)
+                     + ". Zdobyto "
+                     + IntToString(ALCH_XP_BREW_BASE * AlchGetRecipeDifficulty(nRecipeId))
+                     + " PD."));
+        NuiSetBind(oPC, nToken, ALCH_BIND_RESULT_COL, _AlchColorSuccess());
+    }
+}
+
+// ----------------------------------------------------------------
+// Targeting — called from sys_on_target
+// ----------------------------------------------------------------
+
+void AlchHandleTargeting(object oPC)
+{
+    int nSlot = GetLocalInt(oPC, ALCH_LVAR_TARGETING);
+    DeleteLocalInt(oPC, ALCH_LVAR_TARGETING);
+
+    if(nSlot < 1 || nSlot > 3) return;
+
+    int nToken = NuiFindWindow(oPC, ALCH_WINDOW);
+    if(nToken == 0) return;
+
+    object oItem = GetTargetingModeSelectedObject();
+    if(!GetIsObjectValid(oItem) || GetItemPossessor(oItem) != oPC)
+    {
+        SendMessageToPC(oPC, "[Alchemia] Musisz wybrać przedmiot ze swojego ekwipunku.");
+        return;
+    }
+
+    string sSlotVar     = (nSlot == 1) ? ALCH_LVAR_SLOT1
+                        : (nSlot == 2) ? ALCH_LVAR_SLOT2 : ALCH_LVAR_SLOT3;
+    string sSlotObjVar  = (nSlot == 1) ? ALCH_LVAR_SLOT1_OBJ
+                        : (nSlot == 2) ? ALCH_LVAR_SLOT2_OBJ : ALCH_LVAR_SLOT3_OBJ;
+
+    // Check the item isn't already in another slot
+    if(oItem == GetLocalObject(oPC, ALCH_LVAR_SLOT1_OBJ)
+    || oItem == GetLocalObject(oPC, ALCH_LVAR_SLOT2_OBJ)
+    || oItem == GetLocalObject(oPC, ALCH_LVAR_SLOT3_OBJ))
+    {
+        SendMessageToPC(oPC, "[Alchemia] Ten składnik jest już w warzelni.");
+        return;
+    }
+
+    SetLocalString(oPC, sSlotVar, GetTag(oItem));
+    SetLocalObject(oPC, sSlotObjVar, oItem);
+
+    AlchFeedSlotLabels(oPC, nToken);
+}

--- a/Alchemy/Scripts/lib_alch_def.nss
+++ b/Alchemy/Scripts/lib_alch_def.nss
@@ -1,0 +1,290 @@
+#include "lib_nui"
+
+void AlchOpenWindow(object oPC);
+void AlchFeedRecipeList(object oPC, int nToken);
+void AlchFeedSlotLabels(object oPC, int nToken);
+void AlchFeedRecipeInfo(object oPC, int nToken, int nRecipeId);
+void AlchBrew(object oPC, int nToken);
+void AlchHandleTargeting(object oPC);
+
+// ----------------------------------------------------------------
+// Window / event
+// ----------------------------------------------------------------
+
+const string ALCH_WINDOW        = "ALCH_WINDOW";
+const string ALCH_EV_SCRIPT     = "lib_alch_ev";
+const string ALCH_WIN_GEOM      = "alch_win_geom";
+
+// ----------------------------------------------------------------
+// Bind names
+// ----------------------------------------------------------------
+
+// Recipe list (listbox)
+const string ALCH_BIND_RCP_LABEL  = "alch_rcp_label";
+const string ALCH_BIND_RCP_ENA    = "alch_rcp_ena";
+const string ALCH_BIND_RCP_COLOR  = "alch_rcp_color";
+const string ALCH_BIND_RCP_ENC    = "alch_rcp_enc";
+
+// Recipe detail panel (right side, top)
+const string ALCH_BIND_RCP_NAME   = "alch_rcp_name";
+const string ALCH_BIND_RCP_DESC   = "alch_rcp_desc";
+const string ALCH_BIND_RCP_INGR1  = "alch_rcp_ingr1";
+const string ALCH_BIND_RCP_INGR2  = "alch_rcp_ingr2";
+const string ALCH_BIND_RCP_INGR3  = "alch_rcp_ingr3";
+const string ALCH_BIND_RCP_DIFF   = "alch_rcp_diff";
+
+// Workbench slots
+const string ALCH_BIND_SLOT_LBL   = "alch_slot_lbl";   // + "1"/"2"/"3"
+const string ALCH_BIND_SLOT_ENA   = "alch_slot_ena";   // + "1"/"2"/"3"
+const string ALCH_BIND_SLOT_CLR   = "alch_slot_clr";   // + "1"/"2"/"3"
+
+// Brew result feedback
+const string ALCH_BIND_RESULT_LBL = "alch_result_lbl";
+const string ALCH_BIND_RESULT_COL = "alch_result_col";
+
+// Brew button
+const string ALCH_BIND_BREW_ENA   = "alch_brew_ena";
+
+// ----------------------------------------------------------------
+// Button IDs
+// ----------------------------------------------------------------
+
+const string ALCH_BTN_CLOSE       = "alch_btn_close";
+const string ALCH_BTN_RCP_ROW     = "alch_btn_rcp_row";  // + IntToString(id)
+const string ALCH_BTN_SLOT        = "alch_btn_slot";     // + "1"/"2"/"3"
+const string ALCH_BTN_SLOT_CLR    = "alch_btn_slotclr";  // + "1"/"2"/"3"
+const string ALCH_BTN_BREW        = "alch_btn_brew";
+
+// ----------------------------------------------------------------
+// Local variables on PC
+// ----------------------------------------------------------------
+
+const string ALCH_LVAR_SEL_RCP    = "ALCH_SEL_RCP";       // selected recipe id (-1 = none)
+const string ALCH_LVAR_SLOT1      = "ALCH_SLOT1_TAG";
+const string ALCH_LVAR_SLOT2      = "ALCH_SLOT2_TAG";
+const string ALCH_LVAR_SLOT3      = "ALCH_SLOT3_TAG";
+const string ALCH_LVAR_SLOT1_OBJ  = "ALCH_SLOT1_OBJ";
+const string ALCH_LVAR_SLOT2_OBJ  = "ALCH_SLOT2_OBJ";
+const string ALCH_LVAR_SLOT3_OBJ  = "ALCH_SLOT3_OBJ";
+const string ALCH_LVAR_TARGETING  = "ALCH_TARGETING_SLOT"; // 1/2/3 during targeting mode
+
+// ----------------------------------------------------------------
+// Layout
+// ----------------------------------------------------------------
+
+const float ALCH_W          = 680.0;
+const float ALCH_H          = 500.0;
+const int   ALCH_RCP_ROWS   = 10;
+
+// ----------------------------------------------------------------
+// Recipes
+// Each recipe: id, name (PL), description (PL), 3 ingredient tags,
+//              result resref, result stack count, difficulty (1-3).
+// Ingredient tag "" = slot unused (recipe needs fewer than 3 items).
+// Ingredient tags reference items that must exist in the HAK/module.
+// ----------------------------------------------------------------
+
+const int ALCH_RECIPE_COUNT = 10;
+
+// Recipe IDs
+const int ALCH_RCP_HEAL_MINOR   = 0;
+const int ALCH_RCP_HEAL_MAJOR   = 1;
+const int ALCH_RCP_ANTIDOTE     = 2;
+const int ALCH_RCP_SHADOW_OIL   = 3;
+const int ALCH_RCP_FIRE_RESIST  = 4;
+const int ALCH_RCP_POISON_BLADE = 5;
+const int ALCH_RCP_SPEED        = 6;
+const int ALCH_RCP_STONESKIN    = 7;
+const int ALCH_RCP_NECTAR_DEATH = 8;
+const int ALCH_RCP_WITCHBLOOD   = 9;
+
+// XP reward tables
+const int ALCH_XP_BREW_BASE     = 25;   // per successful brew
+const int ALCH_XP_DISCOVER      = 100;  // bonus for first discovery
+
+string AlchGetRecipeName(int nId)
+{
+    switch(nId)
+    {
+        case ALCH_RCP_HEAL_MINOR:   return "Eliksir Uzdrowienia";
+        case ALCH_RCP_HEAL_MAJOR:   return "Wielki Eliksir Uzdrowienia";
+        case ALCH_RCP_ANTIDOTE:     return "Antidotum";
+        case ALCH_RCP_SHADOW_OIL:   return "Olej Cienia";
+        case ALCH_RCP_FIRE_RESIST:  return "Napar z Ognistego Korzenia";
+        case ALCH_RCP_POISON_BLADE: return "Trucizna Ostrza";
+        case ALCH_RCP_SPEED:        return "Esencja Przyspieszenia";
+        case ALCH_RCP_STONESKIN:    return "Wywar z Kamiennej Skóry";
+        case ALCH_RCP_NECTAR_DEATH: return "Nektar Umarłych";
+        case ALCH_RCP_WITCHBLOOD:   return "Krew Czarownicy";
+    }
+    return "Nieznany przepis";
+}
+
+string AlchGetRecipeDesc(int nId)
+{
+    switch(nId)
+    {
+        case ALCH_RCP_HEAL_MINOR:
+            return "Prosta nalewka z korzenia głogu i łez elfiego drzewa. Zamyka płytkie rany, lecz nie uleczy tych głębokich.";
+        case ALCH_RCP_HEAL_MAJOR:
+            return "Potężna mikstura warzona trzema składnikami przez noc pełni. Przywraca siły po nawet najcięższych zranieniach.";
+        case ALCH_RCP_ANTIDOTE:
+            return "Wywar z Rośliny Archanioła i sproszkowanego kamienia bezoarowego neutralizuje większość trucizn krążących w tym świecie.";
+        case ALCH_RCP_SHADOW_OIL:
+            return "Nakłada się na ostrze przed zasadzką. Zabija głos kroków i rozmazuje sylwetkę w mroku. Lubiany przez cichociemnych.";
+        case ALCH_RCP_FIRE_RESIST:
+            return "Alchemik z Krainy Ognia opisał ten przepis przed śmiercią na stosie. Skóra nim namaszczona odpiera żar przez krótką chwilę.";
+        case ALCH_RCP_POISON_BLADE:
+            return "Ciemnozielona maź z jadu żmii i soku krowiej pietruszki. Jedna dawka starczy na trzy ciosy. Nie liż palców.";
+        case ALCH_RCP_SPEED:
+            return "Destylat z serc wróbli i ziela kolibrzycy przyspiesza krew i myśl ponad miarę człowieka. Efekt trwa krótko, lecz bywa zbawczy.";
+        case ALCH_RCP_STONESKIN:
+            return "Mieszanka gliny z Głębinowych Kopalni i oleju kamiennego twardnieje na skórze jak zbroja. Ciężka, lecz skuteczna.";
+        case ALCH_RCP_NECTAR_DEATH:
+            return "Przepis zakazany przez Kościół Świętego Ognia. Wzmacnia nieumarłe siły w krwi. Pita przez żywego — pali od środka.";
+        case ALCH_RCP_WITCHBLOOD:
+            return "Z krwi wiedźmy, odrostów grzyba-cienia i pyłu z rozgniecionej runy. Wzmacnia magiczne zdolności na jedną walkę.";
+    }
+    return "";
+}
+
+// Ingredient tag — tag of the item object (GetTag). "" = slot empty.
+string AlchGetRecipeIngr(int nId, int nSlot)
+{
+    switch(nId)
+    {
+        case ALCH_RCP_HEAL_MINOR:
+            if(nSlot == 1) return "alch_herb_glasswort";
+            if(nSlot == 2) return "alch_herb_elfwood";
+            return "";
+        case ALCH_RCP_HEAL_MAJOR:
+            if(nSlot == 1) return "alch_herb_glasswort";
+            if(nSlot == 2) return "alch_herb_elfwood";
+            if(nSlot == 3) return "alch_herb_bloodmoss";
+            return "";
+        case ALCH_RCP_ANTIDOTE:
+            if(nSlot == 1) return "alch_herb_archangel";
+            if(nSlot == 2) return "alch_mineral_bezoar";
+            return "";
+        case ALCH_RCP_SHADOW_OIL:
+            if(nSlot == 1) return "alch_herb_nightshade";
+            if(nSlot == 2) return "alch_fat_shadowcat";
+            return "";
+        case ALCH_RCP_FIRE_RESIST:
+            if(nSlot == 1) return "alch_herb_firecoral";
+            if(nSlot == 2) return "alch_mineral_sulfur";
+            if(nSlot == 3) return "alch_fat_salamander";
+            return "";
+        case ALCH_RCP_POISON_BLADE:
+            if(nSlot == 1) return "alch_gland_viper";
+            if(nSlot == 2) return "alch_herb_cowparsley";
+            return "";
+        case ALCH_RCP_SPEED:
+            if(nSlot == 1) return "alch_gland_sparrowheart";
+            if(nSlot == 2) return "alch_herb_colibrina";
+            if(nSlot == 3) return "alch_mineral_quartz";
+            return "";
+        case ALCH_RCP_STONESKIN:
+            if(nSlot == 1) return "alch_clay_deep";
+            if(nSlot == 2) return "alch_oil_stone";
+            return "";
+        case ALCH_RCP_NECTAR_DEATH:
+            if(nSlot == 1) return "alch_herb_deathcap";
+            if(nSlot == 2) return "alch_blood_unholy";
+            if(nSlot == 3) return "alch_mineral_ashbone";
+            return "";
+        case ALCH_RCP_WITCHBLOOD:
+            if(nSlot == 1) return "alch_blood_witch";
+            if(nSlot == 2) return "alch_shroom_shadow";
+            if(nSlot == 3) return "alch_dust_rune";
+            return "";
+    }
+    return "";
+}
+
+// Resref of result item (must exist in HAK or standard resources)
+string AlchGetRecipeResultResref(int nId)
+{
+    switch(nId)
+    {
+        case ALCH_RCP_HEAL_MINOR:   return "alch_pot_heal_s";
+        case ALCH_RCP_HEAL_MAJOR:   return "alch_pot_heal_l";
+        case ALCH_RCP_ANTIDOTE:     return "alch_pot_antidote";
+        case ALCH_RCP_SHADOW_OIL:   return "alch_oil_shadow";
+        case ALCH_RCP_FIRE_RESIST:  return "alch_pot_fireres";
+        case ALCH_RCP_POISON_BLADE: return "alch_oil_poison";
+        case ALCH_RCP_SPEED:        return "alch_pot_speed";
+        case ALCH_RCP_STONESKIN:    return "alch_pot_stone";
+        case ALCH_RCP_NECTAR_DEATH: return "alch_pot_death";
+        case ALCH_RCP_WITCHBLOOD:   return "alch_pot_witch";
+    }
+    return "";
+}
+
+int AlchGetRecipeDifficulty(int nId)
+{
+    switch(nId)
+    {
+        case ALCH_RCP_HEAL_MINOR:   return 1;
+        case ALCH_RCP_HEAL_MAJOR:   return 2;
+        case ALCH_RCP_ANTIDOTE:     return 1;
+        case ALCH_RCP_SHADOW_OIL:   return 2;
+        case ALCH_RCP_FIRE_RESIST:  return 3;
+        case ALCH_RCP_POISON_BLADE: return 2;
+        case ALCH_RCP_SPEED:        return 2;
+        case ALCH_RCP_STONESKIN:    return 3;
+        case ALCH_RCP_NECTAR_DEATH: return 3;
+        case ALCH_RCP_WITCHBLOOD:   return 3;
+    }
+    return 1;
+}
+
+string AlchGetRecipeIngrLabel(int nId, int nSlot)
+{
+    string sTag = AlchGetRecipeIngr(nId, nSlot);
+    if(sTag == "") return "—";
+    return sTag;
+}
+
+string AlchDifficultyLabel(int nDiff)
+{
+    switch(nDiff)
+    {
+        case 1: return "Prosta";
+        case 2: return "Złożona";
+        case 3: return "Mistrzowska";
+    }
+    return "";
+}
+
+// Returns a sorted 3-element signature string used for recipe matching.
+// Order of slots doesn't matter — we canonicalise by sorting.
+string AlchBuildSignature(string sA, string sB, string sC)
+{
+    // Bubble-sort three strings
+    string sTmp;
+    if(sA > sB) { sTmp = sA; sA = sB; sB = sTmp; }
+    if(sB > sC) { sTmp = sB; sB = sC; sC = sTmp; }
+    if(sA > sB) { sTmp = sA; sA = sB; sB = sTmp; }
+    return sA + "|" + sB + "|" + sC;
+}
+
+string AlchGetRecipeSignature(int nId)
+{
+    return AlchBuildSignature(
+        AlchGetRecipeIngr(nId, 1),
+        AlchGetRecipeIngr(nId, 2),
+        AlchGetRecipeIngr(nId, 3));
+}
+
+// Returns recipe id whose canonical ingredient signature matches, or -1.
+int AlchFindRecipeBySignature(string sSig)
+{
+    int i;
+    for(i = 0; i < ALCH_RECIPE_COUNT; i++)
+    {
+        if(AlchGetRecipeSignature(i) == sSig)
+            return i;
+    }
+    return -1;
+}

--- a/Alchemy/Scripts/lib_alch_ev.nss
+++ b/Alchemy/Scripts/lib_alch_ev.nss
@@ -1,0 +1,82 @@
+#include "lib_alch"
+
+void AlchOnNuiEvent()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetWindowToken();
+    string sWin   = NuiGetWindowId();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+
+    if(sWin != ALCH_WINDOW) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        AlchClearAllSlots(oPC);
+        DeleteLocalInt(oPC, ALCH_LVAR_SEL_RCP);
+        return;
+    }
+
+    if(sEvent != EVENT_TYPE_CLICK) return;
+
+    // Close button
+    if(sElem == ALCH_BTN_CLOSE)
+    {
+        NuiDestroy(oPC, nToken);
+        return;
+    }
+
+    // Brew button
+    if(sElem == ALCH_BTN_BREW)
+    {
+        AlchBrew(oPC, nToken);
+        return;
+    }
+
+    // Slot clear buttons: "alch_btn_slotclr1" / "2" / "3"
+    if(GetStringLeft(sElem, GetStringLength(ALCH_BTN_SLOT_CLR)) == ALCH_BTN_SLOT_CLR)
+    {
+        string sSuf = GetStringRight(sElem, 1);
+        int nSlot   = StringToInt(sSuf);
+        if(nSlot >= 1 && nSlot <= 3)
+        {
+            string sVar    = (nSlot == 1) ? ALCH_LVAR_SLOT1
+                           : (nSlot == 2) ? ALCH_LVAR_SLOT2 : ALCH_LVAR_SLOT3;
+            string sObjVar = (nSlot == 1) ? ALCH_LVAR_SLOT1_OBJ
+                           : (nSlot == 2) ? ALCH_LVAR_SLOT2_OBJ : ALCH_LVAR_SLOT3_OBJ;
+            DeleteLocalString(oPC, sVar);
+            DeleteLocalObject(oPC, sObjVar);
+            AlchFeedSlotLabels(oPC, nToken);
+        }
+        return;
+    }
+
+    // Slot pick buttons: "alch_btn_slot1" / "2" / "3" — enter targeting mode
+    if(GetStringLeft(sElem, GetStringLength(ALCH_BTN_SLOT)) == ALCH_BTN_SLOT
+    && GetStringLength(sElem) == GetStringLength(ALCH_BTN_SLOT) + 1)
+    {
+        string sSuf = GetStringRight(sElem, 1);
+        int nSlot   = StringToInt(sSuf);
+        if(nSlot >= 1 && nSlot <= 3)
+        {
+            SetLocalInt(oPC, ALCH_LVAR_TARGETING, nSlot);
+            EnterTargetingMode(oPC, OBJECT_TYPE_ITEM);
+        }
+        return;
+    }
+
+    // Recipe row buttons: "alch_btn_rcp_row0" … "alch_btn_rcp_row9"
+    if(GetStringLeft(sElem, GetStringLength(ALCH_BTN_RCP_ROW)) == ALCH_BTN_RCP_ROW)
+    {
+        string sSuf  = GetStringRight(sElem, GetStringLength(sElem) - GetStringLength(ALCH_BTN_RCP_ROW));
+        int nRecipeId = StringToInt(sSuf);
+        if(nRecipeId >= 0 && nRecipeId < ALCH_RECIPE_COUNT
+        && AlchIsRecipeKnown(oPC, nRecipeId))
+        {
+            SetLocalInt(oPC, ALCH_LVAR_SEL_RCP, nRecipeId);
+            AlchFeedRecipeList(oPC, nToken);
+            AlchFeedRecipeInfo(oPC, nToken, nRecipeId);
+        }
+        return;
+    }
+}

--- a/Alchemy/Scripts/sql_alch.nss
+++ b/Alchemy/Scripts/sql_alch.nss
@@ -1,0 +1,83 @@
+#include "lib_alch_def"
+
+// ----------------------------------------------------------------
+// Schema
+// Per-PC known recipes stored in the campaign database "alchemy".
+// ----------------------------------------------------------------
+
+void AlchCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("alchemy",
+        "CREATE TABLE IF NOT EXISTS alch_known ("
+        "  pc_uuid    TEXT    NOT NULL,"
+        "  recipe_id  INTEGER NOT NULL,"
+        "  learned_at INTEGER DEFAULT 0,"
+        "  brew_count INTEGER DEFAULT 0,"
+        "  PRIMARY KEY (pc_uuid, recipe_id)"
+        ")");
+    SqlStep(q);
+}
+
+// ----------------------------------------------------------------
+// Recipe knowledge
+// ----------------------------------------------------------------
+
+int AlchIsRecipeKnown(object oPC, int nRecipeId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("alchemy",
+        "SELECT 1 FROM alch_known WHERE pc_uuid = @uuid AND recipe_id = @rid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@rid",  nRecipeId);
+    return SqlStep(q);
+}
+
+void AlchLearnRecipe(object oPC, int nRecipeId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("alchemy",
+        "INSERT OR IGNORE INTO alch_known (pc_uuid, recipe_id, learned_at) "
+        "VALUES (@uuid, @rid, strftime('%s','now'))");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@rid",  nRecipeId);
+    SqlStep(q);
+}
+
+void AlchIncrementBrewCount(object oPC, int nRecipeId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("alchemy",
+        "UPDATE alch_known SET brew_count = brew_count + 1 "
+        "WHERE pc_uuid = @uuid AND recipe_id = @rid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@rid",  nRecipeId);
+    SqlStep(q);
+}
+
+int AlchGetBrewCount(object oPC, int nRecipeId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("alchemy",
+        "SELECT brew_count FROM alch_known WHERE pc_uuid = @uuid AND recipe_id = @rid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@rid",  nRecipeId);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+int AlchGetKnownCount(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("alchemy",
+        "SELECT COUNT(*) FROM alch_known WHERE pc_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// Returns JsonArray of known recipe_ids for this PC.
+json AlchGetKnownRecipeIds(object oPC)
+{
+    json jIds = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("alchemy",
+        "SELECT recipe_id FROM alch_known WHERE pc_uuid = @uuid ORDER BY recipe_id ASC");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    while(SqlStep(q))
+        jIds = JsonArrayInsert(jIds, JsonInt(SqlGetInt(q, 0)));
+    return jIds;
+}

--- a/Alchemy/Scripts/sys_on_enter.nss
+++ b/Alchemy/Scripts/sys_on_enter.nss
@@ -1,0 +1,16 @@
+#include "lib_alch_def"
+#include "sql_alch"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC)) return;
+
+    int nKnown = AlchGetKnownCount(oPC);
+    if(nKnown > 0)
+    {
+        string sMsg = "[Alchemia] Znasz " + IntToString(nKnown) + " przepis"
+                    + (nKnown == 1 ? "." : (nKnown < 5 ? "y." : "ów."));
+        SendMessageToPC(oPC, sMsg);
+    }
+}

--- a/Alchemy/Scripts/sys_on_load.nss
+++ b/Alchemy/Scripts/sys_on_load.nss
@@ -1,0 +1,7 @@
+#include "lib_alch_def"
+#include "sql_alch"
+
+void main()
+{
+    AlchCreateTables();
+}

--- a/Alchemy/Scripts/sys_on_target.nss
+++ b/Alchemy/Scripts/sys_on_target.nss
@@ -1,0 +1,11 @@
+#include "lib_alch"
+
+void main()
+{
+    object oPC = GetLastPlayerToSelectTarget();
+    if(!GetIsPC(oPC)) return;
+
+    if(NuiFindWindow(oPC, ALCH_WINDOW) != 0
+    && GetLocalInt(oPC, ALCH_LVAR_TARGETING) > 0)
+        AlchHandleTargeting(oPC);
+}

--- a/Alchemy/Scripts/test_alch.nss
+++ b/Alchemy/Scripts/test_alch.nss
@@ -1,0 +1,35 @@
+// OnUsed script for an alchemist's bench placeable.
+// For demo/testing: if the player has no known recipes, they start with the
+// two simplest ones (HEAL_MINOR, ANTIDOTE) so the UI is immediately usable.
+// In a real module these would be learned through in-world discovery.
+
+#include "lib_alch"
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    // Seed starter recipes for new alchemists
+    if(!AlchIsRecipeKnown(oPC, ALCH_RCP_HEAL_MINOR))
+        AlchLearnRecipe(oPC, ALCH_RCP_HEAL_MINOR);
+    if(!AlchIsRecipeKnown(oPC, ALCH_RCP_ANTIDOTE))
+        AlchLearnRecipe(oPC, ALCH_RCP_ANTIDOTE);
+
+    // Give test ingredients when used with shift (DM) or always in demo
+    // Spawns one of each ingredient needed for the two starter recipes
+    string aTestIngr[4];
+    aTestIngr[0] = "alch_herb_glasswort";
+    aTestIngr[1] = "alch_herb_elfwood";
+    aTestIngr[2] = "alch_herb_archangel";
+    aTestIngr[3] = "alch_mineral_bezoar";
+
+    int i;
+    for(i = 0; i < 4; i++)
+    {
+        if(!GetIsObjectValid(GetItemPossessedBy(oPC, aTestIngr[i])))
+            CreateItemOnObject(aTestIngr[i], oPC);
+    }
+
+    AlchOpenWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

Moduł **Alchemy** dodaje stół alchemiczny z dwupanelowym oknem NUI: po lewej
lista poznanych przepisów (kolorowanie: znany/nieznany/zaznaczony), po prawej
warzelnia z 3 slotami na składniki i przyciskiem „Warzyć".

## Mechanika

- Gracz kliknie slot → EnterTargetingMode → wybiera przedmiot z ekwipunku.
- Kliknie „Warzyć" → system canonicalizuje tagi 3 składników (posortowane),
  szuka pasującego przepisu.
- **Znany przepis** → `CreateItemOnObject` z wynikowym resrefem + XP proporcjonalne do trudności (25/50/75 PD).
- **Nieznana, ale poprawna kombinacja** → odkrycie przepisu zapisywane w SQLite + 100 PD bonusu.
- **Błędna kombinacja** → składniki przepadają; 30% szansa na acid splash (2d6).
- Postęp per-postać (UUID) persystowany w campaign DB `"alchemy"`.

Zaimplementowano 10 przepisów w klimacie dark fantasy (od prostego Eliksiru
Uzdrowienia przez Olej Cienia po zakazany Nektar Umarłych i Krew Czarownicy).

## Pliki

```
Alchemy/
├── INTEGRATION.md
└── Scripts/
    ├── lib_alch_def.nss   — stałe, ID bindów, dane 10 przepisów, matchers
    ├── sql_alch.nss       — schema SQLite + CRUD (learn/count/list/brew_count)
    ├── lib_alch.nss       — NUI layout, AlchBrew, AlchHandleTargeting
    ├── lib_alch_ev.nss    — switch po NuiGetEventType(): click/close
    ├── sys_on_load.nss    — AlchCreateTables()
    ├── sys_on_enter.nss   — info o liczbie znanych przepisów na wejściu
    ├── sys_on_target.nss  — przekaz do AlchHandleTargeting gdy slot aktywny
    └── test_alch.nss      — OnUsed na placeable; seeduje starterowe przepisy i składniki
```

## Zależności (NWNX? SQL?)

- **Brak NWNX** — wyłącznie natywne NWN:EE API.
- SQLite campaign DB `"alchemy"` — `SqlPrepareQueryCampaign` (tabela `alch_known`).
- Wymagane resrefy składników i mikstury w HAK lub module (pełna lista w `INTEGRATION.md`).

## Jak włączyć w istniejącym module

1. Dodaj wywołania do istniejących hooków (szczegóły w `INTEGRATION.md`):
   - `OnModuleLoad` → `AlchCreateTables()`
   - `OnClientEnter` → opcjonalna wiadomość o znanych przepisach
   - `OnPlayerTarget` → `AlchHandleTargeting(oPC)` gdy flaga `ALCH_LVAR_TARGETING` ustawiona
2. Ustaw skrypt `test_alch` jako OnUsed na dowolnym placeable stołu alchemicznego.
3. Dodaj wymagane itemy (składniki + wyniki) do HAK lub modułu (tagi = resrefy z `INTEGRATION.md`).
4. Aby z zewnątrz nauczyć gracza przepisu: `AlchLearnRecipe(oPC, ALCH_RCP_*_ID)`.

## Co celowo pominięto

- Grafika tła okna (DrawList image) — łatwo dodać wzorując się na Mailbox.
- Sprawdzenie umiejętności Craft Alchemy / Lore — można dodać w `AlchBrew` bez zmian API.
- Receptury dynamiczne definiowane przez DM w runtime — wymagałoby dodatkowej tabeli i edytora.
- System jakości mikstury (szansa na wersję silniejszą/słabszą zależna od skill roll).
- Czas warzenia z animacją postaci — można dodać `DelayCommand` + `ActionPlayAnimation`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GYbwkF7c7wVj8j3iA12y83)_