### PR TITLE
feat: Demonic Pacts

### DIFF
--- a/Demonic Pacts/INTEGRATION.md
+++ b/Demonic Pacts/INTEGRATION.md
@@ -1,0 +1,57 @@
+# Demonic Pacts — Integration Guide
+
+## Required Module Event Hooks
+
+| Event | Script |
+|-------|--------|
+| OnModuleLoad | `sys_on_load.nss` |
+| OnClientEnter | `sys_on_enter.nss` |
+| OnHeartbeat | `sys_on_heartbeat.nss` |
+
+If your module already has scripts on these events, call the Demonic Pacts
+functions from within them:
+
+```nss
+// in your existing OnModuleLoad:
+#include "sql_pact"
+// ...
+PactCreateTables();
+
+// in your existing OnClientEnter:
+#include "lib_pact"
+// ...
+if(GetIsPC(GetEnteringObject()))
+    DelayCommand(3.0, PactCheckAndApply(GetEnteringObject()));
+
+// in your existing OnHeartbeat (fires every 6 s):
+#include "lib_pact"
+// ...
+object oPC = GetFirstPC();
+while(GetIsObjectValid(oPC)) { PactCollectToll(oPC); oPC = GetNextPC(); }
+```
+
+## Opening the Window
+
+Place a custom placeable in the world (Altar of Covenants) and assign
+`test_pact.nss` to its **OnUsed** event.
+
+## NWNX Dependencies
+
+None. Pure NWN EE (build 8193.24+) is required for:
+- `EffectSetTag` / `GetEffectTag`
+- `SqlPrepareQueryCampaign` / `SqlStep`
+
+## Campaign Database
+
+`pact.sqlite3` is created automatically on module load in the campaign
+database directory. Table: `pact_active` (one row per signed pact).
+
+## Adjusting the Toll Interval
+
+Change `PACT_TOLL_INTERVAL` in `lib_pact_def.nss` (default: 7200 seconds).
+Set to 60 or 120 during testing.
+
+## Adjusting Break Penalties
+
+`PACT_BREAK_HP_COST` — instant HP damage on voluntary pact break (default 20).
+`PACT_BREAK_CURSE_SECS` — duration of the stat-penalty curse (default 1800 s).

--- a/Demonic Pacts/Scripts/lib_pact.nss
+++ b/Demonic Pacts/Scripts/lib_pact.nss
@@ -1,0 +1,366 @@
+#include "lib_pact_def"
+
+// ---- UI panel builders ----
+
+json BuildPactListPanel(object oPC)
+{
+    float fW    = GetNuiScaleDimension(oPC, 185.0);
+    float fRowH = GetNuiScaleDimension(oPC, 46.0);
+    float fListH= GetNuiScaleDimension(oPC, 200.0);
+
+    json jNameLbl = NuiLabel(NuiBind(PACT_BIND_LIST_NAME), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+
+    json jCell = NuiGroup(NuiRow(JsonArrayInsert(JsonArray(), jNameLbl)), TRUE, NUI_SCROLLBARS_NONE);
+    jCell = NuiId(jCell, PACT_BTN_ROW);
+    jCell = NuiEncouraged(jCell, NuiBind(PACT_BIND_LIST_ENC));
+
+    json jTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jCell, 0.0, TRUE));
+    json jList = NuiList(jTmpl, NuiBind(PACT_BIND_LIST_CNT), fRowH);
+    jList = NuiHeight(jList, fListH);
+
+    json jHeaderLbl = NuiLabel(JsonString("Dostepne pakty"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jHeaderLbl = NuiHeight(jHeaderLbl, GetNuiScaleDimension(oPC, 24.0));
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jHeaderLbl);
+    jCol = JsonArrayInsert(jCol, jList);
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+
+    return NuiWidth(NuiCol(jCol), fW);
+}
+
+json BuildPactDetailPanel(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 30.0);
+    float fLoreH = GetNuiScaleDimension(oPC, 110.0);
+    float fLblH  = GetNuiScaleDimension(oPC, 22.0);
+
+    json jDemonName = NuiLabel(NuiBind(PACT_BIND_DETAIL_NAME), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jDemonName = NuiHeight(jDemonName, GetNuiScaleDimension(oPC, 28.0));
+    jDemonName = NuiStyleForegroundColor(jDemonName, NuiColor(210, 60, 60));
+
+    json jLoreGrp = NuiGroup(NuiText(NuiBind(PACT_BIND_DETAIL_LORE), FALSE), FALSE, NUI_SCROLLBARS_NONE);
+    jLoreGrp = NuiHeight(jLoreGrp, fLoreH);
+
+    json jBuffLbl = NuiLabel(NuiBind(PACT_BIND_DETAIL_BUFF), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jBuffLbl = NuiHeight(jBuffLbl, fLblH);
+    jBuffLbl = NuiStyleForegroundColor(jBuffLbl, NuiColor(90, 200, 90));
+
+    json jTollLbl = NuiLabel(NuiBind(PACT_BIND_DETAIL_TOLL), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTollLbl = NuiHeight(jTollLbl, fLblH);
+    jTollLbl = NuiStyleForegroundColor(jTollLbl, NuiColor(200, 80, 80));
+
+    json jSignBtn = NuiButton(NuiBind(PACT_BIND_SIGN_LBL));
+    jSignBtn = NuiId(jSignBtn, PACT_BTN_SIGN);
+    jSignBtn = NuiEnabled(jSignBtn, NuiBind(PACT_BIND_SIGN_ENA));
+    jSignBtn = NuiWidth(jSignBtn,  GetNuiScaleDimension(oPC, 230.0));
+    jSignBtn = NuiHeight(jSignBtn, fBtnH);
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, jSignBtn);
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jDemonName);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jLoreGrp);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jBuffLbl);
+    jCol = JsonArrayInsert(jCol, jTollLbl);
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+
+    return NuiCol(jCol);
+}
+
+json BuildPactStatusBar(object oPC)
+{
+    float fBtnH = GetNuiScaleDimension(oPC, 30.0);
+    float fBarH = GetNuiScaleDimension(oPC, 46.0);
+
+    json jStatusLbl = NuiLabel(NuiBind(PACT_BIND_STATUS_LBL), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+
+    json jBreakBtn = NuiButton(NuiBind(PACT_BIND_BREAK_LBL));
+    jBreakBtn = NuiId(jBreakBtn, PACT_BTN_BREAK);
+    jBreakBtn = NuiEnabled(jBreakBtn, NuiBind(PACT_BIND_BREAK_ENA));
+    jBreakBtn = NuiWidth(jBreakBtn,  GetNuiScaleDimension(oPC, 210.0));
+    jBreakBtn = NuiHeight(jBreakBtn, fBtnH);
+
+    json jRow = JsonArray();
+    jRow = JsonArrayInsert(jRow, jStatusLbl);
+    jRow = JsonArrayInsert(jRow, NuiSpacer());
+    jRow = JsonArrayInsert(jRow, jBreakBtn);
+
+    json jBar = NuiGroup(NuiRow(jRow), TRUE, NUI_SCROLLBARS_NONE);
+    jBar = NuiHeight(jBar, fBarH);
+    return jBar;
+}
+
+// ---- Feed functions ----
+
+void FeedPactList(object oPC, int nToken)
+{
+    json jActive  = PactGetActive(oPC);
+    string sActId = "";
+    if(JsonGetType(jActive) != JSON_TYPE_NULL)
+        sActId = JsonGetString(JsonObjectGet(jActive, "demon_id"));
+
+    string sSelId = GetLocalString(oPC, PACT_LVAR_SEL);
+
+    json jNames = JsonArray();
+    json jEncs  = JsonArray();
+    int i;
+    for(i = 0; i < PACT_DEMON_COUNT; i++)
+    {
+        string sId   = PactGetDemonId(i);
+        string sName = PactGetDemonName(sId);
+        if(sId == sActId) sName = "* " + sName;
+        jNames = JsonArrayInsert(jNames, JsonString(sName));
+        jEncs  = JsonArrayInsert(jEncs,  JsonBool(sId == sSelId));
+    }
+
+    NuiSetBind(oPC, nToken, PACT_BIND_LIST_NAME, jNames);
+    NuiSetBind(oPC, nToken, PACT_BIND_LIST_ENC,  jEncs);
+    NuiSetBind(oPC, nToken, PACT_BIND_LIST_CNT,  JsonInt(PACT_DEMON_COUNT));
+}
+
+void FeedPactDetail(object oPC, int nToken, string sDemonId)
+{
+    json   jActive = PactGetActive(oPC);
+    string sActId  = "";
+    if(JsonGetType(jActive) != JSON_TYPE_NULL)
+        sActId = JsonGetString(JsonObjectGet(jActive, "demon_id"));
+
+    int bHasPact  = (sActId != "");
+    int bIsActive = (sDemonId == sActId);
+
+    NuiSetBind(oPC, nToken, PACT_BIND_DETAIL_NAME, JsonString(PactGetDemonName(sDemonId)));
+    NuiSetBind(oPC, nToken, PACT_BIND_DETAIL_LORE, JsonString(PactGetDemonLore(sDemonId)));
+    NuiSetBind(oPC, nToken, PACT_BIND_DETAIL_BUFF, JsonString(PactGetDemonBuff(sDemonId)));
+    NuiSetBind(oPC, nToken, PACT_BIND_DETAIL_TOLL, JsonString(PactGetDemonToll(sDemonId)));
+
+    string sSignLbl;
+    int    bSignEna;
+    if(bIsActive)
+    {
+        sSignLbl = "Pakt aktywny";
+        bSignEna = FALSE;
+    }
+    else if(bHasPact)
+    {
+        sSignLbl = "Masz juz aktywny pakt";
+        bSignEna = FALSE;
+    }
+    else
+    {
+        sSignLbl = "Zawrzyj Pakt";
+        bSignEna = TRUE;
+    }
+
+    NuiSetBind(oPC, nToken, PACT_BIND_SIGN_LBL, JsonString(sSignLbl));
+    NuiSetBind(oPC, nToken, PACT_BIND_SIGN_ENA, JsonBool(bSignEna));
+}
+
+void FeedPactStatus(object oPC, int nToken)
+{
+    json jActive = PactGetActive(oPC);
+    if(JsonGetType(jActive) == JSON_TYPE_NULL)
+    {
+        NuiSetBind(oPC, nToken, PACT_BIND_STATUS_LBL, JsonString("Brak aktywnego paktu. Pieczen oltarza pozostaje nienaruszona."));
+        NuiSetBind(oPC, nToken, PACT_BIND_BREAK_LBL,  JsonString("Brak paktu"));
+        NuiSetBind(oPC, nToken, PACT_BIND_BREAK_ENA,  JsonBool(FALSE));
+        return;
+    }
+
+    string sId    = JsonGetString(JsonObjectGet(jActive, "demon_id"));
+    int    nTolls = JsonGetInt   (JsonObjectGet(jActive, "toll_count"));
+
+    string sStatus = "Aktywny: " + PactGetDemonName(sId) + "  |  Haracz pobrany: " + IntToString(nTolls) + "x";
+    string sBreak  = "Zerwij Pakt (" + IntToString(PACT_BREAK_HP_COST) + " PZ + klatwa)";
+
+    NuiSetBind(oPC, nToken, PACT_BIND_STATUS_LBL, JsonString(sStatus));
+    NuiSetBind(oPC, nToken, PACT_BIND_BREAK_LBL,  JsonString(sBreak));
+    NuiSetBind(oPC, nToken, PACT_BIND_BREAK_ENA,  JsonBool(TRUE));
+}
+
+// ---- Window creation ----
+
+void CreatePactWindow(object oPC)
+{
+    int nExisting = NuiFindWindow(oPC, PACT_WINDOW);
+    if(nExisting != 0)
+    {
+        FeedPactList(oPC, nExisting);
+        FeedPactStatus(oPC, nExisting);
+        return;
+    }
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))
+                 - GetNuiScaleDimension(oPC, PACT_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT))
+                 - GetNuiScaleDimension(oPC, PACT_H)) / 2.0;
+    json jGeom = NuiRect(fCX, fCY, GetNuiScaleDimension(oPC, PACT_W), GetNuiScaleDimension(oPC, PACT_H));
+
+    // Top bar: title label + close button
+    float fBtnH = GetNuiScaleDimension(oPC, 30.0);
+    json jTitleLbl = NuiLabel(JsonString("Oltarz Paktow"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitleLbl = NuiStyleForegroundColor(jTitleLbl, NuiColor(210, 60, 60));
+    json jCloseBtn = NuiButton(JsonString("X"));
+    jCloseBtn = NuiId(jCloseBtn, PACT_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn,  GetNuiScaleDimension(oPC, 30.0));
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jTopRow = JsonArray();
+    jTopRow = JsonArrayInsert(jTopRow, jTitleLbl);
+    jTopRow = JsonArrayInsert(jTopRow, NuiSpacer());
+    jTopRow = JsonArrayInsert(jTopRow, jCloseBtn);
+
+    // Content row: demon list (fixed width) | detail panel (elastic)
+    json jSepCol = NuiWidth(NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer())), GetNuiScaleDimension(oPC, 12.0));
+    json jContentRow = JsonArray();
+    jContentRow = JsonArrayInsert(jContentRow, BuildPactListPanel(oPC));
+    jContentRow = JsonArrayInsert(jContentRow, jSepCol);
+    jContentRow = JsonArrayInsert(jContentRow, BuildPactDetailPanel(oPC));
+
+    // Root column
+    json jRootCol = JsonArray();
+    jRootCol = JsonArrayInsert(jRootCol, NuiRow(jTopRow));
+    jRootCol = JsonArrayInsert(jRootCol, NuiRow(jContentRow));
+    jRootCol = JsonArrayInsert(jRootCol, BuildPactStatusBar(oPC));
+
+    json jWin = NuiWindow(NuiCol(jRootCol),
+        JsonBool(FALSE),
+        NuiBind(PACT_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    int nToken = NuiCreate(oPC, jWin, PACT_WINDOW, PACT_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, PACT_WIN_GEOM, jGeom);
+
+    // Default selection: first demon
+    SetLocalString(oPC, PACT_LVAR_SEL, PACT_DEMON_ORCUS);
+    FeedPactList(oPC, nToken);
+    FeedPactDetail(oPC, nToken, PACT_DEMON_ORCUS);
+    FeedPactStatus(oPC, nToken);
+}
+
+// ---- Game logic ----
+
+void PactRemoveEffects(object oPC)
+{
+    // Iterate effects; safe pattern for removal during iteration.
+    effect eCur = GetFirstEffect(oPC);
+    while(GetIsEffectValid(eCur))
+    {
+        effect eNext = GetNextEffect(oPC);
+        if(GetStringLeft(GetEffectTag(eCur), GetStringLength(PACT_EFFECT_PREFIX)) == PACT_EFFECT_PREFIX)
+            RemoveEffect(oPC, eCur);
+        eCur = eNext;
+    }
+}
+
+void PactApplyEffects(object oPC, string sDemonId)
+{
+    PactRemoveEffects(oPC);
+
+    if(sDemonId == PACT_DEMON_ORCUS)
+    {
+        effect eRegen = EffectSetTag(SupernaturalEffect(EffectRegenerate(2, 6.0)), "PACT_ORCUS_REGEN");
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eRegen, oPC);
+    }
+    else if(sDemonId == PACT_DEMON_BAEL)
+    {
+        effect eStr = EffectSetTag(SupernaturalEffect(EffectAbilityIncrease(ABILITY_STRENGTH, 4)), "PACT_BAEL_STR");
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eStr, oPC);
+    }
+    else if(sDemonId == PACT_DEMON_GLASYA)
+    {
+        effect eHide = EffectSetTag(SupernaturalEffect(EffectSkillIncrease(SKILL_HIDE, 6)), "PACT_GLASYA_HIDE");
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eHide, oPC);
+
+        effect eMove = EffectSetTag(SupernaturalEffect(EffectSkillIncrease(SKILL_MOVE_SILENTLY, 6)), "PACT_GLASYA_MOVE");
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eMove, oPC);
+    }
+    else if(sDemonId == PACT_DEMON_JUIBLEX)
+    {
+        effect eAC = EffectSetTag(SupernaturalEffect(EffectACIncrease(5, AC_NATURAL_BONUS)), "PACT_JUIBLEX_AC");
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eAC, oPC);
+    }
+}
+
+void PactCollectToll(object oPC)
+{
+    json jActive = PactGetActive(oPC);
+    if(JsonGetType(jActive) == JSON_TYPE_NULL) return;
+    if(PactGetTimeSinceLastToll(oPC) < PACT_TOLL_INTERVAL) return;
+
+    string sDemonId = JsonGetString(JsonObjectGet(jActive, "demon_id"));
+    PactRecordToll(oPC);
+
+    if(sDemonId == PACT_DEMON_ORCUS)
+    {
+        ApplyEffectToObject(DURATION_TYPE_INSTANT,
+            EffectDamage(12, DAMAGE_TYPE_NEGATIVE, DAMAGE_POWER_NORMAL), oPC);
+        SendMessageToPC(oPC, "[Pakt] Pieczen krwi pulsuje slabo... Orcus pobiera swoj haracz.");
+    }
+    else if(sDemonId == PACT_DEMON_BAEL)
+    {
+        ApplyEffectToObject(DURATION_TYPE_INSTANT,
+            EffectDamage(8, DAMAGE_TYPE_NEGATIVE, DAMAGE_POWER_NORMAL), oPC);
+        int nNewXP = GetXP(oPC) - 50;
+        if(nNewXP < 0) nNewXP = 0;
+        SetXP(oPC, nNewXP);
+        SendMessageToPC(oPC, "[Pakt] Zelazna dlon zaciska sie na duszy... Bael pobiera swoj haracz.");
+    }
+    else if(sDemonId == PACT_DEMON_GLASYA)
+    {
+        int nNewXP = GetXP(oPC) - 60;
+        if(nNewXP < 0) nNewXP = 0;
+        SetXP(oPC, nNewXP);
+        SendMessageToPC(oPC, "[Pakt] Fragment wspomnien odplywa w mrok... Glasya pobiera swoj haracz.");
+    }
+    else if(sDemonId == PACT_DEMON_JUIBLEX)
+    {
+        ApplyEffectToObject(DURATION_TYPE_INSTANT,
+            EffectDamage(10, DAMAGE_TYPE_ACID, DAMAGE_POWER_NORMAL), oPC);
+
+        // Random curse chosen each toll — Juiblex is unpredictable.
+        int nRoll = d4();
+        effect eCurse;
+        if(nRoll == 1)
+            eCurse = EffectConfused();
+        else if(nRoll == 2)
+            eCurse = EffectBlindness();
+        else if(nRoll == 3)
+            eCurse = EffectAbilityDecrease(ABILITY_INTELLIGENCE, 2);
+        else
+            eCurse = EffectAbilityDecrease(ABILITY_WISDOM, 2);
+
+        effect eLinked = EffectLinkEffects(eCurse, EffectVisualEffect(VFX_DUR_BLUR));
+        ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eLinked, oPC, 30.0);
+        SendMessageToPC(oPC, "[Pakt] Cos gnitego wnika w mysli... Juiblex pobiera swoj haracz.");
+    }
+
+    // Refresh open window if visible.
+    int nToken = NuiFindWindow(oPC, PACT_WINDOW);
+    if(nToken != 0) FeedPactStatus(oPC, nToken);
+}
+
+void PactCheckAndApply(object oPC)
+{
+    json jActive = PactGetActive(oPC);
+    if(JsonGetType(jActive) == JSON_TYPE_NULL)
+    {
+        PactRemoveEffects(oPC);
+        return;
+    }
+
+    string sDemonId = JsonGetString(JsonObjectGet(jActive, "demon_id"));
+    int    nTolls   = JsonGetInt   (JsonObjectGet(jActive, "toll_count"));
+    PactApplyEffects(oPC, sDemonId);
+    SendMessageToPC(oPC, "[Pakt] Aktywny: " + PactGetDemonName(sDemonId)
+        + " (haracz pobrany: " + IntToString(nTolls) + "x). Pieczen krwi plonie.");
+}

--- a/Demonic Pacts/Scripts/lib_pact_def.nss
+++ b/Demonic Pacts/Scripts/lib_pact_def.nss
@@ -1,0 +1,113 @@
+#include "lib_nui"
+#include "sql_pact"
+
+void CreatePactWindow(object oPC);
+void PactCheckAndApply(object oPC);
+void PactApplyEffects(object oPC, string sDemonId);
+void PactRemoveEffects(object oPC);
+void PactCollectToll(object oPC);
+
+// ---- Window / UI identifiers ----
+const string PACT_WINDOW    = "PACT_WINDOW";
+const string PACT_EV_SCRIPT = "lib_pact_ev";
+const string PACT_WIN_GEOM  = "pact_win_geom";
+
+// ---- NUI bind names ----
+const string PACT_BIND_LIST_NAME    = "pact_list_name";
+const string PACT_BIND_LIST_ENC     = "pact_list_enc";
+const string PACT_BIND_LIST_CNT     = "pact_list_cnt";
+const string PACT_BIND_DETAIL_NAME  = "pact_det_name";
+const string PACT_BIND_DETAIL_LORE  = "pact_det_lore";
+const string PACT_BIND_DETAIL_BUFF  = "pact_det_buff";
+const string PACT_BIND_DETAIL_TOLL  = "pact_det_toll";
+const string PACT_BIND_SIGN_LBL     = "pact_sign_lbl";
+const string PACT_BIND_SIGN_ENA     = "pact_sign_ena";
+const string PACT_BIND_STATUS_LBL   = "pact_status_lbl";
+const string PACT_BIND_BREAK_LBL    = "pact_break_lbl";
+const string PACT_BIND_BREAK_ENA    = "pact_break_ena";
+
+// ---- Button IDs ----
+const string PACT_BTN_CLOSE = "pact_btn_close";
+const string PACT_BTN_ROW   = "pact_btn_row";
+const string PACT_BTN_SIGN  = "pact_btn_sign";
+const string PACT_BTN_BREAK = "pact_btn_break";
+
+// ---- Local variables on PC ----
+const string PACT_LVAR_SEL = "PACT_SEL";    // currently highlighted demon ID in UI
+
+// ---- Demon IDs ----
+const string PACT_DEMON_ORCUS   = "ORCUS";
+const string PACT_DEMON_BAEL    = "BAEL";
+const string PACT_DEMON_GLASYA  = "GLASYA";
+const string PACT_DEMON_JUIBLEX = "JUIBLEX";
+
+// All pact effects carry this tag prefix so they can be stripped as a group.
+const string PACT_EFFECT_PREFIX = "PACT_";
+
+// ---- Config ----
+const int   PACT_DEMON_COUNT      = 4;
+const int   PACT_TOLL_INTERVAL    = 7200;   // seconds between tolls (2 real hours)
+const int   PACT_BREAK_HP_COST    = 20;     // HP damage when voluntarily breaking a pact
+const int   PACT_BREAK_CURSE_SECS = 1800;   // duration of the break-penalty curse (30 min)
+
+// ---- Window dimensions ----
+const float PACT_W = 680.0;
+const float PACT_H = 450.0;
+
+// ---- Demon data accessors ----
+
+string PactGetDemonId(int nIdx)
+{
+    if(nIdx == 0) return PACT_DEMON_ORCUS;
+    if(nIdx == 1) return PACT_DEMON_BAEL;
+    if(nIdx == 2) return PACT_DEMON_GLASYA;
+    return PACT_DEMON_JUIBLEX;
+}
+
+string PactGetDemonName(string sId)
+{
+    if(sId == PACT_DEMON_ORCUS)   return "Pakt Agonii — Orcus";
+    if(sId == PACT_DEMON_BAEL)    return "Pakt Zelaza — Bael";
+    if(sId == PACT_DEMON_GLASYA)  return "Pakt Cienia — Glasya";
+    if(sId == PACT_DEMON_JUIBLEX) return "Pakt Odmetu — Juiblex";
+    return "—";
+}
+
+string PactGetDemonBuff(string sId)
+{
+    if(sId == PACT_DEMON_ORCUS)   return "Premia: Regeneracja 2 PZ/runde (nadprzyrodzona)";
+    if(sId == PACT_DEMON_BAEL)    return "Premia: +4 do Sily (nadprzyrodzony)";
+    if(sId == PACT_DEMON_GLASYA)  return "Premia: +6 do Skradania i Ukrywania sie";
+    if(sId == PACT_DEMON_JUIBLEX) return "Premia: +5 do AC naturalnego";
+    return "";
+}
+
+string PactGetDemonToll(string sId)
+{
+    if(sId == PACT_DEMON_ORCUS)   return "Haracz (co 2h): 12 obrazen negatywnych";
+    if(sId == PACT_DEMON_BAEL)    return "Haracz (co 2h): 8 obrazen + 50 doswiadczenia";
+    if(sId == PACT_DEMON_GLASYA)  return "Haracz (co 2h): 60 doswiadczenia";
+    if(sId == PACT_DEMON_JUIBLEX) return "Haracz (co 2h): 10 obrazen kwasem + losowa klatwa";
+    return "";
+}
+
+string PactGetDemonLore(string sId)
+{
+    if(sId == PACT_DEMON_ORCUS)
+        return "Orcus, Niosacy Laske Czaszki, daruje nieumarla witalnosc tym,\n"
+             + "ktorzy podpisza sie wlasna krwia. Krew powraca — lecz\n"
+             + "z kazdym haraczem niesie ze soba coraz wiecej mroku.";
+    if(sId == PACT_DEMON_BAEL)
+        return "Bael, Wielki Krol Piekiel, kuje sile z cudzej slabosci.\n"
+             + "Jego zelazna dlon zaciska sie na ramieniu sygnatariusza\n"
+             + "z kazdym pobranym haraczem — cicho, nieublaganie.";
+    if(sId == PACT_DEMON_GLASYA)
+        return "Glasya, Corka Asmodeia, handluje cieniem i zapomnieniem.\n"
+             + "Ci, ktorzy pisza jej imie we wlasnej krwi, znikaja ze\n"
+             + "swiata — ona zas zachowuje kazde wspomnienie dla siebie.";
+    if(sId == PACT_DEMON_JUIBLEX)
+        return "Juiblex, Bezksztaltny, nie posiada formy ani litosci.\n"
+             + "Jego bloto z Otchlani opancerza cialo, lecz z kazdym\n"
+             + "haraczem rozpuszcza kolejny fragment jazni sygnatariusza.";
+    return "";
+}

--- a/Demonic Pacts/Scripts/lib_pact_ev.nss
+++ b/Demonic Pacts/Scripts/lib_pact_ev.nss
@@ -1,0 +1,116 @@
+#include "lib_pact"
+
+void PactHandleSign(object oPC, int nToken)
+{
+    string sDemonId = GetLocalString(oPC, PACT_LVAR_SEL);
+    if(sDemonId == "") return;
+
+    json jActive = PactGetActive(oPC);
+    if(JsonGetType(jActive) != JSON_TYPE_NULL)
+    {
+        SendMessageToPC(oPC, "[Pakt] Masz juz aktywny pakt. Najpierw go zerwij przy oltarzu.");
+        return;
+    }
+
+    PactSign(oPC, sDemonId);
+    PactApplyEffects(oPC, sDemonId);
+
+    FloatingTextStringOnCreature("Pieczen krwi plonie czerwienia. Pakt zawarty.", oPC, FALSE);
+    SendMessageToPC(oPC, "[Pakt] Pakt z " + PactGetDemonName(sDemonId) + " zawarty.");
+
+    FeedPactList(oPC, nToken);
+    FeedPactDetail(oPC, nToken, sDemonId);
+    FeedPactStatus(oPC, nToken);
+}
+
+void PactHandleBreak(object oPC, int nToken)
+{
+    json jActive = PactGetActive(oPC);
+    if(JsonGetType(jActive) == JSON_TYPE_NULL) return;
+
+    string sDemonId = JsonGetString(JsonObjectGet(jActive, "demon_id"));
+
+    PactBreak(oPC);
+    PactRemoveEffects(oPC);
+
+    // Penalty: immediate HP damage.
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectDamage(PACT_BREAK_HP_COST, DAMAGE_TYPE_NEGATIVE, DAMAGE_POWER_NORMAL), oPC);
+
+    // Penalty: timed curse on STR, DEX, CON for PACT_BREAK_CURSE_SECS.
+    effect eCurse = EffectLinkEffects(
+        EffectAbilityDecrease(ABILITY_STRENGTH,     2),
+        EffectLinkEffects(
+            EffectAbilityDecrease(ABILITY_DEXTERITY,    2),
+            EffectLinkEffects(
+                EffectAbilityDecrease(ABILITY_CONSTITUTION, 2),
+                EffectVisualEffect(VFX_DUR_AURA_EVIL_OPPONENT)
+            )
+        )
+    );
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eCurse, oPC, IntToFloat(PACT_BREAK_CURSE_SECS));
+
+    FloatingTextStringOnCreature("Pieczen kruszy sie. Klatwa spada!", oPC, FALSE);
+    SendMessageToPC(oPC, "[Pakt] Pakt z " + PactGetDemonName(sDemonId)
+        + " zerwany. Klatwa trwa " + IntToString(PACT_BREAK_CURSE_SECS / 60) + " minut.");
+
+    string sSelId = GetLocalString(oPC, PACT_LVAR_SEL);
+    FeedPactList(oPC, nToken);
+    if(sSelId != "")
+        FeedPactDetail(oPC, nToken, sSelId);
+    FeedPactStatus(oPC, nToken);
+}
+
+// ---- Main NUI event handler ----
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    if(nToken != NuiFindWindow(oPC, PACT_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalString(oPC, PACT_LVAR_SEL);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_MOUSEDOWN && sElem == PACT_BTN_ROW)
+    {
+        if(nIdx < 0 || nIdx >= PACT_DEMON_COUNT) return;
+        string sDemonId = PactGetDemonId(nIdx);
+        SetLocalString(oPC, PACT_LVAR_SEL, sDemonId);
+
+        json jEncs = JsonArray();
+        int i;
+        for(i = 0; i < PACT_DEMON_COUNT; i++)
+            jEncs = JsonArrayInsert(jEncs, JsonBool(i == nIdx));
+        NuiSetBind(oPC, nToken, PACT_BIND_LIST_ENC, jEncs);
+
+        FeedPactDetail(oPC, nToken, sDemonId);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == PACT_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+        if(sElem == PACT_BTN_SIGN)
+        {
+            PactHandleSign(oPC, nToken);
+            return;
+        }
+        if(sElem == PACT_BTN_BREAK)
+        {
+            PactHandleBreak(oPC, nToken);
+            return;
+        }
+    }
+}

--- a/Demonic Pacts/Scripts/sql_pact.nss
+++ b/Demonic Pacts/Scripts/sql_pact.nss
@@ -1,0 +1,72 @@
+// SQL schema and queries for Demonic Pacts module.
+// Campaign database name: "pact"
+
+void PactCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("pact",
+        "CREATE TABLE IF NOT EXISTS pact_active ("
+        "pc_uuid TEXT PRIMARY KEY, "
+        "demon_id TEXT NOT NULL, "
+        "signed_at INTEGER DEFAULT 0, "
+        "last_toll_at INTEGER DEFAULT 0, "
+        "toll_count INTEGER DEFAULT 0"
+        ")");
+    SqlStep(q);
+}
+
+// Returns {demon_id, signed_at, last_toll_at, toll_count} or JSON_NULL if no pact.
+json PactGetActive(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("pact",
+        "SELECT demon_id, signed_at, last_toll_at, toll_count "
+        "FROM pact_active WHERE pc_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(!SqlStep(q)) return JsonNull();
+
+    json j = JsonObject();
+    j = JsonObjectSet(j, "demon_id",     JsonString(SqlGetString(q, 0)));
+    j = JsonObjectSet(j, "signed_at",    JsonInt   (SqlGetInt   (q, 1)));
+    j = JsonObjectSet(j, "last_toll_at", JsonInt   (SqlGetInt   (q, 2)));
+    j = JsonObjectSet(j, "toll_count",   JsonInt   (SqlGetInt   (q, 3)));
+    return j;
+}
+
+void PactSign(object oPC, string sDemonId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("pact",
+        "INSERT OR REPLACE INTO pact_active "
+        "(pc_uuid, demon_id, signed_at, last_toll_at, toll_count) "
+        "VALUES (@uuid, @demon, strftime('%s','now'), strftime('%s','now'), 0)");
+    SqlBindString(q, "@uuid",  GetObjectUUID(oPC));
+    SqlBindString(q, "@demon", sDemonId);
+    SqlStep(q);
+}
+
+void PactBreak(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("pact",
+        "DELETE FROM pact_active WHERE pc_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+void PactRecordToll(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("pact",
+        "UPDATE pact_active "
+        "SET last_toll_at = strftime('%s','now'), toll_count = toll_count + 1 "
+        "WHERE pc_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+// Returns seconds elapsed since last toll, or 0 if no record.
+int PactGetTimeSinceLastToll(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("pact",
+        "SELECT CAST(strftime('%s','now') AS INTEGER) - last_toll_at "
+        "FROM pact_active WHERE pc_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}

--- a/Demonic Pacts/Scripts/sys_on_enter.nss
+++ b/Demonic Pacts/Scripts/sys_on_enter.nss
@@ -1,0 +1,10 @@
+#include "lib_pact"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC)) return;
+
+    // Delay to let the client finish loading before applying effects/messages.
+    DelayCommand(3.0, PactCheckAndApply(oPC));
+}

--- a/Demonic Pacts/Scripts/sys_on_heartbeat.nss
+++ b/Demonic Pacts/Scripts/sys_on_heartbeat.nss
@@ -1,0 +1,14 @@
+#include "lib_pact"
+
+// Runs every 6 seconds (module OnHeartbeat). PactCollectToll is a no-op
+// until PACT_TOLL_INTERVAL seconds have elapsed since the last toll,
+// so the per-PC SQL cost here is one lightweight SELECT by primary key.
+void main()
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        PactCollectToll(oPC);
+        oPC = GetNextPC();
+    }
+}

--- a/Demonic Pacts/Scripts/sys_on_load.nss
+++ b/Demonic Pacts/Scripts/sys_on_load.nss
@@ -1,0 +1,6 @@
+#include "sql_pact"
+
+void main()
+{
+    PactCreateTables();
+}

--- a/Demonic Pacts/Scripts/test_pact.nss
+++ b/Demonic Pacts/Scripts/test_pact.nss
@@ -1,0 +1,10 @@
+#include "lib_pact"
+
+// Attach to a placeable's OnUsed event.
+// The placeable acts as the physical Altar of Covenants in the world.
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+    CreatePactWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

System mrocznych paktów z demonami. Gracz podchodzi do Ołtarza Paktów (placeable z `test_pact.nss` na OnUsed), otwiera dwupanelowe okno NUI, wybiera jednego z czterech demonów, czyta klimatyczny lore i zawiera pakt jednym kliknięciem. Efekty są nadprzyrodzone (`SupernaturalEffect`) i trwają permanentnie — aż do zerwania paktu lub śmierci postaci. Co 2 godziny realnego czasu system automatycznie pobiera haracz (obrażenia i/lub XP). Gracz może mieć tylko jeden aktywny pakt; zerwanie kosztuje HP i nakłada 30-minutową klątwę stat-debuff.

## Mechanika

**4 dostępne pakty:**

| Demon | Premia (nadprzyrodzona) | Haracz co 2h |
|-------|------------------------|--------------|
| **Orcus** — Pakt Agonii | Regeneracja 2 PŻ/rundę | 12 obrażeń negatywnych |
| **Bael** — Pakt Żelaza | +4 do Siły | 8 obrażeń + 50 XP |
| **Glasya** — Pakt Cienia | +6 Hide, +6 Move Silently | 60 XP |
| **Juiblex** — Pakt Odmętu | +5 Natural AC | 10 obrażeń kwasem + losowa klątwa (confusion / blindness / -2 INT / -2 WIS, 30 s) |

**Zerwanie paktu:** 20 HP damage + klatwa −2 STR/DEX/CON przez 30 minut.

Efekty identyfikowane przez tag (`EffectSetTag` / `GetEffectTag`, NWN EE 8193.24+), dzięki czemu można je masowo usunąć przy zerwaniu lub ponownym logowaniu bez wpływu na inne efekty postaci.

Haracz pobierany w `sys_on_heartbeat.nss` (moduł bije co 6 s); SQL-owa kolumna `last_toll_at` blokuje wielokrotne pobranie — rzeczywisty koszt to jeden SELECT po kluczu głównym na gracza.

## Pliki

```
Demonic Pacts/
├── INTEGRATION.md
└── Scripts/
    ├── sql_pact.nss        — schemat SQLite + CRUD (baza "pact")
    ├── lib_pact_def.nss    — stałe, ID bindów, ID przycisków, accessory danych demonów
    ├── lib_pact.nss        — budowa NUI (lista + panel detali + pasek statusu), Feed*, logika gry
    ├── lib_pact_ev.nss     — handler zdarzeń NUI (wybór demona, zawarcie, zerwanie)
    ├── sys_on_load.nss     — PactCreateTables()
    ├── sys_on_enter.nss    — PactCheckAndApply() przy logowaniu
    ├── sys_on_heartbeat.nss — PactCollectToll() dla każdego gracza
    └── test_pact.nss       — OnUsed na placeable (Ołtarz Paktów)
```

## Zależności (NWNX? SQL?)

- **NWNX:** brak
- **NWN EE build:** 8193.24+ (`EffectSetTag`, `GetEffectTag`, `SqlPrepareQueryCampaign`)
- **SQLite:** kampanijna baza `pact` — tworzona automatycznie w `OnModuleLoad`

## Jak włączyć w istniejącym module

1. Skopiuj folder `Demonic Pacts/Scripts/` do HAK lub override modułu.
2. Podepnij hooki do zdarzeń modułu (szczegóły w `INTEGRATION.md`):
   - `OnModuleLoad` → `sys_on_load.nss`
   - `OnClientEnter` → `sys_on_enter.nss`
   - `OnHeartbeat` → `sys_on_heartbeat.nss`
3. Umieść placeable w świecie i przypisz `test_pact.nss` do jego `OnUsed`.

## Co celowo pominięto

- **Grafika / ikony demonów** — brak własnego HAK; do dodania jako rozszerzenie.
- **Potwierdzenie zerwania paktu** — koszty są widoczne na przycisku; popup confirm uznany za zbędny narzut kodu.
- **Limit aktywnych paktów > 1** — celowo jeden pakt naraz, żeby decyzja miała wagę.
- **Konfigurowalne receptury przez DM** — zakres poza dniem; hooki i stałe w `lib_pact_def.nss` wystarczają do ręcznej regulacji.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X1k3MnBcirqEXXU5V7cvmc)_