### PR TITLE
feat: Wróżbiarstwo (Divination)

### DIFF
--- a/Divination/INTEGRATION.md
+++ b/Divination/INTEGRATION.md
@@ -1,0 +1,97 @@
+# Wróżbiarstwo (Divination) — Integracja
+
+## Wymagania
+
+- NWN EE (Enhanced Edition) — wymagane dla NUI, TagEffect, GetEffectTag
+- Brak NWNX — moduł działa wyłącznie na czystym NWScript + SQLite
+
+## Hooki do podpięcia
+
+| Zdarzenie modułu | Skrypt       | Opis                                               |
+|------------------|--------------|----------------------------------------------------|
+| OnModuleLoad     | sys_on_load  | Tworzy tabelę `div_players` w bazie `divination`  |
+| OnClientEnter    | sys_on_enter | Rejestruje gracza, odnawia aktywne efekty kart     |
+| OnClientLeave    | sys_on_leave | Czyści tymczasowe zmienne sesji                   |
+
+Jeśli w module istnieją już własne skrypty dla tych hooków, dołącz
+odpowiednie `#include "..."` i wywołaj funkcje:
+
+```nss
+// W istniejącym OnModuleLoad:
+#include "sql_div"
+// ...
+DivInitTables();
+
+// W istniejącym OnClientEnter:
+#include "lib_div"
+// ...
+DivEnsureRow(oPC);
+DivReapplyPersistentEffects(oPC);
+
+// W istniejącym OnClientLeave:
+#include "lib_div_def"
+// ...
+DeleteLocalJson(oPC, DIV_LVAR_CARDS);
+DeleteLocalInt(oPC, DIV_LVAR_REVEALED);
+DeleteLocalInt(oPC, DIV_LVAR_CARDCNT);
+DeleteLocalInt(oPC, DIV_LVAR_LASTCARD);
+```
+
+## Placeable do testu
+
+1. Umieść dowolny placeable (stół, skrzynia, ołtarz) na scenie.
+2. Ustaw jego skrypt `OnUsed` na `test_div`.
+3. Gracz klika placeable → otwiera się okno Wróżbiarstwa.
+
+## Pliki skryptów do skopiowania do hak/.mod
+
+```
+lib_div_def.nss
+lib_div.nss
+lib_div_ev.nss
+sql_div.nss
+lib_nui.nss
+lib_nui_utility.nss
+sys_on_load.nss
+sys_on_enter.nss
+sys_on_leave.nss
+test_div.nss
+```
+
+## Baza danych
+
+Kampania: `divination`
+Tabela: `div_players`
+
+| Kolumna          | Typ     | Opis                                          |
+|------------------|---------|-----------------------------------------------|
+| uuid             | TEXT PK | UUID gracza (GetObjectUUID)                  |
+| char_name        | TEXT    | Imię postaci (czytelność logów)              |
+| last_reading_at  | INTEGER | Unix epoch ostatniego odczytania             |
+| effects_json     | TEXT    | JSON array aktywnych pieczęci + expiry        |
+| total_readings   | INTEGER | Łączna liczba odczytań (statystyki)          |
+
+Format `effects_json`:
+```json
+[
+  { "card_id": 4, "expires_at": 1746700000 },
+  { "card_id": 9, "expires_at": 1746710000 }
+]
+```
+
+## Mechanika — skrót
+
+- **Małe Odczytanie**: 3 karty, 50 złota, cooldown 24h
+- **Wielkie Odczytanie**: 5 kart, 150 złota, cooldown 24h
+- **Cooldown** wspólny dla obu rodzajów — jedno odczytanie dziennie
+- Gracz klika każdą kartę by ją odsłonić; efekty widoczne przed akceptacją
+- **Przyjmij Los** — aplikuje efekty i zapisuje w SQLite
+- **Anuluj** — wraca bez efektów, złoto przepadło (los nie cofa)
+- Po zalogowaniu wszystkie aktywne pieczęcie są automatycznie odnawiane
+
+## Co celowo pominięto
+
+- Animacja „odwracania kart" — NUI nie wspiera animacji tweening bez NWNX
+- Grafiki kart — brak obrazków w hak; nazwy wystarczą dla klimatu
+- System „złej wróżbitki" karzącej za wielokrotne odmowy — wymagałby dodatkowego NPCdialog systemu
+- Integracja z innymi modułami (np. Pantheon) — każdy moduł pozostaje samodzielny

--- a/Divination/Scripts/lib_div.nss
+++ b/Divination/Scripts/lib_div.nss
@@ -1,0 +1,911 @@
+#include "lib_div_def"
+
+// ================================================================
+// Effect management
+// ================================================================
+
+void DivRemoveAllDivEffects(object oPC)
+{
+    effect e = GetFirstEffect(oPC);
+    while(GetIsEffectValid(e))
+    {
+        effect eNext = GetNextEffect(oPC);
+        if(GetStringLeft(GetEffectTag(e), 4) == "DIV_")
+            RemoveEffect(oPC, e);
+        e = eNext;
+    }
+}
+
+void DivRemoveNegativeDivEffects(object oPC)
+{
+    effect e = GetFirstEffect(oPC);
+    while(GetIsEffectValid(e))
+    {
+        effect eNext = GetNextEffect(oPC);
+        string sTag = GetEffectTag(e);
+        if(GetStringLeft(sTag, 4) == "DIV_")
+        {
+            int nId = StringToInt(GetStringRight(sTag,
+                GetStringLength(sTag) - 4));
+            if(DivCardIsNegative(nId))
+                RemoveEffect(oPC, e);
+        }
+        e = eNext;
+    }
+}
+
+// ================================================================
+// Apply a single card's effects to oPC
+// ================================================================
+
+void DivApplySingleCardEffect(object oPC, int nCardId)
+{
+    string sTag = "DIV_" + IntToString(nCardId);
+    effect eVFX = EffectVisualEffect(VFX_IMP_MAGIC_PROTECTION);
+
+    switch(nCardId)
+    {
+        case DIV_CARD_FOOL:
+        {
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAttackDecrease(1), sTag), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectACDecrease(1, AC_DODGE_BONUS), sTag), oPC);
+            eVFX = EffectVisualEffect(VFX_IMP_DOOM);
+            break;
+        }
+        case DIV_CARD_MAGICIAN:
+        {
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAttackIncrease(1, ATTACK_BONUS_MISC), sTag), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectSavingThrowIncrease(SAVING_THROW_ALL, 1), sTag), oPC);
+            break;
+        }
+        case DIV_CARD_PRIESTESS:
+        {
+            int nHeal = GetMaxHitPoints(oPC) / 5;
+            if(nHeal < 1) nHeal = 1;
+            ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectHeal(nHeal), oPC);
+            eVFX = EffectVisualEffect(VFX_IMP_HEALING_S);
+            break;
+        }
+        case DIV_CARD_EMPRESS:
+        {
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAbilityIncrease(ABILITY_CONSTITUTION, 2), sTag), oPC);
+            break;
+        }
+        case DIV_CARD_EMPEROR:
+        {
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAbilityIncrease(ABILITY_STRENGTH, 2), sTag), oPC);
+            break;
+        }
+        case DIV_CARD_HIEROPHANT:
+        {
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectSavingThrowIncrease(SAVING_THROW_WILL, 2), sTag), oPC);
+            break;
+        }
+        case DIV_CARD_LOVERS:
+        {
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAbilityIncrease(ABILITY_CHARISMA, 2), sTag), oPC);
+            break;
+        }
+        case DIV_CARD_CHARIOT:
+        {
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectSavingThrowIncrease(SAVING_THROW_REFLEX, 2), sTag), oPC);
+            break;
+        }
+        case DIV_CARD_STRENGTH:
+        {
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAttackIncrease(1, ATTACK_BONUS_MISC), sTag), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectDamageIncrease(1, DAMAGE_TYPE_BLUDGEONING), sTag), oPC);
+            eVFX = EffectVisualEffect(VFX_IMP_MAGICAL_VISION);
+            break;
+        }
+        case DIV_CARD_HERMIT:
+        {
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectSkillIncrease(SKILL_HIDE, 4), sTag), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectSkillIncrease(SKILL_MOVE_SILENTLY, 4), sTag), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectUltravision(), sTag), oPC);
+            eVFX = EffectVisualEffect(VFX_DUR_GHOSTLY_VISAGE);
+            break;
+        }
+        case DIV_CARD_WHEEL:
+        {
+            int nRoll = d3();
+            if(nRoll == 1)
+            {
+                GiveGoldToCreature(oPC, 100);
+                FloatingTextStringOnCreature(
+                    "Koło Fortuny daje ci 100 złotych monet!", oPC, FALSE);
+            }
+            else if(nRoll == 2)
+            {
+                int nHave = GetGold(oPC);
+                int nTake = (nHave < 75) ? nHave : 75;
+                AssignCommand(oPC, TakeGoldFromCreature(nTake, oPC, TRUE));
+                FloatingTextStringOnCreature(
+                    "Koło Fortuny bierze " + IntToString(nTake) + " złotych...",
+                    oPC, FALSE);
+            }
+            else
+            {
+                FloatingTextStringOnCreature(
+                    "Koło kręci się... i nic nie przynosi.", oPC, FALSE);
+            }
+            eVFX = EffectVisualEffect(VFX_IMP_PULSE_WIND);
+            break;
+        }
+        case DIV_CARD_JUSTICE:
+        {
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectSkillIncrease(SKILL_DISCIPLINE, 2), sTag), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectSkillIncrease(SKILL_PERSUADE, 2), sTag), oPC);
+            break;
+        }
+        case DIV_CARD_HANGED:
+        {
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAttackDecrease(1), sTag), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectSavingThrowDecrease(SAVING_THROW_ALL, 1), sTag), oPC);
+            eVFX = EffectVisualEffect(VFX_IMP_DOOM);
+            break;
+        }
+        case DIV_CARD_DEATH:
+        {
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY, EffectStunned(), oPC, 3.0);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAbilityDecrease(ABILITY_CONSTITUTION, 2), sTag), oPC);
+            eVFX = EffectVisualEffect(VFX_IMP_DOOM);
+            break;
+        }
+        case DIV_CARD_TEMPERANCE:
+        {
+            // Remove negative curses first (effects + SQL)
+            DivRemoveNegativeDivEffects(oPC);
+
+            string sRaw = DivGetEffectsJson(oPC);
+            json jOld   = JsonParse(sRaw);
+            json jClean = JsonArray();
+            int nC = JsonGetLength(jOld);
+            int i;
+            for(i = 0; i < nC; i++)
+            {
+                json jE = JsonArrayGet(jOld, i);
+                int nCId = JsonGetInt(JsonObjectGet(jE, "card_id"));
+                if(!DivCardIsNegative(nCId))
+                    jClean = JsonArrayInsert(jClean, jE);
+            }
+            // Add Temperance's AC bonus and persist it
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectACIncrease(2, AC_DODGE_BONUS), sTag), oPC);
+
+            int nExp = DivGetNow() + DivCardDurationS(DIV_CARD_TEMPERANCE);
+            json jMe = JsonObject();
+            jMe = JsonObjectSet(jMe, "card_id",    JsonInt(DIV_CARD_TEMPERANCE));
+            jMe = JsonObjectSet(jMe, "expires_at", JsonInt(nExp));
+            jClean = JsonArrayInsert(jClean, jMe);
+            DivSetEffectsJson(oPC, JsonDump(jClean));
+
+            eVFX = EffectVisualEffect(VFX_IMP_HOLY_AID);
+            FloatingTextStringOnCreature(
+                "Pieczęcie klątw zostały oczyszczone.", oPC, FALSE);
+            break;
+        }
+        case DIV_CARD_DEVIL:
+        {
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectSkillIncrease(SKILL_INTIMIDATE, 4), sTag), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAbilityDecrease(ABILITY_CHARISMA, 2), sTag), oPC);
+            eVFX = EffectVisualEffect(VFX_IMP_NEGATIVE_ENERGY);
+            break;
+        }
+        case DIV_CARD_TOWER:
+        {
+            int nDmg = d8() + d8() + d8();
+            ApplyEffectToObject(DURATION_TYPE_INSTANT,
+                EffectDamage(nDmg, DAMAGE_TYPE_MAGICAL, DAMAGE_POWER_NORMAL), oPC);
+            FloatingTextStringOnCreature(
+                "Wieża spada. Otrzymujesz " + IntToString(nDmg) + " obrażeń.",
+                oPC, FALSE);
+            eVFX = EffectVisualEffect(VFX_IMP_LIGHTNING_S);
+            break;
+        }
+        case DIV_CARD_STAR:
+        {
+            int nHeal = GetMaxHitPoints(oPC) * 2 / 5;
+            if(nHeal < 1) nHeal = 1;
+            ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectHeal(nHeal), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectRegenerate(2, 6.0), sTag), oPC);
+            eVFX = EffectVisualEffect(VFX_IMP_HEALING_L);
+            break;
+        }
+        case DIV_CARD_MOON:
+        {
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectSeeInvisible(), sTag), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAttackDecrease(1), sTag), oPC);
+            eVFX = EffectVisualEffect(VFX_DUR_GHOSTLY_VISAGE);
+            break;
+        }
+        case DIV_CARD_SUN:
+        {
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAbilityIncrease(ABILITY_STRENGTH, 2), sTag), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAbilityIncrease(ABILITY_DEXTERITY, 2), sTag), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAbilityIncrease(ABILITY_CONSTITUTION, 2), sTag), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAbilityIncrease(ABILITY_INTELLIGENCE, 2), sTag), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAbilityIncrease(ABILITY_WISDOM, 2), sTag), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAbilityIncrease(ABILITY_CHARISMA, 2), sTag), oPC);
+            eVFX = EffectVisualEffect(VFX_IMP_SUNSTRIKE);
+            break;
+        }
+        case DIV_CARD_JUDGEMENT:
+        {
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectSavingThrowIncrease(SAVING_THROW_ALL, 2), sTag), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectImmunity(IMMUNITY_TYPE_FEAR), sTag), oPC);
+            eVFX = EffectVisualEffect(VFX_IMP_HOLY_AID);
+            break;
+        }
+        case DIV_CARD_WORLD:
+        {
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAbilityIncrease(ABILITY_STRENGTH, 1), sTag), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAbilityIncrease(ABILITY_DEXTERITY, 1), sTag), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAbilityIncrease(ABILITY_CONSTITUTION, 1), sTag), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAbilityIncrease(ABILITY_INTELLIGENCE, 1), sTag), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAbilityIncrease(ABILITY_WISDOM, 1), sTag), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAbilityIncrease(ABILITY_CHARISMA, 1), sTag), oPC);
+            break;
+        }
+    }
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, eVFX, oPC);
+}
+
+// ================================================================
+// SQL active-effect helpers
+// ================================================================
+
+void DivAddActiveEffect(object oPC, int nCardId)
+{
+    if(!DivCardIsPersistent(nCardId)) return;
+    // TEMPERANCE writes its own entry in DivApplySingleCardEffect
+    if(nCardId == DIV_CARD_TEMPERANCE) return;
+
+    int nExpAt  = DivGetNow() + DivCardDurationS(nCardId);
+    json jArr   = JsonParse(DivGetEffectsJson(oPC));
+    json jNew   = JsonArray();
+    int nCount  = JsonGetLength(jArr);
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jE = JsonArrayGet(jArr, i);
+        if(JsonGetInt(JsonObjectGet(jE, "card_id")) != nCardId)
+            jNew = JsonArrayInsert(jNew, jE);
+    }
+    json jEntry = JsonObject();
+    jEntry = JsonObjectSet(jEntry, "card_id",    JsonInt(nCardId));
+    jEntry = JsonObjectSet(jEntry, "expires_at", JsonInt(nExpAt));
+    jNew = JsonArrayInsert(jNew, jEntry);
+    DivSetEffectsJson(oPC, JsonDump(jNew));
+}
+
+// Prune expired entries and return the surviving list.
+json DivPruneGetActive(object oPC)
+{
+    int nNow   = DivGetNow();
+    json jArr  = JsonParse(DivGetEffectsJson(oPC));
+    json jLive = JsonArray();
+    int nCount = JsonGetLength(jArr);
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jE = JsonArrayGet(jArr, i);
+        if(JsonGetInt(JsonObjectGet(jE, "expires_at")) > nNow)
+            jLive = JsonArrayInsert(jLive, jE);
+    }
+    if(JsonGetLength(jLive) != nCount)
+        DivSetEffectsJson(oPC, JsonDump(jLive));
+    return jLive;
+}
+
+void DivReapplyPersistentEffects(object oPC)
+{
+    DivRemoveAllDivEffects(oPC);
+    json jLive = DivPruneGetActive(oPC);
+    int nCount = JsonGetLength(jLive);
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        int nId = JsonGetInt(JsonObjectGet(JsonArrayGet(jLive, i), "card_id"));
+        DivApplySingleCardEffect(oPC, nId);
+    }
+}
+
+// ================================================================
+// Cooldown helpers
+// ================================================================
+
+int DivGetSecondsUntilRead(object oPC)
+{
+    int nLast = DivGetLastReadingAt(oPC);
+    if(nLast == 0) return 0;
+    int nRem  = nLast + DIV_COOLDOWN_S - DivGetNow();
+    return (nRem > 0) ? nRem : 0;
+}
+
+int DivCanRead(object oPC)
+{
+    return (DivGetSecondsUntilRead(oPC) == 0);
+}
+
+// ================================================================
+// Utility
+// ================================================================
+
+string DivFormatSeconds(int nSec)
+{
+    if(nSec <= 0) return "";
+    int nH = nSec / 3600;
+    int nM = (nSec % 3600) / 60;
+    string s = "";
+    if(nH > 0) s = IntToString(nH) + " godz. ";
+    if(nM > 0) s += IntToString(nM) + " min.";
+    if(s == "") s = "< 1 min.";
+    return s;
+}
+
+// Pick nCount unique random card IDs, store as LVAR json array.
+void DivDrawCards(object oPC, int nCount)
+{
+    json jDeck = JsonArray();
+    int i;
+    for(i = 0; i < DIV_CARD_COUNT; i++)
+        jDeck = JsonArrayInsert(jDeck, JsonInt(i));
+
+    json jHand = JsonArray();
+    int nLeft = DIV_CARD_COUNT;
+    while(JsonGetLength(jHand) < nCount && nLeft > 0)
+    {
+        int nIdx = Random(nLeft);
+        json jCard = JsonArrayGet(jDeck, nIdx);
+        jHand = JsonArrayInsert(jHand, jCard);
+        // remove drawn card from deck
+        json jTmp = JsonArray();
+        int j;
+        for(j = 0; j < nLeft; j++)
+        {
+            if(j != nIdx)
+                jTmp = JsonArrayInsert(jTmp, JsonArrayGet(jDeck, j));
+        }
+        jDeck = jTmp;
+        nLeft--;
+    }
+    SetLocalJson(oPC, DIV_LVAR_CARDS, jHand);
+}
+
+// ================================================================
+// NUI layout builders
+// ================================================================
+
+json BuildDivMainView(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 32.0);
+    float fRowH  = GetNuiScaleDimension(oPC, 24.0);
+    float fListH = GetNuiScaleDimension(oPC, 132.0);
+    float fSpcS  = GetNuiScaleDimension(oPC, 6.0);
+
+    // Title row
+    json jTitle = NuiLabel(JsonString("Tafle Losu"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitle = NuiHeight(jTitle, fBtnH);
+
+    json jClose = NuiButton(JsonString("X"));
+    jClose = NuiId(jClose, DIV_BTN_CLOSE);
+    jClose = NuiWidth(jClose, GetNuiScaleDimension(oPC, 30.0));
+    jClose = NuiHeight(jClose, fBtnH);
+
+    json jTRow = JsonArray();
+    jTRow = JsonArrayInsert(jTRow, jTitle);
+    jTRow = JsonArrayInsert(jTRow, jClose);
+
+    // Flavor label
+    json jFlv = NuiLabel(
+        JsonString("Stara wróżbitka muskała palcami tafle kart..."),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jFlv = NuiHeight(jFlv, fRowH);
+    jFlv = NuiStyleForegroundColor(jFlv, NuiColor(165, 145, 100));
+
+    // Active effects header
+    json jEffHdr = NuiLabel(JsonString("Aktywne pieczęcie losu:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jEffHdr = NuiHeight(jEffHdr, fRowH);
+
+    // No-effects placeholder
+    json jNoEff = NuiLabel(NuiBind(DIV_BIND_NOEFF_LBL),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jNoEff = NuiHeight(jNoEff, fRowH);
+    jNoEff = NuiVisible(jNoEff, NuiBind(DIV_BIND_NOEFF_VIS));
+    jNoEff = NuiStyleForegroundColor(jNoEff, NuiColor(120, 110, 90));
+
+    // Effect list template row
+    json jEffName = NuiLabel(NuiBind(DIV_BIND_EFF_NAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jEffName = NuiStyleForegroundColor(jEffName, NuiBind(DIV_BIND_EFF_COLOR));
+
+    json jEffTime = NuiLabel(NuiBind(DIV_BIND_EFF_TIME),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jEffTime = NuiWidth(jEffTime, GetNuiScaleDimension(oPC, 88.0));
+    jEffTime = NuiStyleForegroundColor(jEffTime, NuiColor(150, 135, 100));
+
+    json jEffRow = JsonArray();
+    jEffRow = JsonArrayInsert(jEffRow, jEffName);
+    jEffRow = JsonArrayInsert(jEffRow, jEffTime);
+    json jEffList = NuiList(NuiRow(jEffRow), NuiBind(DIV_BIND_EFF_LEN), fRowH);
+    jEffList = NuiHeight(jEffList, fListH);
+    jEffList = NuiVisible(jEffList, NuiBind(DIV_BIND_EFFLIST_VIS));
+
+    json jSpc = NuiHeight(NuiSpacer(), fSpcS);
+
+    // Small reading info + button
+    json jSmInfo = NuiLabel(
+        JsonString("Małe Odczytanie (" + IntToString(DIV_SMALL_CARDS) +
+                   " karty) — " + IntToString(DIV_SMALL_COST) + " złota"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jSmInfo = NuiHeight(jSmInfo, fRowH);
+    jSmInfo = NuiStyleForegroundColor(jSmInfo, NuiColor(155, 145, 110));
+
+    json jSmBtn = NuiButton(JsonString("Losuj: Małe Odczytanie"));
+    jSmBtn = NuiId(jSmBtn, DIV_BTN_SMALL);
+    jSmBtn = NuiEnabled(jSmBtn, NuiBind(DIV_BIND_BTN_READ_ENA));
+    jSmBtn = NuiHeight(jSmBtn, fBtnH);
+
+    // Grand reading info + button
+    json jGrInfo = NuiLabel(
+        JsonString("Wielkie Odczytanie (" + IntToString(DIV_GRAND_CARDS) +
+                   " kart) — " + IntToString(DIV_GRAND_COST) + " złota"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jGrInfo = NuiHeight(jGrInfo, fRowH);
+    jGrInfo = NuiStyleForegroundColor(jGrInfo, NuiColor(155, 145, 110));
+
+    json jGrBtn = NuiButton(JsonString("Losuj: Wielkie Odczytanie"));
+    jGrBtn = NuiId(jGrBtn, DIV_BTN_GRAND);
+    jGrBtn = NuiEnabled(jGrBtn, NuiBind(DIV_BIND_BTN_READ_ENA));
+    jGrBtn = NuiHeight(jGrBtn, fBtnH);
+
+    // Cooldown status label
+    json jCdLbl = NuiLabel(NuiBind(DIV_BIND_COOLDOWN_LBL),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jCdLbl = NuiHeight(jCdLbl, fRowH);
+    jCdLbl = NuiStyleForegroundColor(jCdLbl, NuiColor(130, 115, 80));
+
+    // Assemble column
+    json jA = JsonArray();
+    jA = JsonArrayInsert(jA, NuiRow(jTRow));
+    jA = JsonArrayInsert(jA, CreateEmptyRow(oPC, 4.0));
+    jA = JsonArrayInsert(jA, NuiRow(JsonArrayInsert(JsonArray(), jFlv)));
+    jA = JsonArrayInsert(jA, CreateEmptyRow(oPC, 4.0));
+    jA = JsonArrayInsert(jA, NuiRow(JsonArrayInsert(JsonArray(), jEffHdr)));
+    jA = JsonArrayInsert(jA, jNoEff);
+    jA = JsonArrayInsert(jA, jEffList);
+    jA = JsonArrayInsert(jA, jSpc);
+    jA = JsonArrayInsert(jA, NuiRow(JsonArrayInsert(JsonArray(), jSmInfo)));
+    jA = JsonArrayInsert(jA, NuiRow(JsonArrayInsert(JsonArray(), jSmBtn)));
+    jA = JsonArrayInsert(jA, jSpc);
+    jA = JsonArrayInsert(jA, NuiRow(JsonArrayInsert(JsonArray(), jGrInfo)));
+    jA = JsonArrayInsert(jA, NuiRow(JsonArrayInsert(JsonArray(), jGrBtn)));
+    jA = JsonArrayInsert(jA, jSpc);
+    jA = JsonArrayInsert(jA, NuiRow(JsonArrayInsert(JsonArray(), jCdLbl)));
+    jA = JsonArrayInsert(jA, NuiSpacer());
+
+    json jSide = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    float fCW  = GetNuiScaleDimension(oPC, DIV_CONTENT_W);
+    json jMR   = JsonArray();
+    jMR = JsonArrayInsert(jMR, jSide);
+    jMR = JsonArrayInsert(jMR, NuiWidth(NuiCol(jA), fCW));
+    jMR = JsonArrayInsert(jMR, jSide);
+    return NuiRow(jMR);
+}
+
+json BuildDivReadingView(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 32.0);
+    float fRowH  = GetNuiScaleDimension(oPC, 24.0);
+    float fCardW = GetNuiScaleDimension(oPC, DIV_CARD_W);
+    float fCardH = GetNuiScaleDimension(oPC, DIV_CARD_H);
+    float fSpcS  = GetNuiScaleDimension(oPC, 6.0);
+
+    // Title row
+    json jTitle = NuiLabel(NuiBind(DIV_BIND_RD_TITLE),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitle = NuiHeight(jTitle, fBtnH);
+
+    json jClose = NuiButton(JsonString("X"));
+    jClose = NuiId(jClose, DIV_BTN_CLOSE);
+    jClose = NuiWidth(jClose, GetNuiScaleDimension(oPC, 30.0));
+    jClose = NuiHeight(jClose, fBtnH);
+
+    json jTRow = JsonArray();
+    jTRow = JsonArrayInsert(jTRow, jTitle);
+    jTRow = JsonArrayInsert(jTRow, jClose);
+
+    // Instruction label
+    json jInstr = NuiLabel(
+        JsonString("Dotknij karty, by ujawnić jej znaczenie..."),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jInstr = NuiHeight(jInstr, fRowH);
+    jInstr = NuiStyleForegroundColor(jInstr, NuiColor(165, 145, 100));
+
+    // Card slot buttons (always 5, unused ones are hidden)
+    json jCardRow = JsonArray();
+    int i;
+    for(i = 0; i < DIV_MAX_SLOTS; i++)
+    {
+        string sId  = DIV_BTN_CARD + IntToString(i);
+        string sLbl = DIV_BIND_SLOT_LBL + IntToString(i);
+        string sEna = DIV_BIND_SLOT_ENA + IntToString(i);
+        string sCol = DIV_BIND_SLOT_COL + IntToString(i);
+        string sVis = DIV_BIND_SLOT_VIS + IntToString(i);
+        string sTip = DIV_BIND_SLOT_TIP + IntToString(i);
+
+        json jBtn = NuiButton(NuiBind(sLbl));
+        jBtn = NuiId(jBtn, sId);
+        jBtn = NuiEnabled(jBtn, NuiBind(sEna));
+        jBtn = NuiVisible(jBtn, NuiBind(sVis));
+        jBtn = NuiWidth(jBtn, fCardW);
+        jBtn = NuiHeight(jBtn, fCardH);
+        jBtn = NuiTooltip(jBtn, NuiBind(sTip));
+        jBtn = NuiStyleForegroundColor(jBtn, NuiBind(sCol));
+        jCardRow = JsonArrayInsert(jCardRow, jBtn);
+    }
+
+    // Detail panel — shown after first card revealed
+    json jDetName = NuiLabel(NuiBind(DIV_BIND_DETAIL_NAME),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jDetName = NuiHeight(jDetName, GetNuiScaleDimension(oPC, 28.0));
+    jDetName = NuiStyleForegroundColor(jDetName, NuiColor(230, 210, 160));
+
+    json jDetFlv = NuiLabel(NuiBind(DIV_BIND_DETAIL_FLAV),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jDetFlv = NuiHeight(jDetFlv, GetNuiScaleDimension(oPC, 38.0));
+    jDetFlv = NuiStyleForegroundColor(jDetFlv, NuiColor(155, 140, 105));
+
+    json jDetEff = NuiLabel(NuiBind(DIV_BIND_DETAIL_EFF),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jDetEff = NuiHeight(jDetEff, fRowH);
+    jDetEff = NuiStyleForegroundColor(jDetEff, NuiColor(200, 185, 140));
+
+    json jDetPanel = JsonArray();
+    jDetPanel = JsonArrayInsert(jDetPanel, NuiRow(JsonArrayInsert(JsonArray(), jDetName)));
+    jDetPanel = JsonArrayInsert(jDetPanel, NuiRow(JsonArrayInsert(JsonArray(), jDetFlv)));
+    jDetPanel = JsonArrayInsert(jDetPanel, NuiRow(JsonArrayInsert(JsonArray(), jDetEff)));
+    json jDetGrp = NuiGroup(NuiCol(jDetPanel), FALSE, NUI_SCROLLBARS_NONE);
+    jDetGrp = NuiHeight(jDetGrp, GetNuiScaleDimension(oPC, 100.0));
+    jDetGrp = NuiVisible(jDetGrp, NuiBind(DIV_BIND_DETAIL_VIS));
+
+    // Accept / Back buttons
+    json jAccept = NuiButton(JsonString("Przyjmij Los"));
+    jAccept = NuiId(jAccept, DIV_BTN_ACCEPT);
+    jAccept = NuiEnabled(jAccept, NuiBind(DIV_BIND_ACCEPT_ENA));
+    jAccept = NuiHeight(jAccept, fBtnH);
+
+    json jBack = NuiButton(JsonString("Anuluj"));
+    jBack = NuiId(jBack, DIV_BTN_BACK);
+    jBack = NuiHeight(jBack, fBtnH);
+    jBack = NuiWidth(jBack, GetNuiScaleDimension(oPC, 90.0));
+
+    json jBotRow = JsonArray();
+    jBotRow = JsonArrayInsert(jBotRow, jBack);
+    jBotRow = JsonArrayInsert(jBotRow, NuiSpacer());
+    jBotRow = JsonArrayInsert(jBotRow, jAccept);
+
+    // Assemble column
+    json jA = JsonArray();
+    jA = JsonArrayInsert(jA, NuiRow(jTRow));
+    jA = JsonArrayInsert(jA, CreateEmptyRow(oPC, 4.0));
+    jA = JsonArrayInsert(jA, NuiRow(JsonArrayInsert(JsonArray(), jInstr)));
+    jA = JsonArrayInsert(jA, NuiHeight(NuiSpacer(), fSpcS));
+    jA = JsonArrayInsert(jA, NuiRow(jCardRow));
+    jA = JsonArrayInsert(jA, NuiHeight(NuiSpacer(), fSpcS));
+    jA = JsonArrayInsert(jA, jDetGrp);
+    jA = JsonArrayInsert(jA, NuiSpacer());
+    jA = JsonArrayInsert(jA, NuiRow(jBotRow));
+
+    json jSide = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    float fCW  = GetNuiScaleDimension(oPC, DIV_CONTENT_W);
+    json jMR   = JsonArray();
+    jMR = JsonArrayInsert(jMR, jSide);
+    jMR = JsonArrayInsert(jMR, NuiWidth(NuiCol(jA), fCW));
+    jMR = JsonArrayInsert(jMR, jSide);
+    return NuiRow(jMR);
+}
+
+// ================================================================
+// Window lifecycle
+// ================================================================
+
+void DivShowWindow(object oPC)
+{
+    if(NuiFindWindow(oPC, DIV_WINDOW) != 0)
+    {
+        NuiSetGroupLayout(oPC, NuiFindWindow(oPC, DIV_WINDOW),
+            DIV_GRP_SWAP, BuildDivMainView(oPC));
+        DivFeedMain(oPC, NuiFindWindow(oPC, DIV_WINDOW));
+        return;
+    }
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC,
+                    PLAYER_DEVICE_PROPERTY_GUI_WIDTH))
+                - GetNuiScaleDimension(oPC, DIV_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC,
+                    PLAYER_DEVICE_PROPERTY_GUI_HEIGHT))
+                - GetNuiScaleDimension(oPC, DIV_H)) / 2.0;
+    json jGeom = NuiRect(fCX, fCY,
+        GetNuiScaleDimension(oPC, DIV_W),
+        GetNuiScaleDimension(oPC, DIV_H));
+
+    json jSwap = NuiGroup(BuildDivMainView(oPC), FALSE, NUI_SCROLLBARS_NONE);
+    jSwap = NuiId(jSwap, DIV_GRP_SWAP);
+
+    json jRoot = NuiCol(JsonArrayInsert(JsonArray(), jSwap));
+    json jWin  = NuiWindow(jRoot,
+        JsonBool(FALSE),
+        NuiBind(DIV_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    int nToken = NuiCreate(oPC, jWin, DIV_WINDOW, DIV_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, DIV_WIN_GEOM, jGeom);
+    DivFeedMain(oPC, nToken);
+}
+
+// ================================================================
+// Feed functions
+// ================================================================
+
+void DivFeedMain(object oPC, int nToken)
+{
+    json jLive = DivPruneGetActive(oPC);
+    int  nLive = JsonGetLength(jLive);
+    int  nNow  = DivGetNow();
+
+    json jNames  = JsonArray();
+    json jTimes  = JsonArray();
+    json jColors = JsonArray();
+    int i;
+    for(i = 0; i < nLive; i++)
+    {
+        json jE     = JsonArrayGet(jLive, i);
+        int  nId    = JsonGetInt(JsonObjectGet(jE, "card_id"));
+        int  nExpAt = JsonGetInt(JsonObjectGet(jE, "expires_at"));
+        int  nRem   = nExpAt - nNow;
+
+        string sShort = DivCardEffectDesc(nId);
+        // Truncate long descriptions for list display
+        if(GetStringLength(sShort) > 48)
+            sShort = GetStringLeft(sShort, 45) + "...";
+
+        jNames  = JsonArrayInsert(jNames,  JsonString(DivCardName(nId) + " — " + sShort));
+        jTimes  = JsonArrayInsert(jTimes,  JsonString(DivFormatSeconds(nRem)));
+        jColors = JsonArrayInsert(jColors, DivCardColor(nId));
+    }
+
+    NuiSetBind(oPC, nToken, DIV_BIND_EFF_NAME,    jNames);
+    NuiSetBind(oPC, nToken, DIV_BIND_EFF_TIME,    jTimes);
+    NuiSetBind(oPC, nToken, DIV_BIND_EFF_COLOR,   jColors);
+    NuiSetBind(oPC, nToken, DIV_BIND_EFF_LEN,     JsonInt(nLive));
+    NuiSetBind(oPC, nToken, DIV_BIND_EFFLIST_VIS, JsonBool(nLive > 0));
+    NuiSetBind(oPC, nToken, DIV_BIND_NOEFF_VIS,   JsonBool(nLive == 0));
+    NuiSetBind(oPC, nToken, DIV_BIND_NOEFF_LBL,
+        JsonString("— żadnych aktywnych pieczęci —"));
+
+    int nCdSec = DivGetSecondsUntilRead(oPC);
+    int bCanRead = (nCdSec == 0);
+    NuiSetBind(oPC, nToken, DIV_BIND_BTN_READ_ENA, JsonBool(bCanRead));
+    NuiSetBind(oPC, nToken, DIV_BIND_COOLDOWN_LBL,
+        JsonString(bCanRead
+            ? "Wróżbitka jest gotowa przyjąć cię."
+            : "Następne odczytanie za: " + DivFormatSeconds(nCdSec)));
+}
+
+void DivFeedCards(object oPC, int nToken)
+{
+    json jCards  = GetLocalJson(oPC, DIV_LVAR_CARDS);
+    int  nCnt    = GetLocalInt(oPC, DIV_LVAR_CARDCNT);
+    int  nMask   = GetLocalInt(oPC, DIV_LVAR_REVEALED);
+    int  nLast   = GetLocalInt(oPC, DIV_LVAR_LASTCARD);
+    int  nRevealed = 0;
+    int  i;
+
+    for(i = 0; i < nCnt; i++)
+        if(nMask & (1 << i)) nRevealed++;
+
+    int bAll = (nRevealed == nCnt);
+
+    for(i = 0; i < DIV_MAX_SLOTS; i++)
+    {
+        string sLbl = DIV_BIND_SLOT_LBL + IntToString(i);
+        string sEna = DIV_BIND_SLOT_ENA + IntToString(i);
+        string sCol = DIV_BIND_SLOT_COL + IntToString(i);
+        string sVis = DIV_BIND_SLOT_VIS + IntToString(i);
+        string sTip = DIV_BIND_SLOT_TIP + IntToString(i);
+
+        int bInUse    = (i < nCnt);
+        int bRevealed = bInUse && (nMask & (1 << i));
+
+        NuiSetBind(oPC, nToken, sVis, JsonBool(bInUse));
+
+        if(!bInUse)
+        {
+            NuiSetBind(oPC, nToken, sLbl, JsonString(""));
+            NuiSetBind(oPC, nToken, sEna, JsonBool(FALSE));
+            NuiSetBind(oPC, nToken, sCol, NuiColor(80, 80, 80));
+            NuiSetBind(oPC, nToken, sTip, JsonString(""));
+            continue;
+        }
+
+        if(bRevealed)
+        {
+            int nId = JsonGetInt(JsonArrayGet(jCards, i));
+            NuiSetBind(oPC, nToken, sLbl, JsonString(DivCardName(nId)));
+            NuiSetBind(oPC, nToken, sEna, JsonBool(FALSE));
+            NuiSetBind(oPC, nToken, sCol, DivCardColor(nId));
+            NuiSetBind(oPC, nToken, sTip, JsonString(DivCardEffectDesc(nId)));
+        }
+        else
+        {
+            NuiSetBind(oPC, nToken, sLbl, JsonString("?"));
+            NuiSetBind(oPC, nToken, sEna, JsonBool(TRUE));
+            NuiSetBind(oPC, nToken, sCol, NuiColor(140, 120, 80));
+            NuiSetBind(oPC, nToken, sTip, JsonString("Kliknij, by ujawnić kartę."));
+        }
+    }
+
+    // Detail panel for last revealed card
+    int bShowDetail = (nRevealed > 0);
+    NuiSetBind(oPC, nToken, DIV_BIND_DETAIL_VIS, JsonBool(bShowDetail));
+    if(bShowDetail)
+    {
+        NuiSetBind(oPC, nToken, DIV_BIND_DETAIL_NAME,
+            JsonString("— " + DivCardName(nLast) + " —"));
+        NuiSetBind(oPC, nToken, DIV_BIND_DETAIL_FLAV,
+            JsonString(DivCardFlavor(nLast)));
+        NuiSetBind(oPC, nToken, DIV_BIND_DETAIL_EFF,
+            JsonString(DivCardEffectDesc(nLast)));
+    }
+    else
+    {
+        NuiSetBind(oPC, nToken, DIV_BIND_DETAIL_NAME, JsonString(""));
+        NuiSetBind(oPC, nToken, DIV_BIND_DETAIL_FLAV, JsonString(""));
+        NuiSetBind(oPC, nToken, DIV_BIND_DETAIL_EFF,  JsonString(""));
+    }
+
+    NuiSetBind(oPC, nToken, DIV_BIND_ACCEPT_ENA, JsonBool(bAll));
+}
+
+// ================================================================
+// Reading flow
+// ================================================================
+
+void DivStartReading(object oPC, int nToken, int nCardCount)
+{
+    int nCost = (nCardCount == DIV_SMALL_CARDS) ? DIV_SMALL_COST : DIV_GRAND_COST;
+
+    if(!DivCanRead(oPC))
+    {
+        SendMessageToPC(oPC,
+            "[Wróżbiarstwo] Karty pamiętają jeszcze poprzednie odczytanie.");
+        return;
+    }
+    if(GetGold(oPC) < nCost)
+    {
+        SendMessageToPC(oPC,
+            "[Wróżbiarstwo] Nie masz " + IntToString(nCost) + " złota.");
+        return;
+    }
+
+    AssignCommand(oPC, TakeGoldFromCreature(nCost, oPC, TRUE));
+
+    SetLocalInt(oPC, DIV_LVAR_CARDCNT,  nCardCount);
+    SetLocalInt(oPC, DIV_LVAR_REVEALED, 0);
+    SetLocalInt(oPC, DIV_LVAR_LASTCARD, -1);
+    DivDrawCards(oPC, nCardCount);
+
+    string sTitle = (nCardCount == DIV_SMALL_CARDS)
+        ? "Małe Odczytanie — Ujawnij karty"
+        : "Wielkie Odczytanie — Ujawnij karty";
+
+    NuiSetGroupLayout(oPC, nToken, DIV_GRP_SWAP, BuildDivReadingView(oPC));
+    NuiSetBind(oPC, nToken, DIV_BIND_RD_TITLE, JsonString(sTitle));
+    NuiSetBind(oPC, nToken, DIV_BIND_DETAIL_VIS, JsonBool(FALSE));
+    DivFeedCards(oPC, nToken);
+}
+
+void DivRevealCard(object oPC, int nToken, int nSlot)
+{
+    int nCnt  = GetLocalInt(oPC, DIV_LVAR_CARDCNT);
+    if(nSlot < 0 || nSlot >= nCnt) return;
+
+    int nMask = GetLocalInt(oPC, DIV_LVAR_REVEALED);
+    if(nMask & (1 << nSlot)) return;  // already revealed
+
+    nMask |= (1 << nSlot);
+    SetLocalInt(oPC, DIV_LVAR_REVEALED, nMask);
+
+    json jCards = GetLocalJson(oPC, DIV_LVAR_CARDS);
+    int  nId    = JsonGetInt(JsonArrayGet(jCards, nSlot));
+    SetLocalInt(oPC, DIV_LVAR_LASTCARD, nId);
+
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectVisualEffect(VFX_IMP_PULSE_WIND), oPC);
+    DivFeedCards(oPC, nToken);
+}
+
+void DivAcceptFate(object oPC, int nToken)
+{
+    json jCards = GetLocalJson(oPC, DIV_LVAR_CARDS);
+    int  nCnt   = GetLocalInt(oPC, DIV_LVAR_CARDCNT);
+    int  nMask  = GetLocalInt(oPC, DIV_LVAR_REVEALED);
+
+    int i;
+    for(i = 0; i < nCnt; i++)
+    {
+        if(!(nMask & (1 << i))) continue;
+        int nId = JsonGetInt(JsonArrayGet(jCards, i));
+        DivApplySingleCardEffect(oPC, nId);
+        DivAddActiveEffect(oPC, nId);
+    }
+
+    DivSetLastReadingAt(oPC, DivGetNow());
+
+    DeleteLocalJson(oPC, DIV_LVAR_CARDS);
+    DeleteLocalInt(oPC, DIV_LVAR_REVEALED);
+    DeleteLocalInt(oPC, DIV_LVAR_CARDCNT);
+    DeleteLocalInt(oPC, DIV_LVAR_LASTCARD);
+
+    NuiSetGroupLayout(oPC, nToken, DIV_GRP_SWAP, BuildDivMainView(oPC));
+    DivFeedMain(oPC, nToken);
+    SendMessageToPC(oPC, "[Wróżbiarstwo] Pieczęcie losu zostały odciśnięte.");
+}
+
+void DivCancelReading(object oPC, int nToken)
+{
+    // Gold already spent; no refund — fate does not reverse.
+    DeleteLocalJson(oPC, DIV_LVAR_CARDS);
+    DeleteLocalInt(oPC, DIV_LVAR_REVEALED);
+    DeleteLocalInt(oPC, DIV_LVAR_CARDCNT);
+    DeleteLocalInt(oPC, DIV_LVAR_LASTCARD);
+
+    NuiSetGroupLayout(oPC, nToken, DIV_GRP_SWAP, BuildDivMainView(oPC));
+    DivFeedMain(oPC, nToken);
+}

--- a/Divination/Scripts/lib_div_def.nss
+++ b/Divination/Scripts/lib_div_def.nss
@@ -1,0 +1,304 @@
+#include "lib_nui"
+#include "sql_div"
+
+// Forward declarations
+void DivShowWindow(object oPC);
+void DivFeedMain(object oPC, int nToken);
+void DivFeedCards(object oPC, int nToken);
+void DivStartReading(object oPC, int nToken, int nCardCount);
+void DivRevealCard(object oPC, int nToken, int nSlot);
+void DivAcceptFate(object oPC, int nToken);
+void DivRemoveAllDivEffects(object oPC);
+void DivRemoveNegativeDivEffects(object oPC);
+void DivReapplyPersistentEffects(object oPC);
+
+// ----------------------------------------------------------------
+// Window & group IDs
+// ----------------------------------------------------------------
+
+const string DIV_WINDOW      = "DIV_WIN";
+const string DIV_EV_SCRIPT   = "lib_div_ev";
+const string DIV_WIN_GEOM    = "div_win_geom";
+const string DIV_GRP_SWAP    = "div_grp_swap";
+
+// ----------------------------------------------------------------
+// Main view bind names
+// ----------------------------------------------------------------
+
+const string DIV_BIND_EFF_NAME      = "div_eff_name";
+const string DIV_BIND_EFF_TIME      = "div_eff_time";
+const string DIV_BIND_EFF_COLOR     = "div_eff_color";
+const string DIV_BIND_EFF_LEN       = "div_eff_len";
+const string DIV_BIND_EFFLIST_VIS   = "div_efflist_vis";
+const string DIV_BIND_NOEFF_LBL     = "div_noeff_lbl";
+const string DIV_BIND_NOEFF_VIS     = "div_noeff_vis";
+const string DIV_BIND_BTN_READ_ENA  = "div_read_ena";
+const string DIV_BIND_COOLDOWN_LBL  = "div_cd_lbl";
+
+// ----------------------------------------------------------------
+// Reading view bind names
+// ----------------------------------------------------------------
+
+// Per-slot (append IntToString(i), i=0..4)
+const string DIV_BIND_SLOT_LBL  = "div_slot_lbl_";
+const string DIV_BIND_SLOT_ENA  = "div_slot_ena_";
+const string DIV_BIND_SLOT_COL  = "div_slot_col_";
+const string DIV_BIND_SLOT_VIS  = "div_slot_vis_";
+const string DIV_BIND_SLOT_TIP  = "div_slot_tip_";
+
+const string DIV_BIND_DETAIL_VIS  = "div_det_vis";
+const string DIV_BIND_DETAIL_NAME = "div_det_name";
+const string DIV_BIND_DETAIL_FLAV = "div_det_flav";
+const string DIV_BIND_DETAIL_EFF  = "div_det_eff";
+const string DIV_BIND_ACCEPT_ENA  = "div_accept_ena";
+const string DIV_BIND_RD_TITLE    = "div_rd_title";
+
+// ----------------------------------------------------------------
+// Button IDs
+// ----------------------------------------------------------------
+
+const string DIV_BTN_CLOSE  = "div_close";
+const string DIV_BTN_SMALL  = "div_small";
+const string DIV_BTN_GRAND  = "div_grand";
+const string DIV_BTN_CARD   = "div_card_";   // + IntToString(i)
+const string DIV_BTN_ACCEPT = "div_accept";
+const string DIV_BTN_BACK   = "div_back";
+
+// ----------------------------------------------------------------
+// LVARs on PC (session-only, cleared on leave)
+// ----------------------------------------------------------------
+
+const string DIV_LVAR_CARDS    = "DIV_CARDS";
+const string DIV_LVAR_REVEALED = "DIV_REVEALED";   // int bitmask
+const string DIV_LVAR_CARDCNT  = "DIV_CARD_COUNT";
+const string DIV_LVAR_LASTCARD = "DIV_LAST_CARD";
+
+// ----------------------------------------------------------------
+// Game constants
+// ----------------------------------------------------------------
+
+const int   DIV_SMALL_CARDS  = 3;
+const int   DIV_GRAND_CARDS  = 5;
+const int   DIV_MAX_SLOTS    = 5;
+const int   DIV_SMALL_COST   = 50;
+const int   DIV_GRAND_COST   = 150;
+const int   DIV_COOLDOWN_S   = 86400;  // 24h real time
+const int   DIV_DUR_LONG_S   = 14400; // 4h default effect duration
+const int   DIV_DUR_MED_S    = 7200;  // 2h
+const int   DIV_DUR_SHORT_S  = 3600;  // 1h
+
+// ----------------------------------------------------------------
+// Card IDs (Major Arcana, dark fantasy flavoured)
+// ----------------------------------------------------------------
+
+const int   DIV_CARD_FOOL       = 0;
+const int   DIV_CARD_MAGICIAN   = 1;
+const int   DIV_CARD_PRIESTESS  = 2;
+const int   DIV_CARD_EMPRESS    = 3;
+const int   DIV_CARD_EMPEROR    = 4;
+const int   DIV_CARD_HIEROPHANT = 5;
+const int   DIV_CARD_LOVERS     = 6;
+const int   DIV_CARD_CHARIOT    = 7;
+const int   DIV_CARD_STRENGTH   = 8;
+const int   DIV_CARD_HERMIT     = 9;
+const int   DIV_CARD_WHEEL      = 10;
+const int   DIV_CARD_JUSTICE    = 11;
+const int   DIV_CARD_HANGED     = 12;
+const int   DIV_CARD_DEATH      = 13;
+const int   DIV_CARD_TEMPERANCE = 14;
+const int   DIV_CARD_DEVIL      = 15;
+const int   DIV_CARD_TOWER      = 16;
+const int   DIV_CARD_STAR       = 17;
+const int   DIV_CARD_MOON       = 18;
+const int   DIV_CARD_SUN        = 19;
+const int   DIV_CARD_JUDGEMENT  = 20;
+const int   DIV_CARD_WORLD      = 21;
+const int   DIV_CARD_COUNT      = 22;
+
+// ----------------------------------------------------------------
+// Layout
+// ----------------------------------------------------------------
+
+const float DIV_W          = 500.0;
+const float DIV_H          = 640.0;
+const float DIV_CONTENT_W  = 460.0;
+const float DIV_CARD_W     = 76.0;
+const float DIV_CARD_H     = 106.0;
+
+// ================================================================
+// Card data accessors
+// ================================================================
+
+string DivCardName(int n)
+{
+    switch(n)
+    {
+        case DIV_CARD_FOOL:       return "Głupiec";
+        case DIV_CARD_MAGICIAN:   return "Mag";
+        case DIV_CARD_PRIESTESS:  return "Kapłanka";
+        case DIV_CARD_EMPRESS:    return "Cesarzowa";
+        case DIV_CARD_EMPEROR:    return "Cesarz";
+        case DIV_CARD_HIEROPHANT: return "Kapłan";
+        case DIV_CARD_LOVERS:     return "Kochankowie";
+        case DIV_CARD_CHARIOT:    return "Rydwan";
+        case DIV_CARD_STRENGTH:   return "Siła";
+        case DIV_CARD_HERMIT:     return "Pustelnik";
+        case DIV_CARD_WHEEL:      return "Koło Fortuny";
+        case DIV_CARD_JUSTICE:    return "Sprawiedliwość";
+        case DIV_CARD_HANGED:     return "Wisielec";
+        case DIV_CARD_DEATH:      return "Śmierć";
+        case DIV_CARD_TEMPERANCE: return "Umiarkowanie";
+        case DIV_CARD_DEVIL:      return "Diabeł";
+        case DIV_CARD_TOWER:      return "Wieża";
+        case DIV_CARD_STAR:       return "Gwiazda";
+        case DIV_CARD_MOON:       return "Księżyc";
+        case DIV_CARD_SUN:        return "Słońce";
+        case DIV_CARD_JUDGEMENT:  return "Sąd Ostateczny";
+        case DIV_CARD_WORLD:      return "Świat";
+    }
+    return "?";
+}
+
+string DivCardFlavor(int n)
+{
+    switch(n)
+    {
+        case DIV_CARD_FOOL:
+            return "\"Brak mądrości chroni przez chwilę... lecz przepaść nie czeka.\"";
+        case DIV_CARD_MAGICIAN:
+            return "\"Wiedza to narzędzie. Jak każde narzędzie — ma dwa końce.\"";
+        case DIV_CARD_PRIESTESS:
+            return "\"Tajemnica przemawia ciszą. Słuchaj, nim ciemność wróci.\"";
+        case DIV_CARD_EMPRESS:
+            return "\"Z ziemi rodzi się siła. Z bólu rodzi się mądrość.\"";
+        case DIV_CARD_EMPEROR:
+            return "\"Władza to ciężar. Niosą go wyłącznie silni.\"";
+        case DIV_CARD_HIEROPHANT:
+            return "\"Tradycja jest łańcuchem — ocal siebie lub zakuj innych.\"";
+        case DIV_CARD_LOVERS:
+            return "\"Miłość i zdrada — dwie strony tej samej monety.\"";
+        case DIV_CARD_CHARIOT:
+            return "\"Prędkość jest jedynym ratunkiem, gdy mury runęły.\"";
+        case DIV_CARD_STRENGTH:
+            return "\"Mięśnie nie kłamią. Żelazo też nie.\"";
+        case DIV_CARD_HERMIT:
+            return "\"Samotność uczy rzeczy, których tłum nigdy nie pojmie.\"";
+        case DIV_CARD_WHEEL:
+            return "\"Fortuna kręci kołem bez litości. Dziś dar, jutro kara.\"";
+        case DIV_CARD_JUSTICE:
+            return "\"Sprawiedliwość nie ma oczu, lecz ma dłonie.\"";
+        case DIV_CARD_HANGED:
+            return "\"Zawieszony między dwiema prawdami — żadnej nie znasz.\"";
+        case DIV_CARD_DEATH:
+            return "\"Śmierć nie pyta o gotowość. Po prostu przychodzi.\"";
+        case DIV_CARD_TEMPERANCE:
+            return "\"Cnota czyści skazę. Lecz ile warte jest oczyszczenie?\"";
+        case DIV_CARD_DEVIL:
+            return "\"Strach jest łańcuchem — ty go więżesz lub nosisz sam.\"";
+        case DIV_CARD_TOWER:
+            return "\"Ruiny są dowodem tego, co mogło być wzniosłe.\"";
+        case DIV_CARD_STAR:
+            return "\"Gwiazdy pamiętają to, co świat zdążył zapomnieć.\"";
+        case DIV_CARD_MOON:
+            return "\"Księżyc skrywa to, co dzień ujawnia blaskiem stali.\"";
+        case DIV_CARD_SUN:
+            return "\"Łaska Słońca jest rzadka i oślepiająca jak wyrok.\"";
+        case DIV_CARD_JUDGEMENT:
+            return "\"Przeznaczenie jeszcze nie skończyło z tobą.\"";
+        case DIV_CARD_WORLD:
+            return "\"Ciężar świata — nagroda dla tych, którzy przeżyli.\"";
+    }
+    return "";
+}
+
+string DivCardEffectDesc(int n)
+{
+    switch(n)
+    {
+        case DIV_CARD_FOOL:
+            return "KLĄTWA: -1 do trafień, -1 do KP (4 godz.)";
+        case DIV_CARD_MAGICIAN:
+            return "+1 do trafień, +1 do wszystkich rzutów obronnych (4 godz.)";
+        case DIV_CARD_PRIESTESS:
+            return "Natychmiast regeneruje 20% maksimum PŻ.";
+        case DIV_CARD_EMPRESS:
+            return "+2 do Budowy (4 godz.)";
+        case DIV_CARD_EMPEROR:
+            return "+2 do Siły (4 godz.)";
+        case DIV_CARD_HIEROPHANT:
+            return "+2 do rzutów Wolą (4 godz.)";
+        case DIV_CARD_LOVERS:
+            return "+2 do Charyzmy (4 godz.)";
+        case DIV_CARD_CHARIOT:
+            return "+2 do rzutów Refleksem (4 godz.)";
+        case DIV_CARD_STRENGTH:
+            return "+1 do trafień i +1 do obrażeń (4 godz.)";
+        case DIV_CARD_HERMIT:
+            return "+4 do Skradania i Ukrywania, Nadwzroczność (4 godz.)";
+        case DIV_CARD_WHEEL:
+            return "Natychmiastowy los: złoto, kara lub nicość.";
+        case DIV_CARD_JUSTICE:
+            return "+2 do Dyscypliny i Perswazji (4 godz.)";
+        case DIV_CARD_HANGED:
+            return "KLĄTWA: -1 do trafień, -1 do wszystkich rzutów (4 godz.)";
+        case DIV_CARD_DEATH:
+            return "KLĄTWA: ogłuszenie 3s, -2 do Budowy (4 godz.)";
+        case DIV_CARD_TEMPERANCE:
+            return "Usuwa pieczęcie klątw. +2 do KP (2 godz.)";
+        case DIV_CARD_DEVIL:
+            return "+4 do Zastraszania, -2 do Charyzmy (4 godz.)";
+        case DIV_CARD_TOWER:
+            return "KLĄTWA: natychmiastowe 3k8 obrażeń magicznych.";
+        case DIV_CARD_STAR:
+            return "Natychmiast 40% PŻ + regeneracja 2 PŻ/6s (2 godz.)";
+        case DIV_CARD_MOON:
+            return "Widzenie Niewidzialnych (2 godz.), -1 do trafień (2 godz.)";
+        case DIV_CARD_SUN:
+            return "+2 do WSZYSTKICH cech (1 godz.)";
+        case DIV_CARD_JUDGEMENT:
+            return "+2 do wszystkich rzutów, Odporność na Strach (4 godz.)";
+        case DIV_CARD_WORLD:
+            return "+1 do WSZYSTKICH cech (4 godz.)";
+    }
+    return "";
+}
+
+int DivCardIsNegative(int n)
+{
+    return (n == DIV_CARD_FOOL  || n == DIV_CARD_HANGED  ||
+            n == DIV_CARD_DEATH || n == DIV_CARD_TOWER   ||
+            n == DIV_CARD_WHEEL);
+}
+
+// Returns FALSE for instant-only cards that need no SQL entry.
+int DivCardIsPersistent(int n)
+{
+    return (n != DIV_CARD_PRIESTESS &&
+            n != DIV_CARD_WHEEL     &&
+            n != DIV_CARD_TOWER     &&
+            n != DIV_CARD_TEMPERANCE);
+}
+
+int DivCardDurationS(int n)
+{
+    if(n == DIV_CARD_SUN)        return DIV_DUR_SHORT_S;
+    if(n == DIV_CARD_MOON)       return DIV_DUR_MED_S;
+    if(n == DIV_CARD_STAR)       return DIV_DUR_MED_S;
+    if(n == DIV_CARD_TEMPERANCE) return DIV_DUR_MED_S;
+    return DIV_DUR_LONG_S;
+}
+
+json DivCardColor(int n)
+{
+    if(DivCardIsNegative(n))
+        return NuiColor(210, 80, 80);
+    switch(n)
+    {
+        case DIV_CARD_PRIESTESS:
+        case DIV_CARD_STAR:      return NuiColor(100, 200, 150);
+        case DIV_CARD_SUN:       return NuiColor(255, 215, 70);
+        case DIV_CARD_MOON:      return NuiColor(150, 185, 225);
+        case DIV_CARD_TEMPERANCE:return NuiColor(120, 200, 200);
+    }
+    return NuiColor(185, 165, 120);
+}

--- a/Divination/Scripts/lib_div_ev.nss
+++ b/Divination/Scripts/lib_div_ev.nss
@@ -1,0 +1,76 @@
+#include "lib_div"
+
+// Main NUI event handler — set as nUI event script in DivShowWindow.
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+
+    if(nToken != NuiFindWindow(oPC, DIV_WINDOW)) return;
+
+    // ---- Window closed by chrome X ----
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        // If reading was in progress and not accepted, refund is not given
+        // but we clean up session state.
+        DeleteLocalJson(oPC, DIV_LVAR_CARDS);
+        DeleteLocalInt(oPC, DIV_LVAR_REVEALED);
+        DeleteLocalInt(oPC, DIV_LVAR_CARDCNT);
+        DeleteLocalInt(oPC, DIV_LVAR_LASTCARD);
+        return;
+    }
+
+    if(sEvent != EVENT_TYPE_CLICK) return;
+
+    // ---- Close button ----
+    if(sElem == DIV_BTN_CLOSE)
+    {
+        DeleteLocalJson(oPC, DIV_LVAR_CARDS);
+        DeleteLocalInt(oPC, DIV_LVAR_REVEALED);
+        DeleteLocalInt(oPC, DIV_LVAR_CARDCNT);
+        DeleteLocalInt(oPC, DIV_LVAR_LASTCARD);
+        NuiDestroy(oPC, nToken);
+        return;
+    }
+
+    // ---- Main view: small reading ----
+    if(sElem == DIV_BTN_SMALL)
+    {
+        DivStartReading(oPC, nToken, DIV_SMALL_CARDS);
+        return;
+    }
+
+    // ---- Main view: grand reading ----
+    if(sElem == DIV_BTN_GRAND)
+    {
+        DivStartReading(oPC, nToken, DIV_GRAND_CARDS);
+        return;
+    }
+
+    // ---- Reading view: card slot clicked ----
+    int bCardPrefix = (GetStringLeft(sElem, GetStringLength(DIV_BTN_CARD))
+                       == DIV_BTN_CARD);
+    if(bCardPrefix)
+    {
+        int nSlot = StringToInt(GetStringRight(sElem,
+            GetStringLength(sElem) - GetStringLength(DIV_BTN_CARD)));
+        DivRevealCard(oPC, nToken, nSlot);
+        return;
+    }
+
+    // ---- Reading view: accept fate ----
+    if(sElem == DIV_BTN_ACCEPT)
+    {
+        DivAcceptFate(oPC, nToken);
+        return;
+    }
+
+    // ---- Reading view: cancel / back ----
+    if(sElem == DIV_BTN_BACK)
+    {
+        DivCancelReading(oPC, nToken);
+        return;
+    }
+}

--- a/Divination/Scripts/lib_nui.nss
+++ b/Divination/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Divination/Scripts/lib_nui_utility.nss
+++ b/Divination/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Divination/Scripts/sql_div.nss
+++ b/Divination/Scripts/sql_div.nss
@@ -1,0 +1,70 @@
+// Divination - persistence (campaign DB "divination")
+
+const string DIV_DB = "divination";
+
+void DivInitTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign(DIV_DB,
+        "CREATE TABLE IF NOT EXISTS div_players ("
+        + "uuid TEXT PRIMARY KEY, "
+        + "char_name TEXT DEFAULT '', "
+        + "last_reading_at INTEGER DEFAULT 0, "
+        + "effects_json TEXT DEFAULT '[]', "
+        + "total_readings INTEGER DEFAULT 0)");
+    SqlStep(q);
+}
+
+int DivGetNow()
+{
+    sqlquery q = SqlPrepareQueryCampaign(DIV_DB,
+        "SELECT CAST(strftime('%s','now') AS INTEGER)");
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+void DivEnsureRow(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign(DIV_DB,
+        "INSERT OR IGNORE INTO div_players (uuid, char_name) VALUES (@u, @n)");
+    SqlBindString(q, "@u", GetObjectUUID(oPC));
+    SqlBindString(q, "@n", GetName(oPC));
+    SqlStep(q);
+}
+
+int DivGetLastReadingAt(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign(DIV_DB,
+        "SELECT last_reading_at FROM div_players WHERE uuid = @u");
+    SqlBindString(q, "@u", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+void DivSetLastReadingAt(object oPC, int nNow)
+{
+    sqlquery q = SqlPrepareQueryCampaign(DIV_DB,
+        "UPDATE div_players "
+        + "SET last_reading_at = @t, total_readings = total_readings + 1 "
+        + "WHERE uuid = @u");
+    SqlBindInt   (q, "@t", nNow);
+    SqlBindString(q, "@u", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+string DivGetEffectsJson(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign(DIV_DB,
+        "SELECT effects_json FROM div_players WHERE uuid = @u");
+    SqlBindString(q, "@u", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetString(q, 0);
+    return "[]";
+}
+
+void DivSetEffectsJson(object oPC, string sJson)
+{
+    sqlquery q = SqlPrepareQueryCampaign(DIV_DB,
+        "UPDATE div_players SET effects_json = @j WHERE uuid = @u");
+    SqlBindString(q, "@j", sJson);
+    SqlBindString(q, "@u", GetObjectUUID(oPC));
+    SqlStep(q);
+}

--- a/Divination/Scripts/sys_on_enter.nss
+++ b/Divination/Scripts/sys_on_enter.nss
@@ -1,0 +1,12 @@
+#include "lib_div"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC) || GetIsDMPossessed(oPC)) return;
+
+    DivEnsureRow(oPC);
+    // Remove any stale DIV_ effects from the saved .bic, then reapply
+    // whatever is still live in the DB — this is the single source of truth.
+    DivReapplyPersistentEffects(oPC);
+}

--- a/Divination/Scripts/sys_on_leave.nss
+++ b/Divination/Scripts/sys_on_leave.nss
@@ -1,0 +1,13 @@
+#include "lib_div_def"
+
+void main()
+{
+    object oPC = GetExitingObject();
+    if(!GetIsPC(oPC)) return;
+
+    // Clean session-only LVARs; SQL state survives for reapply on next enter.
+    DeleteLocalJson(oPC, DIV_LVAR_CARDS);
+    DeleteLocalInt(oPC, DIV_LVAR_REVEALED);
+    DeleteLocalInt(oPC, DIV_LVAR_CARDCNT);
+    DeleteLocalInt(oPC, DIV_LVAR_LASTCARD);
+}

--- a/Divination/Scripts/sys_on_load.nss
+++ b/Divination/Scripts/sys_on_load.nss
@@ -1,0 +1,6 @@
+#include "sql_div"
+
+void main()
+{
+    DivInitTables();
+}

--- a/Divination/Scripts/test_div.nss
+++ b/Divination/Scripts/test_div.nss
@@ -1,0 +1,11 @@
+#include "lib_div"
+
+// OnUsed on a placeable (e.g. "Stolik Wróżbitki") — opens the Divination window.
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    DivEnsureRow(oPC);
+    DivShowWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

Moduł **Wróżbiarstwo** pozwala graczowi interaktywnie losować Karty Losu u mistycznej wróżbitki. Każda karta nakłada na postać mechaniczny efekt (bonus lub kara) trwający od 1 do 4 godzin, zapisywany w SQLite i odnawiany automatycznie po zalogowaniu.

## Mechanika

- Gracz używa placeabla „Stolik Wróżbitki" (skrypt `test_div`) — otwiera się okno NUI.
- Do wyboru: **Małe Odczytanie** (3 karty, 50 złota) lub **Wielkie Odczytanie** (5 kart, 150 złota).
- Karty leżą zakryte; gracz klika każdą, by ją odkryć i zobaczyć efekt.
- Po odsłonięciu wszystkich kart aktywuje się przycisk **Przyjmij Los** — efekty zostają zastosowane.
- **Anuluj** cofa do widoku głównego, ale złoto przepada (los nie cofa się).
- Cooldown: **jedno odczytanie na 24h** realnego czasu, wspólny dla obu rodzajów.
- Karta **Umiarkowanie** czyści wszystkie aktywne negatywne pieczęcie + daje +2 KP.
- Aktywne pieczęcie widoczne w widoku głównym okna (nazwa, opis, czas do wygaśnięcia).

### Karty (22 z Wielkich Arkanów):

| Karta | Efekt | Czas |
|---|---|---|
| Głupiec | KLĄTWA: -1 trafień, -1 KP | 4h |
| Mag | +1 trafień, +1 wszystkie rzuty | 4h |
| Kapłanka | Leczy 20% max PŻ (chwilowe) | instant |
| Cesarzowa | +2 Budowa | 4h |
| Cesarz | +2 Siła | 4h |
| Kapłan | +2 rzuty Wolą | 4h |
| Kochankowie | +2 Charyzma | 4h |
| Rydwan | +2 rzuty Refleksem | 4h |
| Siła | +1 trafień, +1 obrażeń | 4h |
| Pustelnik | +4 Skradanie/Ukrywanie, Nadwzroczność | 4h |
| Koło Fortuny | Losowo: +100 złota / -75 złota / nic | instant |
| Sprawiedliwość | +2 Dyscyplina, +2 Perswazja | 4h |
| Wisielec | KLĄTWA: -1 trafień, -1 wszystkie rzuty | 4h |
| Śmierć | KLĄTWA: ogłuszenie 3s, -2 Budowa | 4h |
| Umiarkowanie | Usuwa klątwy, +2 KP | 2h |
| Diabeł | +4 Zastraszanie, -2 Charyzma | 4h |
| Wieża | KLĄTWA: 3k8 obrażeń magicznych | instant |
| Gwiazda | Leczy 40% max PŻ, +2 regeneracja/6s | 2h |
| Księżyc | Widzenie Niewidzialnych, -1 trafień | 2h |
| Słońce | +2 do WSZYSTKICH cech | 1h |
| Sąd Ostateczny | +2 wszystkie rzuty, odporność na Strach | 4h |
| Świat | +1 do WSZYSTKICH cech | 4h |

## Pliki

```
Divination/Scripts/sql_div.nss          — schemat SQLite + helpery
Divination/Scripts/lib_div_def.nss      — stałe, ID bindów, dane 22 kart
Divination/Scripts/lib_div.nss          — rdzeń: NUI, logika efektów, flow
Divination/Scripts/lib_div_ev.nss       — handler NUI eventów
Divination/Scripts/sys_on_load.nss      — init tabeli
Divination/Scripts/sys_on_enter.nss     — ensure row + reapply efektów
Divination/Scripts/sys_on_leave.nss     — czyszczenie LVARów sesji
Divination/Scripts/test_div.nss         — OnUsed na placeablu demo
Divination/INTEGRATION.md              — instrukcja integracji
```

## Zależności (NWNX? SQL?)

- **Brak NWNX** — wyłącznie czysty NWScript + NUI.
- **SQLite** (wbudowany w NWN EE): kampania `"divination"`, tabela `div_players`.
- **NWN EE ≥ 8193.14** — wymagane dla `TagEffect` / `GetEffectTag`.

## Jak włączyć w istniejącym module

1. Skopiuj wszystkie pliki z `Divination/Scripts/` do hak lub folderu skryptów modułu.
2. Podepnij hooki:
   - `OnModuleLoad` → `sys_on_load` (lub wywołaj `DivInitTables()`)
   - `OnClientEnter` → `sys_on_enter` (lub wywołaj `DivEnsureRow` + `DivReapplyPersistentEffects`)
   - `OnClientLeave` → `sys_on_leave` (lub posprzątaj LVARy)
3. Umieść placeable i ustaw jego `OnUsed` na `test_div`.
4. Szczegóły w `INTEGRATION.md`.

## Co celowo pominięto

- **Grafiki kart** — brak pliku .hak; nazwy + kolory wystarczają dla klimatu
- **Animacje** — NUI nie wspiera tweening bez NWNX
- **Plik .mod** — środowisko nie pozwala spakować .mod; zamiast tego INTEGRATION.md
- **Integracja z innymi modułami** (Pantheon, Alchemy) — każdy moduł jest samodzielny

---
_Generated by [Claude Code](https://claude.ai/code/session_017Sa676g4qS1sdWnBSrmNn7)_