### PR TITLE
feat: Kuźnia Runiczna

### DIFF
--- a/Runic Forge/INTEGRATION.md
+++ b/Runic Forge/INTEGRATION.md
@@ -1,0 +1,57 @@
+# Kuźnia Runiczna — Integracja z modułem NWN
+
+## Wymagania
+
+- NWN EE 8193.36+ (dla `GetObjectByUUID`, `SqlPrepareQueryCampaign`, NUI)
+- NWNX: **nie wymagany**
+- Kampania SQL: skrypt tworzy własną bazę `runic_forge`
+
+## Pliki do skopiowania
+
+Wszystkie pliki z `Scripts/` dodaj do HAK modułu lub skompiluj bezpośrednio.
+Plik `lib_nui.nss` i `lib_nui_utility.nss` (z innego modułu w repo) muszą
+być dostępne w tym samym HAK.
+
+## Hooki modułowe
+
+| Hook modułu        | Skrypt do podpięcia         | Uwagi |
+|--------------------|-----------------------------|-------|
+| OnModuleLoad       | `sys_on_load.nss`           | tworzy tabele SQL |
+| OnPlayerTarget     | `sys_on_target.nss`         | obsługuje wybór broni w trybie celowania |
+
+Jeśli moduł używa już własnego `OnPlayerTarget`, do istniejącego handlera
+dodaj wywołanie `RFOnPlayerTarget(GetLastPlayerToSelectTarget())` — funkcja
+sprawdza flagę `RF_TARGETING` i nic nie robi, gdy targeting pochodzi od
+innego systemu.
+
+## Placeable "Kuźnia Runiczna"
+
+1. Utwórz placeable (np. `wp_forge` lub dowolny kowadło/piec z HAK).
+2. W zdarzeniu **OnUsed** ustaw skrypt `test_rf`.
+3. Postaw obiekt w grze — gracze klikają i otwiera się UI.
+
+## Weryfikacja działania
+
+1. Zaloguj się jako PC z > 500 sztuk złota.
+2. Kliknij placeable kuźni.
+3. Kliknij **"Wybierz bron"** i zaznacz miecz w ekwipunku.
+4. Wybierz runę (np. Runa Ognia).
+5. Kliknij **"KUJ!"** — okno kuźni zamknie się, pojawi się okno minigry.
+6. Zapamiętaj sekwencję podświetlanych przycisków (4 kroki dla poziomu 0→1).
+7. Powtórz sekwencję — przy sukcesie broń dostaje trwały `1k4 obrażeń Ogniem`.
+8. Przy kolejnych próbach sekwencja rośnie, a każdy wyższy poziom kosztuje więcej złota.
+
+## Ograniczenia (celowe pominięcia)
+
+- **Walidacja broni**: moduł używa kolumny `DieToRoll` z `baseitems.2da`.
+  Przedmioty rzucane (strzały, bełty) mogą przejść walidację — wyklucz je
+  ręcznie w `RFOnPlayerTarget` jeśli potrzeba.
+- **Brak wizualnych efektów FX**: `EffectVisualEffect` przy sukcesie pominięty,
+  bo wymaga resref z HAK. Dodaj `ApplyEffectToObject(DURATION_TYPE_INSTANT,
+  EffectVisualEffect(VFX_FNF_SUMMON_GATE), oItem_location)` wg własnych zasobów.
+- **Brak HAK**: moduł nie dodaje własnych obrazków — przyciski NUI używają
+  czystego stylu systemowego.
+- **Jeden timer globalny**: timeout minigry nie uwzględnia pauzy serwera (lag).
+  Przy dużym lagsie gracz może mieć efektywnie mniej czasu.
+- **Poziom 5 = cap**: po osiągnięciu poziomu V konkretnej runy na konkretnej
+  broni przycisk "KUJ!" jest zablokowany. Nie ma mechanizmu zdejmowania rун.

--- a/Runic Forge/Scripts/lib_rf.nss
+++ b/Runic Forge/Scripts/lib_rf.nss
@@ -1,0 +1,627 @@
+#include "lib_rf_def"
+
+// -----------------------------------------------------------------------
+// Data helpers
+// -----------------------------------------------------------------------
+
+string RFRuneName(int nRune)
+{
+    if(nRune == RF_RUNE_FIRE)     return "Runa Ognia";
+    if(nRune == RF_RUNE_ICE)      return "Runa Lodu";
+    if(nRune == RF_RUNE_STORM)    return "Runa Burzy";
+    if(nRune == RF_RUNE_SHADOW)   return "Runa Mroku";
+    if(nRune == RF_RUNE_RADIANCE) return "Runa Blasku";
+    if(nRune == RF_RUNE_BLOOD)    return "Runa Krwi";
+    return "Nieznana";
+}
+
+// IP_CONST_DAMAGEBONUS_TYPE_ for each element rune.
+int RFDamageType(int nRune)
+{
+    if(nRune == RF_RUNE_FIRE)     return IP_CONST_DAMAGEBONUS_TYPE_FIRE;
+    if(nRune == RF_RUNE_ICE)      return IP_CONST_DAMAGEBONUS_TYPE_COLD;
+    if(nRune == RF_RUNE_STORM)    return IP_CONST_DAMAGEBONUS_TYPE_ELECTRICAL;
+    if(nRune == RF_RUNE_SHADOW)   return IP_CONST_DAMAGEBONUS_TYPE_NEGATIVE;
+    if(nRune == RF_RUNE_RADIANCE) return IP_CONST_DAMAGEBONUS_TYPE_DIVINE;
+    return IP_CONST_DAMAGEBONUS_TYPE_FIRE; // RF_RUNE_BLOOD handled separately
+}
+
+// Returns IP_CONST_DAMAGEBONUS_ die constant for the given enchant level (1-5).
+int RFDiceConst(int nLevel)
+{
+    if(nLevel <= 1) return IP_CONST_DAMAGEBONUS_1d4;
+    if(nLevel == 2) return IP_CONST_DAMAGEBONUS_1d6;
+    if(nLevel == 3) return IP_CONST_DAMAGEBONUS_1d8;
+    if(nLevel == 4) return IP_CONST_DAMAGEBONUS_1d10;
+    return IP_CONST_DAMAGEBONUS_2d6; // level 5
+}
+
+string RFDiceLabel(int nLevel)
+{
+    if(nLevel <= 1) return "1k4";
+    if(nLevel == 2) return "1k6";
+    if(nLevel == 3) return "1k8";
+    if(nLevel == 4) return "1k10";
+    return "2k6";
+}
+
+int RFGetCost(int nCurrentLevel)
+{
+    return RF_BASE_COST + nCurrentLevel * RF_COST_PER_LEVEL;
+}
+
+// Sequence length grows with each upgrade attempt.
+int RFSequenceLength(int nCurrentLevel)
+{
+    int nLen = 4 + nCurrentLevel; // 4 at level 0, 9 at level 5
+    if(nLen > 9) nLen = 9;
+    return nLen;
+}
+
+// Human-readable summary of all runes on an item for the forge panel.
+string RFEnchantSummary(string sItemUuid)
+{
+    if(sItemUuid == "") return "brak";
+    json jEnchs = RFGetItemEnchants(sItemUuid);
+    int nCount = JsonGetLength(jEnchs);
+    if(nCount == 0) return "brak run";
+    string sResult = "";
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jE    = JsonArrayGet(jEnchs, i);
+        int nRune  = JsonGetInt(JsonObjectGet(jE, "rune_id"));
+        int nLevel = JsonGetInt(JsonObjectGet(jE, "level"));
+        if(sResult != "") sResult = sResult + ", ";
+        sResult = sResult + RFRuneName(nRune) + " " + IntToString(nLevel);
+    }
+    return sResult;
+}
+
+
+// -----------------------------------------------------------------------
+// Enchant application
+// -----------------------------------------------------------------------
+
+// Removes any existing ItemProperty on the weapon that matches this rune's type.
+// Blood rune uses ITEM_PROPERTY_VAMPIRIC_REGENERATION; others use ITEM_PROPERTY_DAMAGE_BONUS.
+void RFRemoveRuneProperty(object oItem, int nRune)
+{
+    int nTargetPropType = (nRune == RF_RUNE_BLOOD)
+        ? ITEM_PROPERTY_VAMPIRIC_REGENERATION
+        : ITEM_PROPERTY_DAMAGE_BONUS;
+    int nTargetSubType  = (nRune == RF_RUNE_BLOOD) ? -1 : RFDamageType(nRune);
+
+    itemproperty ip = GetFirstItemProperty(oItem);
+    while(GetIsItemPropertyValid(ip))
+    {
+        if(GetItemPropertyType(ip) == nTargetPropType)
+        {
+            if(nRune == RF_RUNE_BLOOD || GetItemPropertySubType(ip) == nTargetSubType)
+                RemoveItemProperty(oItem, ip);
+        }
+        ip = GetNextItemProperty(oItem);
+    }
+}
+
+void RFApplyEnchant(object oItem, int nRune, int nLevel)
+{
+    RFRemoveRuneProperty(oItem, nRune);
+
+    itemproperty ipNew;
+    if(nRune == RF_RUNE_BLOOD)
+        ipNew = ItemPropertyVampiricRegeneration(nLevel);
+    else
+        ipNew = ItemPropertyDamageBonus(RFDamageType(nRune), RFDiceConst(nLevel));
+
+    AddItemProperty(DURATION_TYPE_PERMANENT, ipNew, oItem);
+}
+
+
+// -----------------------------------------------------------------------
+// NUI: Forge window
+// -----------------------------------------------------------------------
+
+json RFBuildRuneRow(object oPC, int nStart)
+{
+    float fBtnH = GetNuiScaleDimension(oPC, 34.0);
+    json jRow = JsonArray();
+    int i;
+    for(i = nStart; i < nStart + 3 && i < RF_RUNE_COUNT; i++)
+    {
+        json jBtn = NuiButton(JsonString(RFRuneName(i)));
+        jBtn = NuiId(jBtn, RF_BTN_RUNE + IntToString(i));
+        jBtn = NuiEncouraged(jBtn, NuiBind(RF_BIND_RUNE_ENC + IntToString(i)));
+        jBtn = NuiHeight(jBtn, fBtnH);
+        jRow = JsonArrayInsert(jRow, jBtn);
+    }
+    return NuiRow(jRow);
+}
+
+json RFBuildForgeContent(object oPC)
+{
+    float fLblH  = GetNuiScaleDimension(oPC, 26.0);
+    float fBtnH  = GetNuiScaleDimension(oPC, 32.0);
+    float fWpnBW = GetNuiScaleDimension(oPC, 140.0);
+
+    // -- Weapon selector row --
+    json jWpnBtn = NuiButton(JsonString("Wybierz bron"));
+    jWpnBtn = NuiId(jWpnBtn, RF_BTN_WEAPON);
+    jWpnBtn = NuiEnabled(jWpnBtn, NuiBind(RF_BIND_WPN_ENA));
+    jWpnBtn = NuiWidth(jWpnBtn, fWpnBW);
+    jWpnBtn = NuiHeight(jWpnBtn, fBtnH);
+    jWpnBtn = NuiTooltip(jWpnBtn, JsonString("Wskaż broń w swoim ekwipunku"));
+
+    json jWpnLbl = NuiLabel(NuiBind(RF_BIND_WPN_NAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jWpnLbl = NuiHeight(jWpnLbl, fBtnH);
+
+    json jWpnRow = JsonArray();
+    jWpnRow = JsonArrayInsert(jWpnRow, jWpnBtn);
+    jWpnRow = JsonArrayInsert(jWpnRow, NuiWidth(NuiSpacer(), GetNuiScaleDimension(oPC, 8.0)));
+    jWpnRow = JsonArrayInsert(jWpnRow, jWpnLbl);
+
+    // -- Rune header --
+    json jRuneHdr = NuiLabel(JsonString("Wybierz rune:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRuneHdr = NuiHeight(jRuneHdr, fLblH);
+    jRuneHdr = NuiStyleForegroundColor(jRuneHdr, NuiColor(185, 150, 100, 255));
+
+    // -- Enchant info --
+    json jEnchHdr = NuiLabel(JsonString("Aktualny enchant:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jEnchHdr = NuiHeight(jEnchHdr, fLblH);
+    jEnchHdr = NuiStyleForegroundColor(jEnchHdr, NuiColor(185, 150, 100, 255));
+
+    json jEnchLbl = NuiLabel(NuiBind(RF_BIND_ENCH_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jEnchLbl = NuiHeight(jEnchLbl, fLblH);
+
+    // -- Cost info --
+    json jCostLbl = NuiLabel(NuiBind(RF_BIND_COST_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jCostLbl = NuiHeight(jCostLbl, fLblH);
+
+    // -- Forge button --
+    float fForgeBW = GetNuiScaleDimension(oPC, 140.0);
+    float fForgeBH = GetNuiScaleDimension(oPC, 38.0);
+    json jForgeBtn = NuiButton(JsonString("KUJ!"));
+    jForgeBtn = NuiId(jForgeBtn, RF_BTN_FORGE);
+    jForgeBtn = NuiEnabled(jForgeBtn, NuiBind(RF_BIND_FORGE_ENA));
+    jForgeBtn = NuiWidth(jForgeBtn, fForgeBW);
+    jForgeBtn = NuiHeight(jForgeBtn, fForgeBH);
+    jForgeBtn = NuiTooltip(jForgeBtn, JsonString("Rozpocznij próbę rytowania — zapłać i uruchom minigrę"));
+
+    json jForgeRow = JsonArray();
+    jForgeRow = JsonArrayInsert(jForgeRow, NuiSpacer());
+    jForgeRow = JsonArrayInsert(jForgeRow, jForgeBtn);
+    jForgeRow = JsonArrayInsert(jForgeRow, NuiSpacer());
+
+    // -- Assemble column --
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(jWpnRow));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jRuneHdr)));
+    jCol = JsonArrayInsert(jCol, RFBuildRuneRow(oPC, 0)); // Ogień, Lód, Burza
+    jCol = JsonArrayInsert(jCol, RFBuildRuneRow(oPC, 3)); // Mrok, Blask, Krew
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jEnchHdr)));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jEnchLbl)));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jCostLbl)));
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+    jCol = JsonArrayInsert(jCol, NuiRow(jForgeRow));
+
+    return NuiCol(jCol);
+}
+
+void RFOpenForge(object oPC)
+{
+    // If already open, just re-feed it.
+    int nToken = NuiFindWindow(oPC, RF_WIN_FORGE);
+    if(nToken != 0)
+    {
+        RFFeedForge(oPC, nToken);
+        return;
+    }
+
+    // Clear any leftover state from previous session.
+    SetLocalInt(oPC, RF_LVAR_SEL_RUNE, -1);
+    DeleteLocalString(oPC, RF_LVAR_WPN_UUID);
+    DeleteLocalString(oPC, RF_LVAR_WPN_NAME);
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - GetNuiScaleDimension(oPC, RF_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - GetNuiScaleDimension(oPC, RF_H)) / 2.0;
+    json jGeom = NuiRect(fCX, fCY, GetNuiScaleDimension(oPC, RF_W), GetNuiScaleDimension(oPC, RF_H));
+
+    // Close button in manual title row (window itself has no OS chrome)
+    float fBtnH = GetNuiScaleDimension(oPC, 28.0);
+    json jTitleLbl = NuiLabel(JsonString("KUZNIA RUNICZNA"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitleLbl = NuiHeight(jTitleLbl, fBtnH);
+    jTitleLbl = NuiStyleForegroundColor(jTitleLbl, NuiColor(185, 150, 100, 255));
+
+    json jCloseBtn = NuiButton(JsonString("X"));
+    jCloseBtn = NuiId(jCloseBtn, RF_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, GetNuiScaleDimension(oPC, 28.0));
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jTitleRow = JsonArray();
+    jTitleRow = JsonArrayInsert(jTitleRow, jTitleLbl);
+    jTitleRow = JsonArrayInsert(jTitleRow, NuiSpacer());
+    jTitleRow = JsonArrayInsert(jTitleRow, jCloseBtn);
+
+    json jPadRow = JsonArray();
+    jPadRow = JsonArrayInsert(jPadRow, NuiWidth(NuiSpacer(), GetNuiScaleDimension(oPC, 12.0)));
+    jPadRow = JsonArrayInsert(jPadRow, RFBuildForgeContent(oPC));
+    jPadRow = JsonArrayInsert(jPadRow, NuiWidth(NuiSpacer(), GetNuiScaleDimension(oPC, 12.0)));
+
+    json jRoot = JsonArray();
+    jRoot = JsonArrayInsert(jRoot, NuiRow(jTitleRow));
+    jRoot = JsonArrayInsert(jRoot, NuiRow(jPadRow));
+    jRoot = JsonArrayInsert(jRoot, CreateEmptyRow(oPC, 10.0));
+
+    json jWin = NuiWindow(NuiCol(jRoot),
+        JsonBool(FALSE),
+        NuiBind(RF_BIND_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    nToken = NuiCreate(oPC, jWin, RF_WIN_FORGE, RF_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, RF_BIND_WIN_GEOM, jGeom);
+
+    RFFeedForge(oPC, nToken);
+}
+
+// Refreshes all dynamic binds in the forge window.
+void RFFeedForge(object oPC, int nToken)
+{
+    string sUuid = GetLocalString(oPC, RF_LVAR_WPN_UUID);
+    string sName = GetLocalString(oPC, RF_LVAR_WPN_NAME);
+    int nSelRune = GetLocalInt(oPC, RF_LVAR_SEL_RUNE); // -1 = none
+
+    // Weapon name / placeholder
+    string sWpnLabel = (sUuid == "") ? "(kliknij Wybierz bron)" : sName;
+    NuiSetBind(oPC, nToken, RF_BIND_WPN_NAME, JsonString(sWpnLabel));
+    NuiSetBind(oPC, nToken, RF_BIND_WPN_ENA,  JsonBool(TRUE));
+
+    // Rune enc states
+    int i;
+    for(i = 0; i < RF_RUNE_COUNT; i++)
+        NuiSetBind(oPC, nToken, RF_BIND_RUNE_ENC + IntToString(i), JsonBool(i == nSelRune));
+
+    // Enchant summary
+    NuiSetBind(oPC, nToken, RF_BIND_ENCH_LBL, JsonString(RFEnchantSummary(sUuid)));
+
+    // Cost + forge button
+    int bReady = (sUuid != "" && nSelRune >= 0);
+    if(bReady)
+    {
+        int nCurLevel = RFGetEnchantLevel(sUuid, nSelRune);
+        if(nCurLevel >= RF_MAX_LEVEL)
+        {
+            NuiSetBind(oPC, nToken, RF_BIND_COST_LBL,  JsonString("Maksymalny poziom osiagniety (V)"));
+            NuiSetBind(oPC, nToken, RF_BIND_FORGE_ENA,  JsonBool(FALSE));
+        }
+        else
+        {
+            int nCost = RFGetCost(nCurLevel);
+            string sCostLbl = "Koszt: " + IntToString(nCost) + " sztuk zlota"
+                + "  |  poziom: " + IntToString(nCurLevel) + " -> " + IntToString(nCurLevel + 1)
+                + "  (" + RFDiceLabel(nCurLevel + 1) + ")";
+            NuiSetBind(oPC, nToken, RF_BIND_COST_LBL,  JsonString(sCostLbl));
+            NuiSetBind(oPC, nToken, RF_BIND_FORGE_ENA,  JsonBool(TRUE));
+        }
+    }
+    else
+    {
+        NuiSetBind(oPC, nToken, RF_BIND_COST_LBL,  JsonString("Wybierz bron i rune"));
+        NuiSetBind(oPC, nToken, RF_BIND_FORGE_ENA,  JsonBool(FALSE));
+    }
+}
+
+
+// -----------------------------------------------------------------------
+// NUI: Minigame window
+// -----------------------------------------------------------------------
+
+json RFBuildMinigameButton(object oPC, int nIdx)
+{
+    float fBtnSz = GetNuiScaleDimension(oPC, 80.0);
+    json jBtn = NuiButton(JsonString(IntToString(nIdx + 1)));
+    jBtn = NuiId(jBtn, RF_BTN_MG + IntToString(nIdx));
+    jBtn = NuiEnabled(jBtn, NuiBind(RF_BIND_MG_ENA + IntToString(nIdx)));
+    jBtn = NuiEncouraged(jBtn, NuiBind(RF_BIND_MG_ENC + IntToString(nIdx)));
+    jBtn = NuiWidth(jBtn, fBtnSz);
+    jBtn = NuiHeight(jBtn, fBtnSz);
+    return jBtn;
+}
+
+json RFBuildMGRow(object oPC, int nStart)
+{
+    json jRow = JsonArray();
+    int i;
+    for(i = nStart; i < nStart + 3; i++)
+        jRow = JsonArrayInsert(jRow, RFBuildMinigameButton(oPC, i));
+    return NuiRow(jRow);
+}
+
+void RFOpenMinigame(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, RF_WIN_MINIGAME);
+    if(nToken != 0) NuiDestroy(oPC, nToken);
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - GetNuiScaleDimension(oPC, RF_MG_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - GetNuiScaleDimension(oPC, RF_MG_H)) / 2.0;
+    json jGeom = NuiRect(fCX, fCY, GetNuiScaleDimension(oPC, RF_MG_W), GetNuiScaleDimension(oPC, RF_MG_H));
+
+    float fLblH = GetNuiScaleDimension(oPC, 28.0);
+
+    json jTitle = NuiLabel(JsonString("PROBA KUZNI"),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitle = NuiHeight(jTitle, fLblH);
+    jTitle = NuiStyleForegroundColor(jTitle, NuiColor(185, 150, 100, 255));
+
+    json jStatus = NuiLabel(NuiBind(RF_BIND_MG_STATUS),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jStatus = NuiHeight(jStatus, fLblH);
+
+    json jStep = NuiLabel(NuiBind(RF_BIND_MG_STEP),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jStep = NuiHeight(jStep, fLblH);
+
+    json jRoot = JsonArray();
+    jRoot = JsonArrayInsert(jRoot, NuiRow(JsonArrayInsert(JsonArray(), jTitle)));
+    jRoot = JsonArrayInsert(jRoot, NuiRow(JsonArrayInsert(JsonArray(), jStatus)));
+    jRoot = JsonArrayInsert(jRoot, CreateEmptyRow(oPC, 8.0));
+    jRoot = JsonArrayInsert(jRoot, RFBuildMGRow(oPC, 0)); // 1 2 3
+    jRoot = JsonArrayInsert(jRoot, RFBuildMGRow(oPC, 3)); // 4 5 6
+    jRoot = JsonArrayInsert(jRoot, RFBuildMGRow(oPC, 6)); // 7 8 9
+    jRoot = JsonArrayInsert(jRoot, CreateEmptyRow(oPC, 8.0));
+    jRoot = JsonArrayInsert(jRoot, NuiRow(JsonArrayInsert(JsonArray(), jStep)));
+
+    json jWin = NuiWindow(NuiCol(jRoot),
+        JsonBool(FALSE),
+        NuiBind(RF_BIND_MG_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),  // closable — closing is treated as abort
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    nToken = NuiCreate(oPC, jWin, RF_WIN_MINIGAME, RF_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, RF_BIND_MG_GEOM, jGeom);
+
+    // All buttons start disabled and unhighlighted.
+    int i;
+    for(i = 0; i < 9; i++)
+    {
+        NuiSetBind(oPC, nToken, RF_BIND_MG_ENA + IntToString(i), JsonBool(FALSE));
+        NuiSetBind(oPC, nToken, RF_BIND_MG_ENC + IntToString(i), JsonBool(FALSE));
+    }
+    NuiSetBind(oPC, nToken, RF_BIND_MG_STATUS, JsonString("Zapamiętaj sekwencję run..."));
+    NuiSetBind(oPC, nToken, RF_BIND_MG_STEP,   JsonString(""));
+}
+
+
+// -----------------------------------------------------------------------
+// Minigame logic
+// -----------------------------------------------------------------------
+
+// Generates a random button sequence of the given length (each 0-8).
+json RFGenerateSequence(int nLen)
+{
+    json jSeq = JsonArray();
+    int i;
+    for(i = 0; i < nLen; i++)
+        jSeq = JsonArrayInsert(jSeq, JsonInt(Random(9)));
+    return jSeq;
+}
+
+// Sets enc on only the given button index; clears all others.
+void RFSetOnlyEnc(object oPC, int nToken, int nBtn)
+{
+    int i;
+    for(i = 0; i < 9; i++)
+        NuiSetBind(oPC, nToken, RF_BIND_MG_ENC + IntToString(i), JsonBool(i == nBtn));
+}
+
+void RFClearAllEnc(object oPC, int nToken)
+{
+    int i;
+    for(i = 0; i < 9; i++)
+        NuiSetBind(oPC, nToken, RF_BIND_MG_ENC + IntToString(i), JsonBool(FALSE));
+}
+
+// Starts the minigame: deducts gold, generates sequence, opens window, begins display.
+void RFMinigameStart(object oPC)
+{
+    string sUuid  = GetLocalString(oPC, RF_LVAR_WPN_UUID);
+    int nRune     = GetLocalInt(oPC, RF_LVAR_SEL_RUNE);
+    int nCurLevel = RFGetEnchantLevel(sUuid, nRune);
+
+    if(nCurLevel >= RF_MAX_LEVEL)
+    {
+        SendMessageToPC(oPC, "[Kuźnia] Ta runa osiągnęła już maksymalny poziom na tej broni.");
+        return;
+    }
+
+    // Verify weapon still in inventory.
+    object oItem = GetObjectByUUID(sUuid);
+    if(!GetIsObjectValid(oItem) || GetItemPossessor(oItem) != oPC)
+    {
+        SendMessageToPC(oPC, "[Kuźnia] Nie masz już tej broni w ekwipunku.");
+        return;
+    }
+
+    int nCost = RFGetCost(nCurLevel);
+    if(GetGold(oPC) < nCost)
+    {
+        SendMessageToPC(oPC, "[Kuźnia] Brakuje ci " + IntToString(nCost) + " sztuk złota.");
+        return;
+    }
+
+    // Deduct gold upfront — attempt costs regardless of outcome.
+    AssignCommand(oPC, TakeGoldFromCreature(nCost, oPC, TRUE));
+    SetLocalInt(oPC, RF_LVAR_MG_COST, nCost);
+
+    int nLen = RFSequenceLength(nCurLevel);
+    json jSeq = RFGenerateSequence(nLen);
+    SetLocalJson(oPC, RF_LVAR_MG_SEQ,  jSeq);
+    SetLocalInt(oPC,  RF_LVAR_MG_PHASE, 0);  // display phase
+    SetLocalInt(oPC,  RF_LVAR_MG_POS,   0);
+    SetLocalInt(oPC,  RF_LVAR_MG_DONE,  0);
+    // Snapshot these now — the forge CLOSE event fires asynchronously and resets the originals.
+    SetLocalString(oPC, RF_LVAR_MG_WPN,  sUuid);
+    SetLocalInt(oPC,    RF_LVAR_MG_RUNE, nRune);
+
+    RFOpenMinigame(oPC);
+
+    // Schedule display start after brief pause, and a global timeout.
+    float fTimeout = IntToFloat(nLen) * 1.5 + 8.0;
+    DelayCommand(0.6, RFMGDisplayHighlight(oPC, 0));
+    DelayCommand(fTimeout, RFMinigameFail(oPC));
+}
+
+// Highlights button at sequence step nStep, then schedules unhighlight.
+void RFMGDisplayHighlight(object oPC, int nStep)
+{
+    if(GetLocalInt(oPC, RF_LVAR_MG_DONE)) return;
+
+    int nToken = NuiFindWindow(oPC, RF_WIN_MINIGAME);
+    if(nToken == 0) return;
+
+    json jSeq = GetLocalJson(oPC, RF_LVAR_MG_SEQ);
+    int nLen  = JsonGetLength(jSeq);
+    int nBtn  = JsonGetInt(JsonArrayGet(jSeq, nStep));
+
+    RFSetOnlyEnc(oPC, nToken, nBtn);
+    NuiSetBind(oPC, nToken, RF_BIND_MG_STATUS,
+        JsonString("Zapamiętaj: " + IntToString(nStep + 1) + "/" + IntToString(nLen)));
+
+    DelayCommand(0.65, RFMGDisplayUnhighlight(oPC, nStep));
+}
+
+// Clears highlight after showing one step, then advances to next.
+void RFMGDisplayUnhighlight(object oPC, int nStep)
+{
+    if(GetLocalInt(oPC, RF_LVAR_MG_DONE)) return;
+
+    int nToken = NuiFindWindow(oPC, RF_WIN_MINIGAME);
+    if(nToken == 0) return;
+
+    RFClearAllEnc(oPC, nToken);
+
+    json jSeq = GetLocalJson(oPC, RF_LVAR_MG_SEQ);
+    int nLen  = JsonGetLength(jSeq);
+
+    if(nStep + 1 < nLen)
+        DelayCommand(0.25, RFMGDisplayHighlight(oPC, nStep + 1));
+    else
+        DelayCommand(0.4, RFMGEnableInput(oPC));
+}
+
+// Switches from display phase to input phase — enables all buttons.
+void RFMGEnableInput(object oPC)
+{
+    if(GetLocalInt(oPC, RF_LVAR_MG_DONE)) return;
+
+    int nToken = NuiFindWindow(oPC, RF_WIN_MINIGAME);
+    if(nToken == 0) return;
+
+    SetLocalInt(oPC, RF_LVAR_MG_PHASE, 1);
+    SetLocalInt(oPC, RF_LVAR_MG_POS,   0);
+
+    int i;
+    for(i = 0; i < 9; i++)
+        NuiSetBind(oPC, nToken, RF_BIND_MG_ENA + IntToString(i), JsonBool(TRUE));
+
+    json jSeq = GetLocalJson(oPC, RF_LVAR_MG_SEQ);
+    NuiSetBind(oPC, nToken, RF_BIND_MG_STATUS,
+        JsonString("Powtórz sekwencję!"));
+    NuiSetBind(oPC, nToken, RF_BIND_MG_STEP,
+        JsonString("Krok: 0/" + IntToString(JsonGetLength(jSeq))));
+}
+
+// Called on wrong button, timeout, or window close during input.
+void RFMinigameFail(object oPC)
+{
+    if(GetLocalInt(oPC, RF_LVAR_MG_DONE)) return;
+    SetLocalInt(oPC, RF_LVAR_MG_DONE, 1);
+
+    int nToken = NuiFindWindow(oPC, RF_WIN_MINIGAME);
+    if(nToken != 0) NuiDestroy(oPC, nToken);
+
+    SendMessageToPC(oPC, "[Kuźnia] Rytowanie nie powiodło się. Złoto przepadło w ogniu pieca.");
+    FloatingTextStringOnCreature("Pieczęć krwi pulsuje słabo... i gaśnie.", oPC, FALSE);
+}
+
+// Called when player correctly repeats the full sequence.
+void RFMinigameSuccess(object oPC)
+{
+    if(GetLocalInt(oPC, RF_LVAR_MG_DONE)) return;
+    SetLocalInt(oPC, RF_LVAR_MG_DONE, 1);
+
+    int nToken = NuiFindWindow(oPC, RF_WIN_MINIGAME);
+    if(nToken != 0) NuiDestroy(oPC, nToken);
+
+    // Read from snapshot LVARs — the forge window may have already closed and reset the originals.
+    string sUuid  = GetLocalString(oPC, RF_LVAR_MG_WPN);
+    int nRune     = GetLocalInt(oPC, RF_LVAR_MG_RUNE);
+    int nCurLevel = RFGetEnchantLevel(sUuid, nRune);
+    int nNewLevel = nCurLevel + 1;
+
+    object oItem = GetObjectByUUID(sUuid);
+    if(!GetIsObjectValid(oItem))
+    {
+        SendMessageToPC(oPC, "[Kuźnia] Broń nie została znaleziona — runa nie może zostać osadzona.");
+        return;
+    }
+
+    RFApplyEnchant(oItem, nRune, nNewLevel);
+    RFUpsertEnchant(GetObjectUUID(oPC), sUuid, nRune, nNewLevel);
+
+    string sMsg = "[Kuźnia] " + RFRuneName(nRune) + " poziom " + IntToString(nNewLevel)
+        + " wypalona na " + GetName(oItem) + "!";
+    SendMessageToPC(oPC, sMsg);
+    FloatingTextStringOnCreature("Runa jarzy się blaskiem mocy!", oPC, FALSE);
+
+    // Re-open forge so player sees updated enchant summary.
+    DelayCommand(0.5, RFOpenForge(oPC));
+}
+
+// Called from lib_rf_ev.nss when a minigame button is clicked during input phase.
+void RFHandleMGButton(object oPC, int nBtn)
+{
+    if(GetLocalInt(oPC, RF_LVAR_MG_PHASE) != 1) return; // still in display
+    if(GetLocalInt(oPC, RF_LVAR_MG_DONE))       return;
+
+    json jSeq  = GetLocalJson(oPC, RF_LVAR_MG_SEQ);
+    int nLen   = JsonGetLength(jSeq);
+    int nPos   = GetLocalInt(oPC, RF_LVAR_MG_POS);
+    int nExpected = JsonGetInt(JsonArrayGet(jSeq, nPos));
+
+    if(nBtn != nExpected)
+    {
+        RFMinigameFail(oPC);
+        return;
+    }
+
+    nPos++;
+    SetLocalInt(oPC, RF_LVAR_MG_POS, nPos);
+
+    int nToken = NuiFindWindow(oPC, RF_WIN_MINIGAME);
+    if(nToken != 0)
+    {
+        // Brief enc flash on correct button.
+        RFSetOnlyEnc(oPC, nToken, nBtn);
+        NuiSetBind(oPC, nToken, RF_BIND_MG_STEP,
+            JsonString("Krok: " + IntToString(nPos) + "/" + IntToString(nLen)));
+        DelayCommand(0.2, RFClearAllEnc(oPC, nToken));
+    }
+
+    if(nPos >= nLen)
+        RFMinigameSuccess(oPC);
+}

--- a/Runic Forge/Scripts/lib_rf_def.nss
+++ b/Runic Forge/Scripts/lib_rf_def.nss
@@ -1,0 +1,111 @@
+#include "lib_nui"
+#include "sql_rf"
+
+// Forward declarations (implementations in lib_rf.nss)
+void RFOpenForge(object oPC);
+void RFFeedForge(object oPC, int nToken);
+void RFMGDisplayHighlight(object oPC, int nStep);
+void RFMGDisplayUnhighlight(object oPC, int nStep);
+void RFMGEnableInput(object oPC);
+void RFMinigameFail(object oPC);
+void RFMinigameSuccess(object oPC);
+
+// ---- Window IDs ----
+const string RF_WIN_FORGE      = "RF_WIN_FORGE";
+const string RF_WIN_MINIGAME   = "RF_WIN_MINIGAME";
+const string RF_EV_SCRIPT      = "lib_rf_ev";
+
+// ---- Forge window binds ----
+const string RF_BIND_WIN_GEOM  = "rf_win_geom";
+const string RF_BIND_WPN_NAME  = "rf_wpn_name";  // weapon name label or placeholder
+const string RF_BIND_WPN_ENA   = "rf_wpn_ena";   // "Wybierz" button enabled
+const string RF_BIND_ENCH_LBL  = "rf_ench_lbl";  // current enchant summary label
+const string RF_BIND_COST_LBL  = "rf_cost_lbl";  // gold cost label
+const string RF_BIND_FORGE_ENA = "rf_forge_ena"; // "Kuj!" button enabled
+const string RF_BIND_RUNE_ENC  = "rf_rune_enc_"; // + IntToString(i), 6 binds
+
+// ---- Minigame window binds ----
+const string RF_BIND_MG_GEOM   = "rf_mg_geom";
+const string RF_BIND_MG_STATUS = "rf_mg_status"; // phase description label
+const string RF_BIND_MG_STEP   = "rf_mg_step";   // "Krok: 2/5"
+const string RF_BIND_MG_ENC    = "rf_mg_enc_";   // + IntToString(i), 9 binds
+const string RF_BIND_MG_ENA    = "rf_mg_ena_";   // + IntToString(i), 9 binds
+
+// ---- Button element IDs ----
+const string RF_BTN_CLOSE      = "rf_btn_close";
+const string RF_BTN_WEAPON     = "rf_btn_weapon";
+const string RF_BTN_RUNE       = "rf_btn_rune_"; // + IntToString(i)
+const string RF_BTN_FORGE      = "rf_btn_forge";
+const string RF_BTN_MG         = "rf_mg_btn_";   // + IntToString(i)
+
+// ---- Local variables stored on PC object ----
+const string RF_LVAR_WPN_UUID  = "RF_WPN_UUID";
+const string RF_LVAR_WPN_NAME  = "RF_WPN_NAME";
+const string RF_LVAR_SEL_RUNE  = "RF_SEL_RUNE";  // -1 = none
+const string RF_LVAR_TARGETING = "RF_TARGETING"; // 1 = forge targeting active
+const string RF_LVAR_MG_SEQ    = "RF_MG_SEQ";     // JsonArray<int> button sequence
+const string RF_LVAR_MG_POS    = "RF_MG_POS";     // next expected index during input
+const string RF_LVAR_MG_PHASE  = "RF_MG_PHASE";   // 0=display, 1=input
+const string RF_LVAR_MG_DONE   = "RF_MG_DONE";    // 1 = minigame resolved (stops DelayCommands)
+const string RF_LVAR_MG_COST   = "RF_MG_COST";    // gold paid for current attempt
+// Copied from forge LVARs at minigame start; outlive the forge window close event.
+const string RF_LVAR_MG_WPN    = "RF_MG_WPN";     // weapon UUID for active minigame attempt
+const string RF_LVAR_MG_RUNE   = "RF_MG_RUNE";    // rune ID for active minigame attempt
+
+// ---- Rune IDs ----
+const int RF_RUNE_FIRE         = 0;
+const int RF_RUNE_ICE          = 1;
+const int RF_RUNE_STORM        = 2;
+const int RF_RUNE_SHADOW       = 3;
+const int RF_RUNE_RADIANCE     = 4;
+const int RF_RUNE_BLOOD        = 5;
+const int RF_RUNE_COUNT        = 6;
+
+const int RF_MAX_LEVEL         = 5;
+const int RF_BASE_COST         = 500;
+const int RF_COST_PER_LEVEL    = 300;
+
+// ---- Layout dimensions ----
+const float RF_W               = 500.0;
+const float RF_H               = 450.0;
+const float RF_MG_W            = 380.0;
+const float RF_MG_H            = 380.0;
+
+
+// -----------------------------------------------------------------------
+// Targeting callback — invoked from sys_on_target.nss
+// -----------------------------------------------------------------------
+
+void RFOnPlayerTarget(object oPC)
+{
+    if(!GetLocalInt(oPC, RF_LVAR_TARGETING)) return;
+    DeleteLocalInt(oPC, RF_LVAR_TARGETING);
+
+    int nToken = NuiFindWindow(oPC, RF_WIN_FORGE);
+    if(nToken == 0) return;
+
+    NuiSetBind(oPC, nToken, RF_BIND_WPN_ENA, JsonBool(TRUE));
+
+    object oItem = GetTargetingModeSelectedObject();
+
+    if(!GetIsObjectValid(oItem) || GetItemPossessor(oItem) != oPC)
+    {
+        SendMessageToPC(oPC, "[Kuźnia] Wybierz broń ze swojego ekwipunku.");
+        return;
+    }
+
+    // Weapons have a non-zero die in baseitems.2da; armour/shields/misc do not.
+    string sDie = Get2DAString("baseitems", "DieToRoll", GetBaseItemType(oItem));
+    if(sDie == "****" || StringToInt(sDie) == 0)
+    {
+        SendMessageToPC(oPC, "[Kuźnia] Tylko bronie mogą być rytowane runami.");
+        return;
+    }
+
+    string sUuid = GetObjectUUID(oItem);
+    string sName = GetName(oItem);
+    SetLocalString(oPC, RF_LVAR_WPN_UUID, sUuid);
+    SetLocalString(oPC, RF_LVAR_WPN_NAME, sName);
+
+    RFFeedForge(oPC, nToken);
+}

--- a/Runic Forge/Scripts/lib_rf_ev.nss
+++ b/Runic Forge/Scripts/lib_rf_ev.nss
@@ -1,0 +1,106 @@
+#include "lib_rf"
+
+// NUI event handler script for Runic Forge.
+// Set as the event script for both RF_WIN_FORGE and RF_WIN_MINIGAME.
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+
+    // ---- Minigame window events ----
+    if(nToken == NuiFindWindow(oPC, RF_WIN_MINIGAME))
+    {
+        if(sEvent == EVENT_TYPE_CLOSE)
+        {
+            // Player closed the window manually.
+            // Refund gold only if still in display phase (never got to play).
+            if(GetLocalInt(oPC, RF_LVAR_MG_PHASE) == 0 && !GetLocalInt(oPC, RF_LVAR_MG_DONE))
+            {
+                int nCost = GetLocalInt(oPC, RF_LVAR_MG_COST);
+                if(nCost > 0)
+                {
+                    GiveGoldToCreature(oPC, nCost);
+                    SendMessageToPC(oPC, "[Kuźnia] Przerwano przed próbą — złoto zwrócone.");
+                }
+            }
+            SetLocalInt(oPC, RF_LVAR_MG_DONE, 1);
+            return;
+        }
+
+        if(sEvent == EVENT_TYPE_CLICK)
+        {
+            int nBtnLen = GetStringLength(RF_BTN_MG);
+            if(GetStringLeft(sElem, nBtnLen) == RF_BTN_MG)
+            {
+                int nBtn = StringToInt(GetStringRight(sElem, GetStringLength(sElem) - nBtnLen));
+                RFHandleMGButton(oPC, nBtn);
+                return;
+            }
+        }
+
+        return;
+    }
+
+    // ---- Forge window events ----
+    if(nToken != NuiFindWindow(oPC, RF_WIN_FORGE)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        // Clean up state on window close.
+        DeleteLocalString(oPC, RF_LVAR_WPN_UUID);
+        DeleteLocalString(oPC, RF_LVAR_WPN_NAME);
+        SetLocalInt(oPC, RF_LVAR_SEL_RUNE, -1);
+        DeleteLocalInt(oPC, RF_LVAR_TARGETING);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == RF_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        if(sElem == RF_BTN_WEAPON)
+        {
+            // Enter item-targeting mode; flag so sys_on_target.nss knows it's ours.
+            SetLocalInt(oPC, RF_LVAR_TARGETING, 1);
+            NuiSetBind(oPC, nToken, RF_BIND_WPN_ENA, JsonBool(FALSE));
+            EnterTargetingMode(oPC, OBJECT_TYPE_ITEM);
+            SendMessageToPC(oPC, "[Kuźnia] Kliknij broń w swoim ekwipunku.");
+            return;
+        }
+
+        // Rune selection buttons
+        int nBtnPfxLen = GetStringLength(RF_BTN_RUNE);
+        if(GetStringLeft(sElem, nBtnPfxLen) == RF_BTN_RUNE)
+        {
+            int nRune = StringToInt(GetStringRight(sElem, GetStringLength(sElem) - nBtnPfxLen));
+            if(nRune < 0 || nRune >= RF_RUNE_COUNT) return;
+            SetLocalInt(oPC, RF_LVAR_SEL_RUNE, nRune);
+            RFFeedForge(oPC, nToken);
+            return;
+        }
+
+        if(sElem == RF_BTN_FORGE)
+        {
+            string sUuid = GetLocalString(oPC, RF_LVAR_WPN_UUID);
+            int nRune    = GetLocalInt(oPC, RF_LVAR_SEL_RUNE);
+
+            if(sUuid == "" || nRune < 0)
+            {
+                SendMessageToPC(oPC, "[Kuźnia] Wybierz najpierw broń i runę.");
+                return;
+            }
+
+            // Close the forge before opening the minigame.
+            NuiDestroy(oPC, nToken);
+            RFMinigameStart(oPC);
+            return;
+        }
+    }
+}

--- a/Runic Forge/Scripts/sql_rf.nss
+++ b/Runic Forge/Scripts/sql_rf.nss
@@ -1,0 +1,60 @@
+// SQLite schema and queries for Runic Forge.
+// Campaign DB: "runic_forge"
+
+void RFCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("runic_forge",
+        "CREATE TABLE IF NOT EXISTS rf_enchants ("
+        "  id           INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "  pc_uuid      TEXT    NOT NULL,"
+        "  item_uuid    TEXT    NOT NULL,"
+        "  rune_id      INTEGER NOT NULL,"
+        "  level        INTEGER NOT NULL DEFAULT 1,"
+        "  enchanted_at INTEGER DEFAULT 0,"
+        "  UNIQUE(item_uuid, rune_id)"
+        ")");
+    SqlStep(q);
+}
+
+// Returns current enchant level for this item+rune (0 = not yet enchanted).
+int RFGetEnchantLevel(string sItemUuid, int nRuneId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("runic_forge",
+        "SELECT level FROM rf_enchants WHERE item_uuid=@item AND rune_id=@rune");
+    SqlBindString(q, "@item", sItemUuid);
+    SqlBindInt(q,    "@rune", nRuneId);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// Insert or update enchant record (upsert).
+void RFUpsertEnchant(string sPcUuid, string sItemUuid, int nRuneId, int nLevel)
+{
+    sqlquery q = SqlPrepareQueryCampaign("runic_forge",
+        "INSERT INTO rf_enchants (pc_uuid, item_uuid, rune_id, level, enchanted_at)"
+        " VALUES (@pc, @item, @rune, @lvl, strftime('%s','now'))"
+        " ON CONFLICT(item_uuid, rune_id) DO UPDATE SET"
+        "   level=@lvl, pc_uuid=@pc, enchanted_at=strftime('%s','now')");
+    SqlBindString(q, "@pc",   sPcUuid);
+    SqlBindString(q, "@item", sItemUuid);
+    SqlBindInt(q,    "@rune", nRuneId);
+    SqlBindInt(q,    "@lvl",  nLevel);
+    SqlStep(q);
+}
+
+// Returns JsonArray of {rune_id, level} for all enchants on an item.
+json RFGetItemEnchants(string sItemUuid)
+{
+    json jResult = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("runic_forge",
+        "SELECT rune_id, level FROM rf_enchants WHERE item_uuid=@item ORDER BY rune_id");
+    SqlBindString(q, "@item", sItemUuid);
+    while(SqlStep(q))
+    {
+        json jEntry = JsonObject();
+        jEntry = JsonObjectSet(jEntry, "rune_id", JsonInt(SqlGetInt(q, 0)));
+        jEntry = JsonObjectSet(jEntry, "level",   JsonInt(SqlGetInt(q, 1)));
+        jResult = JsonArrayInsert(jResult, jEntry);
+    }
+    return jResult;
+}

--- a/Runic Forge/Scripts/sys_on_load.nss
+++ b/Runic Forge/Scripts/sys_on_load.nss
@@ -1,0 +1,6 @@
+#include "lib_rf_def"
+
+void main()
+{
+    RFCreateTables();
+}

--- a/Runic Forge/Scripts/sys_on_target.nss
+++ b/Runic Forge/Scripts/sys_on_target.nss
@@ -1,0 +1,11 @@
+#include "lib_rf_def"
+
+// OnPlayerTarget event hook.
+// If this module shares the hook with others, call this from the central dispatcher
+// and guard with RF_LVAR_TARGETING so only active forge selections are processed.
+
+void main()
+{
+    object oPC = GetLastPlayerToSelectTarget();
+    RFOnPlayerTarget(oPC);
+}

--- a/Runic Forge/Scripts/test_rf.nss
+++ b/Runic Forge/Scripts/test_rf.nss
@@ -1,0 +1,11 @@
+#include "lib_rf"
+
+// OnUsed script for a "Kuźnia Runiczna" placeable.
+// Place this script in the OnUsed event of any placeable acting as the forge.
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+    RFOpenForge(oPC);
+}


### PR DESCRIPTION
## Co to robi

Moduł **Kuźnia Runiczna** pozwala graczom rytować bronie runami przez NUI z minigrą Simon-Says. Gracz wskazuje broń z ekwipunku, wybiera jedną z sześciu run i inicjuje próbę rytu — opłacając złotem. Otwiera się okno minigry z siatką 3×3 przycisków; silnik wyświetla losową sekwencję podświetleń, którą gracz musi powtórzyć w określonym czasie. Sukces wypalą trwały `ItemProperty` na broni; porażka oznacza stratę złota bez efektu.

## Mechanika

- **6 run**: Ogień, Lód, Burza, Mrok, Blask, Krew — każda nakłada inny typ obrażeń (`DAMAGE_BONUS_*`) lub Vampiric Regeneration (Krew).
- **5 poziomów** per runa per broń: obrażenia rosną 1k4 → 1k6 → 1k8 → 1k10 → 2k6. Każdy kolejny poziom kosztuje więcej złota (500 + 300 × poziom_bieżący) i wymaga dłuższej sekwencji (4–8 przycisków).
- **Minigrá**: faza display (DelayCommand pokazuje podświetlenia po kolei) → faza input (gracz klika). Błędny przycisk lub timeout → porażka. Czas = długość_sekwencji × 1,5 s + 8 s globalny bufor.
- **Persistencja**: SQLite (`rf_enchants`, kampania `runic_forge`) z UNIQUE(item_uuid, rune_id) i upsert — bezpieczna przy reloadzie serwera.
- **Snapshoting LVARów**: przy otwarciu minigry UUID broni i ID runy są kopiowane do osobnych `RF_MG_WPN`/`RF_MG_RUNE`, bo asynchroniczne zdarzenie CLOSE okna kuźni usuwa oryginalne LVARy zanim success-handler zdąży je odczytać.

## Pliki

| Plik | Rola |
|------|------|
| `Scripts/sql_rf.nss` | Schemat SQL, `CREATE IF NOT EXISTS`, upsert, query per-item |
| `Scripts/lib_rf_def.nss` | Stałe (bind IDs, button IDs, rune IDs), `RFOnPlayerTarget` |
| `Scripts/lib_rf.nss` | Logika rdzenia: NUI builders, aplikacja enchantów, sekwencja minigry |
| `Scripts/lib_rf_ev.nss` | Handler NUI eventów (switch po `NuiGetEventType()` + element) |
| `Scripts/sys_on_load.nss` | `RFCreateTables()` na OnModuleLoad |
| `Scripts/sys_on_target.nss` | Deleguje do `RFOnPlayerTarget` (guard przez LVAR) |
| `Scripts/test_rf.nss` | OnUsed placeble'a — otwiera okno kuźni |
| `INTEGRATION.md` | Tabela hooków, setup, ograniczenia |

## Zależności (NWNX? SQL?)

- **NWNX**: nie wymagany.
- **NWN EE**: wymagane 8193.36+ dla `GetObjectByUUID`, `SqlPrepareQueryCampaign`, NUI.
- **SQL**: własna kampania `runic_forge` tworzona automatycznie przez `sys_on_load.nss`.
- **lib_nui.nss / lib_nui_utility.nss**: muszą być dostępne w tym samym HAK (identyczne jak w Mailbox/Appearance).

## Jak włączyć w istniejącym module

1. Skopiuj wszystkie pliki z `Scripts/` do HAK modułu.
2. W **OnModuleLoad** wywołaj `sys_on_load` (lub dodaj `#include "lib_rf_def"` + `RFCreateTables()` do istniejącego loadera).
3. W **OnPlayerTarget** wywołaj `sys_on_target` lub dołącz `RFOnPlayerTarget(GetLastPlayerToSelectTarget())` do centralnego dispatchera — funkcja jest idempotentna (sprawdza flagę `RF_TARGETING`).
4. Postaw placeable z OnUsed = `test_rf`.

## Co celowo pominięto

- **Efekty wizualne FX** przy sukcesie — wymagają resrefu z HAK; udokumentowane w INTEGRATION.md.
- **Wizualne ikony run** w przyciskach — brak customowych obrazków; czyste etykiety tekstowe.
- **Zdejmowanie run** — brak mechanizmu usuwania enchantów po naniesieniu.
- **Plik .mod** — środowisko nie pakuje binarnego .mod; zastępuje go INTEGRATION.md.

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qoq1HBhQyjPMsrk7FV1Nh)_