### PR TITLE
feat: Plague — Zaraźliwe Choroby

### DIFF
--- a/Plague/INTEGRATION.md
+++ b/Plague/INTEGRATION.md
@@ -1,0 +1,106 @@
+# Plague — Integracja z modułem NWN
+
+## Wymagane hooki
+
+| Zdarzenie modułu | Skrypt |
+|---|---|
+| OnModuleLoad | `sys_on_load` |
+| OnClientEnter | `sys_on_enter` |
+| OnHeartbeat | `sys_on_heartbeat` |
+
+Jeśli moduł ma już własne skrypty dla tych zdarzeń, wywołaj
+odpowiednie funkcje Plague z istniejącego skryptu:
+
+```nwscript
+// W istniejącym OnModuleLoad:
+#include "sql_plg"
+// ...
+PlgCreateTables();
+
+// W istniejącym OnClientEnter:
+#include "lib_plg"
+// ...
+object oPC = GetEnteringObject();
+if(GetIsPC(oPC)) PlgOnClientEnter(oPC);
+
+// W istniejącym OnHeartbeat:
+#include "lib_plg"
+// ...
+object oPC = GetFirstPC();
+while(GetIsObjectValid(oPC))
+{
+    PlgCheckProgression(oPC);
+    PlgApplyPerTick(oPC);
+    oPC = GetNextPC();
+}
+```
+
+## Zależności
+
+- **NWN:EE 8193+** — wymagane dla funkcji `TagEffect`, `GetEffectTag`
+  (`RemoveEffect` iteruje po efektach ręcznie, więc nie wymaga NWNX)
+- **SQLite (natywny NWN:EE)** — kampania `"plague"` tworzona automatycznie
+- **NWNX** — *niewymagany*
+
+## Placeable "Zwierciadło Diagnostyczne"
+
+Stwórz dowolny placeable (np. lustro lub kryształowa kula).
+Ustaw jego skrypt **OnUsed**: `test_plg`.
+
+W trybie produkcyjnym zastąp `test_plg` dedykowanym skryptem
+wywołującym wyłącznie `CreatePlgWindow(oPC)` bez opcji debug.
+
+## Zarażanie postaci z zewnętrznych skryptów
+
+```nwscript
+#include "lib_plg"
+
+// Zaraź gracza Bagienną Gorączką (PLG_DIS_SWAMP_FEVER = 2):
+PlgContractAndNotify(oPC, PLG_DIS_SWAMP_FEVER);
+
+// Ulecz:
+PlgCureAndNotify(oPC);
+```
+
+## Przedmioty leczące
+
+Każda choroba wymaga przedmiotu o konkretnym tagu w ekwipunku gracza.
+Stwórz te przedmioty w swoim module i umieść je w świecie gry:
+
+| Choroba | Tag przedmiotu | Propozycja nazwy PL |
+|---|---|---|
+| Czarna Dżuma | `plg_rem_plaga` | Napar z czarnej malwy |
+| Krwawa Zgnilizna | `plg_rem_krew` | Ziołowy bandaż hemostatyczny |
+| Bagienka Gorączka | `plg_rem_bagna` | Korzeń topoli bagiennej |
+| Nekrotyczna Rana | `plg_rem_nkr` | Poświęcona woda |
+| Przekleństwo Wilkołaka | `plg_rem_wilk` | Srebrna woda |
+
+Przedmioty mogą być zwykłymi misc-itemami lub potionami — system
+sprawdza jedynie tag (`GetItemPossessedBy`).
+
+## Skrócone czasy do testów
+
+Domyślne interwały (godziny rzeczywiste) są zaprojektowane pod
+sesje CRPG. Do testów możesz edytować `PlgPhaseInterval` w `lib_plg_def.nss`:
+
+```nwscript
+// Zmień np. dla Bagiennej Gorączki wszystkie fazy na 60 sekund:
+case PLG_PHASE_INCUBATION: return 60;
+case PLG_PHASE_MILD:       return 60;
+case PLG_PHASE_SEVERE:     return 60;
+```
+
+Panel debug `test_plg` oferuje też natychmiastowe zarażenie i uzdrowienie.
+
+## Co celowo pominięto
+
+- Transmisja przez kontakt z zainfekowanymi NPC/graczami — nie ma
+  dedykowanego hooka do proximity check bez NWNX; łatwo dodać
+  wywołując `PlgContractAndNotify` z trigger OnEnter lub creature
+  OnHeartbeat z odpowiednią logiką odległości.
+- Wizualne zmiany wyglądu postaci per-faza (bąble, bladość) — wymaga
+  hak z dedykowanymi teksturami; poza zakresem tego modułu.
+- System odporności / szczepień — do rozbudowania jako follow-up.
+- Resetowanie SQL po utracie postaci — decyzja mechaniki serwera
+  (obecne zachowanie: choroba zostaje dopóki nie wyleczona lub
+  nie usunięta ręcznie z tabeli `plg_diseases`).

--- a/Plague/Scripts/lib_nui.nss
+++ b/Plague/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Plague/Scripts/lib_nui_utility.nss
+++ b/Plague/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Plague/Scripts/lib_plg.nss
+++ b/Plague/Scripts/lib_plg.nss
@@ -1,0 +1,524 @@
+#include "lib_plg_def"
+
+void CreatePlgWindow(object oPC);
+void CreatePlgTestWindow(object oPC);
+void PlgCheckProgression(object oPC);
+void PlgApplyPerTick(object oPC);
+
+// ================================================================
+// Effect management
+// ================================================================
+
+// Removes all previously-applied plague effects by iterating the effect list.
+// TagEffect + GetEffectTag are NWN:EE 8193+ functions.
+void PlgRemoveEffects(object oPC)
+{
+    effect eEff  = GetFirstEffect(oPC);
+    effect eNext;
+    while(GetIsEffectValid(eEff))
+    {
+        eNext = GetNextEffect(oPC);
+        if(GetEffectTag(eEff) == PLG_EFFECT_TAG)
+            RemoveEffect(oPC, eEff);
+        eEff = eNext;
+    }
+}
+
+// Builds and applies stat-change effects for the given disease+phase.
+// Always call PlgRemoveEffects first to avoid stacking.
+void PlgApplyEffects(object oPC, int nDiseaseId, int nPhase)
+{
+    PlgRemoveEffects(oPC);
+    if(nPhase < PLG_PHASE_MILD) return; // incubation: no mechanical effects
+
+    effect eLink;
+
+    if(nDiseaseId == PLG_DIS_BLACK_PLAGUE)
+    {
+        int nCon = (nPhase == PLG_PHASE_MILD) ? 2 : (nPhase == PLG_PHASE_SEVERE) ? 4 : 6;
+        int nStr = (nPhase == PLG_PHASE_MILD) ? 0 : (nPhase == PLG_PHASE_SEVERE) ? 2 : 4;
+        eLink = EffectAbilityDecrease(ABILITY_CONSTITUTION, nCon);
+        if(nStr > 0)
+            eLink = EffectLinkEffects(eLink, EffectAbilityDecrease(ABILITY_STRENGTH, nStr));
+    }
+    else if(nDiseaseId == PLG_DIS_BLOOD_ROT)
+    {
+        int nPen = (nPhase == PLG_PHASE_MILD) ? 1 : (nPhase == PLG_PHASE_SEVERE) ? 2 : 3;
+        eLink = EffectACDecrease(nPen, AC_DODGE_BONUS);
+        eLink = EffectLinkEffects(eLink, EffectSavingThrowDecrease(SAVING_THROW_FORT, nPen));
+    }
+    else if(nDiseaseId == PLG_DIS_SWAMP_FEVER)
+    {
+        int nDex = (nPhase == PLG_PHASE_MILD) ? 2 : (nPhase == PLG_PHASE_SEVERE) ? 4 : 6;
+        int nWis = (nPhase == PLG_PHASE_MILD) ? 0 : (nPhase == PLG_PHASE_SEVERE) ? 2 : 4;
+        eLink = EffectAbilityDecrease(ABILITY_DEXTERITY, nDex);
+        if(nWis > 0)
+            eLink = EffectLinkEffects(eLink, EffectAbilityDecrease(ABILITY_WISDOM, nWis));
+    }
+    else if(nDiseaseId == PLG_DIS_NECROTIC)
+    {
+        int nStr = (nPhase == PLG_PHASE_MILD) ? 1 : (nPhase == PLG_PHASE_SEVERE) ? 3 : 5;
+        int nCon = (nPhase == PLG_PHASE_MILD) ? 0 : (nPhase == PLG_PHASE_SEVERE) ? 2 : 4;
+        eLink = EffectAbilityDecrease(ABILITY_STRENGTH, nStr);
+        if(nCon > 0)
+            eLink = EffectLinkEffects(eLink, EffectAbilityDecrease(ABILITY_CONSTITUTION, nCon));
+    }
+    else if(nDiseaseId == PLG_DIS_LYCANTHROPY)
+    {
+        int nStr = (nPhase == PLG_PHASE_MILD) ? 2 : (nPhase == PLG_PHASE_SEVERE) ? 4 : 6;
+        int nWis = (nPhase == PLG_PHASE_MILD) ? 2 : (nPhase == PLG_PHASE_SEVERE) ? 4 : 6;
+        eLink = EffectAbilityIncrease(ABILITY_STRENGTH, nStr);
+        eLink = EffectLinkEffects(eLink, EffectAbilityDecrease(ABILITY_WISDOM, nWis));
+    }
+    else return;
+
+    eLink = TagEffect(eLink, PLG_EFFECT_TAG);
+    ApplyEffectToObject(DURATION_TYPE_PERMANENT, eLink, oPC);
+}
+
+// ================================================================
+// Disease contraction and cure (high-level, with notifications)
+// ================================================================
+
+void PlgContractAndNotify(object oPC, int nDiseaseId)
+{
+    // Silently replace any existing disease — each PC carries at most one.
+    PlgRemoveEffects(oPC);
+    int nInterval = PlgPhaseInterval(nDiseaseId, PLG_PHASE_INCUBATION);
+    PlgContractDisease(oPC, nDiseaseId, nInterval);
+    SetLocalInt(oPC, PLG_LVAR_DISEASE, nDiseaseId);
+    SetLocalInt(oPC, PLG_LVAR_PHASE,   PLG_PHASE_INCUBATION);
+    SetLocalInt(oPC, PLG_LVAR_TICK,    0);
+
+    string sMsg = "[Zaraza] Pieczęć choroby pulsuje słabo... Coś się we mnie wlało.";
+    SendMessageToPC(oPC, sMsg);
+    FloatingTextStringOnCreature(sMsg, oPC, FALSE);
+}
+
+void PlgCureAndNotify(object oPC)
+{
+    PlgRemoveEffects(oPC);
+    PlgCureDisease(oPC);
+    SetLocalInt(oPC, PLG_LVAR_DISEASE, PLG_DIS_NONE);
+    SetLocalInt(oPC, PLG_LVAR_PHASE,   PLG_PHASE_NONE);
+    SetLocalInt(oPC, PLG_LVAR_TICK,    0);
+
+    string sMsg = "[Zaraza] Ciemność opuszcza twoje ciało. Jesteś wolny od zarazy.";
+    SendMessageToPC(oPC, sMsg);
+    FloatingTextStringOnCreature(sMsg, oPC, FALSE);
+
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+        EffectVisualEffect(VFX_DUR_SPELL_BARKSKIN), oPC, 3.0);
+}
+
+// ================================================================
+// Progression check (called from heartbeat for each PC)
+// ================================================================
+
+void PlgCheckProgression(object oPC)
+{
+    int nDiseaseId = GetLocalInt(oPC, PLG_LVAR_DISEASE);
+    if(nDiseaseId == PLG_DIS_NONE) return;
+
+    int nPhase = GetLocalInt(oPC, PLG_LVAR_PHASE);
+    if(nPhase >= PLG_PHASE_CRITICAL) return; // critical does not advance further
+
+    json jState = PlgGetState(oPC);
+    if(JsonGetType(jState) == JSON_TYPE_NULL) return;
+
+    int nPhaseEnd = JsonGetInt(JsonObjectGet(jState, "phase_end"));
+    if(PlgUnixNow() < nPhaseEnd) return; // not time yet
+
+    int nNewPhase    = nPhase + 1;
+    // For critical phase, pass 0 interval so phase_end is stored as 0 (sentinel).
+    int nNextInterval = (nNewPhase < PLG_PHASE_CRITICAL)
+        ? PlgPhaseInterval(nDiseaseId, nNewPhase) : 0;
+
+    PlgAdvancePhase(oPC, nNewPhase, nPhaseEnd, nNextInterval);
+    SetLocalInt(oPC, PLG_LVAR_PHASE, nNewPhase);
+
+    PlgApplyEffects(oPC, nDiseaseId, nNewPhase);
+
+    string sName = PlgDiseaseName(nDiseaseId);
+    string sPhase = PlgPhaseName(nNewPhase);
+    string sMsg = "[Zaraza] " + sName + " — " + sPhase + ".";
+    SendMessageToPC(oPC, sMsg);
+    FloatingTextStringOnCreature(sMsg, oPC, FALSE);
+
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+        EffectVisualEffect(VFX_COM_BLOOD_CRT_RED), oPC, 2.0);
+
+    // Refresh open window immediately
+    int nToken = NuiFindWindow(oPC, PLG_WINDOW);
+    if(nToken != 0) FeedPlgWindow(oPC, nToken);
+}
+
+// ================================================================
+// Per-tick damage for critical phases (called every heartbeat tick)
+// Uses a simple counter so damage fires every ~30 s (5 × 6 s heartbeat).
+// ================================================================
+
+void PlgApplyPerTick(object oPC)
+{
+    int nDiseaseId = GetLocalInt(oPC, PLG_LVAR_DISEASE);
+    int nPhase     = GetLocalInt(oPC, PLG_LVAR_PHASE);
+
+    if(nDiseaseId == PLG_DIS_NONE || nPhase < PLG_PHASE_CRITICAL) return;
+
+    int nTick = GetLocalInt(oPC, PLG_LVAR_TICK) + 1;
+    if(nTick < 5)
+    {
+        SetLocalInt(oPC, PLG_LVAR_TICK, nTick);
+        return;
+    }
+    SetLocalInt(oPC, PLG_LVAR_TICK, 0);
+
+    if(nDiseaseId == PLG_DIS_BLOOD_ROT)
+    {
+        ApplyEffectToObject(DURATION_TYPE_INSTANT,
+            EffectDamage(4, DAMAGE_TYPE_MAGICAL), oPC);
+        SendMessageToPC(oPC, "[Zaraza] Krwawa Zgnilizna wysysa twoją siłę życiową...");
+    }
+    else if(nDiseaseId == PLG_DIS_NECROTIC)
+    {
+        int nDmg = Random(4) + 1;
+        ApplyEffectToObject(DURATION_TYPE_INSTANT,
+            EffectDamage(nDmg, DAMAGE_TYPE_NEGATIVE), oPC);
+        SendMessageToPC(oPC, "[Zaraza] Nekrotyczna rana drenauje twoją żywotność...");
+    }
+    else if(nDiseaseId == PLG_DIS_LYCANTHROPY)
+    {
+        // Feral rage: 20 % chance per 30 s — visual only, no forced attack (avoid griefing)
+        if(Random(100) < 20)
+        {
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                EffectVisualEffect(VFX_DUR_MIND_AFFECTING_NEGATIVE), oPC, 2.0);
+            SendMessageToPC(oPC, "[Zaraza] Bestia wewnątrz wyje. Utrzymanie kontroli kosztuje cię wszystko...");
+        }
+    }
+}
+
+// ================================================================
+// NUI — main plague status window
+// ================================================================
+
+json PlgBuildMainWindow(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 30.0);
+    float fProgH = GetNuiScaleDimension(oPC, 18.0);
+    float fBodyH = GetNuiScaleDimension(oPC, 160.0);
+    float fRowH  = GetNuiScaleDimension(oPC, 24.0);
+
+    // -- Header: disease name + phase --
+    json jNameLbl = NuiLabel(NuiBind(PLG_BIND_NAME), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jNameLbl = NuiHeight(jNameLbl, fBtnH);
+
+    json jPhaseLbl = NuiLabel(NuiBind(PLG_BIND_PHASE), JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jPhaseLbl = NuiWidth(jPhaseLbl, GetNuiScaleDimension(oPC, 140.0));
+    jPhaseLbl = NuiHeight(jPhaseLbl, fBtnH);
+
+    json jHdrRow = JsonArray();
+    jHdrRow = JsonArrayInsert(jHdrRow, jNameLbl);
+    jHdrRow = JsonArrayInsert(jHdrRow, jPhaseLbl);
+
+    // -- Progress bar (time into current phase) --
+    json jProg = NuiProgressBar(NuiBind(PLG_BIND_PROG));
+    jProg = NuiHeight(jProg, fProgH);
+    jProg = NuiStyleForegroundColor(jProg, NuiBind(PLG_BIND_PROG_COL));
+
+    // -- Timer label --
+    json jTimerLbl = NuiLabel(NuiBind(PLG_BIND_TIMER), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jTimerLbl = NuiHeight(jTimerLbl, fRowH);
+
+    // -- Separator label --
+    json jSepLbl = NuiLabel(JsonString("OBJAWY"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jSepLbl = NuiHeight(jSepLbl, fRowH);
+
+    // -- Symptoms --
+    json jSympLbl = NuiLabel(NuiBind(PLG_BIND_SYMPTOMS), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jSympLbl = NuiHeight(jSympLbl, fRowH);
+
+    // -- Flavor text (scrollable group) --
+    json jFlavorSepLbl = NuiLabel(JsonString("OPIS"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jFlavorSepLbl = NuiHeight(jFlavorSepLbl, fRowH);
+
+    json jFlavorTxt = NuiGroup(
+        NuiText(NuiBind(PLG_BIND_FLAVOR), FALSE),
+        TRUE, NUI_SCROLLBARS_NONE);
+    jFlavorTxt = NuiHeight(jFlavorTxt, fBodyH);
+
+    // -- Remedy section --
+    json jRemSepLbl = NuiLabel(JsonString("LEKARSTWO"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRemSepLbl = NuiHeight(jRemSepLbl, fRowH);
+
+    json jRemLbl = NuiLabel(NuiBind(PLG_BIND_REMEDY), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRemLbl = NuiHeight(jRemLbl, fRowH);
+
+    // -- Cure button --
+    json jCureBtn = NuiButton(JsonString("Użyj lekarstwa"));
+    jCureBtn = NuiId(jCureBtn, PLG_BTN_CURE);
+    jCureBtn = NuiEnabled(jCureBtn, NuiBind(PLG_BIND_CURE_ENA));
+    jCureBtn = NuiHeight(jCureBtn, fBtnH);
+
+    // -- Close button --
+    json jCloseBtn = NuiButton(JsonString("Zamknij"));
+    jCloseBtn = NuiId(jCloseBtn, PLG_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, GetNuiScaleDimension(oPC, 80.0));
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jBotRow = JsonArray();
+    jBotRow = JsonArrayInsert(jBotRow, jCureBtn);
+    jBotRow = JsonArrayInsert(jBotRow, NuiSpacer());
+    jBotRow = JsonArrayInsert(jBotRow, jCloseBtn);
+
+    // -- Assemble --
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(jHdrRow));
+    jCol = JsonArrayInsert(jCol, jProg);
+    jCol = JsonArrayInsert(jCol, jTimerLbl);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jSepLbl);
+    jCol = JsonArrayInsert(jCol, jSympLbl);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jFlavorSepLbl);
+    jCol = JsonArrayInsert(jCol, jFlavorTxt);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jRemSepLbl);
+    jCol = JsonArrayInsert(jCol, jRemLbl);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBotRow));
+
+    json jSide = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    float fContentW = GetNuiScaleDimension(oPC, PLG_W - 40.0);
+    json jMainRow = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiCol(jCol), fContentW));
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    return NuiRow(jMainRow);
+}
+
+// Fills all binds based on current SQL state.
+void FeedPlgWindow(object oPC, int nToken)
+{
+    int nDiseaseId = GetLocalInt(oPC, PLG_LVAR_DISEASE);
+    int nPhase     = GetLocalInt(oPC, PLG_LVAR_PHASE);
+
+    if(nDiseaseId == PLG_DIS_NONE || nPhase == PLG_PHASE_NONE)
+    {
+        NuiSetBind(oPC, nToken, PLG_BIND_NAME,     JsonString("Brak zarazy"));
+        NuiSetBind(oPC, nToken, PLG_BIND_PHASE,    JsonString("—"));
+        NuiSetBind(oPC, nToken, PLG_BIND_FLAVOR,   JsonString("Twoje ciało jest wolne od choroby."));
+        NuiSetBind(oPC, nToken, PLG_BIND_SYMPTOMS, JsonString("—"));
+        NuiSetBind(oPC, nToken, PLG_BIND_REMEDY,   JsonString("—"));
+        NuiSetBind(oPC, nToken, PLG_BIND_CURE_ENA, JsonBool(FALSE));
+        NuiSetBind(oPC, nToken, PLG_BIND_PROG,     JsonFloat(0.0));
+        NuiSetBind(oPC, nToken, PLG_BIND_PROG_COL, NuiColor(80, 80, 80));
+        NuiSetBind(oPC, nToken, PLG_BIND_TIMER,    JsonString(""));
+        return;
+    }
+
+    // Progress bar and timer
+    float fProg = 0.0;
+    string sTimer = "";
+    json jState = PlgGetState(oPC);
+
+    if(JsonGetType(jState) != JSON_TYPE_NULL)
+    {
+        int nPhaseStart = JsonGetInt(JsonObjectGet(jState, "phase_start"));
+        int nPhaseEnd   = JsonGetInt(JsonObjectGet(jState, "phase_end"));
+        int nNow        = PlgUnixNow();
+
+        if(nPhase < PLG_PHASE_CRITICAL && nPhaseEnd > nPhaseStart)
+        {
+            int nDur     = nPhaseEnd - nPhaseStart;
+            int nElapsed = nNow - nPhaseStart;
+            if(nElapsed < 0) nElapsed = 0;
+            fProg = IntToFloat(nElapsed) / IntToFloat(nDur);
+            if(fProg > 1.0) fProg = 1.0;
+
+            int nRemain = nPhaseEnd - nNow;
+            if(nRemain < 0) nRemain = 0;
+            int nH = nRemain / 3600;
+            int nM = (nRemain % 3600) / 60;
+            int nS = nRemain % 60;
+            string sH = (nH < 10 ? "0" : "") + IntToString(nH);
+            string sM = (nM < 10 ? "0" : "") + IntToString(nM);
+            string sSec = (nS < 10 ? "0" : "") + IntToString(nS);
+            sTimer = "Następna faza za: " + sH + ":" + sM + ":" + sSec;
+        }
+        else
+        {
+            // Critical — no next phase
+            fProg = 1.0;
+            sTimer = "Stan krytyczny — nie ma już kolejnej fazy.";
+        }
+    }
+
+    // Cure button: enabled only if PC has the remedy item in inventory
+    string sRemedyTag = PlgDiseaseRemedyTag(nDiseaseId);
+    int bHasRemedy = GetIsObjectValid(GetItemPossessedBy(oPC, sRemedyTag));
+
+    NuiSetBind(oPC, nToken, PLG_BIND_NAME,     JsonString(PlgDiseaseName(nDiseaseId)));
+    NuiSetBind(oPC, nToken, PLG_BIND_PHASE,    JsonString(PlgPhaseName(nPhase)));
+    NuiSetBind(oPC, nToken, PLG_BIND_FLAVOR,   JsonString(PlgPhaseFlavor(nDiseaseId, nPhase)));
+    NuiSetBind(oPC, nToken, PLG_BIND_SYMPTOMS, JsonString(PlgPhaseSymptoms(nDiseaseId, nPhase)));
+    NuiSetBind(oPC, nToken, PLG_BIND_REMEDY,   JsonString(PlgDiseaseRemedyName(nDiseaseId)));
+    NuiSetBind(oPC, nToken, PLG_BIND_CURE_ENA, JsonBool(bHasRemedy));
+    NuiSetBind(oPC, nToken, PLG_BIND_PROG,     JsonFloat(fProg));
+    NuiSetBind(oPC, nToken, PLG_BIND_PROG_COL, PlgDiseaseColor(nDiseaseId));
+    NuiSetBind(oPC, nToken, PLG_BIND_TIMER,    JsonString(sTimer));
+}
+
+void CreatePlgWindow(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, PLG_WINDOW);
+    if(nToken != 0)
+    {
+        FeedPlgWindow(oPC, nToken);
+        return;
+    }
+
+    float fGuiW = IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH));
+    float fGuiH = IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT));
+    float fWinW = GetNuiScaleDimension(oPC, PLG_W);
+    float fWinH = GetNuiScaleDimension(oPC, PLG_H);
+    float fCX   = (fGuiW - fWinW) / 2.0;
+    float fCY   = (fGuiH - fWinH) / 2.0;
+    json jGeom  = NuiRect(fCX, fCY, fWinW, fWinH);
+
+    json jWin = NuiWindow(
+        PlgBuildMainWindow(oPC),
+        JsonString("Schorzenie Postaci"),
+        NuiBind(PLG_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    nToken = NuiCreate(oPC, jWin, PLG_WINDOW, PLG_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, PLG_WIN_GEOM, jGeom);
+    FeedPlgWindow(oPC, nToken);
+}
+
+// ================================================================
+// NUI — test/debug window (placeable OnUsed)
+// ================================================================
+
+json PlgBuildTestWindow(object oPC)
+{
+    float fBtnH = GetNuiScaleDimension(oPC, 30.0);
+    float fRowH = GetNuiScaleDimension(oPC, 26.0);
+    float fListH = GetNuiScaleDimension(oPC, 150.0);
+
+    json jTitle = NuiLabel(JsonString("Zaraź się chorobą (debug):"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitle = NuiHeight(jTitle, fBtnH);
+
+    // Disease list
+    json jDisLbl  = NuiLabel(NuiBind(PLG_BIND_TEST_DIS), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    json jDisCell = NuiGroup(NuiRow(JsonArrayInsert(JsonArray(), jDisLbl)), TRUE, NUI_SCROLLBARS_NONE);
+    jDisCell = NuiId(jDisCell, PLG_BTN_TEST_ROW);
+
+    json jTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jDisCell, 0.0, TRUE));
+    json jList = NuiList(jTmpl, NuiBind(PLG_BIND_TEST_LEN), fRowH);
+    jList = NuiHeight(jList, fListH);
+
+    json jOpenBtn = NuiButton(JsonString("Sprawdź stan zdrowia"));
+    jOpenBtn = NuiId(jOpenBtn, PLG_BTN_TEST_OPEN);
+    jOpenBtn = NuiHeight(jOpenBtn, fBtnH);
+
+    json jCureBtn = NuiButton(JsonString("Natychmiastowe uzdrowienie (debug)"));
+    jCureBtn = NuiId(jCureBtn, PLG_BTN_TEST_CURE);
+    jCureBtn = NuiHeight(jCureBtn, fBtnH);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jTitle);
+    jCol = JsonArrayInsert(jCol, jList);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jOpenBtn);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, jCureBtn);
+
+    json jSide = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    float fContentW = GetNuiScaleDimension(oPC, PLG_TEST_W - 30.0);
+    json jRow = JsonArray();
+    jRow = JsonArrayInsert(jRow, jSide);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiCol(jCol), fContentW));
+    jRow = JsonArrayInsert(jRow, jSide);
+    return NuiRow(jRow);
+}
+
+void FeedPlgTestWindow(object oPC, int nToken)
+{
+    json jNames = JsonArray();
+    int i;
+    for(i = 0; i < PLG_DIS_COUNT; i++)
+        jNames = JsonArrayInsert(jNames, JsonString(PlgDiseaseName(i)));
+    NuiSetBind(oPC, nToken, PLG_BIND_TEST_DIS, jNames);
+    NuiSetBind(oPC, nToken, PLG_BIND_TEST_LEN, JsonInt(PLG_DIS_COUNT));
+}
+
+void CreatePlgTestWindow(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, PLG_WIN_TEST);
+    if(nToken != 0)
+    {
+        NuiDestroy(oPC, nToken);
+        return;
+    }
+
+    float fGuiW = IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH));
+    float fGuiH = IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT));
+    float fWinW = GetNuiScaleDimension(oPC, PLG_TEST_W);
+    float fWinH = GetNuiScaleDimension(oPC, PLG_TEST_H);
+    json jGeom  = NuiRect((fGuiW - fWinW) / 2.0, (fGuiH - fWinH) / 2.0, fWinW, fWinH);
+
+    json jWin = NuiWindow(
+        PlgBuildTestWindow(oPC),
+        JsonString("[Debug] Zwierciadło Diagnostyczne"),
+        NuiBind(PLG_TEST_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    nToken = NuiCreate(oPC, jWin, PLG_WIN_TEST, PLG_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, PLG_TEST_GEOM, jGeom);
+    FeedPlgTestWindow(oPC, nToken);
+}
+
+// ================================================================
+// OnClientEnter helper — reapplies effects after server restart
+// ================================================================
+
+void PlgOnClientEnter(object oPC)
+{
+    json jState = PlgGetState(oPC);
+    if(JsonGetType(jState) == JSON_TYPE_NULL)
+    {
+        SetLocalInt(oPC, PLG_LVAR_DISEASE, PLG_DIS_NONE);
+        SetLocalInt(oPC, PLG_LVAR_PHASE,   PLG_PHASE_NONE);
+        return;
+    }
+
+    int nDiseaseId = JsonGetInt(JsonObjectGet(jState, "disease_id"));
+    int nPhase     = JsonGetInt(JsonObjectGet(jState, "phase"));
+
+    SetLocalInt(oPC, PLG_LVAR_DISEASE, nDiseaseId);
+    SetLocalInt(oPC, PLG_LVAR_PHASE,   nPhase);
+    SetLocalInt(oPC, PLG_LVAR_TICK,    0);
+
+    PlgApplyEffects(oPC, nDiseaseId, nPhase);
+
+    if(nDiseaseId != PLG_DIS_NONE && nPhase != PLG_PHASE_NONE)
+    {
+        string sMsg = "[Zaraza] " + PlgDiseaseName(nDiseaseId) + " — "
+            + PlgPhaseName(nPhase) + ". Odwiedź zwierciadło diagnostyczne.";
+        DelayCommand(5.0, SendMessageToPC(oPC, sMsg));
+    }
+
+    // Advance any overdue phases immediately
+    DelayCommand(1.0, PlgCheckProgression(oPC));
+}

--- a/Plague/Scripts/lib_plg_def.nss
+++ b/Plague/Scripts/lib_plg_def.nss
@@ -1,0 +1,322 @@
+#include "lib_nui"
+#include "sql_plg"
+
+// Forward declarations (defined in lib_plg.nss)
+void FeedPlgWindow(object oPC, int nToken);
+void PlgApplyEffects(object oPC, int nDiseaseId, int nPhase);
+void PlgRemoveEffects(object oPC);
+void PlgContractAndNotify(object oPC, int nDiseaseId);
+void PlgCureAndNotify(object oPC);
+
+// ================================================================
+// Window / UI constants
+// ================================================================
+const string PLG_WINDOW        = "PLG_WIN";
+const string PLG_WIN_TEST      = "PLG_WIN_TEST";
+const string PLG_EV_SCRIPT     = "lib_plg_ev";
+const string PLG_WIN_GEOM      = "plg_win_geom";
+const string PLG_TEST_GEOM     = "plg_test_geom";
+
+const string PLG_BIND_NAME     = "plg_name";        // disease name label
+const string PLG_BIND_PHASE    = "plg_phase";       // phase name label
+const string PLG_BIND_FLAVOR   = "plg_flavor";      // phase flavor text body
+const string PLG_BIND_SYMPTOMS = "plg_symptoms";    // symptom list label
+const string PLG_BIND_REMEDY   = "plg_remedy";      // remedy name label
+const string PLG_BIND_CURE_ENA = "plg_cure_ena";    // cure button enabled
+const string PLG_BIND_TIMER    = "plg_timer";       // "Następna faza za: HH:MM:SS"
+const string PLG_BIND_PROG     = "plg_prog";        // progress bar 0.0-1.0
+const string PLG_BIND_PROG_COL = "plg_prog_col";   // progress bar tint color
+
+// test window binds
+const string PLG_BIND_TEST_DIS = "plg_t_dis";      // disease name array for list
+const string PLG_BIND_TEST_LEN = "plg_t_len";      // list row count
+
+const string PLG_BTN_CLOSE     = "plg_close";
+const string PLG_BTN_CURE      = "plg_cure";
+const string PLG_BTN_TEST_ROW  = "plg_t_row";      // list row in test window
+const string PLG_BTN_TEST_CURE = "plg_t_cure";     // instant cure in test window
+const string PLG_BTN_TEST_OPEN = "plg_t_open";     // open main window from test
+
+const float  PLG_W             = 440.0;
+const float  PLG_H             = 510.0;
+const float  PLG_TEST_W        = 360.0;
+const float  PLG_TEST_H        = 300.0;
+
+// ================================================================
+// Disease IDs
+// ================================================================
+const int PLG_DIS_NONE         = -1;
+const int PLG_DIS_BLACK_PLAGUE = 0;
+const int PLG_DIS_BLOOD_ROT    = 1;
+const int PLG_DIS_SWAMP_FEVER  = 2;
+const int PLG_DIS_NECROTIC     = 3;
+const int PLG_DIS_LYCANTHROPY  = 4;
+const int PLG_DIS_COUNT        = 5;
+
+// ================================================================
+// Phase IDs
+// ================================================================
+const int PLG_PHASE_NONE       = 0;
+const int PLG_PHASE_INCUBATION = 1;
+const int PLG_PHASE_MILD       = 2;
+const int PLG_PHASE_SEVERE     = 3;
+const int PLG_PHASE_CRITICAL   = 4;
+
+// ================================================================
+// Local variables (cached on PC for fast heartbeat read)
+// ================================================================
+const string PLG_LVAR_DISEASE  = "PLG_DISEASE";   // int: disease id, -1 = none
+const string PLG_LVAR_PHASE    = "PLG_PHASE";     // int: current phase
+const string PLG_LVAR_TICK     = "PLG_TICK";      // int: heartbeat tick counter for DoT
+
+// Tag on every effect applied by this system; allows clean removal via effect loop
+const string PLG_EFFECT_TAG    = "PLG_EFFECT";
+
+// ================================================================
+// Static disease data
+// ================================================================
+
+string PlgDiseaseName(int nId)
+{
+    switch(nId)
+    {
+        case PLG_DIS_BLACK_PLAGUE: return "Czarna Dżuma";
+        case PLG_DIS_BLOOD_ROT:   return "Krwawa Zgnilizna";
+        case PLG_DIS_SWAMP_FEVER: return "Bagienka Gorączka";
+        case PLG_DIS_NECROTIC:    return "Nekrotyczna Rana";
+        case PLG_DIS_LYCANTHROPY: return "Przekleństwo Wilkołaka";
+    }
+    return "Brak";
+}
+
+string PlgDiseaseRemedyTag(int nId)
+{
+    switch(nId)
+    {
+        case PLG_DIS_BLACK_PLAGUE: return "plg_rem_plaga";
+        case PLG_DIS_BLOOD_ROT:   return "plg_rem_krew";
+        case PLG_DIS_SWAMP_FEVER: return "plg_rem_bagna";
+        case PLG_DIS_NECROTIC:    return "plg_rem_nkr";
+        case PLG_DIS_LYCANTHROPY: return "plg_rem_wilk";
+    }
+    return "";
+}
+
+string PlgDiseaseRemedyName(int nId)
+{
+    switch(nId)
+    {
+        case PLG_DIS_BLACK_PLAGUE: return "Napar z czarnej malwy";
+        case PLG_DIS_BLOOD_ROT:   return "Ziołowy bandaż hemostatyczny";
+        case PLG_DIS_SWAMP_FEVER: return "Korzeń topoli bagiennej";
+        case PLG_DIS_NECROTIC:    return "Poświęcona woda";
+        case PLG_DIS_LYCANTHROPY: return "Srebrna woda";
+    }
+    return "Nieznane lekarstwo";
+}
+
+// Color tinting the progression bar per disease
+json PlgDiseaseColor(int nId)
+{
+    switch(nId)
+    {
+        case PLG_DIS_BLACK_PLAGUE: return NuiColor(100,  60, 120);  // dark purple
+        case PLG_DIS_BLOOD_ROT:   return NuiColor(200,  40,  40);  // crimson
+        case PLG_DIS_SWAMP_FEVER: return NuiColor( 80, 160,  60);  // sickly green
+        case PLG_DIS_NECROTIC:    return NuiColor( 60,  80, 120);  // necrotic blue-grey
+        case PLG_DIS_LYCANTHROPY: return NuiColor(180, 140,  60);  // amber
+    }
+    return NuiColor(120, 120, 120);
+}
+
+string PlgPhaseName(int nPhase)
+{
+    switch(nPhase)
+    {
+        case PLG_PHASE_INCUBATION: return "Inkubacja";
+        case PLG_PHASE_MILD:       return "Łagodne objawy";
+        case PLG_PHASE_SEVERE:     return "Choroba";
+        case PLG_PHASE_CRITICAL:   return "Stan krytyczny";
+    }
+    return "—";
+}
+
+string PlgPhaseFlavor(int nDiseaseId, int nPhase)
+{
+    if(nDiseaseId == PLG_DIS_BLACK_PLAGUE)
+    {
+        switch(nPhase)
+        {
+            case PLG_PHASE_INCUBATION:
+                return "Czujesz lekkie drżenie mięśni i nieustępliwe zmęczenie. Plamy pod pachami swędzą — nie przypisujesz im znaczenia.";
+            case PLG_PHASE_MILD:
+                return "Gorączka nie odpuszcza od kilku godzin. Węzły chłonne puchną boleśnie pod skórą. Krew w ślinie zabarwia chustę na różowo.";
+            case PLG_PHASE_SEVERE:
+                return "Czarne bąble pękają, wydzielając cuchnącą meszę. Każdy oddech to agonia. Okoliczne istoty odsuwają się instynktownie.";
+            case PLG_PHASE_CRITICAL:
+                return "Ciemność pulsuje za oczami. Skóra czernieje wzdłuż żył. Bez natychmiastowego leczenia śmierć jest pewna.";
+        }
+    }
+    else if(nDiseaseId == PLG_DIS_BLOOD_ROT)
+    {
+        switch(nPhase)
+        {
+            case PLG_PHASE_INCUBATION:
+                return "Stare blizny zaczęły piec bez powodu. Krew pod paznokciami ma zbyt ciemny kolor.";
+            case PLG_PHASE_MILD:
+                return "Żyły na przedramionach mienią się purpurą. Rany nie chcą się zagoić — każde zadrapanie krwawi zbyt długo.";
+            case PLG_PHASE_SEVERE:
+                return "Skóra pęka wzdłuż żył, jakby ciało chciało otworzyć się od wewnątrz. Każdy ruch zostawia na ubraniu brązowe ślady.";
+            case PLG_PHASE_CRITICAL:
+                return "Krew sączy się z oczu i uszu. Twoje serce bije nieregularnie. Każda chwila bez lekarstwa to kolejna miara życia utracona.";
+        }
+    }
+    else if(nDiseaseId == PLG_DIS_SWAMP_FEVER)
+    {
+        switch(nPhase)
+        {
+            case PLG_PHASE_INCUBATION:
+                return "Mdły zapach błota tkwi w nozdrzach, choć jesteś daleko od mokradeł. Palce drżą przy porannym wstawaniu.";
+            case PLG_PHASE_MILD:
+                return "Gorączka bagienna robi swoje — rzeczywistość zaciera kontury. Widzisz cienie tam, gdzie ich nie ma.";
+            case PLG_PHASE_SEVERE:
+                return "Halucynacje przybierają na sile. Pewność ruchów zanika; nogi niosą cię chwiejnie jak pijanego.";
+            case PLG_PHASE_CRITICAL:
+                return "Drżączka unieruchamia palce. Świat kręci się wokół ciebie. Tylko zimne lekarstwo może przywrócić jasność umysłu.";
+        }
+    }
+    else if(nDiseaseId == PLG_DIS_NECROTIC)
+    {
+        switch(nPhase)
+        {
+            case PLG_PHASE_INCUBATION:
+                return "Rana, od której się wszystko zaczęło, przestała boleć. Mięso wokół jest blade — zbyt blade.";
+            case PLG_PHASE_MILD:
+                return "Nekrotyczna tkanka pełznie wzdłuż ramienia. Skóra zgrabiała i stwardniała jak skóra trupa.";
+            case PLG_PHASE_SEVERE:
+                return "Zaraza sięga głębiej — czujesz, jak siła uchodzi z mięśni, jakby coś wysysało cię od wewnątrz.";
+            case PLG_PHASE_CRITICAL:
+                return "Połowa ciała jest zimna jak kamień. Nekromantyczna trucizna żywi się twoją żywotnością. Poświęcona woda to jedyna nadzieja.";
+        }
+    }
+    else if(nDiseaseId == PLG_DIS_LYCANTHROPY)
+    {
+        switch(nPhase)
+        {
+            case PLG_PHASE_INCUBATION:
+                return "Ugryzienie zagoiło się szybciej, niż powinno. W nocy masz sny o polowaniach i krwi.";
+            case PLG_PHASE_MILD:
+                return "Mięśnie rosną niespodziewanie. Instynkt podpowiada ci zagrożenia, zanim je dostrzeżesz. Coś w tobie tęskni za księżycem.";
+            case PLG_PHASE_SEVERE:
+                return "Myśli stają się prostsze — łup, krew, terytorium. Utrzymanie człowieczeństwa kosztuje coraz więcej wysiłku woli.";
+            case PLG_PHASE_CRITICAL:
+                return "Bestia walczy o kontrolę. Ruchy stają się gwałtowne i niekontrolowane. Srebrna woda jest ostatnią szansą przed pełną przemianą.";
+        }
+    }
+    return "";
+}
+
+// Returns human-readable list of current penalties for the UI symptoms field.
+string PlgPhaseSymptoms(int nDiseaseId, int nPhase)
+{
+    if(nPhase <= PLG_PHASE_INCUBATION) return "Brak widocznych objawów.";
+    if(nDiseaseId == PLG_DIS_BLACK_PLAGUE)
+    {
+        switch(nPhase)
+        {
+            case PLG_PHASE_MILD:     return "-2 Kondycja";
+            case PLG_PHASE_SEVERE:   return "-4 Kondycja, -2 Siła";
+            case PLG_PHASE_CRITICAL: return "-6 Kondycja, -4 Siła";
+        }
+    }
+    else if(nDiseaseId == PLG_DIS_BLOOD_ROT)
+    {
+        switch(nPhase)
+        {
+            case PLG_PHASE_MILD:     return "-1 Pancerz, -1 do Rzutów Obronnych";
+            case PLG_PHASE_SEVERE:   return "-2 Pancerz, -2 do Rzutów Obronnych";
+            case PLG_PHASE_CRITICAL: return "-3 Pancerz, -3 do Rzutów Obronnych, krwotok co 30s";
+        }
+    }
+    else if(nDiseaseId == PLG_DIS_SWAMP_FEVER)
+    {
+        switch(nPhase)
+        {
+            case PLG_PHASE_MILD:     return "-2 Zręczność";
+            case PLG_PHASE_SEVERE:   return "-4 Zręczność, -2 Mądrość";
+            case PLG_PHASE_CRITICAL: return "-6 Zręczność, -4 Mądrość";
+        }
+    }
+    else if(nDiseaseId == PLG_DIS_NECROTIC)
+    {
+        switch(nPhase)
+        {
+            case PLG_PHASE_MILD:     return "-1 Siła";
+            case PLG_PHASE_SEVERE:   return "-3 Siła, -2 Kondycja";
+            case PLG_PHASE_CRITICAL: return "-5 Siła, -4 Kondycja, obrażenia nekrotyczne co 30s";
+        }
+    }
+    else if(nDiseaseId == PLG_DIS_LYCANTHROPY)
+    {
+        switch(nPhase)
+        {
+            case PLG_PHASE_MILD:     return "+2 Siła, -2 Mądrość";
+            case PLG_PHASE_SEVERE:   return "+4 Siła, -4 Mądrość";
+            case PLG_PHASE_CRITICAL: return "+6 Siła, -6 Mądrość, napady wściekłości";
+        }
+    }
+    return "";
+}
+
+// Seconds before this phase advances to the next one.
+// Phase 4 (critical) never advances — pass 0 to PlgAdvancePhase.
+int PlgPhaseInterval(int nDiseaseId, int nPhase)
+{
+    if(nDiseaseId == PLG_DIS_BLACK_PLAGUE)
+    {
+        switch(nPhase)
+        {
+            case PLG_PHASE_INCUBATION: return 3600;
+            case PLG_PHASE_MILD:       return 7200;
+            case PLG_PHASE_SEVERE:     return 14400;
+        }
+    }
+    else if(nDiseaseId == PLG_DIS_BLOOD_ROT)
+    {
+        switch(nPhase)
+        {
+            case PLG_PHASE_INCUBATION: return 1800;
+            case PLG_PHASE_MILD:       return 3600;
+            case PLG_PHASE_SEVERE:     return 7200;
+        }
+    }
+    else if(nDiseaseId == PLG_DIS_SWAMP_FEVER)
+    {
+        // Fastest-progressing disease — good for demo/testing
+        switch(nPhase)
+        {
+            case PLG_PHASE_INCUBATION: return 900;
+            case PLG_PHASE_MILD:       return 1800;
+            case PLG_PHASE_SEVERE:     return 3600;
+        }
+    }
+    else if(nDiseaseId == PLG_DIS_NECROTIC)
+    {
+        switch(nPhase)
+        {
+            case PLG_PHASE_INCUBATION: return 1800;
+            case PLG_PHASE_MILD:       return 3600;
+            case PLG_PHASE_SEVERE:     return 10800;
+        }
+    }
+    else if(nDiseaseId == PLG_DIS_LYCANTHROPY)
+    {
+        switch(nPhase)
+        {
+            case PLG_PHASE_INCUBATION: return 7200;
+            case PLG_PHASE_MILD:       return 14400;
+            case PLG_PHASE_SEVERE:     return 28800;
+        }
+    }
+    return 3600;
+}

--- a/Plague/Scripts/lib_plg_ev.nss
+++ b/Plague/Scripts/lib_plg_ev.nss
@@ -1,0 +1,75 @@
+#include "lib_plg"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    // ---- Test / debug window ----
+    if(nToken == NuiFindWindow(oPC, PLG_WIN_TEST))
+    {
+        if(sEvent == EVENT_TYPE_MOUSEDOWN && sElem == PLG_BTN_TEST_ROW)
+        {
+            if(nIdx < 0 || nIdx >= PLG_DIS_COUNT) return;
+            NuiDestroy(oPC, nToken);
+            PlgContractAndNotify(oPC, nIdx);
+            CreatePlgWindow(oPC);
+        }
+        else if(sEvent == EVENT_TYPE_CLICK && sElem == PLG_BTN_TEST_CURE)
+        {
+            PlgCureAndNotify(oPC);
+            NuiDestroy(oPC, nToken);
+            int nMain = NuiFindWindow(oPC, PLG_WINDOW);
+            if(nMain != 0) FeedPlgWindow(oPC, nMain);
+        }
+        else if(sEvent == EVENT_TYPE_CLICK && sElem == PLG_BTN_TEST_OPEN)
+        {
+            NuiDestroy(oPC, nToken);
+            CreatePlgWindow(oPC);
+        }
+        return;
+    }
+
+    // ---- Main status window ----
+    if(nToken != NuiFindWindow(oPC, PLG_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+        return; // nothing to clean up
+
+    if(sEvent == EVENT_TYPE_OPEN)
+    {
+        FeedPlgWindow(oPC, nToken);
+        return;
+    }
+
+    if(sEvent != EVENT_TYPE_CLICK) return;
+
+    if(sElem == PLG_BTN_CLOSE)
+    {
+        NuiDestroy(oPC, nToken);
+        return;
+    }
+
+    if(sElem == PLG_BTN_CURE)
+    {
+        int nDiseaseId = GetLocalInt(oPC, PLG_LVAR_DISEASE);
+        if(nDiseaseId == PLG_DIS_NONE) return;
+
+        string sRemedyTag = PlgDiseaseRemedyTag(nDiseaseId);
+        object oRemedy    = GetItemPossessedBy(oPC, sRemedyTag);
+        if(!GetIsObjectValid(oRemedy))
+        {
+            SendMessageToPC(oPC, "[Zaraza] Nie masz przy sobie odpowiedniego lekarstwa.");
+            NuiSetBind(oPC, nToken, PLG_BIND_CURE_ENA, JsonBool(FALSE));
+            return;
+        }
+
+        DestroyObject(oRemedy);
+        PlgCureAndNotify(oPC);
+        FeedPlgWindow(oPC, nToken);
+        return;
+    }
+}

--- a/Plague/Scripts/sql_plg.nss
+++ b/Plague/Scripts/sql_plg.nss
@@ -1,0 +1,76 @@
+const string PLG_CAMPAIGN = "plague";
+
+void PlgCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign(PLG_CAMPAIGN,
+        "CREATE TABLE IF NOT EXISTS plg_diseases ("
+        "  uuid        TEXT    PRIMARY KEY,"
+        "  disease_id  INTEGER NOT NULL DEFAULT -1,"
+        "  phase       INTEGER NOT NULL DEFAULT 0,"
+        "  phase_start INTEGER NOT NULL DEFAULT 0,"
+        "  phase_end   INTEGER NOT NULL DEFAULT 0"
+        ")");
+    SqlStep(q);
+}
+
+// Returns {disease_id, phase, phase_start, phase_end} or JSON_TYPE_NULL if no row.
+json PlgGetState(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign(PLG_CAMPAIGN,
+        "SELECT disease_id, phase, phase_start, phase_end "
+        "FROM plg_diseases WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(!SqlStep(q)) return JsonNull();
+
+    json j = JsonObject();
+    j = JsonObjectSet(j, "disease_id",  JsonInt(SqlGetInt(q, 0)));
+    j = JsonObjectSet(j, "phase",       JsonInt(SqlGetInt(q, 1)));
+    j = JsonObjectSet(j, "phase_start", JsonInt(SqlGetInt(q, 2)));
+    j = JsonObjectSet(j, "phase_end",   JsonInt(SqlGetInt(q, 3)));
+    return j;
+}
+
+// Sets initial disease (phase 1 = incubation).
+void PlgContractDisease(object oPC, int nDiseaseId, int nPhaseInterval)
+{
+    sqlquery q = SqlPrepareQueryCampaign(PLG_CAMPAIGN,
+        "INSERT OR REPLACE INTO plg_diseases "
+        "(uuid, disease_id, phase, phase_start, phase_end) "
+        "VALUES (@uuid, @did, 1, strftime('%s','now'), strftime('%s','now') + @dur)");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@did",  nDiseaseId);
+    SqlBindInt   (q, "@dur",  nPhaseInterval);
+    SqlStep(q);
+}
+
+// Advances to a new phase; phase_start = old phase_end, phase_end = phase_start + duration.
+// Pass nNextInterval = 0 for phase 4 (critical – no further advance).
+void PlgAdvancePhase(object oPC, int nNewPhase, int nOldPhaseEnd, int nNextInterval)
+{
+    int nNewEnd = (nNextInterval > 0) ? nOldPhaseEnd + nNextInterval : 0;
+    sqlquery q = SqlPrepareQueryCampaign(PLG_CAMPAIGN,
+        "UPDATE plg_diseases "
+        "SET phase = @phase, phase_start = @ps, phase_end = @pe "
+        "WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid",  GetObjectUUID(oPC));
+    SqlBindInt   (q, "@phase", nNewPhase);
+    SqlBindInt   (q, "@ps",    nOldPhaseEnd);
+    SqlBindInt   (q, "@pe",    nNewEnd);
+    SqlStep(q);
+}
+
+void PlgCureDisease(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign(PLG_CAMPAIGN,
+        "DELETE FROM plg_diseases WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+// Returns current unix time from SQLite (authoritative clock for phase checks).
+int PlgUnixNow()
+{
+    sqlquery q = SqlPrepareQueryCampaign(PLG_CAMPAIGN, "SELECT strftime('%s','now')");
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}

--- a/Plague/Scripts/sys_on_enter.nss
+++ b/Plague/Scripts/sys_on_enter.nss
@@ -1,0 +1,9 @@
+#include "lib_plg"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC)) return;
+
+    PlgOnClientEnter(oPC);
+}

--- a/Plague/Scripts/sys_on_heartbeat.nss
+++ b/Plague/Scripts/sys_on_heartbeat.nss
@@ -1,0 +1,12 @@
+#include "lib_plg"
+
+void main()
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        PlgCheckProgression(oPC);
+        PlgApplyPerTick(oPC);
+        oPC = GetNextPC();
+    }
+}

--- a/Plague/Scripts/sys_on_load.nss
+++ b/Plague/Scripts/sys_on_load.nss
@@ -1,0 +1,6 @@
+#include "sql_plg"
+
+void main()
+{
+    PlgCreateTables();
+}

--- a/Plague/Scripts/test_plg.nss
+++ b/Plague/Scripts/test_plg.nss
@@ -1,0 +1,11 @@
+#include "lib_plg"
+
+// OnUsed handler for the "Zwierciadło Diagnostyczne" (Diagnostic Mirror) placeable.
+// Opens the test/debug window so QA can contract any disease and check the status UI.
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    CreatePlgTestWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

Moduł wprowadza system pięciu zaraźliwych chorób z automatyczną progresją faz, trwałymi efektami statystyk i NUI panelem diagnostycznym. Każda choroba posiada unikalne flavor texty, kary i lekarstwo wymagające konkretnego przedmiotu.

## Mechanika

- **5 chorób**: Czarna Dżuma, Krwawa Zgnilizna, Bagienka Gorączka, Nekrotyczna Rana, Przekleństwo Wilkołaka
- **4 fazy progresji**: Inkubacja → Łagodne objawy → Choroba → Stan krytyczny — każda faza zmienia się automatycznie po upływie czasu (15 min–8 h, zależnie od choroby) sprawdzanego przez `OnHeartbeat` względem znacznika SQL
- **Trwałe efekty**: Każda faza stosuje odpowiednie kary (`EffectAbilityDecrease`, `EffectACDecrease`, `EffectSavingThrowDecrease`) lub premie (Wilkołactwo: +STR, -WIS) tagowane `PLG_EFFECT_TAG`; efekty są odtwarzane po ponownym logowaniu przez iterację `GetFirstEffect`/`RemoveEffect`
- **DoT w fazie krytycznej**: Blood Rot i Necrotic Wound zadają obrażenia co ~30 s (5 tyknięć heartbeat × 6 s); Wilkołactwo w fazie krytycznej losowo wyświetla efekt szału (20% co 30 s)
- **NUI panel**: Pokazuje nazwę choroby, fazę, pasek postępu czasu do następnej fazy, opis objawów, flavor text i przycisk leczenia (aktywny gdy odpowiedni przedmiot jest w ekwipunku)
- **Leczenie**: Każda choroba ma dedykowany tag przedmiotu; `DestroyObject(oRemedy)` + `PlgCureAndNotify` usuwa efekty, czyści SQL i powiadamia gracza
- **Zarażanie z zewnątrz**: `PlgContractAndNotify(oPC, nDiseaseId)` można wywołać z triggerów, creature skryptów lub questowych eventów

## Pliki

| Plik | Opis |
|---|---|
| `Plague/Scripts/sql_plg.nss` | Schemat SQLite (`plague`), CRUD per-PC |
| `Plague/Scripts/lib_plg_def.nss` | Stałe, bindy NUI, statyczne dane chorób (nazwy, flavor, interway, symptomy, kolory) |
| `Plague/Scripts/lib_plg.nss` | Rdzeń: efekty, progresja, DoT, builder NUI, FeedPlgWindow, okno debug |
| `Plague/Scripts/lib_plg_ev.nss` | Handler NUI (switch na `NuiGetEventType()`), okno statusu i debug |
| `Plague/Scripts/sys_on_load.nss` | `PlgCreateTables()` |
| `Plague/Scripts/sys_on_enter.nss` | `PlgOnClientEnter(oPC)` — restore efektów po logowaniu |
| `Plague/Scripts/sys_on_heartbeat.nss` | `PlgCheckProgression` + `PlgApplyPerTick` dla każdego PC |
| `Plague/Scripts/test_plg.nss` | OnUsed placeable — otwiera debug NUI z wyborem choroby i natychmiastowym leczeniem |
| `Plague/INTEGRATION.md` | Instrukcja podpięcia hooków, tabela tagów przedmiotów, skrócone interwały do testów |

## Zależności

- **NWN:EE 8193+** — wymaga `TagEffect` / `GetEffectTag` (bez NWNX)
- **SQLite** — natywne; kampania `"plague"` tworzona automatycznie przez `CREATE TABLE IF NOT EXISTS`
- **NWNX** — *niewymagany*

## Jak włączyć w istniejącym module

Dodaj wywołania do istniejących hooków (szczegóły w `INTEGRATION.md`):

```
OnModuleLoad  → sys_on_load       (PlgCreateTables)
OnClientEnter → sys_on_enter      (PlgOnClientEnter)
OnHeartbeat   → sys_on_heartbeat  (PlgCheckProgression + PlgApplyPerTick)
```

Stwórz placeable z OnUsed = `test_plg` (demo/QA) lub `skrypt wywołujący CreatePlgWindow(oPC)` (produkcja). Dodaj przedmioty leczące z tagami `plg_rem_*` do świata gry.

## Co celowo pominięto

- Transmisja przez proximity (bliskość zainfekowanych NPC) — wymaga NWNX lub dedykowanego triggera; API zarażenia (`PlgContractAndNotify`) jest gotowe do podpięcia
- Wizualne zmiany appearance per-faza — wymagają haka z teksturami, poza zakresem modułu
- System odporności/szczepień — follow-up feature
- Resetowanie stanu po śmierci PC — pozostawiono decyzji mechaniki serwera

---
_Generated by [Claude Code](https://claude.ai/code/session_01MiS7Dc2nvK8kKAEQgTMfmy)_