### PR TITLE
feat: System Reputacji Frakcji

### DIFF
--- a/Faction Reputation/INTEGRATION.md
+++ b/Faction Reputation/INTEGRATION.md
@@ -1,0 +1,125 @@
+# Faction Reputation — Integration Guide
+
+## Co to robi
+
+System czterech rywalizujących frakcji mrocznego fantasy z trwałą reputacją
+(-1000 … +1000 punktów per frakcja) i mechanicznymi konsekwencjami zależnymi
+od poziomu nastawienia. Okno NUI pokazuje reputację, opis i aktualne efekty
+każdej frakcji. Pasywne efekty (bonus do umiejętności / statystyk) są
+automatycznie reaplikowane po każdej zmianie i po każdym logowaniu.
+
+## Frakcje
+
+| ID | Nazwa | Rival |
+|----|-------|-------|
+| 0 | Zelazna Straz | Bractwo Cienia |
+| 1 | Bractwo Cienia | Zelazna Straz |
+| 2 | Kult Wiecznej Nocy | Zakon Plomienia |
+| 3 | Zakon Plomienia | Kult Wiecznej Nocy |
+
+Zysk reputacji u jednej frakcji = 50% kary u rywala (automatyczne).
+
+## Poziomy nastawienia
+
+| Poziom | Zakres | Efekt pasywny |
+|--------|--------|---------------|
+| Wrogi | <= -500 | Kara statystyczna |
+| Nieufny | -499 .. -100 | Brak |
+| Neutralny | -99 .. 99 | Brak |
+| Przychylny | 100 .. 499 | Niewielki bonus |
+| Szanowany | 500 .. 749 | Sredni bonus |
+| Wyniesiony | 750 .. 1000 | Pelny bonus + tytul |
+
+## Pliki
+
+```
+Faction Reputation/
+  Scripts/
+    sql_fac.nss        — schemat SQLite + CRUD (DB: "factions")
+    lib_fac_def.nss    — stalé, dane frakcji, helpery standing
+    lib_fac.nss        — logika glowna, NUI, efekty pasywne
+    lib_fac_ev.nss     — handler zdarzen NUI
+    sys_on_load.nss    — hook OnModuleLoad (tworzy tabele)
+    sys_on_enter.nss   — hook OnClientEnter (reaplikuje efekty)
+    test_fac.nss       — placeable OnUsed, demo reputacji
+```
+
+## Zależności
+
+- **NWScript NUI** (wbudowany od NWN EE 8193.14) — wymagany
+- **SQLite campaign DB** (wbudowany od NWN EE) — wymagany, DB name: `"factions"`
+- **NWNX** — opcjonalny; moduł nie wymaga żadnego pluginu NWNX
+
+## Jak włączyć w istniejącym module
+
+### 1. Hooki modułu
+
+W toolsecie, w Module Properties → Events:
+
+| Zdarzenie | Skrypt |
+|-----------|--------|
+| OnModuleLoad | `sys_on_load` (lub wywołaj `FacInit()` w istniejącym) |
+| OnClientEnter | `sys_on_enter` (lub wywołaj `FacApplyAllEffects(oPC)`) |
+| OnNuiEvent | `lib_fac_ev` (lub dispatcher z `NuiFindWindow` check) |
+
+### 2. Otwieranie okna
+
+Podepnij pod przycisk NPC / placeable / item:
+
+```nss
+#include "lib_fac"
+void main() { FacOpenWindow(GetPCSpeaker()); }
+```
+
+### 3. Zmiana reputacji ze skryptu questa / zdarzenia
+
+```nss
+#include "lib_fac"
+
+// Gracz pomógł Żelaznej Straży pojmać zbiega:
+FacAdjust(oPC, FAC_ID_IRON_GUARD, 150, "quest:fugitive_captured");
+
+// Gracz zabił strażnika:
+FacAdjust(oPC, FAC_ID_IRON_GUARD, -200, "event:guard_killed");
+
+// Gracz ukończył rytuał Kultu:
+FacAdjust(oPC, FAC_ID_NIGHT_CULT, 300, "quest:cult_ritual");
+```
+
+### 4. Odczyt reputacji w skryptach NPC (np. dialog, OnSpawn)
+
+```nss
+#include "lib_fac"
+
+void main()
+{
+    object oPC = GetPCSpeaker();
+    int nPts = FacGetPoints(oPC, FAC_ID_IRON_GUARD);
+    int nStanding = FacGetStanding(nPts);
+
+    if(nStanding <= FAC_STANDING_HOSTILE)
+    {
+        // NPC atakuje
+        SetIsTemporaryEnemy(oPC, OBJECT_SELF);
+        ActionAttack(oPC);
+    }
+    else if(nStanding >= FAC_STANDING_HONORED)
+    {
+        // NPC ma specjalny dialog
+        BeginConversation();
+    }
+}
+```
+
+## Co celowo pominięto
+
+- **DM panel** — brak GUI dla mistrza gry do ręcznej edycji reputacji;
+  można to zrobić przez chat command lub dodatkowy placeable z test_fac.
+- **Logi online** — historia zapisywana w `fac_history`, ale brak UI do
+  jej przeglądania.
+- **NPC-specific faction tags** — moduł nie zarządza automatycznie
+  wrogością konkretnych NPC; to należy do skryptów OnSpawn/OnPerception
+  danego placeable lub NPC (przykład w sekcji wyżej).
+- **Merchant price modifiers** — konsekwencje cenowe opisane w UI,
+  ale wymaga hooka OnStore lub rozmowy z konkretnym kupcem.
+- **Offline progression** — reputacja nie zmienia się gdy gracz jest offline.

--- a/Faction Reputation/Scripts/lib_fac.nss
+++ b/Faction Reputation/Scripts/lib_fac.nss
@@ -1,0 +1,551 @@
+// lib_fac.nss - Faction Reputation: core logic, NUI window, effect management
+//
+// Public API (call from other scripts):
+//   FacAdjust(oPC, nFactionId, nDelta, sReason) - change reputation, apply effects, refresh UI
+//   FacGetPoints(oPC, nFactionId)               - read current points
+//   FacOpenWindow(oPC)                          - open/refresh the reputation panel
+//   FacApplyAllEffects(oPC)                     - reapply effects on login
+//   FacInit()                                   - called from sys_on_load
+
+#include "lib_fac_def"
+
+// ================================================================
+// Forward declarations
+// ================================================================
+
+void FacRemoveEffects(object oPC, int nFactionId);
+void FacApplyEffectsForStanding(object oPC, int nFactionId, int nStanding);
+void FacApplyAllEffects(object oPC);
+void FacAdjust(object oPC, int nFactionId, int nDelta, string sReason);
+int  FacGetPoints(object oPC, int nFactionId);
+void FacOpenWindow(object oPC);
+void FacFeedList(object oPC, int nToken);
+void FacFeedDetail(object oPC, int nToken, int nFactionId);
+json FacBuildWindow(object oPC);
+
+// ================================================================
+// Effect management
+// ================================================================
+
+void FacRemoveEffects(object oPC, int nFactionId)
+{
+    string sTag = FAC_EFFECT_TAG + IntToString(nFactionId);
+    effect e = GetFirstEffect(oPC);
+    effect eNext;
+    while(GetIsEffectValid(e))
+    {
+        eNext = GetNextEffect(oPC);
+        if(GetEffectTag(e) == sTag)
+            RemoveEffect(oPC, e);
+        e = eNext;
+    }
+}
+
+// Builds and applies a permanent linked effect for the given faction+standing.
+// Each faction has one active effect stack (tagged FAC_EFF_<id>).
+// HOSTILE grants a curse penalty; NEUTRAL has no mechanical effect.
+void FacApplyEffectsForStanding(object oPC, int nFactionId, int nStanding)
+{
+    FacRemoveEffects(oPC, nFactionId);
+
+    string sTag = FAC_EFFECT_TAG + IntToString(nFactionId);
+    effect eChain;
+    int    bHasEffect = FALSE;
+
+    // Iron Guard
+    if(nFactionId == FAC_ID_IRON_GUARD)
+    {
+        switch(nStanding)
+        {
+            case FAC_STANDING_HOSTILE:
+                eChain = EffectAbilityDecrease(ABILITY_CHARISMA, 2);
+                bHasEffect = TRUE;
+                break;
+            case FAC_STANDING_FRIENDLY:
+                eChain = EffectAbilityIncrease(ABILITY_CHARISMA, 1);
+                eChain = EffectLinkEffects(eChain, EffectSkillIncrease(SKILL_PERSUADE, 2));
+                bHasEffect = TRUE;
+                break;
+            case FAC_STANDING_HONORED:
+                eChain = EffectAbilityIncrease(ABILITY_CHARISMA, 2);
+                eChain = EffectLinkEffects(eChain, EffectSkillIncrease(SKILL_PERSUADE, 4));
+                eChain = EffectLinkEffects(eChain, EffectACIncrease(1, AC_DODGE_BONUS));
+                bHasEffect = TRUE;
+                break;
+            case FAC_STANDING_EXALTED:
+                eChain = EffectAbilityIncrease(ABILITY_CHARISMA, 3);
+                eChain = EffectLinkEffects(eChain, EffectSkillIncrease(SKILL_PERSUADE, 6));
+                eChain = EffectLinkEffects(eChain, EffectACIncrease(2, AC_DODGE_BONUS));
+                eChain = EffectLinkEffects(eChain, EffectAttackIncrease(1, ATTACK_BONUS_MISC));
+                bHasEffect = TRUE;
+                break;
+            default:
+                break;
+        }
+    }
+    // Brotherhood of Shadow
+    else if(nFactionId == FAC_ID_SHADOW)
+    {
+        switch(nStanding)
+        {
+            case FAC_STANDING_HOSTILE:
+                // No passive stat effect — NPC hostility handled by server event
+                break;
+            case FAC_STANDING_FRIENDLY:
+                eChain = EffectSkillIncrease(SKILL_HIDE, 3);
+                eChain = EffectLinkEffects(eChain, EffectSkillIncrease(SKILL_MOVE_SILENTLY, 3));
+                bHasEffect = TRUE;
+                break;
+            case FAC_STANDING_HONORED:
+                eChain = EffectSkillIncrease(SKILL_HIDE, 6);
+                eChain = EffectLinkEffects(eChain, EffectSkillIncrease(SKILL_MOVE_SILENTLY, 6));
+                eChain = EffectLinkEffects(eChain, EffectSkillIncrease(SKILL_PICK_POCKET, 3));
+                bHasEffect = TRUE;
+                break;
+            case FAC_STANDING_EXALTED:
+                eChain = EffectSkillIncrease(SKILL_HIDE, 9);
+                eChain = EffectLinkEffects(eChain, EffectSkillIncrease(SKILL_MOVE_SILENTLY, 9));
+                eChain = EffectLinkEffects(eChain, EffectSkillIncrease(SKILL_PICK_POCKET, 6));
+                eChain = EffectLinkEffects(eChain, EffectConcealment(10, MISS_CHANCE_TYPE_NORMAL));
+                bHasEffect = TRUE;
+                break;
+            default:
+                break;
+        }
+    }
+    // Cult of the Eternal Night
+    else if(nFactionId == FAC_ID_NIGHT_CULT)
+    {
+        switch(nStanding)
+        {
+            case FAC_STANDING_HOSTILE:
+                // Necromantic curse: will save penalty
+                eChain = EffectSavingThrowDecrease(SAVING_THROW_WILL, 2,
+                    SAVING_THROW_TYPE_ALL);
+                bHasEffect = TRUE;
+                break;
+            case FAC_STANDING_FRIENDLY:
+                eChain = EffectSkillIncrease(SKILL_SPELLCRAFT, 3);
+                eChain = EffectLinkEffects(eChain, EffectSkillIncrease(SKILL_LORE, 2));
+                bHasEffect = TRUE;
+                break;
+            case FAC_STANDING_HONORED:
+                eChain = EffectSkillIncrease(SKILL_SPELLCRAFT, 6);
+                eChain = EffectLinkEffects(eChain, EffectSkillIncrease(SKILL_LORE, 4));
+                eChain = EffectLinkEffects(eChain, EffectAbilityIncrease(ABILITY_CONSTITUTION, 1));
+                bHasEffect = TRUE;
+                break;
+            case FAC_STANDING_EXALTED:
+                eChain = EffectSkillIncrease(SKILL_SPELLCRAFT, 9);
+                eChain = EffectLinkEffects(eChain, EffectSkillIncrease(SKILL_LORE, 6));
+                eChain = EffectLinkEffects(eChain, EffectAbilityIncrease(ABILITY_STRENGTH, 2));
+                eChain = EffectLinkEffects(eChain, EffectAbilityIncrease(ABILITY_CONSTITUTION, 1));
+                bHasEffect = TRUE;
+                break;
+            default:
+                break;
+        }
+    }
+    // Order of the Flame
+    else if(nFactionId == FAC_ID_ORDER_FLAME)
+    {
+        switch(nStanding)
+        {
+            case FAC_STANDING_HOSTILE:
+                // Pariah curse: wisdom drain
+                eChain = EffectAbilityDecrease(ABILITY_WISDOM, 2);
+                bHasEffect = TRUE;
+                break;
+            case FAC_STANDING_FRIENDLY:
+                eChain = EffectAbilityIncrease(ABILITY_WISDOM, 1);
+                eChain = EffectLinkEffects(eChain, EffectSkillIncrease(SKILL_HEAL, 2));
+                bHasEffect = TRUE;
+                break;
+            case FAC_STANDING_HONORED:
+                eChain = EffectAbilityIncrease(ABILITY_WISDOM, 2);
+                eChain = EffectLinkEffects(eChain, EffectSkillIncrease(SKILL_HEAL, 4));
+                eChain = EffectLinkEffects(eChain, EffectSavingThrowIncrease(SAVING_THROW_ALL, 1,
+                    SAVING_THROW_TYPE_ALL));
+                bHasEffect = TRUE;
+                break;
+            case FAC_STANDING_EXALTED:
+                eChain = EffectAbilityIncrease(ABILITY_WISDOM, 3);
+                eChain = EffectLinkEffects(eChain, EffectSkillIncrease(SKILL_HEAL, 6));
+                eChain = EffectLinkEffects(eChain, EffectSavingThrowIncrease(SAVING_THROW_ALL, 2,
+                    SAVING_THROW_TYPE_ALL));
+                eChain = EffectLinkEffects(eChain, EffectACIncrease(1, AC_DODGE_BONUS));
+                bHasEffect = TRUE;
+                break;
+            default:
+                break;
+        }
+    }
+
+    if(!bHasEffect) return;
+
+    eChain = TagEffect(eChain, sTag);
+    eChain = ExtraordinaryEffect(eChain);
+    ApplyEffectToObject(DURATION_TYPE_PERMANENT, eChain, oPC);
+}
+
+// Reads all faction reps from DB and applies/reapplies effects.
+// Called on login and after any reputation change.
+void FacApplyAllEffects(object oPC)
+{
+    if(!GetIsPC(oPC) || GetIsDM(oPC)) return;
+
+    int i;
+    for(i = 0; i < FAC_COUNT; i++)
+    {
+        int nPoints  = FacSqlGetPoints(oPC, i);
+        int nStanding = FacGetStanding(nPoints);
+        FacApplyEffectsForStanding(oPC, i, nStanding);
+    }
+}
+
+// ================================================================
+// Reputation adjustment (main public API)
+// ================================================================
+
+int FacGetPoints(object oPC, int nFactionId)
+{
+    return FacSqlGetPoints(oPC, nFactionId);
+}
+
+// Adjusts faction reputation by nDelta, clamped to [FAC_POINTS_MIN, FAC_POINTS_MAX].
+// Applies rival penalty automatically.
+// Reapplies passive effects and refreshes open NUI window.
+void FacAdjust(object oPC, int nFactionId, int nDelta, string sReason)
+{
+    if(!GetIsPC(oPC) || GetIsDM(oPC))    return;
+    if(nFactionId < 0 || nFactionId >= FAC_COUNT) return;
+    if(nDelta == 0) return;
+
+    int nOldPoints   = FacSqlGetPoints(oPC, nFactionId);
+    int nNewPoints   = nOldPoints + nDelta;
+    if(nNewPoints < FAC_POINTS_MIN) nNewPoints = FAC_POINTS_MIN;
+    if(nNewPoints > FAC_POINTS_MAX) nNewPoints = FAC_POINTS_MAX;
+
+    int nActualDelta = nNewPoints - nOldPoints;
+    if(nActualDelta == 0) return;
+
+    FacSqlSetPoints(oPC, nFactionId, nNewPoints);
+    FacSqlLogHistory(oPC, nFactionId, nActualDelta, sReason);
+
+    int nOldStanding = FacGetStanding(nOldPoints);
+    int nNewStanding = FacGetStanding(nNewPoints);
+    FacApplyEffectsForStanding(oPC, nFactionId, nNewStanding);
+
+    // Notify player when standing tier changes
+    if(nNewStanding != nOldStanding)
+    {
+        string sDir = (nNewStanding > nOldStanding) ? "poprawilo" : "pogorszylo";
+        string sMsg = "[Frakcje] Twoje nastawienie wobec " + FacName(nFactionId)
+                    + " " + sDir + " sie: " + FacStandingName(nNewStanding)
+                    + " (" + IntToString(nNewPoints) + ")";
+        SendMessageToPC(oPC, sMsg);
+        FloatingTextStringOnCreature(sMsg, oPC, FALSE, FALSE);
+    }
+
+    // Apply rival penalty
+    int nRivalId = FacGetRival(nFactionId);
+    if(nRivalId >= 0 && nActualDelta != 0)
+    {
+        int nPenalty = -(nActualDelta * FAC_RIVAL_PENALTY_PCT / 100);
+        if(nPenalty != 0)
+        {
+            int nRivalOld = FacSqlGetPoints(oPC, nRivalId);
+            int nRivalNew = nRivalOld + nPenalty;
+            if(nRivalNew < FAC_POINTS_MIN) nRivalNew = FAC_POINTS_MIN;
+            if(nRivalNew > FAC_POINTS_MAX) nRivalNew = FAC_POINTS_MAX;
+
+            int nRivalActual = nRivalNew - nRivalOld;
+            if(nRivalActual != 0)
+            {
+                FacSqlSetPoints(oPC, nRivalId, nRivalNew);
+                FacSqlLogHistory(oPC, nRivalId, nRivalActual, "rivalry:" + sReason);
+
+                int nRivalOldStanding = FacGetStanding(nRivalOld);
+                int nRivalNewStanding = FacGetStanding(nRivalNew);
+                FacApplyEffectsForStanding(oPC, nRivalId, nRivalNewStanding);
+
+                if(nRivalNewStanding != nRivalOldStanding)
+                {
+                    string sDir2 = (nRivalNewStanding > nRivalOldStanding) ? "poprawilo" : "pogorszylo";
+                    string sRMsg = "[Frakcje] Rywalizacja: nastawienie " + FacName(nRivalId)
+                                 + " " + sDir2 + " sie: " + FacStandingName(nRivalNewStanding);
+                    SendMessageToPC(oPC, sRMsg);
+                }
+            }
+        }
+    }
+
+    // Refresh open NUI window
+    int nToken = NuiFindWindow(oPC, FAC_WINDOW);
+    if(nToken != 0)
+    {
+        FacFeedList(oPC, nToken);
+        // Refresh detail for currently selected faction if it changed
+        int nSel = GetLocalInt(oPC, FAC_LVAR_SEL_FACTION);
+        if(nSel == nFactionId || nSel == nRivalId)
+            FacFeedDetail(oPC, nToken, nSel);
+    }
+}
+
+// ================================================================
+// NUI window construction
+// ================================================================
+
+json FacBuildWindow(object oPC)
+{
+    float fW     = GetNuiScaleDimension(oPC, FAC_WIN_W);
+    float fBtnH  = GetNuiScaleDimension(oPC, 28.0);
+    float fRowH  = GetNuiScaleDimension(oPC, 38.0);
+    float fListH = GetNuiScaleDimension(oPC, 164.0); // 4 rows * ~41px
+    float fDetH  = GetNuiScaleDimension(oPC, 268.0);
+
+    // ---- Header row: title label + close button ----
+    json jTitle = NuiLabel(JsonString("Reputacja Frakcji"),
+                           JsonInt(NUI_HALIGN_LEFT),
+                           JsonInt(NUI_VALIGN_MIDDLE));
+    jTitle = NuiHeight(jTitle, fBtnH);
+
+    json jClose = NuiButton(JsonString("Zamknij"));
+    jClose = NuiId(jClose, FAC_BTN_CLOSE);
+    jClose = NuiWidth(jClose, GetNuiScaleDimension(oPC, 80.0));
+    jClose = NuiHeight(jClose, fBtnH);
+
+    json jHeader = JsonArray();
+    jHeader = JsonArrayInsert(jHeader, jTitle);
+    jHeader = JsonArrayInsert(jHeader, jClose);
+
+    // ---- List section: one row per faction ----
+    // Columns: Name | Standing | Points | [Szczegoly]
+    float fNameW    = GetNuiScaleDimension(oPC, 180.0);
+    float fStandW   = GetNuiScaleDimension(oPC, 125.0);
+    float fPtsW     = GetNuiScaleDimension(oPC, 75.0);
+    float fDetailW  = GetNuiScaleDimension(oPC, 90.0);
+
+    json jLstName = NuiLabel(NuiBind(FAC_BIND_LST_NAME),
+                             JsonInt(NUI_HALIGN_LEFT),
+                             JsonInt(NUI_VALIGN_MIDDLE));
+    jLstName = NuiWidth(jLstName, fNameW);
+
+    json jLstStanding = NuiLabel(NuiBind(FAC_BIND_LST_STANDING),
+                                 JsonInt(NUI_HALIGN_LEFT),
+                                 JsonInt(NUI_VALIGN_MIDDLE));
+    jLstStanding = NuiWidth(jLstStanding, fStandW);
+    jLstStanding = NuiStyleForegroundColor(jLstStanding, NuiBind(FAC_BIND_LST_COLOR));
+
+    json jLstPts = NuiLabel(NuiBind(FAC_BIND_LST_POINTS),
+                            JsonInt(NUI_HALIGN_RIGHT),
+                            JsonInt(NUI_VALIGN_MIDDLE));
+    jLstPts = NuiWidth(jLstPts, fPtsW);
+
+    json jLstBtn = NuiId(NuiButton(JsonString("Szczegoly")), FAC_BTN_ROW);
+    jLstBtn = NuiWidth(jLstBtn, fDetailW);
+    jLstBtn = NuiHeight(jLstBtn, GetNuiScaleDimension(oPC, 28.0));
+
+    json jCellRow = JsonArray();
+    jCellRow = JsonArrayInsert(jCellRow, jLstName);
+    jCellRow = JsonArrayInsert(jCellRow, jLstStanding);
+    jCellRow = JsonArrayInsert(jCellRow, jLstPts);
+    jCellRow = JsonArrayInsert(jCellRow, jLstBtn);
+
+    json jCell = NuiGroup(NuiRow(jCellRow), FALSE, NUI_SCROLLBARS_NONE);
+    jCell = NuiEncouraged(jCell, NuiBind(FAC_BIND_LST_ROW_ENC));
+
+    json jTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jCell, 0.0, TRUE));
+    json jList = NuiList(jTmpl, NuiBind(FAC_BIND_LST_COUNT), fRowH);
+    jList = NuiHeight(jList, fListH);
+
+    // ---- Detail section ----
+    float fDetNameW    = GetNuiScaleDimension(oPC, 280.0);
+    float fDetStandW   = GetNuiScaleDimension(oPC, 150.0);
+    float fProgH       = GetNuiScaleDimension(oPC, 16.0);
+    float fFlavorH     = GetNuiScaleDimension(oPC, 70.0);
+    float fConsH       = GetNuiScaleDimension(oPC, 130.0);
+
+    // Faction name + standing (same row)
+    json jDetName = NuiLabel(NuiBind(FAC_BIND_DET_NAME),
+                             JsonInt(NUI_HALIGN_LEFT),
+                             JsonInt(NUI_VALIGN_MIDDLE));
+    jDetName = NuiWidth(jDetName, fDetNameW);
+
+    json jDetStanding = NuiLabel(NuiBind(FAC_BIND_DET_STANDING),
+                                 JsonInt(NUI_HALIGN_RIGHT),
+                                 JsonInt(NUI_VALIGN_MIDDLE));
+    jDetStanding = NuiWidth(jDetStanding, fDetStandW);
+    jDetStanding = NuiStyleForegroundColor(jDetStanding, NuiBind(FAC_BIND_DET_COLOR));
+
+    json jDetNameRow = JsonArray();
+    jDetNameRow = JsonArrayInsert(jDetNameRow, jDetName);
+    jDetNameRow = JsonArrayInsert(jDetNameRow, jDetStanding);
+
+    // Points label
+    json jDetPts = NuiLabel(NuiBind(FAC_BIND_DET_POINTS),
+                            JsonInt(NUI_HALIGN_LEFT),
+                            JsonInt(NUI_VALIGN_MIDDLE));
+    jDetPts = NuiHeight(jDetPts, GetNuiScaleDimension(oPC, 22.0));
+
+    // Progress bar (value bound via JsonObjectSet below)
+    json jDetBar = NuiProgressBar();
+    jDetBar = JsonObjectSet(jDetBar, "value", NuiBind(FAC_BIND_DET_PROGRESS));
+    jDetBar = NuiHeight(jDetBar, fProgH);
+
+    // Flavor description
+    json jFlavorLbl = NuiLabel(JsonString("Opis:"),
+                               JsonInt(NUI_HALIGN_LEFT),
+                               JsonInt(NUI_VALIGN_MIDDLE));
+    jFlavorLbl = NuiHeight(jFlavorLbl, GetNuiScaleDimension(oPC, 20.0));
+
+    json jFlavorBox = NuiGroup(
+        NuiText(NuiBind(FAC_BIND_DET_FLAVOR), FALSE),
+        FALSE, NUI_SCROLLBARS_NONE);
+    jFlavorBox = NuiHeight(jFlavorBox, fFlavorH);
+    jFlavorBox = NuiEnabled(jFlavorBox, JsonBool(FALSE));
+
+    // Consequences
+    json jConsLbl = NuiLabel(JsonString("Konsekwencje:"),
+                             JsonInt(NUI_HALIGN_LEFT),
+                             JsonInt(NUI_VALIGN_MIDDLE));
+    jConsLbl = NuiHeight(jConsLbl, GetNuiScaleDimension(oPC, 20.0));
+
+    json jConsBox = NuiGroup(
+        NuiText(NuiBind(FAC_BIND_DET_CONS), FALSE),
+        TRUE, NUI_SCROLLBARS_AUTO);
+    jConsBox = NuiHeight(jConsBox, fConsH);
+    jConsBox = NuiEnabled(jConsBox, JsonBool(FALSE));
+
+    // Detail column
+    json jDetCol = JsonArray();
+    jDetCol = JsonArrayInsert(jDetCol, NuiRow(jDetNameRow));
+    jDetCol = JsonArrayInsert(jDetCol, jDetPts);
+    jDetCol = JsonArrayInsert(jDetCol, jDetBar);
+    jDetCol = JsonArrayInsert(jDetCol, CreateEmptyRow(oPC, 4.0));
+    jDetCol = JsonArrayInsert(jDetCol, jFlavorLbl);
+    jDetCol = JsonArrayInsert(jDetCol, jFlavorBox);
+    jDetCol = JsonArrayInsert(jDetCol, CreateEmptyRow(oPC, 4.0));
+    jDetCol = JsonArrayInsert(jDetCol, jConsLbl);
+    jDetCol = JsonArrayInsert(jDetCol, jConsBox);
+
+    json jDetGroup = NuiGroup(NuiCol(jDetCol), FALSE, NUI_SCROLLBARS_NONE);
+    jDetGroup = NuiHeight(jDetGroup, fDetH);
+
+    // ---- Root column ----
+    json jRoot = JsonArray();
+    jRoot = JsonArrayInsert(jRoot, NuiRow(jHeader));
+    jRoot = JsonArrayInsert(jRoot, CreateEmptyRow(oPC, 4.0));
+    jRoot = JsonArrayInsert(jRoot, jList);
+    jRoot = JsonArrayInsert(jRoot, CreateEmptyRow(oPC, 6.0));
+    jRoot = JsonArrayInsert(jRoot, jDetGroup);
+
+    return NuiCol(jRoot);
+}
+
+// ================================================================
+// Window lifecycle
+// ================================================================
+
+void FacOpenWindow(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, FAC_WINDOW);
+    if(nToken != 0)
+    {
+        // Already open — just refresh
+        FacFeedList(oPC, nToken);
+        FacFeedDetail(oPC, nToken, GetLocalInt(oPC, FAC_LVAR_SEL_FACTION));
+        return;
+    }
+
+    float fW = GetNuiScaleDimension(oPC, FAC_WIN_W);
+    float fH = GetNuiScaleDimension(oPC, FAC_WIN_H);
+
+    // Center on screen
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - fW) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - fH) / 2.0;
+    json jGeom = NuiRect(fCX, fCY, fW, fH);
+
+    json jLayout = FacBuildWindow(oPC);
+
+    // Wrap content in NuiWindow frame (no native title bar — we have our own header row)
+    json jWin = NuiWindow(jLayout,
+        JsonBool(FALSE),               // no native title text
+        NuiBind(FAC_BIND_WIN_GEOM),    // geometry via bind (allows persistence)
+        JsonBool(FALSE),               // not resizable
+        JsonBool(FALSE),               // not collapsed
+        JsonBool(FALSE),               // no native close button (we have FAC_BTN_CLOSE)
+        JsonBool(FALSE),               // not transparent
+        JsonBool(TRUE));               // with border
+
+    nToken = NuiCreate(oPC, jWin, FAC_WINDOW, FAC_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, FAC_BIND_WIN_GEOM, jGeom);
+
+    SetLocalInt(oPC, FAC_LVAR_SEL_FACTION, FAC_ID_IRON_GUARD);
+
+    FacFeedList(oPC, nToken);
+    FacFeedDetail(oPC, nToken, FAC_ID_IRON_GUARD);
+}
+
+// ================================================================
+// Data feed helpers
+// ================================================================
+
+void FacFeedList(object oPC, int nToken)
+{
+    json jNames     = JsonArray();
+    json jStandings = JsonArray();
+    json jColors    = JsonArray();
+    json jPoints    = JsonArray();
+    json jEncs      = JsonArray();
+    int  nSel       = GetLocalInt(oPC, FAC_LVAR_SEL_FACTION);
+
+    int i;
+    for(i = 0; i < FAC_COUNT; i++)
+    {
+        int    nPts      = FacSqlGetPoints(oPC, i);
+        int    nStanding = FacGetStanding(nPts);
+        string sPts      = IntToString(nPts);
+        if(nPts > 0) sPts = "+" + sPts;
+
+        jNames     = JsonArrayInsert(jNames,     JsonString(FacName(i)));
+        jStandings = JsonArrayInsert(jStandings, JsonString(FacStandingName(nStanding)));
+        jColors    = JsonArrayInsert(jColors,    FacStandingColor(nStanding));
+        jPoints    = JsonArrayInsert(jPoints,    JsonString(sPts));
+        jEncs      = JsonArrayInsert(jEncs,      JsonBool(i == nSel));
+    }
+
+    NuiSetBind(oPC, nToken, FAC_BIND_LST_NAME,     jNames);
+    NuiSetBind(oPC, nToken, FAC_BIND_LST_STANDING, jStandings);
+    NuiSetBind(oPC, nToken, FAC_BIND_LST_COLOR,    jColors);
+    NuiSetBind(oPC, nToken, FAC_BIND_LST_POINTS,   jPoints);
+    NuiSetBind(oPC, nToken, FAC_BIND_LST_ROW_ENC,  jEncs);
+    NuiSetBind(oPC, nToken, FAC_BIND_LST_COUNT,    JsonInt(FAC_COUNT));
+}
+
+void FacFeedDetail(object oPC, int nToken, int nFactionId)
+{
+    if(nFactionId < 0 || nFactionId >= FAC_COUNT) return;
+
+    int    nPts      = FacSqlGetPoints(oPC, nFactionId);
+    int    nStanding = FacGetStanding(nPts);
+    string sPts      = IntToString(nPts);
+    if(nPts > 0) sPts = "+" + sPts;
+
+    NuiSetBind(oPC, nToken, FAC_BIND_DET_NAME,     JsonString(FacName(nFactionId)));
+    NuiSetBind(oPC, nToken, FAC_BIND_DET_STANDING, JsonString(FacStandingName(nStanding)));
+    NuiSetBind(oPC, nToken, FAC_BIND_DET_COLOR,    FacStandingColor(nStanding));
+    NuiSetBind(oPC, nToken, FAC_BIND_DET_POINTS,   JsonString("Punkty: " + sPts + " / " + IntToString(FAC_POINTS_MAX)));
+    NuiSetBind(oPC, nToken, FAC_BIND_DET_PROGRESS, JsonFloat(FacProgressNorm(nPts)));
+    NuiSetBind(oPC, nToken, FAC_BIND_DET_FLAVOR,   JsonString(FacDesc(nFactionId)));
+    NuiSetBind(oPC, nToken, FAC_BIND_DET_CONS,     JsonString(FacConsequences(nFactionId, nStanding)));
+}
+
+// ================================================================
+// Module init
+// ================================================================
+
+void FacInit()
+{
+    FacCreateTables();
+}

--- a/Faction Reputation/Scripts/lib_fac_def.nss
+++ b/Faction Reputation/Scripts/lib_fac_def.nss
@@ -1,0 +1,322 @@
+// lib_fac_def.nss - Faction Reputation: constants, faction data, standing helpers
+//
+// Single source of truth for:
+//   - 4 faction IDs and their display data
+//   - Standing thresholds and names
+//   - NUI window/bind/button constants
+//   - Rivalry map
+//   - Consequences text per faction per standing
+
+#include "lib_nui"
+#include "sql_fac"
+
+// ================================================================
+// Faction IDs
+// ================================================================
+
+const int FAC_ID_IRON_GUARD     = 0;  // Żelazna Straż
+const int FAC_ID_SHADOW         = 1;  // Bractwo Cienia
+const int FAC_ID_NIGHT_CULT     = 2;  // Kult Wiecznej Nocy
+const int FAC_ID_ORDER_FLAME    = 3;  // Zakon Płomienia
+const int FAC_COUNT             = 4;
+
+// ================================================================
+// Standing level IDs (ascending prestige)
+// ================================================================
+
+const int FAC_STANDING_HOSTILE      = 0;  // <= -500
+const int FAC_STANDING_UNFRIENDLY   = 1;  // -499 .. -100
+const int FAC_STANDING_NEUTRAL      = 2;  // -99  ..  99
+const int FAC_STANDING_FRIENDLY     = 3;  //  100 .. 499
+const int FAC_STANDING_HONORED      = 4;  //  500 .. 749
+const int FAC_STANDING_EXALTED      = 5;  //  750 .. 1000
+
+// ================================================================
+// Point range
+// ================================================================
+
+const int FAC_POINTS_MIN =  -1000;
+const int FAC_POINTS_MAX =   1000;
+
+// Gaining rep with one faction costs this % of the delta from the rival.
+const int FAC_RIVAL_PENALTY_PCT = 50;
+
+// ================================================================
+// Effect tag prefix (one permanent effect stack per faction)
+// ================================================================
+
+const string FAC_EFFECT_TAG = "FAC_EFF_";  // + IntToString(faction_id)
+
+// ================================================================
+// Local variables on PC object
+// ================================================================
+
+const string FAC_LVAR_SEL_FACTION = "FAC_SEL_FACTION";  // int: selected faction in UI
+
+// ================================================================
+// NUI window constants
+// ================================================================
+
+const string FAC_WINDOW       = "FAC_WINDOW";
+const string FAC_EV_SCRIPT    = "lib_fac_ev";
+const float  FAC_WIN_W        = 680.0;
+const float  FAC_WIN_H        = 530.0;
+const string FAC_BIND_WIN_GEOM = "fac_win_geom";
+
+// List binds (JsonArray of FAC_COUNT elements)
+const string FAC_BIND_LST_NAME     = "fac_lst_name";      // JsonArray<string>
+const string FAC_BIND_LST_STANDING = "fac_lst_standing";  // JsonArray<string>
+const string FAC_BIND_LST_COLOR    = "fac_lst_color";     // JsonArray<NuiColor>
+const string FAC_BIND_LST_POINTS   = "fac_lst_points";    // JsonArray<string>
+const string FAC_BIND_LST_ROW_ENC  = "fac_lst_enc";       // JsonArray<bool>
+const string FAC_BIND_LST_COUNT    = "fac_lst_count";     // JsonInt
+
+// Detail panel binds (single faction)
+const string FAC_BIND_DET_NAME     = "fac_det_name";
+const string FAC_BIND_DET_STANDING = "fac_det_standing";
+const string FAC_BIND_DET_COLOR    = "fac_det_color";
+const string FAC_BIND_DET_POINTS   = "fac_det_pts";
+const string FAC_BIND_DET_PROGRESS = "fac_det_prog";
+const string FAC_BIND_DET_FLAVOR   = "fac_det_flavor";
+const string FAC_BIND_DET_CONS     = "fac_det_cons";
+
+// Button IDs
+const string FAC_BTN_CLOSE    = "fac_btn_close";
+const string FAC_BTN_ROW      = "fac_btn_row";
+
+// ================================================================
+// Faction display data
+// ================================================================
+
+string FacName(int nId)
+{
+    switch(nId)
+    {
+        case FAC_ID_IRON_GUARD:     return "Zelazna Straz";
+        case FAC_ID_SHADOW:         return "Bractwo Cienia";
+        case FAC_ID_NIGHT_CULT:     return "Kult Wiecznej Nocy";
+        case FAC_ID_ORDER_FLAME:    return "Zakon Plomienia";
+    }
+    return "Nieznana Frakcja";
+}
+
+string FacDesc(int nId)
+{
+    switch(nId)
+    {
+        case FAC_ID_IRON_GUARD:
+            return "Strazacy prawa i porzadku, zbrojne ramie "
+                 + "miast i krolewskich dekreow. Milcza na zloto, "
+                 + "lecz nie na krew. Ich lancuchy sa widoczne — "
+                 + "i dlatego tak wielu je nosi.";
+        case FAC_ID_SHADOW:
+            return "Zlodzieje, mordercy i handlarze tajemnic. "
+                 + "Ich symbol to cien rzucony przez nieistniejaca "
+                 + "swiece. Nie pytaja, skad pochodzi moneta — "
+                 + "pytaja tylko ile jej jest.";
+        case FAC_ID_NIGHT_CULT:
+            return "Wyznawcy Wiecznej Nocy, mistrzowie nekromancji "
+                 + "i plugawych rytualow. Gromadza sie w miejscach, "
+                 + "gdzie ziemia pamieeta smierc i marzy o powrocie.";
+        case FAC_ID_ORDER_FLAME:
+            return "Templariusze i kaplani Wiecznego Plomienia. "
+                 + "Wiernosc dla nich nie jest cnota — jest "
+                 + "obowiazkiem wypalonym w duszy zywym ogniem. "
+                 + "Herezja plonie. Zawsze.";
+    }
+    return "";
+}
+
+// ================================================================
+// Standing helpers
+// ================================================================
+
+int FacGetStanding(int nPoints)
+{
+    if(nPoints <= -500) return FAC_STANDING_HOSTILE;
+    if(nPoints <= -100) return FAC_STANDING_UNFRIENDLY;
+    if(nPoints <   100) return FAC_STANDING_NEUTRAL;
+    if(nPoints <   500) return FAC_STANDING_FRIENDLY;
+    if(nPoints <   750) return FAC_STANDING_HONORED;
+    return FAC_STANDING_EXALTED;
+}
+
+string FacStandingName(int nStanding)
+{
+    switch(nStanding)
+    {
+        case FAC_STANDING_HOSTILE:      return "Wrogi";
+        case FAC_STANDING_UNFRIENDLY:   return "Nieufny";
+        case FAC_STANDING_NEUTRAL:      return "Neutralny";
+        case FAC_STANDING_FRIENDLY:     return "Przychylny";
+        case FAC_STANDING_HONORED:      return "Szanowany";
+        case FAC_STANDING_EXALTED:      return "Wyniesiony";
+    }
+    return "?";
+}
+
+json FacStandingColor(int nStanding)
+{
+    switch(nStanding)
+    {
+        case FAC_STANDING_HOSTILE:      return NuiColor(220, 60,  60,  255);
+        case FAC_STANDING_UNFRIENDLY:   return NuiColor(210, 130, 50,  255);
+        case FAC_STANDING_NEUTRAL:      return NuiColor(170, 170, 170, 255);
+        case FAC_STANDING_FRIENDLY:     return NuiColor(180, 210, 100, 255);
+        case FAC_STANDING_HONORED:      return NuiColor(80,  200, 80,  255);
+        case FAC_STANDING_EXALTED:      return NuiColor(210, 175, 55,  255);
+    }
+    return NuiColor(255, 255, 255, 255);
+}
+
+// Maps -1000..1000 to 0.0..1.0 for progress bar.
+float FacProgressNorm(int nPoints)
+{
+    int nClamped = nPoints;
+    if(nClamped < FAC_POINTS_MIN) nClamped = FAC_POINTS_MIN;
+    if(nClamped > FAC_POINTS_MAX) nClamped = FAC_POINTS_MAX;
+    return (IntToFloat(nClamped) + 1000.0) / 2000.0;
+}
+
+// ================================================================
+// Consequences text (player-visible Polish, dark-fantasy flavour)
+// ================================================================
+
+string FacConsequences(int nFactionId, int nStanding)
+{
+    if(nFactionId == FAC_ID_IRON_GUARD)
+    {
+        switch(nStanding)
+        {
+            case FAC_STANDING_HOSTILE:
+                return "- Strazacy atakuja na widok\n"
+                     + "- Nakaz pojmania rozeslany\n"
+                     + "- Kupcy gildyjni zamykaja drzwi";
+            case FAC_STANDING_UNFRIENDLY:
+                return "- Strazacy obserwuja z podejrzliwoscia\n"
+                     + "- Posterunki zamkniete\n"
+                     + "- Ceny u kupców +15%";
+            case FAC_STANDING_NEUTRAL:
+                return "- Normalne relacje, brak bonusow i kar";
+            case FAC_STANDING_FRIENDLY:
+                return "- +1 Charyzma, +2 Perswazja\n"
+                     + "- Strazacy wspomagaja w walce (raz/godz.)\n"
+                     + "- Kupcy gildyjni: -5% ceny";
+            case FAC_STANDING_HONORED:
+                return "- +2 Charyzma, +4 Perswazja, +1 KP\n"
+                     + "- Dostep do zbrojowni strazy\n"
+                     + "- Kupcy gildyjni: -10% ceny";
+            case FAC_STANDING_EXALTED:
+                return "- +3 Charyzma, +6 Perswazja, +2 KP, +1 atak\n"
+                     + "- Status zastepcy kapitana\n"
+                     + "- Kupcy gildyjni: -15% ceny\n"
+                     + "- Dostep do strzezonych stref";
+        }
+    }
+    else if(nFactionId == FAC_ID_SHADOW)
+    {
+        switch(nStanding)
+        {
+            case FAC_STANDING_HOSTILE:
+                return "- Zabojcy Bractwa tropia bohatera\n"
+                     + "- Kieszonkowcy kradna przy okazji\n"
+                     + "- Dzielnica Cienia zamknieta";
+            case FAC_STANDING_UNFRIENDLY:
+                return "- Handlarze Bractwa odwracaja sie\n"
+                     + "- Informatorzy milcza\n"
+                     + "- Ryzyko zasadzki w zaaulkach";
+            case FAC_STANDING_NEUTRAL:
+                return "- Normalne relacje, brak bonusow i kar";
+            case FAC_STANDING_FRIENDLY:
+                return "- +3 Ukrywanie, +3 Ciche Kroki\n"
+                     + "- Dostep do fenca Bractwa\n"
+                     + "- Informatorzy szepca plotki";
+            case FAC_STANDING_HONORED:
+                return "- +6 Ukrywanie, +6 Ciche Kroki, +3 Kieszonk.\n"
+                     + "- Ochrona przed ulicznymi zlodziejami\n"
+                     + "- Bezpieczny przeejazd przez Dzielnice Cienia";
+            case FAC_STANDING_EXALTED:
+                return "- +9 Ukrywanie, +9 Ciche Kroki, +6 Kieszonk.\n"
+                     + "- 10% Ukrycie z mroku\n"
+                     + "- Tytul Mistrza Cienia\n"
+                     + "- Tajne kontrakty Bractwa";
+        }
+    }
+    else if(nFactionId == FAC_ID_NIGHT_CULT)
+    {
+        switch(nStanding)
+        {
+            case FAC_STANDING_HOSTILE:
+                return "- Kultysci i nieumarli atakuja\n"
+                     + "- Klatwa nekrotyczna: -2 do rzutow obronnych\n"
+                     + "- Swiatynie Kultu zamkniete";
+            case FAC_STANDING_UNFRIENDLY:
+                return "- Kultysci obserwuja z wrogoscia\n"
+                     + "- Nieumarli wykazuja agresje\n"
+                     + "- Rytualy Kultu niedostepne";
+            case FAC_STANDING_NEUTRAL:
+                return "- Normalne relacje, brak bonusow i kar";
+            case FAC_STANDING_FRIENDLY:
+                return "- +3 Wiedza Czarow, +2 Erudycja\n"
+                     + "- Nieumarli ignoruja postac noca\n"
+                     + "- Rytualy nizszej rangi dostepne";
+            case FAC_STANDING_HONORED:
+                return "- +6 Wiedza Czarow, +4 Erudycja, +1 Budowa\n"
+                     + "- Blogoslawienstwo Nocy (ikona efektu)\n"
+                     + "- Biblioteka nekromantyczna dostepna";
+            case FAC_STANDING_EXALTED:
+                return "- +9 Wiedza Czarow, +6 Erudycja, +2 Sila, +1 Budowa\n"
+                     + "- Nieumarli sojusznicy w walce\n"
+                     + "- Tytul Herolda Wiecznej Nocy\n"
+                     + "- Krypta Zalozycieli dostepna";
+        }
+    }
+    else if(nFactionId == FAC_ID_ORDER_FLAME)
+    {
+        switch(nStanding)
+        {
+            case FAC_STANDING_HOSTILE:
+                return "- Templariusze atakuja\n"
+                     + "- Klatwa pariasa: -2 Madrosc\n"
+                     + "- Swiatynie zamkniete, leczenie nedostepne";
+            case FAC_STANDING_UNFRIENDLY:
+                return "- Kaplani odmawiaja blogoslawienstw\n"
+                     + "- Leczenie w swiatyniach +30% drozej\n"
+                     + "- Templariusze ignoruja prosby";
+            case FAC_STANDING_NEUTRAL:
+                return "- Normalne relacje, brak bonusow i kar";
+            case FAC_STANDING_FRIENDLY:
+                return "- +1 Madrosc, +2 Leczenie\n"
+                     + "- Leczenie w swiatyniach -10% taniej\n"
+                     + "- Blogoslawienstwo kaplana raz dziennie";
+            case FAC_STANDING_HONORED:
+                return "- +2 Madrosc, +4 Leczenie, +1 do rzutow obrnn.\n"
+                     + "- Leczenie w swiatyniach -20% taniej\n"
+                     + "- Templariusze wspomagaja w walce";
+            case FAC_STANDING_EXALTED:
+                return "- +3 Madrosc, +6 Leczenie, +2 rzuty obrnn., +1 KP\n"
+                     + "- Tytul Mistrza Plomienia\n"
+                     + "- Leczenie w swiatyniach bezplatne\n"
+                     + "- Odpornosc ogien +10%, +2 Opedzanie Nieumarle";
+        }
+    }
+    return "";
+}
+
+// ================================================================
+// Rivalry
+// ================================================================
+
+// Returns the rival faction ID, or -1 if none.
+// Pair: Iron Guard <-> Shadow Brotherhood | Night Cult <-> Order of Flame
+int FacGetRival(int nFactionId)
+{
+    switch(nFactionId)
+    {
+        case FAC_ID_IRON_GUARD:  return FAC_ID_SHADOW;
+        case FAC_ID_SHADOW:      return FAC_ID_IRON_GUARD;
+        case FAC_ID_NIGHT_CULT:  return FAC_ID_ORDER_FLAME;
+        case FAC_ID_ORDER_FLAME: return FAC_ID_NIGHT_CULT;
+    }
+    return -1;
+}

--- a/Faction Reputation/Scripts/lib_fac_ev.nss
+++ b/Faction Reputation/Scripts/lib_fac_ev.nss
@@ -1,0 +1,50 @@
+// lib_fac_ev.nss - Faction Reputation: NUI event handler
+//
+// Set as the NUI event script for FAC_WINDOW.
+// Module Properties -> Events -> OnNuiEvent -> lib_fac_ev
+
+#include "lib_fac"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    if(nToken != NuiFindWindow(oPC, FAC_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalInt(oPC, FAC_LVAR_SEL_FACTION);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == FAC_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        if(sElem == FAC_BTN_ROW)
+        {
+            // nIdx is the list row index = faction ID
+            if(nIdx < 0 || nIdx >= FAC_COUNT) return;
+
+            SetLocalInt(oPC, FAC_LVAR_SEL_FACTION, nIdx);
+
+            // Refresh highlight on all rows
+            json jEncs = JsonArray();
+            int i;
+            for(i = 0; i < FAC_COUNT; i++)
+                jEncs = JsonArrayInsert(jEncs, JsonBool(i == nIdx));
+            NuiSetBind(oPC, nToken, FAC_BIND_LST_ROW_ENC, jEncs);
+
+            FacFeedDetail(oPC, nToken, nIdx);
+            return;
+        }
+    }
+}

--- a/Faction Reputation/Scripts/sql_fac.nss
+++ b/Faction Reputation/Scripts/sql_fac.nss
@@ -1,0 +1,88 @@
+// sql_fac.nss - Faction Reputation: SQL schema and data access layer
+//
+// Campaign DB: "factions" (separate from other modules)
+// Per-character rep stored keyed by PC UUID + faction ID.
+// History table for audit log (DM panel, optional telemetry).
+
+// ================================================================
+// Table creation (idempotent)
+// ================================================================
+
+void FacCreateTables()
+{
+    sqlquery q;
+
+    q = SqlPrepareQueryCampaign("factions",
+        "CREATE TABLE IF NOT EXISTS fac_reputation ("
+        "  uuid       TEXT    NOT NULL,"
+        "  faction_id INTEGER NOT NULL,"
+        "  points     INTEGER NOT NULL DEFAULT 0,"
+        "  PRIMARY KEY (uuid, faction_id)"
+        ")");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("factions",
+        "CREATE TABLE IF NOT EXISTS fac_history ("
+        "  id         INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "  uuid       TEXT    NOT NULL,"
+        "  faction_id INTEGER NOT NULL,"
+        "  delta      INTEGER NOT NULL,"
+        "  reason     TEXT    DEFAULT '',"
+        "  ts         INTEGER DEFAULT 0"
+        ")");
+    SqlStep(q);
+}
+
+// ================================================================
+// CRUD
+// ================================================================
+
+int FacSqlGetPoints(object oPC, int nFactionId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("factions",
+        "SELECT points FROM fac_reputation WHERE uuid = @uuid AND faction_id = @fid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@fid",  nFactionId);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+void FacSqlSetPoints(object oPC, int nFactionId, int nPoints)
+{
+    sqlquery q = SqlPrepareQueryCampaign("factions",
+        "INSERT OR REPLACE INTO fac_reputation (uuid, faction_id, points)"
+        " VALUES (@uuid, @fid, @pts)");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@fid",  nFactionId);
+    SqlBindInt   (q, "@pts",  nPoints);
+    SqlStep(q);
+}
+
+// Returns JsonArray of {faction_id, points} for all factions.
+json FacSqlGetAllPoints(object oPC)
+{
+    json jArr = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("factions",
+        "SELECT faction_id, points FROM fac_reputation WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    while(SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "faction_id", JsonInt(SqlGetInt(q, 0)));
+        jRow = JsonObjectSet(jRow, "points",     JsonInt(SqlGetInt(q, 1)));
+        jArr = JsonArrayInsert(jArr, jRow);
+    }
+    return jArr;
+}
+
+void FacSqlLogHistory(object oPC, int nFactionId, int nDelta, string sReason)
+{
+    sqlquery q = SqlPrepareQueryCampaign("factions",
+        "INSERT INTO fac_history (uuid, faction_id, delta, reason, ts)"
+        " VALUES (@uuid, @fid, @delta, @reason, strftime('%s','now'))");
+    SqlBindString(q, "@uuid",   GetObjectUUID(oPC));
+    SqlBindInt   (q, "@fid",    nFactionId);
+    SqlBindInt   (q, "@delta",  nDelta);
+    SqlBindString(q, "@reason", sReason);
+    SqlStep(q);
+}

--- a/Faction Reputation/Scripts/sys_on_enter.nss
+++ b/Faction Reputation/Scripts/sys_on_enter.nss
@@ -1,0 +1,15 @@
+// sys_on_enter.nss - Faction Reputation: OnClientEnter hook
+//
+// Wire-up: Module Properties -> Events -> OnClientEnter -> sys_on_enter
+// Reapplies all passive faction effects so they survive server restart.
+
+#include "lib_fac"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC) || GetIsDM(oPC)) return;
+
+    // Small delay so the PC object is fully initialised before effects fire.
+    DelayCommand(2.0, FacApplyAllEffects(oPC));
+}

--- a/Faction Reputation/Scripts/sys_on_load.nss
+++ b/Faction Reputation/Scripts/sys_on_load.nss
@@ -1,0 +1,12 @@
+// sys_on_load.nss - Faction Reputation: module OnModuleLoad hook
+//
+// Wire-up: Module Properties -> Events -> OnModuleLoad -> sys_on_load
+// (If the module already has an OnModuleLoad script, call FacInit() from it
+//  instead of replacing the existing entry point.)
+
+#include "lib_fac"
+
+void main()
+{
+    FacInit();
+}

--- a/Faction Reputation/Scripts/test_fac.nss
+++ b/Faction Reputation/Scripts/test_fac.nss
@@ -1,0 +1,39 @@
+// test_fac.nss - Faction Reputation: demo placeable OnUsed script
+//
+// Place a placeable (e.g. a notice board) in the toolset and set its
+// OnUsed event to "test_fac". Using it cycles through demo scenarios:
+//
+//   First use:  opens the Faction Reputation window
+//   !fac <faction_id> <delta> in chat: adjusts reputation (DM only)
+//
+// Demonstrates the full flow: reputation change -> standing tier flip ->
+// effect reapplication -> UI refresh.
+
+#include "lib_fac"
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    // Demo: grant starting reputation spread so the window is interesting
+    int nAlreadySeeded = GetLocalInt(oPC, "FAC_TEST_SEEDED");
+    if(!nAlreadySeeded)
+    {
+        SetLocalInt(oPC, "FAC_TEST_SEEDED", 1);
+
+        // Iron Guard: friendly territory
+        FacAdjust(oPC, FAC_ID_IRON_GUARD,  200, "test:seed");
+        // Brotherhood: mild dislike (rival penalty already reduced Iron Guard a bit)
+        // Night Cult: deep hostile
+        FacAdjust(oPC, FAC_ID_NIGHT_CULT, -300, "test:seed");
+        // Order of Flame: honored
+        FacAdjust(oPC, FAC_ID_ORDER_FLAME, 600, "test:seed");
+
+        SendMessageToPC(oPC,
+            "[Test Frakcji] Reputacja startowa ustawiona. "
+            "Otwieranie panelu...");
+    }
+
+    FacOpenWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

System czterech rywalizujących frakcji mrocznego fantasy z trwałą reputacją
(-1000 … +1000 punktów per frakcja) i mechanicznymi konsekwencjami zależnymi od poziomu
nastawienia. Pełne okno NUI z listą frakcji, paskiem postępu i panelem szczegółów (opis,
konsekwencje mechaniczne). Efekty pasywne (bonus/kara do umiejętności i statystyk) są
automatycznie reaplikowane po każdej zmianie reputacji i po każdym logowaniu.

## Mechanika

**4 frakcje:**
| ID | Nazwa | Rival |
|----|-------|-------|
| 0 | Żelazna Straż | Bractwo Cienia |
| 1 | Bractwo Cienia | Żelazna Straż |
| 2 | Kult Wiecznej Nocy | Zakon Płomienia |
| 3 | Zakon Płomienia | Kult Wiecznej Nocy |

**6 poziomów nastawienia:** Wrogi (≤ -500) → Nieufny → Neutralny → Przychylny (100+) → Szanowany (500+) → Wyniesiony (750+)

**System rywalizacji:** zysk reputacji u jednej frakcji = automatyczna kara 50% delta u frakcji-rywalki.

**Efekty pasywne** (permanent, TagEffect, ExtraordinaryEffect, reaplikowane po każdej zmianie):
- Wrogi: debuff statystyki (np. Żelazna Straż → -2 Cha; Kult Nocy → -2 Will Save)
- Przychylny: minor skill bonus (np. Bractwo → +3 Hide, +3 Move Silently)
- Szanowany: medium bonus (Zakon → +2 Wis, +4 Heal, +1 saves)
- Wyniesiony: pełny bonus + unikatowy efekt (np. Bractwo → +9 Hide/MoveSilently/PickPocket + 10% Concealment; Kult → +9 Spellcraft/Lore + Str+2/Con+1)

**API dla skryptów questów / zdarzeń:**
```nss
FacAdjust(oPC, FAC_ID_IRON_GUARD,  150, "quest:fugitive_captured");
FacAdjust(oPC, FAC_ID_NIGHT_CULT, -200, "event:cultist_killed");
int nPts      = FacGetPoints(oPC, FAC_ID_ORDER_FLAME);
int nStanding = FacGetStanding(nPts);
FacOpenWindow(oPC);  // otwiera panel NUI
```

## Pliki

```
Faction Reputation/
  Scripts/
    sql_fac.nss        — schemat SQLite (fac_reputation + fac_history) + CRUD
    lib_fac_def.nss    — stałe, dane frakcji, helpery standing, NUI bind IDs
    lib_fac.nss        — core: FacAdjust, efekty, NUI window/feed
    lib_fac_ev.nss     — handler OnNuiEvent (close, row select)
    sys_on_load.nss    — hook OnModuleLoad: tworzy tabele
    sys_on_enter.nss   — hook OnClientEnter: reaplikuje efekty po logowaniu
    test_fac.nss       — placeable OnUsed demo (seed reputacji + otwiera UI)
  INTEGRATION.md       — instrukcja hookowania, przykłady API, omissions
```

**LOC:** ~1077 NWScript (551 lib_fac + 322 lib_fac_def + 88 sql_fac + 50 lib_fac_ev + pozostałe)

## Zależności (NWNX? SQL?)

- **SQLite campaign DB** (wbudowany od NWN EE 8193.14) — DB name: `"factions"`, dwie tabele
- **NWN EE NUI** (wbudowany od 8193.14) — wymagany
- **NWNX** — **nie wymagany**

## Jak włączyć w istniejącym module

| Zdarzenie | Skrypt |
|-----------|--------|
| OnModuleLoad | `sys_on_load` (lub wywołaj `FacInit()`) |
| OnClientEnter | `sys_on_enter` (lub wywołaj `FacApplyAllEffects(oPC)` z 2s delay) |
| OnNuiEvent | `lib_fac_ev` (lub dispatcher z `NuiFindWindow` check) |

Szczegóły i przykłady: `INTEGRATION.md`

## Co celowo pominięto

- **DM panel** — brak GUI do ręcznej edycji; historia jest w `fac_history`, dostępna przez SQL
- **NPC-specific wrogość** — moduł dostarcza API (`FacGetStanding`); hookowanie do OnSpawn/OnPerception NPC należy do buildera
- **Ceny merchantów** — opisane w konsekwencjach UI, ale wymagają hooka OnStore / dialogu kupca
- **Offline progression** — reputacja nie zmienia się gdy gracz offline
- **Plik .mod** — środowisko bez toolsetu; patrz `INTEGRATION.md`


---
_Generated by [Claude Code](https://claude.ai/code/session_016Cx5vRnbdjeokmQPAYmZEE)_