### PR TITLE
feat: Bounty Contracts

### DIFF
--- a/Bounty Contracts/INTEGRATION.md
+++ b/Bounty Contracts/INTEGRATION.md
@@ -1,0 +1,58 @@
+# Bounty Contracts — Integration Guide
+
+## Hooki modułu
+
+| Zdarzenie modułu | Skrypt do podpięcia | Notatka |
+|---|---|---|
+| OnModuleLoad | `sys_on_load` | tworzy tabele SQLite |
+| OnClientEnter | `sys_on_enter` | rejestruje gracza, powiadamia o kontrakcie |
+| OnPlayerDeath | `sys_on_pdeath` | auto-wypłata nagrody za zabicie gracza-celu |
+| OnNUIEvent | `lib_bnt_ev` | obsługa UI (wymagane dla wszystkich okien NUI) |
+
+Jeśli moduł ma już własne skrypty dla tych zdarzeń, wywołaj powyższe przez `ExecuteScript`:
+
+```nss
+// przykład — w istniejącym OnModuleLoad:
+ExecuteScript("sys_on_load", GetModule());
+```
+
+## Placeable — Tablica Ogłoszeń
+
+1. Utwórz placeable (np. `plc_board`) w edytorze modułu.
+2. Ustaw jego skrypt `OnUsed` na `test_bnt`.
+3. Gracze klikają tablicę → otwiera się okno Kontraktów.
+
+## Zależności NWNX
+
+Brak — moduł korzysta wyłącznie z wbudowanych funkcji NWN:EE (NUI, SQLite, JSON).
+
+## Baza danych SQLite
+
+Dane trafiają do kampanii o nazwie `bounty` (`bounty.sqlite3` w katalogu `userdata/saves/`).
+
+Tabele:
+- `bnt_contracts` — wszystkie kontrakty z pełnym stanem
+- `bnt_players`  — rejestr graczy do wyszukiwania celów PC
+
+Schemat jest idempotentny (`CREATE TABLE IF NOT EXISTS`) — bezpieczny po restarcie serwera.
+
+## Jak włączyć automatyczną wypłatę za graczy-PC
+
+Wypłata działa bez dodatkowej konfiguracji pod warunkiem podpięcia `sys_on_pdeath`
+do `OnPlayerDeath`. Identyfikacja zabójcy opiera się na `GetLastHostileActor`
+(fallback: `GetLastDamager`). Jeśli serwer korzysta z NWNX_Events i hookuje
+`NWNX_ON_CREATURE_DEATH_AFTER`, można tam wpleść dodatkowe wywołanie
+`BntCheckDeathPayout` dla pewniejszej identyfikacji zabójcy.
+
+## Co celowo pominięto
+
+- **Wyszukiwanie graczy przez popup** — dla celów PC imię musi być wpisane dokładnie
+  (wielkość liter ignorowana). Wymagałoby to osobnego okna w stylu `Mailbox`.
+- **Ograniczenie liczby aktywnych kontraktów na gracza** — łatwe do dodania przez
+  zapytanie COUNT w `BntHandlePost`.
+- **Historia zakończonych kontraktów** — tabela `bnt_contracts` przechowuje je
+  z `state = 2` (completed), ale brak dedykowanego widoku UI.
+- **Powiadomienia dla posters po ukończeniu** — wiadomo kto zlecał; łatwo dodać
+  `SendMessageToPC` do `sys_on_pdeath` lub `BntHandleClaim`.
+- **.mod demo** — środowisko nie obsługuje pakowania pliku `.mod`; wymagane jest
+  ręczne wgranie skryptów przez Toolset lub `nwnsc`.

--- a/Bounty Contracts/Scripts/lib_bnt.nss
+++ b/Bounty Contracts/Scripts/lib_bnt.nss
@@ -1,0 +1,857 @@
+// lib_bnt.nss — Bounty Contracts: UI builders, feed functions, game-logic handlers.
+#include "lib_bnt_def"
+
+// ============================================================
+// Internal forward declarations
+// ============================================================
+json BntBuildBoardView(object oPC);
+json BntBuildActiveView(object oPC);
+json BntBuildMineView(object oPC);
+json BntBuildPostView(object oPC);
+
+// ============================================================
+// Shared helpers
+// ============================================================
+
+// Top tab bar shared across all views
+json BntBuildTabBar(object oPC)
+{
+    float fBtnH = GetNuiScaleDimension(oPC, 28.0);
+    float fBtnW = GetNuiScaleDimension(oPC, 140.0);
+
+    json jBoard = NuiButton(JsonString("Tablica"));
+    jBoard = NuiId(jBoard, BNT_BTN_TAB_BOARD);
+    jBoard = NuiWidth(jBoard, fBtnW);
+    jBoard = NuiHeight(jBoard, fBtnH);
+
+    json jActive = NuiButton(JsonString("Kontrakt"));
+    jActive = NuiId(jActive, BNT_BTN_TAB_ACTIVE);
+    jActive = NuiWidth(jActive, fBtnW);
+    jActive = NuiHeight(jActive, fBtnH);
+
+    json jMine = NuiButton(JsonString("Moje zlecenia"));
+    jMine = NuiId(jMine, BNT_BTN_TAB_MINE);
+    jMine = NuiWidth(jMine, fBtnW);
+    jMine = NuiHeight(jMine, fBtnH);
+
+    json jPost = NuiButton(JsonString("Nowy kontrakt"));
+    jPost = NuiId(jPost, BNT_BTN_TAB_POST);
+    jPost = NuiWidth(jPost, fBtnW);
+    jPost = NuiHeight(jPost, fBtnH);
+
+    json jRow = JsonArray();
+    jRow = JsonArrayInsert(jRow, jBoard);
+    jRow = JsonArrayInsert(jRow, jActive);
+    jRow = JsonArrayInsert(jRow, jMine);
+    jRow = JsonArrayInsert(jRow, jPost);
+    jRow = JsonArrayInsert(jRow, NuiSpacer());
+    return NuiRow(jRow);
+}
+
+// ============================================================
+// Board view
+// ============================================================
+
+json BntBuildBoardView(object oPC)
+{
+    float fRowH     = GetNuiScaleDimension(oPC, 26.0);
+    float fListH    = GetNuiScaleDimension(oPC, 220.0);
+    float fDetailH  = GetNuiScaleDimension(oPC, 110.0);
+    float fBtnH     = GetNuiScaleDimension(oPC, 28.0);
+    float fRewardW  = GetNuiScaleDimension(oPC, 90.0);
+    float fPosterW  = GetNuiScaleDimension(oPC, 120.0);
+    float fExpW     = GetNuiScaleDimension(oPC, 50.0);
+
+    // -- List row template --
+    json jTargetLbl = NuiLabel(NuiBind(BNT_BIND_BD_TARGET),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTargetLbl = NuiStyleForegroundColor(jTargetLbl, NuiBind(BNT_BIND_BD_COLOR));
+
+    json jRewardLbl = NuiLabel(NuiBind(BNT_BIND_BD_REWARD),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRewardLbl = NuiWidth(jRewardLbl, fRewardW);
+    jRewardLbl = NuiStyleForegroundColor(jRewardLbl, NuiBind(BNT_BIND_BD_COLOR));
+
+    json jPosterLbl = NuiLabel(NuiBind(BNT_BIND_BD_POSTER),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jPosterLbl = NuiWidth(jPosterLbl, fPosterW);
+    jPosterLbl = NuiStyleForegroundColor(jPosterLbl, NuiBind(BNT_BIND_BD_COLOR));
+
+    json jExpLbl = NuiLabel(NuiBind(BNT_BIND_BD_EXP),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jExpLbl = NuiWidth(jExpLbl, fExpW);
+    jExpLbl = NuiStyleForegroundColor(jExpLbl, NuiBind(BNT_BIND_BD_COLOR));
+
+    json jCellRow = JsonArray();
+    jCellRow = JsonArrayInsert(jCellRow, jTargetLbl);
+    jCellRow = JsonArrayInsert(jCellRow, jRewardLbl);
+    jCellRow = JsonArrayInsert(jCellRow, jPosterLbl);
+    jCellRow = JsonArrayInsert(jCellRow, jExpLbl);
+
+    json jCell = NuiGroup(NuiRow(jCellRow), TRUE, NUI_SCROLLBARS_NONE);
+    jCell = NuiId(jCell, BNT_BTN_BD_ROW);
+    jCell = NuiEncouraged(jCell, NuiBind(BNT_BIND_BD_ENC));
+
+    json jTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jCell, 0.0, TRUE));
+    json jList = NuiList(jTmpl, NuiBind(BNT_BIND_BD_COUNT), fRowH);
+    jList = NuiHeight(jList, fListH);
+
+    // -- Detail panel --
+    json jDetail = NuiGroup(NuiText(NuiBind(BNT_BIND_BD_DETAIL), FALSE),
+        TRUE, NUI_SCROLLBARS_NONE);
+    jDetail = NuiHeight(jDetail, fDetailH);
+
+    // -- Bottom row --
+    json jAcceptBtn = NuiButton(JsonString("Przyjmij kontrakt"));
+    jAcceptBtn = NuiId(jAcceptBtn, BNT_BTN_ACCEPT);
+    jAcceptBtn = NuiEnabled(jAcceptBtn, NuiBind(BNT_BIND_ACCEPT_ENA));
+    jAcceptBtn = NuiWidth(jAcceptBtn, GetNuiScaleDimension(oPC, 180.0));
+    jAcceptBtn = NuiHeight(jAcceptBtn, fBtnH);
+
+    json jBotRow = JsonArray();
+    jBotRow = JsonArrayInsert(jBotRow, NuiSpacer());
+    jBotRow = JsonArrayInsert(jBotRow, jAcceptBtn);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, BntBuildTabBar(oPC));
+    jCol = JsonArrayInsert(jCol, jList);
+    jCol = JsonArrayInsert(jCol, jDetail);
+    jCol = JsonArrayInsert(jCol, NuiRow(jBotRow));
+
+    return NuiCol(jCol);
+}
+
+// ============================================================
+// Active-contract view
+// ============================================================
+
+json BntBuildActiveView(object oPC)
+{
+    float fBtnH    = GetNuiScaleDimension(oPC, 28.0);
+    float fDescH   = GetNuiScaleDimension(oPC, 200.0);
+    float fLabelH  = GetNuiScaleDimension(oPC, 24.0);
+
+    json jHeader = NuiLabel(NuiBind(BNT_BIND_ACT_HEADER),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jHeader = NuiHeight(jHeader, GetNuiScaleDimension(oPC, 32.0));
+
+    // Info rows
+    json jTargetRow = JsonArray();
+    json jTargetKey = NuiLabel(JsonString("Cel:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTargetKey = NuiWidth(jTargetKey, GetNuiScaleDimension(oPC, 100.0));
+    jTargetKey = NuiHeight(jTargetKey, fLabelH);
+    json jTargetVal = NuiLabel(NuiBind(BNT_BIND_ACT_TARGET),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTargetVal = NuiHeight(jTargetVal, fLabelH);
+    jTargetRow = JsonArrayInsert(jTargetRow, jTargetKey);
+    jTargetRow = JsonArrayInsert(jTargetRow, jTargetVal);
+
+    json jRewardRow = JsonArray();
+    json jRewardKey = NuiLabel(JsonString("Nagroda:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRewardKey = NuiWidth(jRewardKey, GetNuiScaleDimension(oPC, 100.0));
+    jRewardKey = NuiHeight(jRewardKey, fLabelH);
+    json jRewardVal = NuiLabel(NuiBind(BNT_BIND_ACT_REWARD),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRewardVal = NuiHeight(jRewardVal, fLabelH);
+    jRewardVal = NuiStyleForegroundColor(jRewardVal, NuiColor(220, 180, 60));
+    jRewardRow = JsonArrayInsert(jRewardRow, jRewardKey);
+    jRewardRow = JsonArrayInsert(jRewardRow, jRewardVal);
+
+    json jPosterRow = JsonArray();
+    json jPosterKey = NuiLabel(JsonString("Zleceniodawca:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jPosterKey = NuiWidth(jPosterKey, GetNuiScaleDimension(oPC, 100.0));
+    jPosterKey = NuiHeight(jPosterKey, fLabelH);
+    json jPosterVal = NuiLabel(NuiBind(BNT_BIND_ACT_POSTER),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jPosterVal = NuiHeight(jPosterVal, fLabelH);
+    jPosterRow = JsonArrayInsert(jPosterRow, jPosterKey);
+    jPosterRow = JsonArrayInsert(jPosterRow, jPosterVal);
+
+    json jExpRow = JsonArray();
+    json jExpKey = NuiLabel(JsonString("Wygasa:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jExpKey = NuiWidth(jExpKey, GetNuiScaleDimension(oPC, 100.0));
+    jExpKey = NuiHeight(jExpKey, fLabelH);
+    json jExpVal = NuiLabel(NuiBind(BNT_BIND_ACT_EXP),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jExpVal = NuiHeight(jExpVal, fLabelH);
+    jExpRow = JsonArrayInsert(jExpRow, jExpKey);
+    jExpRow = JsonArrayInsert(jExpRow, jExpVal);
+
+    // Description
+    json jDescGrp = NuiGroup(NuiText(NuiBind(BNT_BIND_ACT_DESC), FALSE),
+        TRUE, NUI_SCROLLBARS_NONE);
+    jDescGrp = NuiHeight(jDescGrp, fDescH);
+
+    // Buttons
+    json jClaimBtn = NuiButton(JsonString("Odbierz nagrode"));
+    jClaimBtn = NuiId(jClaimBtn, BNT_BTN_CLAIM);
+    jClaimBtn = NuiEnabled(jClaimBtn, NuiBind(BNT_BIND_CLAIM_ENA));
+    jClaimBtn = NuiWidth(jClaimBtn, GetNuiScaleDimension(oPC, 180.0));
+    jClaimBtn = NuiHeight(jClaimBtn, fBtnH);
+    jClaimBtn = NuiTooltip(jClaimBtn,
+        JsonString("Odbierz nagrode po wykonaniu kontraktu. Tylko dla celow NPC."));
+
+    json jAbandonBtn = NuiButton(JsonString("Zrezygnuj"));
+    jAbandonBtn = NuiId(jAbandonBtn, BNT_BTN_ABANDON);
+    jAbandonBtn = NuiWidth(jAbandonBtn, GetNuiScaleDimension(oPC, 110.0));
+    jAbandonBtn = NuiHeight(jAbandonBtn, fBtnH);
+    jAbandonBtn = NuiTooltip(jAbandonBtn,
+        JsonString("Zwolnij kontrakt — wróci na tablice. Nagroda nie zostaje zwrocona."));
+
+    json jBotRow = JsonArray();
+    jBotRow = JsonArrayInsert(jBotRow, jAbandonBtn);
+    jBotRow = JsonArrayInsert(jBotRow, NuiSpacer());
+    jBotRow = JsonArrayInsert(jBotRow, jClaimBtn);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, BntBuildTabBar(oPC));
+    jCol = JsonArrayInsert(jCol, jHeader);
+    jCol = JsonArrayInsert(jCol, NuiRow(jTargetRow));
+    jCol = JsonArrayInsert(jCol, NuiRow(jRewardRow));
+    jCol = JsonArrayInsert(jCol, NuiRow(jPosterRow));
+    jCol = JsonArrayInsert(jCol, NuiRow(jExpRow));
+    jCol = JsonArrayInsert(jCol, jDescGrp);
+    jCol = JsonArrayInsert(jCol, NuiRow(jBotRow));
+
+    return NuiCol(jCol);
+}
+
+// ============================================================
+// My-contracts view
+// ============================================================
+
+json BntBuildMineView(object oPC)
+{
+    float fRowH    = GetNuiScaleDimension(oPC, 26.0);
+    float fListH   = GetNuiScaleDimension(oPC, 320.0);
+    float fBtnH    = GetNuiScaleDimension(oPC, 28.0);
+    float fRewardW = GetNuiScaleDimension(oPC, 90.0);
+    float fStateW  = GetNuiScaleDimension(oPC, 80.0);
+    float fHunterW = GetNuiScaleDimension(oPC, 130.0);
+
+    json jTargetLbl = NuiLabel(NuiBind(BNT_BIND_MINE_TARGET),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTargetLbl = NuiStyleForegroundColor(jTargetLbl, NuiBind(BNT_BIND_MINE_COLOR));
+
+    json jRewardLbl = NuiLabel(NuiBind(BNT_BIND_MINE_REWARD),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRewardLbl = NuiWidth(jRewardLbl, fRewardW);
+    jRewardLbl = NuiStyleForegroundColor(jRewardLbl, NuiBind(BNT_BIND_MINE_COLOR));
+
+    json jStateLbl = NuiLabel(NuiBind(BNT_BIND_MINE_STATE),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jStateLbl = NuiWidth(jStateLbl, fStateW);
+    jStateLbl = NuiStyleForegroundColor(jStateLbl, NuiBind(BNT_BIND_MINE_COLOR));
+
+    json jHunterLbl = NuiLabel(NuiBind(BNT_BIND_MINE_HUNTER),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jHunterLbl = NuiWidth(jHunterLbl, fHunterW);
+    jHunterLbl = NuiStyleForegroundColor(jHunterLbl, NuiBind(BNT_BIND_MINE_COLOR));
+
+    json jCellRow = JsonArray();
+    jCellRow = JsonArrayInsert(jCellRow, jTargetLbl);
+    jCellRow = JsonArrayInsert(jCellRow, jRewardLbl);
+    jCellRow = JsonArrayInsert(jCellRow, jStateLbl);
+    jCellRow = JsonArrayInsert(jCellRow, jHunterLbl);
+
+    json jCell = NuiGroup(NuiRow(jCellRow), TRUE, NUI_SCROLLBARS_NONE);
+    jCell = NuiId(jCell, BNT_BTN_MINE_ROW);
+    jCell = NuiEncouraged(jCell, NuiBind(BNT_BIND_MINE_ENC));
+
+    json jTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jCell, 0.0, TRUE));
+    json jList = NuiList(jTmpl, NuiBind(BNT_BIND_MINE_COUNT), fRowH);
+    jList = NuiHeight(jList, fListH);
+
+    json jCancelBtn = NuiButton(JsonString("Anuluj wybrany"));
+    jCancelBtn = NuiId(jCancelBtn, BNT_BTN_CANCEL_OWN);
+    jCancelBtn = NuiEnabled(jCancelBtn, NuiBind(BNT_BIND_CANCEL_ENA));
+    jCancelBtn = NuiWidth(jCancelBtn, GetNuiScaleDimension(oPC, 160.0));
+    jCancelBtn = NuiHeight(jCancelBtn, fBtnH);
+    jCancelBtn = NuiTooltip(jCancelBtn,
+        JsonString("Anuluje kontrakt. Zwrot nagrody tylko jesli nikt go jeszcze nie przyjal."));
+
+    json jBotRow = JsonArray();
+    jBotRow = JsonArrayInsert(jBotRow, NuiSpacer());
+    jBotRow = JsonArrayInsert(jBotRow, jCancelBtn);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, BntBuildTabBar(oPC));
+    jCol = JsonArrayInsert(jCol, jList);
+    jCol = JsonArrayInsert(jCol, NuiRow(jBotRow));
+
+    return NuiCol(jCol);
+}
+
+// ============================================================
+// Post-new-contract view
+// ============================================================
+
+json BntBuildPostView(object oPC)
+{
+    float fBtnH   = GetNuiScaleDimension(oPC, 28.0);
+    float fFieldH = GetNuiScaleDimension(oPC, 28.0);
+    float fDescH  = GetNuiScaleDimension(oPC, 140.0);
+    float fLblW   = GetNuiScaleDimension(oPC, 130.0);
+
+    // Target name row
+    json jTargetLbl = NuiLabel(JsonString("Cel (imie):"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTargetLbl = NuiWidth(jTargetLbl, fLblW);
+    jTargetLbl = NuiHeight(jTargetLbl, fFieldH);
+
+    json jTargetField = NuiTextEdit(JsonString(""), NuiBind(BNT_BIND_POST_TARGET),
+        BNT_MAX_TARGET_NAME, FALSE);
+    jTargetField = NuiHeight(jTargetField, fFieldH);
+
+    json jTargetRow = JsonArray();
+    jTargetRow = JsonArrayInsert(jTargetRow, jTargetLbl);
+    jTargetRow = JsonArrayInsert(jTargetRow, jTargetField);
+
+    // PC checkbox row
+    json jIsPcChk = NuiCheck(JsonString("Cel jest graczem (PC)"), NuiBind(BNT_BIND_POST_IS_PC));
+    jIsPcChk = NuiHeight(jIsPcChk, fFieldH);
+    jIsPcChk = NuiTooltip(jIsPcChk,
+        JsonString("Zaznacz jesli cel to gracz. System automatycznie wyplaci nagrode po smierci."));
+
+    json jPcRow = JsonArray();
+    json jPcSpacer = NuiSpacer();
+    jPcSpacer = NuiWidth(jPcSpacer, fLblW);
+    jPcRow = JsonArrayInsert(jPcRow, jPcSpacer);
+    jPcRow = JsonArrayInsert(jPcRow, jIsPcChk);
+
+    // Reward row
+    json jRewardLbl = NuiLabel(JsonString("Nagroda (zloto):"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRewardLbl = NuiWidth(jRewardLbl, fLblW);
+    jRewardLbl = NuiHeight(jRewardLbl, fFieldH);
+
+    json jRewardField = NuiTextEdit(JsonString(""), NuiBind(BNT_BIND_POST_REWARD), 8, FALSE);
+    jRewardField = NuiWidth(jRewardField, GetNuiScaleDimension(oPC, 140.0));
+    jRewardField = NuiHeight(jRewardField, fFieldH);
+
+    json jRewardRow = JsonArray();
+    jRewardRow = JsonArrayInsert(jRewardRow, jRewardLbl);
+    jRewardRow = JsonArrayInsert(jRewardRow, jRewardField);
+
+    // Description label + multiline field
+    json jDescLbl = NuiLabel(JsonString("Opis / poszlaki:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jDescLbl = NuiHeight(jDescLbl, GetNuiScaleDimension(oPC, 22.0));
+
+    json jDescField = NuiTextEdit(JsonString(""), NuiBind(BNT_BIND_POST_DESC),
+        BNT_MAX_DESC, TRUE);
+    jDescField = NuiHeight(jDescField, fDescH);
+
+    // Status line (validation feedback, Polish)
+    json jStatusLbl = NuiLabel(NuiBind(BNT_BIND_POST_STATUS),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jStatusLbl = NuiHeight(jStatusLbl, GetNuiScaleDimension(oPC, 22.0));
+    jStatusLbl = NuiStyleForegroundColor(jStatusLbl, NuiColor(220, 80, 80));
+
+    // Submit button
+    json jSubmitBtn = NuiButton(JsonString("Zloz kontrakt"));
+    jSubmitBtn = NuiId(jSubmitBtn, BNT_BTN_SUBMIT);
+    jSubmitBtn = NuiEnabled(jSubmitBtn, NuiBind(BNT_BIND_POST_SUB_ENA));
+    jSubmitBtn = NuiWidth(jSubmitBtn, GetNuiScaleDimension(oPC, 160.0));
+    jSubmitBtn = NuiHeight(jSubmitBtn, fBtnH);
+
+    json jBotRow = JsonArray();
+    jBotRow = JsonArrayInsert(jBotRow, jStatusLbl);
+    jBotRow = JsonArrayInsert(jBotRow, NuiSpacer());
+    jBotRow = JsonArrayInsert(jBotRow, jSubmitBtn);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, BntBuildTabBar(oPC));
+    jCol = JsonArrayInsert(jCol, NuiRow(jTargetRow));
+    jCol = JsonArrayInsert(jCol, NuiRow(jPcRow));
+    jCol = JsonArrayInsert(jCol, NuiRow(jRewardRow));
+    jCol = JsonArrayInsert(jCol, jDescLbl);
+    jCol = JsonArrayInsert(jCol, jDescField);
+    jCol = JsonArrayInsert(jCol, NuiRow(jBotRow));
+
+    return NuiCol(jCol);
+}
+
+// ============================================================
+// Window creation
+// ============================================================
+
+void BntOpenWindow(object oPC)
+{
+    BntExpireContracts();
+
+    if(NuiFindWindow(oPC, BNT_WINDOW) != 0)
+    {
+        BntSwapToBoard(oPC, NuiFindWindow(oPC, BNT_WINDOW));
+        return;
+    }
+
+    float fW  = GetNuiScaleDimension(oPC, BNT_W);
+    float fH  = GetNuiScaleDimension(oPC, BNT_H);
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - fW) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - fH) / 2.0;
+
+    json jGeom = NuiRect(fCX, fCY, fW, fH);
+
+    // Close button top-right
+    float fBtnH = GetNuiScaleDimension(oPC, 28.0);
+    json jCloseBtn = NuiButton(JsonString("X"));
+    jCloseBtn = NuiId(jCloseBtn, BNT_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, GetNuiScaleDimension(oPC, 28.0));
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jTitleRow = JsonArray();
+    jTitleRow = JsonArrayInsert(jTitleRow, NuiSpacer());
+    jTitleRow = JsonArrayInsert(jTitleRow, jCloseBtn);
+
+    json jSwapGrp = NuiGroup(BntBuildBoardView(oPC), FALSE, NUI_SCROLLBARS_NONE);
+    jSwapGrp = NuiId(jSwapGrp, BNT_GRP_SWAP);
+
+    json jRootCol = JsonArray();
+    jRootCol = JsonArrayInsert(jRootCol, NuiRow(jTitleRow));
+    jRootCol = JsonArrayInsert(jRootCol, jSwapGrp);
+
+    json jWin = NuiWindow(NuiCol(jRootCol),
+        JsonString("Tablica Kontraktów"),
+        NuiBind(BNT_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    int nToken = NuiCreate(oPC, jWin, BNT_WINDOW, BNT_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, BNT_WIN_GEOM, jGeom);
+
+    BntSwapToBoard(oPC, nToken);
+}
+
+// ============================================================
+// View swaps
+// ============================================================
+
+void BntSwapToBoard(object oPC, int nToken)
+{
+    DeleteLocalInt(oPC, BNT_LVAR_SEL_ID);
+    NuiSetGroupLayout(oPC, nToken, BNT_GRP_SWAP, BntBuildBoardView(oPC));
+    BntFeedBoard(oPC, nToken);
+}
+
+void BntSwapToActive(object oPC, int nToken)
+{
+    NuiSetGroupLayout(oPC, nToken, BNT_GRP_SWAP, BntBuildActiveView(oPC));
+    BntFeedActive(oPC, nToken);
+}
+
+void BntSwapToMine(object oPC, int nToken)
+{
+    DeleteLocalInt(oPC, BNT_LVAR_MINE_SEL);
+    NuiSetGroupLayout(oPC, nToken, BNT_GRP_SWAP, BntBuildMineView(oPC));
+    BntFeedMine(oPC, nToken);
+}
+
+void BntSwapToPost(object oPC, int nToken)
+{
+    NuiSetGroupLayout(oPC, nToken, BNT_GRP_SWAP, BntBuildPostView(oPC));
+    BntFeedPost(oPC, nToken);
+}
+
+// ============================================================
+// Feed — Board
+// ============================================================
+
+void BntFeedBoard(object oPC, int nToken)
+{
+    json jContracts = BntGetOpenContracts();
+    int nCount = JsonGetLength(jContracts);
+
+    json jTargets  = JsonArray();
+    json jRewards  = JsonArray();
+    json jPosters  = JsonArray();
+    json jExps     = JsonArray();
+    json jColors   = JsonArray();
+    json jEncs     = JsonArray();
+
+    json jGold   = NuiColor(220, 180, 60);
+    json jWhite  = NuiColor(220, 200, 170);
+    int nSelId   = GetLocalInt(oPC, BNT_LVAR_SEL_ID);
+
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jRow   = JsonArrayGet(jContracts, i);
+        int  nId    = JsonGetInt   (JsonObjectGet(jRow, "id"));
+        int  nRew   = JsonGetInt   (JsonObjectGet(jRow, "reward"));
+        int  nExp   = JsonGetInt   (JsonObjectGet(jRow, "expires_at"));
+        string sTgt = JsonGetString(JsonObjectGet(jRow, "target_name"));
+        string sPost= JsonGetString(JsonObjectGet(jRow, "poster_name"));
+
+        jTargets = JsonArrayInsert(jTargets, JsonString(sTgt));
+        jRewards = JsonArrayInsert(jRewards, JsonString(IntToString(nRew) + " zl"));
+        jPosters = JsonArrayInsert(jPosters, JsonString(sPost));
+        jExps    = JsonArrayInsert(jExps,    JsonString(BntDaysLeft(nExp)));
+        jColors  = JsonArrayInsert(jColors,  (nId == nSelId) ? jGold : jWhite);
+        jEncs    = JsonArrayInsert(jEncs,    JsonBool(nId == nSelId));
+    }
+
+    NuiSetBind(oPC, nToken, BNT_BIND_BD_TARGET, jTargets);
+    NuiSetBind(oPC, nToken, BNT_BIND_BD_REWARD, jRewards);
+    NuiSetBind(oPC, nToken, BNT_BIND_BD_POSTER, jPosters);
+    NuiSetBind(oPC, nToken, BNT_BIND_BD_EXP,    jExps);
+    NuiSetBind(oPC, nToken, BNT_BIND_BD_COLOR,  jColors);
+    NuiSetBind(oPC, nToken, BNT_BIND_BD_ENC,    jEncs);
+    NuiSetBind(oPC, nToken, BNT_BIND_BD_COUNT,  JsonInt(nCount));
+
+    // detail + accept button state
+    if(nSelId > 0 && nCount > 0)
+    {
+        // Find the selected row's description
+        for(i = 0; i < nCount; i++)
+        {
+            json jRow = JsonArrayGet(jContracts, i);
+            if(JsonGetInt(JsonObjectGet(jRow, "id")) == nSelId)
+            {
+                string sDesc = JsonGetString(JsonObjectGet(jRow, "description"));
+                string sTgt  = JsonGetString(JsonObjectGet(jRow, "target_name"));
+                string sPost = JsonGetString(JsonObjectGet(jRow, "poster_name"));
+                int    nRew  = JsonGetInt   (JsonObjectGet(jRow, "reward"));
+                int    nExp  = JsonGetInt   (JsonObjectGet(jRow, "expires_at"));
+
+                string sDetail = "Cel: " + sTgt + "\n"
+                    + "Nagroda: " + IntToString(nRew) + " zlota\n"
+                    + "Zleceniodawca: " + sPost + "\n"
+                    + "Wygasa: " + BntFormatDate(nExp) + "\n\n"
+                    + (sDesc != "" ? sDesc : "(Brak opisu.)");
+                NuiSetBind(oPC, nToken, BNT_BIND_BD_DETAIL, JsonString(sDetail));
+                break;
+            }
+        }
+        // Allow accept only if hunter has no active contract
+        json jActive = BntGetActiveContract(oPC);
+        int bCanAccept = (JsonGetType(jActive) == JSON_TYPE_NULL);
+        NuiSetBind(oPC, nToken, BNT_BIND_ACCEPT_ENA, JsonBool(bCanAccept));
+    }
+    else
+    {
+        NuiSetBind(oPC, nToken, BNT_BIND_BD_DETAIL,
+            JsonString("Wybierz zlecenie z listy aby zobaczyc szczegoly.\n\n"
+                "Krwawa moneta nie zna litosci — tylko skutecznosc."));
+        NuiSetBind(oPC, nToken, BNT_BIND_ACCEPT_ENA, JsonBool(FALSE));
+    }
+}
+
+// ============================================================
+// Feed — Active contract
+// ============================================================
+
+void BntFeedActive(object oPC, int nToken)
+{
+    json jActive = BntGetActiveContract(oPC);
+
+    if(JsonGetType(jActive) == JSON_TYPE_NULL)
+    {
+        NuiSetBind(oPC, nToken, BNT_BIND_ACT_HEADER,
+            JsonString("Brak aktywnego kontraktu"));
+        NuiSetBind(oPC, nToken, BNT_BIND_ACT_TARGET, JsonString("—"));
+        NuiSetBind(oPC, nToken, BNT_BIND_ACT_REWARD, JsonString("—"));
+        NuiSetBind(oPC, nToken, BNT_BIND_ACT_POSTER, JsonString("—"));
+        NuiSetBind(oPC, nToken, BNT_BIND_ACT_EXP,    JsonString("—"));
+        NuiSetBind(oPC, nToken, BNT_BIND_ACT_DESC,
+            JsonString("Przejdz na Tablice i przyjmij kontrakt.\n\n"
+                "Sztylet w mroku nie zna koloru zlota — tylko smak krwi."));
+        NuiSetBind(oPC, nToken, BNT_BIND_CLAIM_ENA, JsonBool(FALSE));
+        return;
+    }
+
+    string sTgt  = JsonGetString(JsonObjectGet(jActive, "target_name"));
+    string sTuid = JsonGetString(JsonObjectGet(jActive, "target_uuid"));
+    int    nRew  = JsonGetInt   (JsonObjectGet(jActive, "reward"));
+    string sPost = JsonGetString(JsonObjectGet(jActive, "poster_name"));
+    int    nExp  = JsonGetInt   (JsonObjectGet(jActive, "expires_at"));
+    string sDesc = JsonGetString(JsonObjectGet(jActive, "description"));
+    int    nId   = JsonGetInt   (JsonObjectGet(jActive, "id"));
+
+    NuiSetBind(oPC, nToken, BNT_BIND_ACT_HEADER,
+        JsonString("Kontrakt aktywny: " + sTgt));
+    NuiSetBind(oPC, nToken, BNT_BIND_ACT_TARGET, JsonString(sTgt));
+    NuiSetBind(oPC, nToken, BNT_BIND_ACT_REWARD,
+        JsonString(IntToString(nRew) + " zlota"));
+    NuiSetBind(oPC, nToken, BNT_BIND_ACT_POSTER, JsonString(sPost));
+    NuiSetBind(oPC, nToken, BNT_BIND_ACT_EXP,
+        JsonString(BntFormatDate(nExp) + " (" + BntDaysLeft(nExp) + " pozostalo)"));
+
+    // PC-target contracts are paid out automatically on death — no manual claim
+    int bIsPC = (sTuid != "");
+    string sDescFull = (sDesc != "" ? sDesc : "(Brak opisu.)");
+    if(bIsPC)
+        sDescFull = sDescFull + "\n\n[Cel-PC: nagroda wyplaci sie automatycznie po smierci celu.]";
+
+    NuiSetBind(oPC, nToken, BNT_BIND_ACT_DESC, JsonString(sDescFull));
+
+    // Manual claim only for NPC contracts
+    NuiSetBind(oPC, nToken, BNT_BIND_CLAIM_ENA, JsonBool(!bIsPC));
+
+    SetLocalInt(oPC, BNT_LVAR_SEL_ID, nId);
+}
+
+// ============================================================
+// Feed — My contracts
+// ============================================================
+
+void BntFeedMine(object oPC, int nToken)
+{
+    json jMine  = BntGetMyPostedContracts(oPC);
+    int  nCount = JsonGetLength(jMine);
+
+    json jTargets  = JsonArray();
+    json jRewards  = JsonArray();
+    json jStates   = JsonArray();
+    json jHunters  = JsonArray();
+    json jColors   = JsonArray();
+    json jEncs     = JsonArray();
+
+    json jGold  = NuiColor(220, 180, 60);
+    json jWhite = NuiColor(220, 200, 170);
+    json jRed   = NuiColor(220, 100, 80);
+    int nSelId  = GetLocalInt(oPC, BNT_LVAR_MINE_SEL);
+
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jRow = JsonArrayGet(jMine, i);
+        int  nId  = JsonGetInt   (JsonObjectGet(jRow, "id"));
+        int  nSt  = JsonGetInt   (JsonObjectGet(jRow, "state"));
+
+        jTargets = JsonArrayInsert(jTargets, JsonString(JsonGetString(JsonObjectGet(jRow, "target_name"))));
+        jRewards = JsonArrayInsert(jRewards, JsonString(IntToString(JsonGetInt(JsonObjectGet(jRow, "reward"))) + " zl"));
+        jStates  = JsonArrayInsert(jStates,  JsonString(BntStateName(nSt)));
+        jHunters = JsonArrayInsert(jHunters, JsonString(
+            nSt == BNT_STATE_ACCEPTED
+                ? JsonGetString(JsonObjectGet(jRow, "hunter_name"))
+                : "—"));
+        jColors  = JsonArrayInsert(jColors, (nId == nSelId) ? jGold : jWhite);
+        jEncs    = JsonArrayInsert(jEncs,   JsonBool(nId == nSelId));
+    }
+
+    NuiSetBind(oPC, nToken, BNT_BIND_MINE_TARGET, jTargets);
+    NuiSetBind(oPC, nToken, BNT_BIND_MINE_REWARD, jRewards);
+    NuiSetBind(oPC, nToken, BNT_BIND_MINE_STATE,  jStates);
+    NuiSetBind(oPC, nToken, BNT_BIND_MINE_HUNTER, jHunters);
+    NuiSetBind(oPC, nToken, BNT_BIND_MINE_COLOR,  jColors);
+    NuiSetBind(oPC, nToken, BNT_BIND_MINE_ENC,    jEncs);
+    NuiSetBind(oPC, nToken, BNT_BIND_MINE_COUNT,  JsonInt(nCount));
+    NuiSetBind(oPC, nToken, BNT_BIND_CANCEL_ENA,  JsonBool(nSelId > 0));
+}
+
+// ============================================================
+// Feed — Post view
+// ============================================================
+
+void BntFeedPost(object oPC, int nToken)
+{
+    NuiSetBind(oPC, nToken, BNT_BIND_POST_TARGET,  JsonString(""));
+    NuiSetBind(oPC, nToken, BNT_BIND_POST_DESC,    JsonString(""));
+    NuiSetBind(oPC, nToken, BNT_BIND_POST_REWARD,  JsonString(""));
+    NuiSetBind(oPC, nToken, BNT_BIND_POST_IS_PC,   JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, BNT_BIND_POST_STATUS,  JsonString(""));
+    NuiSetBind(oPC, nToken, BNT_BIND_POST_SUB_ENA, JsonBool(FALSE));
+
+    NuiSetBindWatch(oPC, nToken, BNT_BIND_POST_TARGET,  TRUE);
+    NuiSetBindWatch(oPC, nToken, BNT_BIND_POST_REWARD,  TRUE);
+}
+
+// ============================================================
+// Action handlers
+// ============================================================
+
+void BntHandleAccept(object oPC, int nToken)
+{
+    int nId = GetLocalInt(oPC, BNT_LVAR_SEL_ID);
+    if(nId <= 0)
+    {
+        SendMessageToPC(oPC, "[Kontrakty] Najpierw wybierz zlecenie z listy.");
+        return;
+    }
+
+    json jActive = BntGetActiveContract(oPC);
+    if(JsonGetType(jActive) != JSON_TYPE_NULL)
+    {
+        SendMessageToPC(oPC, "[Kontrakty] Masz juz aktywny kontrakt. Zrezygnuj z niego przed przyjęciem nowego.");
+        return;
+    }
+
+    if(!BntAcceptContract(oPC, nId))
+    {
+        SendMessageToPC(oPC, "[Kontrakty] Kontrakt zostal juz przyjety przez kogo innego lub wygasl.");
+        BntSwapToBoard(oPC, nToken);
+        return;
+    }
+
+    SendMessageToPC(oPC, "[Kontrakty] Kontrakt przyjety. Ostrze pragnie krwi.");
+    BntSwapToActive(oPC, nToken);
+}
+
+void BntHandleClaim(object oPC, int nToken)
+{
+    json jActive = BntGetActiveContract(oPC);
+    if(JsonGetType(jActive) == JSON_TYPE_NULL)
+    {
+        SendMessageToPC(oPC, "[Kontrakty] Brak aktywnego kontraktu.");
+        return;
+    }
+
+    // Claim only for NPC contracts — PC contracts autopay on death
+    string sTuid = JsonGetString(JsonObjectGet(jActive, "target_uuid"));
+    if(sTuid != "")
+    {
+        SendMessageToPC(oPC, "[Kontrakty] Ten kontrakt wyplaci sie automatycznie po smierci gracza-celu.");
+        return;
+    }
+
+    int nId     = JsonGetInt(JsonObjectGet(jActive, "id"));
+    int nReward = BntClaimContract(oPC, nId);
+    if(nReward <= 0)
+    {
+        SendMessageToPC(oPC, "[Kontrakty] Nie mozna odebrac nagrody — kontrakt niedostepny.");
+        return;
+    }
+
+    GiveGoldToCreature(oPC, nReward);
+    SendMessageToPC(oPC,
+        "[Kontrakty] Nagroda " + IntToString(nReward) + " zlota odebrana. Krew splynela na zloto.");
+
+    FloatingTextStringOnCreature(
+        "Kontrakt ukończony. +" + IntToString(nReward) + " zl", oPC, FALSE);
+
+    BntSwapToBoard(oPC, nToken);
+}
+
+void BntHandleAbandon(object oPC, int nToken)
+{
+    json jActive = BntGetActiveContract(oPC);
+    if(JsonGetType(jActive) == JSON_TYPE_NULL)
+    {
+        SendMessageToPC(oPC, "[Kontrakty] Brak aktywnego kontraktu.");
+        return;
+    }
+
+    BntAbandonContract(oPC);
+    SendMessageToPC(oPC, "[Kontrakty] Zrezygnowales z kontraktu. Wrócil na tablice.");
+    BntSwapToBoard(oPC, nToken);
+}
+
+void BntHandleCancelOwn(object oPC, int nToken)
+{
+    int nId = GetLocalInt(oPC, BNT_LVAR_MINE_SEL);
+    if(nId <= 0)
+    {
+        SendMessageToPC(oPC, "[Kontrakty] Wybierz kontrakt do anulowania.");
+        return;
+    }
+
+    int nRefund = BntCancelOwnContract(oPC, nId);
+
+    if(nRefund > 0)
+    {
+        GiveGoldToCreature(oPC, nRefund);
+        SendMessageToPC(oPC,
+            "[Kontrakty] Kontrakt anulowany. Zwrócono " + IntToString(nRefund) + " zlota.");
+    }
+    else
+    {
+        SendMessageToPC(oPC,
+            "[Kontrakty] Kontrakt anulowany. Brak zwrotu — łowca byl juz w terenie.");
+    }
+
+    DeleteLocalInt(oPC, BNT_LVAR_MINE_SEL);
+    BntFeedMine(oPC, nToken);
+}
+
+void BntHandlePost(object oPC, int nToken)
+{
+    string sTarget  = JsonGetString(NuiGetBind(oPC, nToken, BNT_BIND_POST_TARGET));
+    string sDesc    = JsonGetString(NuiGetBind(oPC, nToken, BNT_BIND_POST_DESC));
+    string sReward  = JsonGetString(NuiGetBind(oPC, nToken, BNT_BIND_POST_REWARD));
+    int    bIsPC    = JsonGetInt   (NuiGetBind(oPC, nToken, BNT_BIND_POST_IS_PC));
+    int    nReward  = StringToInt(sReward);
+
+    if(sTarget == "")
+    {
+        NuiSetBind(oPC, nToken, BNT_BIND_POST_STATUS, JsonString("Podaj imię celu."));
+        return;
+    }
+    if(nReward < BNT_MIN_REWARD)
+    {
+        NuiSetBind(oPC, nToken, BNT_BIND_POST_STATUS,
+            JsonString("Minimalna nagroda: " + IntToString(BNT_MIN_REWARD) + " zlota."));
+        return;
+    }
+    if(GetGold(oPC) < nReward)
+    {
+        NuiSetBind(oPC, nToken, BNT_BIND_POST_STATUS,
+            JsonString("Nie masz wystarczajaco zlota."));
+        return;
+    }
+
+    string sTargetUuid = "";
+    if(bIsPC)
+    {
+        sTargetUuid = BntFindPlayerUUID(sTarget);
+        if(sTargetUuid == "")
+        {
+            NuiSetBind(oPC, nToken, BNT_BIND_POST_STATUS,
+                JsonString("Nie znaleziono gracza o tym imieniu."));
+            return;
+        }
+        if(sTargetUuid == GetObjectUUID(oPC))
+        {
+            NuiSetBind(oPC, nToken, BNT_BIND_POST_STATUS,
+                JsonString("Nie mozesz wystawic nagrody na wlasna glowe."));
+            return;
+        }
+    }
+
+    AssignCommand(oPC, TakeGoldFromCreature(nReward, oPC, TRUE));
+
+    int nId = BntPostContract(oPC, sTarget, sTargetUuid, sDesc, nReward);
+    if(nId <= 0)
+    {
+        GiveGoldToCreature(oPC, nReward);  // rollback
+        SendMessageToPC(oPC, "[Kontrakty] Blad zapisu kontraktu.");
+        return;
+    }
+
+    SendMessageToPC(oPC,
+        "[Kontrakty] Kontrakt wystawiony. Nagroda " + IntToString(nReward)
+        + " zlota zablokowana az do realizacji lub anulowania.");
+
+    if(bIsPC)
+    {
+        object oTarget = BntGetPCByUUID(sTargetUuid);
+        if(GetIsObjectValid(oTarget))
+        {
+            SendMessageToPC(oTarget,
+                "[Kontrakty] Ktos wystawil kontrakt na twoja glowe. Strzez sie.");
+            FloatingTextStringOnCreature("Kontrakt na twoja glowe!", oTarget, FALSE);
+        }
+    }
+
+    BntSwapToMine(oPC, nToken);
+}
+
+// ============================================================
+// Validate post form for real-time submit-button enable
+// ============================================================
+
+void BntValidatePostForm(object oPC, int nToken)
+{
+    string sTarget = JsonGetString(NuiGetBind(oPC, nToken, BNT_BIND_POST_TARGET));
+    string sReward = JsonGetString(NuiGetBind(oPC, nToken, BNT_BIND_POST_REWARD));
+    int    nReward = StringToInt(sReward);
+    int    bOk     = (sTarget != "" && nReward >= BNT_MIN_REWARD && GetGold(oPC) >= nReward);
+    NuiSetBind(oPC, nToken, BNT_BIND_POST_SUB_ENA, JsonBool(bOk));
+}

--- a/Bounty Contracts/Scripts/lib_bnt_def.nss
+++ b/Bounty Contracts/Scripts/lib_bnt_def.nss
@@ -1,0 +1,127 @@
+// lib_bnt_def.nss — Bounty Contracts: constants, bind names, forward declarations.
+#include "lib_nui"
+#include "sql_bnt"
+
+// ============================================================
+// Forward declarations (resolved in lib_bnt.nss)
+// ============================================================
+void BntOpenWindow(object oPC);
+void BntSwapToBoard(object oPC, int nToken);
+void BntSwapToActive(object oPC, int nToken);
+void BntSwapToMine(object oPC, int nToken);
+void BntSwapToPost(object oPC, int nToken);
+void BntFeedBoard(object oPC, int nToken);
+void BntFeedActive(object oPC, int nToken);
+void BntFeedMine(object oPC, int nToken);
+void BntFeedPost(object oPC, int nToken);
+
+// ============================================================
+// Window / group IDs
+// ============================================================
+const string BNT_WINDOW         = "BNT_WINDOW";
+const string BNT_EV_SCRIPT      = "lib_bnt_ev";
+const string BNT_GRP_SWAP       = "BNT_GRP_SWAP";
+const string BNT_WIN_GEOM       = "bnt_win_geom";
+
+// ============================================================
+// Board-view binds  (list rows)
+// ============================================================
+const string BNT_BIND_BD_TARGET  = "bnt_bd_target";
+const string BNT_BIND_BD_REWARD  = "bnt_bd_reward";
+const string BNT_BIND_BD_POSTER  = "bnt_bd_poster";
+const string BNT_BIND_BD_EXP     = "bnt_bd_exp";
+const string BNT_BIND_BD_ENC     = "bnt_bd_enc";
+const string BNT_BIND_BD_COLOR   = "bnt_bd_color";
+const string BNT_BIND_BD_COUNT   = "bnt_bd_count";
+const string BNT_BIND_BD_DETAIL  = "bnt_bd_detail";
+const string BNT_BIND_ACCEPT_ENA = "bnt_accept_ena";
+
+// ============================================================
+// Active-contract-view binds
+// ============================================================
+const string BNT_BIND_ACT_HEADER = "bnt_act_header";
+const string BNT_BIND_ACT_TARGET = "bnt_act_target";
+const string BNT_BIND_ACT_DESC   = "bnt_act_desc";
+const string BNT_BIND_ACT_REWARD = "bnt_act_reward";
+const string BNT_BIND_ACT_POSTER = "bnt_act_poster";
+const string BNT_BIND_ACT_EXP    = "bnt_act_exp";
+const string BNT_BIND_CLAIM_ENA  = "bnt_claim_ena";
+
+// ============================================================
+// My-contracts-view binds  (list rows + cancel button)
+// ============================================================
+const string BNT_BIND_MINE_TARGET = "bnt_mine_target";
+const string BNT_BIND_MINE_REWARD = "bnt_mine_reward";
+const string BNT_BIND_MINE_STATE  = "bnt_mine_state";
+const string BNT_BIND_MINE_HUNTER = "bnt_mine_hunter";
+const string BNT_BIND_MINE_ENC    = "bnt_mine_enc";
+const string BNT_BIND_MINE_COLOR  = "bnt_mine_color";
+const string BNT_BIND_MINE_COUNT  = "bnt_mine_count";
+const string BNT_BIND_CANCEL_ENA  = "bnt_cancel_ena";
+
+// ============================================================
+// Post-view binds
+// ============================================================
+const string BNT_BIND_POST_TARGET = "bnt_post_target";
+const string BNT_BIND_POST_DESC   = "bnt_post_desc";
+const string BNT_BIND_POST_REWARD = "bnt_post_reward";
+const string BNT_BIND_POST_IS_PC  = "bnt_post_ispc";
+const string BNT_BIND_POST_STATUS = "bnt_post_status";
+const string BNT_BIND_POST_SUB_ENA= "bnt_post_sub_ena";
+
+// ============================================================
+// Button IDs
+// ============================================================
+const string BNT_BTN_CLOSE        = "bnt_btn_close";
+const string BNT_BTN_TAB_BOARD    = "bnt_btn_tab_bd";
+const string BNT_BTN_TAB_ACTIVE   = "bnt_btn_tab_act";
+const string BNT_BTN_TAB_MINE     = "bnt_btn_tab_mine";
+const string BNT_BTN_TAB_POST     = "bnt_btn_tab_post";
+const string BNT_BTN_BD_ROW       = "bnt_btn_bd_row";
+const string BNT_BTN_ACCEPT       = "bnt_btn_accept";
+const string BNT_BTN_CLAIM        = "bnt_btn_claim";
+const string BNT_BTN_ABANDON      = "bnt_btn_abandon";
+const string BNT_BTN_MINE_ROW     = "bnt_btn_mine_row";
+const string BNT_BTN_CANCEL_OWN   = "bnt_btn_cancel";
+const string BNT_BTN_SUBMIT       = "bnt_btn_submit";
+
+// ============================================================
+// PC-local vars
+// ============================================================
+const string BNT_LVAR_SEL_ID      = "BNT_SEL_ID";       // selected board row contract id
+const string BNT_LVAR_MINE_SEL    = "BNT_MINE_SEL";     // selected mine row contract id
+
+// ============================================================
+// Layout
+// ============================================================
+const float BNT_W                 = 720.0;
+const float BNT_H                 = 500.0;
+
+// ============================================================
+// Helper: find online PC by UUID
+// ============================================================
+object BntGetPCByUUID(string sUuid)
+{
+    if(sUuid == "") return OBJECT_INVALID;
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        if(GetObjectUUID(oPC) == sUuid) return oPC;
+        oPC = GetNextPC();
+    }
+    return OBJECT_INVALID;
+}
+
+// State int → short Polish label
+string BntStateName(int nState)
+{
+    switch(nState)
+    {
+        case BNT_STATE_OPEN:      return "otwarty";
+        case BNT_STATE_ACCEPTED:  return "przyjety";
+        case BNT_STATE_COMPLETED: return "ukonczony";
+        case BNT_STATE_EXPIRED:   return "wygasly";
+        case BNT_STATE_CANCELLED: return "anulowany";
+    }
+    return "?";
+}

--- a/Bounty Contracts/Scripts/lib_bnt_ev.nss
+++ b/Bounty Contracts/Scripts/lib_bnt_ev.nss
@@ -1,0 +1,129 @@
+// lib_bnt_ev.nss — Bounty Contracts: NUI event handler (OnNUIEvent).
+#include "lib_bnt"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    if(nToken != NuiFindWindow(oPC, BNT_WINDOW)) return;
+
+    // ---- Window close ----
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalInt(oPC, BNT_LVAR_SEL_ID);
+        DeleteLocalInt(oPC, BNT_LVAR_MINE_SEL);
+        return;
+    }
+
+    // ---- Tab navigation ----
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == BNT_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        if(sElem == BNT_BTN_TAB_BOARD)
+        {
+            BntSwapToBoard(oPC, nToken);
+            return;
+        }
+        if(sElem == BNT_BTN_TAB_ACTIVE)
+        {
+            BntSwapToActive(oPC, nToken);
+            return;
+        }
+        if(sElem == BNT_BTN_TAB_MINE)
+        {
+            BntSwapToMine(oPC, nToken);
+            return;
+        }
+        if(sElem == BNT_BTN_TAB_POST)
+        {
+            BntSwapToPost(oPC, nToken);
+            return;
+        }
+
+        // ---- Board actions ----
+        if(sElem == BNT_BTN_ACCEPT)
+        {
+            BntHandleAccept(oPC, nToken);
+            return;
+        }
+
+        // ---- Active contract actions ----
+        if(sElem == BNT_BTN_CLAIM)
+        {
+            BntHandleClaim(oPC, nToken);
+            return;
+        }
+        if(sElem == BNT_BTN_ABANDON)
+        {
+            BntHandleAbandon(oPC, nToken);
+            return;
+        }
+
+        // ---- Mine actions ----
+        if(sElem == BNT_BTN_CANCEL_OWN)
+        {
+            BntHandleCancelOwn(oPC, nToken);
+            return;
+        }
+
+        // ---- Post actions ----
+        if(sElem == BNT_BTN_SUBMIT)
+        {
+            BntHandlePost(oPC, nToken);
+            return;
+        }
+    }
+
+    // ---- List row selection (mousedown gives index before click fires) ----
+    if(sEvent == EVENT_TYPE_MOUSEDOWN)
+    {
+        if(sElem == BNT_BTN_BD_ROW)
+        {
+            json jContracts = BntGetOpenContracts();
+            if(nIdx < 0 || nIdx >= JsonGetLength(jContracts)) return;
+
+            json jRow = JsonArrayGet(jContracts, nIdx);
+            int  nId  = JsonGetInt(JsonObjectGet(jRow, "id"));
+
+            // Toggle: clicking already-selected row deselects
+            int nPrev = GetLocalInt(oPC, BNT_LVAR_SEL_ID);
+            SetLocalInt(oPC, BNT_LVAR_SEL_ID, (nPrev == nId) ? 0 : nId);
+            BntFeedBoard(oPC, nToken);
+            return;
+        }
+
+        if(sElem == BNT_BTN_MINE_ROW)
+        {
+            json jMine = BntGetMyPostedContracts(oPC);
+            if(nIdx < 0 || nIdx >= JsonGetLength(jMine)) return;
+
+            json jRow = JsonArrayGet(jMine, nIdx);
+            int  nId  = JsonGetInt(JsonObjectGet(jRow, "id"));
+
+            int nPrev = GetLocalInt(oPC, BNT_LVAR_MINE_SEL);
+            SetLocalInt(oPC, BNT_LVAR_MINE_SEL, (nPrev == nId) ? 0 : nId);
+            BntFeedMine(oPC, nToken);
+            return;
+        }
+    }
+
+    // ---- Watch: real-time form validation on post view ----
+    if(sEvent == EVENT_TYPE_WATCH)
+    {
+        if(sElem == BNT_BIND_POST_TARGET || sElem == BNT_BIND_POST_REWARD)
+        {
+            NuiSetBind(oPC, nToken, BNT_BIND_POST_STATUS, JsonString(""));
+            BntValidatePostForm(oPC, nToken);
+            return;
+        }
+    }
+}

--- a/Bounty Contracts/Scripts/lib_nui.nss
+++ b/Bounty Contracts/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Bounty Contracts/Scripts/lib_nui_utility.nss
+++ b/Bounty Contracts/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Bounty Contracts/Scripts/sql_bnt.nss
+++ b/Bounty Contracts/Scripts/sql_bnt.nss
@@ -1,0 +1,324 @@
+// sql_bnt.nss — Bounty Contracts: SQL schema and all data-layer queries.
+
+// ============================================================
+// Contract states
+// ============================================================
+const int BNT_STATE_OPEN      = 0;
+const int BNT_STATE_ACCEPTED  = 1;
+const int BNT_STATE_COMPLETED = 2;
+const int BNT_STATE_EXPIRED   = 3;
+const int BNT_STATE_CANCELLED = 4;
+
+// ============================================================
+// Tuning constants
+// ============================================================
+const int BNT_EXPIRY_DAYS     = 7;
+const int BNT_MIN_REWARD      = 50;
+const int BNT_MAX_REWARD      = 999999;
+const int BNT_MAX_DESC        = 200;
+const int BNT_MAX_TARGET_NAME = 60;
+
+// ============================================================
+// Schema
+// ============================================================
+
+void BntCreateTables()
+{
+    sqlquery q;
+
+    q = SqlPrepareQueryCampaign("bounty",
+        "CREATE TABLE IF NOT EXISTS bnt_contracts ("
+        "  id          INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "  target_name TEXT    NOT NULL DEFAULT '',"
+        "  target_uuid TEXT             DEFAULT '',"
+        "  description TEXT             DEFAULT '',"
+        "  reward      INTEGER          DEFAULT 0,"
+        "  poster_uuid TEXT    NOT NULL DEFAULT '',"
+        "  poster_name TEXT    NOT NULL DEFAULT '',"
+        "  hunter_uuid TEXT             DEFAULT '',"
+        "  hunter_name TEXT             DEFAULT '',"
+        "  state       INTEGER          DEFAULT 0,"
+        "  posted_at   INTEGER          DEFAULT (strftime('%s','now')),"
+        "  expires_at  INTEGER          DEFAULT 0,"
+        "  completed_at INTEGER         DEFAULT 0"
+        ")");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("bounty",
+        "CREATE TABLE IF NOT EXISTS bnt_players ("
+        "  uuid      TEXT PRIMARY KEY,"
+        "  char_name TEXT DEFAULT '',"
+        "  last_seen INTEGER DEFAULT (strftime('%s','now'))"
+        ")");
+    SqlStep(q);
+}
+
+// ============================================================
+// Player registry
+// ============================================================
+
+void BntRegisterPlayer(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("bounty",
+        "INSERT OR REPLACE INTO bnt_players (uuid, char_name, last_seen) "
+        "VALUES (@uuid, @name, strftime('%s','now'))");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindString(q, "@name", GetName(oPC));
+    SqlStep(q);
+}
+
+// Returns uuid string or "" if not found
+string BntFindPlayerUUID(string sName)
+{
+    sqlquery q = SqlPrepareQueryCampaign("bounty",
+        "SELECT uuid FROM bnt_players WHERE LOWER(char_name) = LOWER(@name) LIMIT 1");
+    SqlBindString(q, "@name", sName);
+    if(SqlStep(q)) return SqlGetString(q, 0);
+    return "";
+}
+
+// ============================================================
+// Maintenance
+// ============================================================
+
+void BntExpireContracts()
+{
+    sqlquery q = SqlPrepareQueryCampaign("bounty",
+        "UPDATE bnt_contracts SET state = @exp "
+        "WHERE state IN (@open, @acc) AND expires_at > 0 AND expires_at < strftime('%s','now')");
+    SqlBindInt(q, "@exp",  BNT_STATE_EXPIRED);
+    SqlBindInt(q, "@open", BNT_STATE_OPEN);
+    SqlBindInt(q, "@acc",  BNT_STATE_ACCEPTED);
+    SqlStep(q);
+}
+
+// ============================================================
+// Write operations
+// ============================================================
+
+// Returns new contract id, or 0 on failure
+int BntPostContract(object oPoster, string sTargetName, string sTargetUuid,
+                    string sDesc, int nReward)
+{
+    sqlquery q = SqlPrepareQueryCampaign("bounty",
+        "INSERT INTO bnt_contracts "
+        "  (target_name, target_uuid, description, reward, poster_uuid, poster_name,"
+        "   state, posted_at, expires_at) "
+        "VALUES (@tname, @tuuid, @desc, @rew, @puuid, @pname, "
+        "        @open, strftime('%s','now'), strftime('%s','now') + @exp)");
+    SqlBindString(q, "@tname", sTargetName);
+    SqlBindString(q, "@tuuid", sTargetUuid);
+    SqlBindString(q, "@desc",  sDesc);
+    SqlBindInt   (q, "@rew",   nReward);
+    SqlBindString(q, "@puuid", GetObjectUUID(oPoster));
+    SqlBindString(q, "@pname", GetName(oPoster));
+    SqlBindInt   (q, "@open",  BNT_STATE_OPEN);
+    SqlBindInt   (q, "@exp",   BNT_EXPIRY_DAYS * 86400);
+    SqlStep(q);
+
+    sqlquery qId = SqlPrepareQueryCampaign("bounty", "SELECT last_insert_rowid()");
+    if(SqlStep(qId)) return SqlGetInt(qId, 0);
+    return 0;
+}
+
+// Returns TRUE if successfully accepted (contract was open)
+int BntAcceptContract(object oPC, int nId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("bounty",
+        "UPDATE bnt_contracts SET state = @acc, hunter_uuid = @uuid, hunter_name = @name "
+        "WHERE id = @id AND state = @open");
+    SqlBindInt   (q, "@acc",  BNT_STATE_ACCEPTED);
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindString(q, "@name", GetName(oPC));
+    SqlBindInt   (q, "@id",   nId);
+    SqlBindInt   (q, "@open", BNT_STATE_OPEN);
+    SqlStep(q);
+
+    sqlquery qC = SqlPrepareQueryCampaign("bounty", "SELECT changes()");
+    if(SqlStep(qC)) return SqlGetInt(qC, 0) > 0;
+    return FALSE;
+}
+
+void BntAbandonContract(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("bounty",
+        "UPDATE bnt_contracts SET state = @open, hunter_uuid = '', hunter_name = '' "
+        "WHERE hunter_uuid = @uuid AND state = @acc");
+    SqlBindInt   (q, "@open", BNT_STATE_OPEN);
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@acc",  BNT_STATE_ACCEPTED);
+    SqlStep(q);
+}
+
+// Returns reward gold if claim succeeded, 0 otherwise
+int BntClaimContract(object oPC, int nId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("bounty",
+        "SELECT reward FROM bnt_contracts WHERE id = @id AND hunter_uuid = @uuid AND state = @acc");
+    SqlBindInt   (q, "@id",   nId);
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@acc",  BNT_STATE_ACCEPTED);
+    if(!SqlStep(q)) return 0;
+    int nReward = SqlGetInt(q, 0);
+
+    sqlquery qU = SqlPrepareQueryCampaign("bounty",
+        "UPDATE bnt_contracts SET state = @done, completed_at = strftime('%s','now') "
+        "WHERE id = @id AND hunter_uuid = @uuid AND state = @acc");
+    SqlBindInt   (qU, "@done", BNT_STATE_COMPLETED);
+    SqlBindInt   (qU, "@id",   nId);
+    SqlBindString(qU, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (qU, "@acc",  BNT_STATE_ACCEPTED);
+    SqlStep(qU);
+
+    return nReward;
+}
+
+// Returns gold refunded (full if open, 0 if already accepted)
+int BntCancelOwnContract(object oPC, int nId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("bounty",
+        "SELECT reward, state FROM bnt_contracts WHERE id = @id AND poster_uuid = @uuid");
+    SqlBindInt   (q, "@id",   nId);
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(!SqlStep(q)) return 0;
+
+    int nReward = SqlGetInt(q, 0);
+    int nState  = SqlGetInt(q, 1);
+    int nRefund = (nState == BNT_STATE_OPEN) ? nReward : 0;
+
+    sqlquery qU = SqlPrepareQueryCampaign("bounty",
+        "UPDATE bnt_contracts SET state = @can "
+        "WHERE id = @id AND poster_uuid = @uuid AND state IN (@open, @acc)");
+    SqlBindInt   (qU, "@can",  BNT_STATE_CANCELLED);
+    SqlBindInt   (qU, "@id",   nId);
+    SqlBindString(qU, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (qU, "@open", BNT_STATE_OPEN);
+    SqlBindInt   (qU, "@acc",  BNT_STATE_ACCEPTED);
+    SqlStep(qU);
+
+    return nRefund;
+}
+
+// Called from OnPlayerDeath — auto-payout when killer has active contract on dead PC.
+// Returns reward paid out, 0 if nothing triggered.
+int BntCheckDeathPayout(object oDeadPC, object oKillerPC)
+{
+    if(!GetIsObjectValid(oKillerPC) || !GetIsPC(oKillerPC)) return 0;
+
+    string sDeadUuid   = GetObjectUUID(oDeadPC);
+    string sKillerUuid = GetObjectUUID(oKillerPC);
+
+    sqlquery q = SqlPrepareQueryCampaign("bounty",
+        "SELECT id, reward FROM bnt_contracts "
+        "WHERE target_uuid = @tuuid AND hunter_uuid = @huuid AND state = @acc LIMIT 1");
+    SqlBindString(q, "@tuuid", sDeadUuid);
+    SqlBindString(q, "@huuid", sKillerUuid);
+    SqlBindInt   (q, "@acc",   BNT_STATE_ACCEPTED);
+    if(!SqlStep(q)) return 0;
+
+    int nId     = SqlGetInt(q, 0);
+    int nReward = SqlGetInt(q, 1);
+
+    sqlquery qU = SqlPrepareQueryCampaign("bounty",
+        "UPDATE bnt_contracts SET state = @done, completed_at = strftime('%s','now') "
+        "WHERE id = @id");
+    SqlBindInt(qU, "@done", BNT_STATE_COMPLETED);
+    SqlBindInt(qU, "@id",   nId);
+    SqlStep(qU);
+
+    return nReward;
+}
+
+// ============================================================
+// Read operations
+// ============================================================
+
+// Returns JsonArray [{id, target_name, reward, poster_name, expires_at, description}, ...]
+// ordered by reward DESC
+json BntGetOpenContracts()
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("bounty",
+        "SELECT id, target_name, reward, poster_name, expires_at, description "
+        "FROM bnt_contracts WHERE state = @open ORDER BY reward DESC");
+    SqlBindInt(q, "@open", BNT_STATE_OPEN);
+    while(SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "id",          JsonInt   (SqlGetInt   (q, 0)));
+        jRow = JsonObjectSet(jRow, "target_name", JsonString(SqlGetString(q, 1)));
+        jRow = JsonObjectSet(jRow, "reward",      JsonInt   (SqlGetInt   (q, 2)));
+        jRow = JsonObjectSet(jRow, "poster_name", JsonString(SqlGetString(q, 3)));
+        jRow = JsonObjectSet(jRow, "expires_at",  JsonInt   (SqlGetInt   (q, 4)));
+        jRow = JsonObjectSet(jRow, "description", JsonString(SqlGetString(q, 5)));
+        jRows = JsonArrayInsert(jRows, jRow);
+    }
+    return jRows;
+}
+
+// Returns JsonObject for active (accepted) contract held by this hunter, or JsonNull()
+json BntGetActiveContract(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("bounty",
+        "SELECT id, target_name, target_uuid, description, reward, poster_name, expires_at "
+        "FROM bnt_contracts WHERE hunter_uuid = @uuid AND state = @acc");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@acc",  BNT_STATE_ACCEPTED);
+    if(!SqlStep(q)) return JsonNull();
+
+    json j = JsonObject();
+    j = JsonObjectSet(j, "id",          JsonInt   (SqlGetInt   (q, 0)));
+    j = JsonObjectSet(j, "target_name", JsonString(SqlGetString(q, 1)));
+    j = JsonObjectSet(j, "target_uuid", JsonString(SqlGetString(q, 2)));
+    j = JsonObjectSet(j, "description", JsonString(SqlGetString(q, 3)));
+    j = JsonObjectSet(j, "reward",      JsonInt   (SqlGetInt   (q, 4)));
+    j = JsonObjectSet(j, "poster_name", JsonString(SqlGetString(q, 5)));
+    j = JsonObjectSet(j, "expires_at",  JsonInt   (SqlGetInt   (q, 6)));
+    return j;
+}
+
+// Returns JsonArray [{id, target_name, reward, state, hunter_name}, ...] for poster
+json BntGetMyPostedContracts(object oPC)
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("bounty",
+        "SELECT id, target_name, reward, state, hunter_name "
+        "FROM bnt_contracts WHERE poster_uuid = @uuid AND state IN (@open, @acc) "
+        "ORDER BY posted_at DESC");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@open", BNT_STATE_OPEN);
+    SqlBindInt   (q, "@acc",  BNT_STATE_ACCEPTED);
+    while(SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "id",          JsonInt   (SqlGetInt   (q, 0)));
+        jRow = JsonObjectSet(jRow, "target_name", JsonString(SqlGetString(q, 1)));
+        jRow = JsonObjectSet(jRow, "reward",      JsonInt   (SqlGetInt   (q, 2)));
+        jRow = JsonObjectSet(jRow, "state",       JsonInt   (SqlGetInt   (q, 3)));
+        jRow = JsonObjectSet(jRow, "hunter_name", JsonString(SqlGetString(q, 4)));
+        jRows = JsonArrayInsert(jRows, jRow);
+    }
+    return jRows;
+}
+
+// ============================================================
+// Formatting helpers
+// ============================================================
+
+string BntFormatDate(int nUnix)
+{
+    sqlquery q = SqlPrepareQueryCampaign("bounty",
+        "SELECT strftime('%d.%m.%y', @ts, 'unixepoch')");
+    SqlBindInt(q, "@ts", nUnix);
+    if(SqlStep(q)) return SqlGetString(q, 0);
+    return "";
+}
+
+string BntDaysLeft(int nExpiresAt)
+{
+    sqlquery q = SqlPrepareQueryCampaign("bounty",
+        "SELECT MAX(0, CAST((@exp - strftime('%s','now')) / 86400 AS INTEGER))");
+    SqlBindInt(q, "@exp", nExpiresAt);
+    if(SqlStep(q)) return IntToString(SqlGetInt(q, 0)) + "d";
+    return "?d";
+}

--- a/Bounty Contracts/Scripts/sys_on_enter.nss
+++ b/Bounty Contracts/Scripts/sys_on_enter.nss
@@ -1,0 +1,27 @@
+// sys_on_enter.nss — Bounty Contracts: OnClientEnter hook.
+// Registers the entering PC in the players table so they can be searched
+// as bounty targets, and notifies them if a contract exists on their head.
+#include "lib_bnt_def"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC) || GetIsDMPossessed(oPC)) return;
+
+    BntRegisterPlayer(oPC);
+
+    // Check if anyone has posted a bounty on this PC
+    sqlquery q = SqlPrepareQueryCampaign("bounty",
+        "SELECT COUNT(*) FROM bnt_contracts "
+        "WHERE target_uuid = @uuid AND state IN (@open, @acc)");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@open", BNT_STATE_OPEN);
+    SqlBindInt   (q, "@acc",  BNT_STATE_ACCEPTED);
+    if(SqlStep(q) && SqlGetInt(q, 0) > 0)
+    {
+        DelayCommand(3.0, SendMessageToPC(oPC,
+            "[Kontrakty] Na twoja glowe wystawiono nagrode. Oczy w slepy zaul."));
+        DelayCommand(3.0, FloatingTextStringOnCreature(
+            "Kontrakt na twoja glowe!", oPC, FALSE));
+    }
+}

--- a/Bounty Contracts/Scripts/sys_on_load.nss
+++ b/Bounty Contracts/Scripts/sys_on_load.nss
@@ -1,0 +1,7 @@
+// sys_on_load.nss — Bounty Contracts: OnModuleLoad hook.
+#include "lib_bnt_def"
+
+void main()
+{
+    BntCreateTables();
+}

--- a/Bounty Contracts/Scripts/sys_on_pdeath.nss
+++ b/Bounty Contracts/Scripts/sys_on_pdeath.nss
@@ -1,0 +1,29 @@
+// sys_on_pdeath.nss — Bounty Contracts: OnPlayerDeath hook.
+// Auto-pays the reward when a hunter kills a PC target they have an active contract on.
+#include "lib_bnt"
+
+void main()
+{
+    object oDeadPC = GetLastPlayerDied();
+    if(!GetIsObjectValid(oDeadPC)) return;
+
+    // Identify the killer: try hostile actor first, then last damager
+    object oKiller = GetLastHostileActor(oDeadPC);
+    if(!GetIsObjectValid(oKiller) || !GetIsPC(oKiller))
+        oKiller = GetLastDamager(oDeadPC);
+
+    int nReward = BntCheckDeathPayout(oDeadPC, oKiller);
+    if(nReward <= 0) return;
+
+    GiveGoldToCreature(oKiller, nReward);
+
+    string sMsg = "[Kontrakty] Kontrakt na " + GetName(oDeadPC)
+        + " ukończony. Nagroda: " + IntToString(nReward) + " zlota.";
+    SendMessageToPC(oKiller, sMsg);
+    FloatingTextStringOnCreature(
+        "Kontrakt ukończony. +" + IntToString(nReward) + " zl", oKiller, FALSE);
+
+    // Refresh the killer's window if open
+    int nTk = NuiFindWindow(oKiller, BNT_WINDOW);
+    if(nTk != 0) BntSwapToBoard(oKiller, nTk);
+}

--- a/Bounty Contracts/Scripts/test_bnt.nss
+++ b/Bounty Contracts/Scripts/test_bnt.nss
@@ -1,0 +1,11 @@
+// test_bnt.nss — Bounty Contracts: OnUsed script for demo placeable.
+// Place a placeable in the module and set this script as its OnUsed event.
+// Using it opens the Bounty Board window for the activating PC.
+#include "lib_bnt"
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+    BntOpenWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

Moduł **Kontrakty Krwi** — tablica ogłoszeń gildi łowców głów. Gracze wystawiają nagrody pieniężne na głowy celów (graczy PC lub NPCów), łowcy przeglądają i przyjmują zlecenia, a po wykonaniu odbierają wynagrodzenie. Dla kontraktów na graczy-PC wypłata następuje automatycznie w chwili śmierci, gdy zabójca ma aktywny kontrakt na zabitego.

## Mechanika

- **Wystawianie kontraktu**: gracz wpłaca nagrodę z góry (min. 50 zl), wpisuje imię celu i opis/poszlaki. Dla celów PC zaznacza checkbox — system szuka UUID w tabeli `bnt_players` i linkuje kontrakt; przy śmierci celu wypłata jest automatyczna. Dla NPCów odbiór jest manualny (honor system).
- **Przyjęcie / zrezygnowanie**: łowca może trzymać dokładnie jeden aktywny kontrakt. Zrezygnowanie oddaje kontrakt na tablicę bez kar; anulowanie przez poster zwraca złoto tylko jeśli kontrakt nie był jeszcze przyjęty.
- **Wygasanie**: kontrakty nieukończone w ciągu 7 dni (`BNT_EXPIRY_DAYS`) przechodzą w stan `expired` przy następnym otwarciu okna lub wejściu gracza do serwera.

## Pliki

| Plik | Rola |
|---|---|
| `sql_bnt.nss` | Schemat SQLite + wszystkie zapytania (CRUD, payout, wyszukiwanie) |
| `lib_bnt_def.nss` | Stałe (bindy NUI, przyciski, LVARy, layout), forward deklaracje |
| `lib_bnt.nss` | Cztery widoki NUI (Tablica / Kontrakt / Moje / Nowy), feed, handlery akcji |
| `lib_bnt_ev.nss` | Handler `OnNUIEvent` — nawigacja tabami, selekcja list, kliknięcia, watch |
| `sys_on_load.nss` | `OnModuleLoad` — inicjalizacja tabel |
| `sys_on_enter.nss` | `OnClientEnter` — rejestracja gracza, powiadomienie o kontrakcie |
| `sys_on_pdeath.nss` | `OnPlayerDeath` — auto-wypłata dla kontraktów PC |
| `test_bnt.nss` | `OnUsed` placeable — otwiera okno tablicy |
| `INTEGRATION.md` | Opis podpięcia hooków, zależności, znane ograniczenia |

## Zależności (NWNX? SQL?)

- **NWNX**: brak. Moduł korzysta wyłącznie z wbudowanych funkcji NWN:EE.
- **SQLite**: kampania `bounty` (`bounty.sqlite3`). Schemat idempotentny.

## Jak włączyć w istniejącym module

```nss
// OnModuleLoad:
ExecuteScript("sys_on_load", GetModule());

// OnClientEnter:
ExecuteScript("sys_on_enter", GetEnteringObject());

// OnPlayerDeath:
ExecuteScript("sys_on_pdeath", GetModule());

// OnNUIEvent:
ExecuteScript("lib_bnt_ev", GetModule());
```

Utwórz placeable z `OnUsed = test_bnt` jako punkt dostępu do tablicy. Szczegóły w `INTEGRATION.md`.

## Co celowo pominięto

- **Popup wyszukiwania graczy-PC** — imię musi być podane dokładnie (case-insensitive); pełne wyszukiwanie wymagałoby osobnego okna w stylu Mailbox
- **Widok historii ukończonych kontraktów** — dane są w tabeli (`state=2`), brak dedykowanego widoku UI
- **Powiadomienie postera po realizacji** — łatwe do dodania; pominięte dla uproszczenia logiki
- **Ograniczenie liczby kontraktów na gracza** — brak limitu po stronie postera
- **Plik `.mod`** — środowisko nie obsługuje pakowania; wymagane ręczne wgranie przez Toolset


---
_Generated by [Claude Code](https://claude.ai/code/session_017KUPBS43aaipvQLQmUPjLv)_