### PR TITLE
feat: Curse System (Klątwy)

### DIFF
--- a/Curse System/INTEGRATION.md
+++ b/Curse System/INTEGRATION.md
@@ -1,0 +1,80 @@
+# Curse System — Integracja
+
+## Co to robi
+
+System klątw dla dark-fantasy CRPG. Gracze mogą być dotknięci jedną z 6 nazwanych
+klątw (Gnijąca Dłoń, Piętno Zarazy, Cień Rozpaczy, Klątwa Drżenia, Mróz Duszy,
+Pieczęć Krwi). Każda klątwa ma 3 stadia nasilenia, mechaniczne kary (utrata statystyk,
+spowolnienie, spell failure, HP drain) i flavor text po polsku. Zdjęcie klątwy wymaga
+przedmiotu Święty Olej (`crs_hol_oil`) i złota. Stadium postępuje automatycznie co ~10
+minut realnego czasu.
+
+## Wymagania
+
+- **NWN:EE** build 8193.36 lub wyższy (NUI + TagEffect + SqlPrepareQueryCampaign).
+- Brak zależności NWNX — wszystko korzysta z natywnego API.
+- Kampania SQLite o nazwie `curses` (CreateCampaignDatabase automatycznie).
+
+## Hooki do podpięcia w istniejącym module
+
+| Zdarzenie modułu | Skrypt do wywołania | Opis |
+|---|---|---|
+| OnModuleLoad | `sys_on_load.nss` | Tworzy tabelę `crs_active` |
+| OnClientEnter | `sys_on_enter.nss` | Przywraca efekty, startuje tick |
+| OnClientLeave | `sys_on_leave.nss` | Czyści flagę tickingu |
+
+Jeśli masz już własne skrypty na te zdarzenia, włącz je przez `#include` i wywołaj
+odpowiednią funkcję (`CrsCreateTables()`, itd.).
+
+## Jak nadać/zdjąć klątwę z kodu
+
+```nss
+#include "lib_crs"
+
+// Nadaj klątwę:
+CrsInflict(oPC, CRS_CURSE_PLAGUE_BRAND);
+
+// Otwórz panel klątw:
+CrsOpenWindow(oPC);
+
+// Wymuś zdjęcie (bez kosztu — np. kapłan NPC):
+CrsRemoveEffects(oPC, CRS_CURSE_PLAGUE_BRAND);
+CrsDeleteCurse(oPC, CRS_CURSE_PLAGUE_BRAND);
+```
+
+## Przedmiot: Święty Olej
+
+Stwórz w Toolset przedmiot o tagu `crs_hol_oil` (np. zwykły `it_misc_bottle` z
+nadpisanym tagiem). Umieść go w module lub sprzedawcy. Gracz musi mieć ten przedmiot
+w ekwipunku, by móc skorzystać z przycisku „Zdjąć" w panelu.
+
+## Test (placeable OnUsed)
+
+1. W Toolset stwórz placeable, ustaw `OnUsed = test_crs`.
+2. Umieść w obszarze startowym.
+3. Kliknij: nałoży wszystkie 6 klątw i da 3× Święty Olej.
+4. Kliknij ponownie: otworzy panel klątw.
+
+## Pliki
+
+| Plik | Rola |
+|---|---|
+| `lib_crs_def.nss` | Stałe, lookup nazw/opisów, forward decl |
+| `sql_crs.nss` | Schemat SQLite + CRUD |
+| `lib_crs.nss` | Efekty, logika tick, budowanie i otwieranie NUI |
+| `lib_crs_ev.nss` | Handler eventów NUI |
+| `sys_on_load.nss` | Init tabel |
+| `sys_on_enter.nss` | Restore efektów + start tick |
+| `sys_on_leave.nss` | Cleanup flagi tick |
+| `test_crs.nss` | Demo placeable |
+| `lib_nui.nss` / `lib_nui_utility.nss` | Pomocnicy NUI (wspólne z innymi modułami) |
+
+## Co celowo pominięto
+
+- **HAK z ikoną** — brak niestandardowych ikon; używa domyślnych NWN.
+- **DM panel** — brak osobnego okna dla DM; DM może nadawać klątwy przez
+  `CrsInflict(oPC, id)` z konsolera lub własnego skryptu.
+- **Chat command** (`!klątwy`) — zasugerowany w on_enter, ale nie zaimplementowany;
+  podepnij przez `OnPlayerChat` wg własnych potrzeb.
+- **Odporności rasowe** — klątwy działają na wszystkich; dodaj sprawdzenie rasy/klasy
+  przed `CrsInflict` jeśli potrzebujesz wyjątków.

--- a/Curse System/Scripts/lib_crs.nss
+++ b/Curse System/Scripts/lib_crs.nss
@@ -1,0 +1,486 @@
+#include "lib_crs_def"
+
+// ----------------------------------------------------------------
+// Effect helpers
+// ----------------------------------------------------------------
+
+// Removes all effects with the curse-specific tag from oPC.
+void CrsRemoveEffects(object oPC, int nCurseId)
+{
+    string sTag = CRS_EFF_TAG_PREFIX + IntToString(nCurseId);
+    effect e = GetFirstEffect(oPC);
+    while(GetIsEffectValid(e))
+    {
+        effect eNext = GetNextEffect(oPC);
+        if(GetEffectTag(e) == sTag)
+            RemoveEffect(oPC, e);
+        e = eNext;
+    }
+}
+
+// Removes all curse effects (all IDs) from oPC.
+void CrsRemoveAllEffects(object oPC)
+{
+    CrsRemoveEffects(oPC, CRS_CURSE_ROTTING_HAND);
+    CrsRemoveEffects(oPC, CRS_CURSE_PLAGUE_BRAND);
+    CrsRemoveEffects(oPC, CRS_CURSE_SHADOW_DESPAIR);
+    CrsRemoveEffects(oPC, CRS_CURSE_TREMBLING);
+    CrsRemoveEffects(oPC, CRS_CURSE_SOUL_FROST);
+    CrsRemoveEffects(oPC, CRS_CURSE_BLOOD_SEAL);
+}
+
+// Helper: tag an effect and apply it permanently to oPC.
+void CrsApplyEffect(object oPC, effect e, int nCurseId)
+{
+    e = TagEffect(e, CRS_EFF_TAG_PREFIX + IntToString(nCurseId));
+    e = SupernaturalEffect(e);
+    ApplyEffectToObject(DURATION_TYPE_PERMANENT, e, oPC);
+}
+
+// Applies the mechanical effects for nCurseId at nStage.
+// Call CrsRemoveEffects first to avoid stacking.
+void CrsApplyEffects(object oPC, int nCurseId, int nStage)
+{
+    if(nStage < 1) return;
+
+    switch(nCurseId)
+    {
+        // --- Gnijąca Dłoń: STR/DEX loss + attack penalty ---
+        case CRS_CURSE_ROTTING_HAND:
+        {
+            int nStr = (nStage == 1) ? 2 : (nStage == 2) ? 4 : 6;
+            int nDex = (nStage >= 2) ? (nStage == 2 ? 2 : 4) : 0;
+            int nAtk = (nStage == 1) ? 1 : (nStage == 2) ? 2 : 4;
+            CrsApplyEffect(oPC, EffectAbilityDecrease(ABILITY_STRENGTH,  nStr),   nCurseId);
+            CrsApplyEffect(oPC, EffectAttackDecrease(nAtk, ATTACK_BONUS_MISC),    nCurseId);
+            if(nDex > 0)
+                CrsApplyEffect(oPC, EffectAbilityDecrease(ABILITY_DEXTERITY, nDex), nCurseId);
+            if(nStage == 3)
+                CrsApplyEffect(oPC, EffectSpellFailure(20, SPELL_SCHOOL_GENERAL),  nCurseId);
+            break;
+        }
+        // --- Piętno Zarazy: CON + DEX loss (HP drain is handled in CrsTick) ---
+        case CRS_CURSE_PLAGUE_BRAND:
+        {
+            int nCon = (nStage == 1) ? 2 : (nStage == 2) ? 4 : 6;
+            int nDex = (nStage >= 2) ? (nStage == 2 ? 2 : 4) : 0;
+            int nStr = (nStage == 3) ? 2 : 0;
+            CrsApplyEffect(oPC, EffectAbilityDecrease(ABILITY_CONSTITUTION, nCon), nCurseId);
+            if(nDex > 0)
+                CrsApplyEffect(oPC, EffectAbilityDecrease(ABILITY_DEXTERITY, nDex), nCurseId);
+            if(nStr > 0)
+                CrsApplyEffect(oPC, EffectAbilityDecrease(ABILITY_STRENGTH, nStr),  nCurseId);
+            break;
+        }
+        // --- Cień Rozpaczy: CHA/WIS loss + spell failure ---
+        case CRS_CURSE_SHADOW_DESPAIR:
+        {
+            int nCha = (nStage == 1) ? 3 : (nStage == 2) ? 6 : 9;
+            int nWis = (nStage >= 2) ? (nStage == 2 ? 2 : 4) : 0;
+            int nSkl = (nStage == 1) ? 5 : (nStage == 2) ? 10 : 0;
+            CrsApplyEffect(oPC, EffectAbilityDecrease(ABILITY_CHARISMA, nCha),    nCurseId);
+            if(nWis > 0)
+                CrsApplyEffect(oPC, EffectAbilityDecrease(ABILITY_WISDOM, nWis),  nCurseId);
+            if(nSkl > 0)
+                CrsApplyEffect(oPC, EffectSkillDecrease(SKILL_PERSUADE, nSkl),    nCurseId);
+            if(nStage == 3)
+                CrsApplyEffect(oPC, EffectSpellFailure(25, SPELL_SCHOOL_GENERAL), nCurseId);
+            break;
+        }
+        // --- Klątwa Drżenia: DEX + attack + movement ---
+        case CRS_CURSE_TREMBLING:
+        {
+            int nDex = (nStage == 1) ? 3 : (nStage == 2) ? 6 : 9;
+            int nAtk = (nStage == 1) ? 2 : (nStage == 2) ? 4 : 6;
+            int nMov = (nStage == 1) ? 0 : (nStage == 2) ? 20 : 40;
+            CrsApplyEffect(oPC, EffectAbilityDecrease(ABILITY_DEXTERITY,  nDex), nCurseId);
+            CrsApplyEffect(oPC, EffectAttackDecrease(nAtk, ATTACK_BONUS_MISC),   nCurseId);
+            if(nMov > 0)
+                CrsApplyEffect(oPC, EffectMovementSpeedDecrease(nMov),           nCurseId);
+            break;
+        }
+        // --- Mróz Duszy: WIS/INT loss + movement + spell failure ---
+        case CRS_CURSE_SOUL_FROST:
+        {
+            int nWis = (nStage == 1) ? 2 : (nStage == 2) ? 4 : 6;
+            int nInt = (nStage >= 2) ? (nStage == 2 ? 2 : 4) : 0;
+            int nMov = (nStage == 1) ? 10 : (nStage == 2) ? 20 : 30;
+            CrsApplyEffect(oPC, EffectAbilityDecrease(ABILITY_WISDOM, nWis),      nCurseId);
+            if(nInt > 0)
+                CrsApplyEffect(oPC, EffectAbilityDecrease(ABILITY_INTELLIGENCE, nInt), nCurseId);
+            CrsApplyEffect(oPC, EffectMovementSpeedDecrease(nMov),                nCurseId);
+            if(nStage == 3)
+                CrsApplyEffect(oPC, EffectSpellFailure(15, SPELL_SCHOOL_GENERAL), nCurseId);
+            break;
+        }
+        // --- Pieczęć Krwi: CON + STR loss + attack (HP drain in CrsTick) ---
+        case CRS_CURSE_BLOOD_SEAL:
+        {
+            int nCon = (nStage == 1) ? 2 : (nStage == 2) ? 4 : 6;
+            int nStr = (nStage >= 2) ? (nStage == 2 ? 2 : 4) : 0;
+            int nAtk = (nStage == 3) ? 2 : 0;
+            CrsApplyEffect(oPC, EffectAbilityDecrease(ABILITY_CONSTITUTION, nCon), nCurseId);
+            if(nStr > 0)
+                CrsApplyEffect(oPC, EffectAbilityDecrease(ABILITY_STRENGTH, nStr),  nCurseId);
+            if(nAtk > 0)
+                CrsApplyEffect(oPC, EffectAttackDecrease(nAtk, ATTACK_BONUS_MISC),  nCurseId);
+            break;
+        }
+    }
+}
+
+// Re-applies all effects for oPC from DB state.
+// Removes existing ones first to prevent stacking on login.
+void CrsApplyAllEffects(object oPC)
+{
+    json jAll  = CrsGetAllCurses(oPC);
+    int  nCount = JsonGetLength(jAll);
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jRow    = JsonArrayGet(jAll, i);
+        int nCurseId = JsonGetInt(JsonObjectGet(jRow, "curse_id"));
+        int nStage   = JsonGetInt(JsonObjectGet(jRow, "stage"));
+
+        CrsRemoveEffects(oPC, nCurseId);
+        CrsApplyEffects(oPC, nCurseId, nStage);
+    }
+}
+
+// ----------------------------------------------------------------
+// Inflict / cleanse
+// ----------------------------------------------------------------
+
+void CrsInflict(object oPC, int nCurseId)
+{
+    if(CrsHasCurse(oPC, nCurseId))
+    {
+        SendMessageToPC(oPC, "[Klątwa] Jesteś już dotknięty: " + CrsGetName(nCurseId) + ".");
+        return;
+    }
+
+    CrsAddCurse(oPC, nCurseId);
+    CrsRemoveEffects(oPC, nCurseId);
+    CrsApplyEffects(oPC, nCurseId, 1);
+
+    FloatingTextStringOnCreature("Klątwa: " + CrsGetName(nCurseId), oPC, FALSE);
+    SendMessageToPC(oPC, "[Klątwa] Dosięgła cię: " + CrsGetName(nCurseId) + ". Szukaj świętego oleju, by ją zdjąć.");
+
+    int nToken = NuiFindWindow(oPC, CRS_WINDOW);
+    if(nToken != 0)
+        CrsFeedList(oPC, nToken);
+}
+
+void CrsCleanse(object oPC, int nCurseId)
+{
+    json jCurse = CrsGetCurse(oPC, nCurseId);
+    if(JsonGetType(jCurse) == JSON_TYPE_NULL)
+    {
+        SendMessageToPC(oPC, "[Klątwa] Nie masz tej klątwy.");
+        return;
+    }
+
+    int nStage = JsonGetInt(JsonObjectGet(jCurse, "stage"));
+    int nCost  = CrsGetCleanseCost(nCurseId, nStage);
+
+    if(GetItemPossessedBy(oPC, CRS_ITEM_HOLY_OIL) == OBJECT_INVALID)
+    {
+        SendMessageToPC(oPC, "[Klątwa] Brakuje świętego oleju (crs_hol_oil).");
+        return;
+    }
+    if(GetGold(oPC) < nCost)
+    {
+        SendMessageToPC(oPC, "[Klątwa] Brakuje złota. Potrzebujesz: " + IntToString(nCost) + " sztuk złota.");
+        return;
+    }
+
+    // Consume one holy oil
+    DestroyObject(GetItemPossessedBy(oPC, CRS_ITEM_HOLY_OIL));
+    AssignCommand(oPC, TakeGoldFromCreature(nCost, oPC, TRUE));
+
+    CrsRemoveEffects(oPC, nCurseId);
+    CrsDeleteCurse(oPC, nCurseId);
+
+    FloatingTextStringOnCreature("Klątwa zdjęta: " + CrsGetName(nCurseId), oPC, FALSE);
+    SendMessageToPC(oPC, "[Klątwa] Klątwa " + CrsGetName(nCurseId) + " została zdjęta. Zapłacono " + IntToString(nCost) + " złota.");
+
+    int nToken = NuiFindWindow(oPC, CRS_WINDOW);
+    if(nToken != 0)
+        CrsFeedList(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Tick (called via DelayCommand chain started in sys_on_enter)
+// ----------------------------------------------------------------
+
+void CrsTick(object oPC)
+{
+    if(!GetIsObjectValid(oPC)) return;
+    if(!GetIsPC(oPC))          return;
+
+    json jAll   = CrsGetAllCurses(oPC);
+    int  nCount = JsonGetLength(jAll);
+    if(nCount == 0)
+    {
+        // No curses: reschedule anyway so we catch new inflictions
+        DelayCommand(CRS_TICK_INTERVAL, CrsTick(oPC));
+        return;
+    }
+
+    // HP drain for each curse that has it
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jRow    = JsonArrayGet(jAll, i);
+        int nCurseId = JsonGetInt(JsonObjectGet(jRow, "curse_id"));
+        int nStage   = JsonGetInt(JsonObjectGet(jRow, "stage"));
+
+        int nDrain = CrsGetDrainPerTick(nCurseId, nStage);
+        if(nDrain > 0)
+        {
+            int nHP = GetCurrentHitPoints(oPC);
+            if(nHP > 1)
+            {
+                int nActual = (nDrain >= nHP) ? (nHP - 1) : nDrain;
+                ApplyEffectToObject(DURATION_TYPE_INSTANT,
+                    EffectDamage(nActual, DAMAGE_TYPE_MAGICAL), oPC);
+            }
+        }
+    }
+
+    // Advance tick counters; get list of curses that progressed a stage
+    json jProgressed = CrsTickAllCurses(oPC, CRS_TICKS_PER_STAGE);
+    int nProgCount   = JsonGetLength(jProgressed);
+    for(i = 0; i < nProgCount; i++)
+    {
+        json jP      = JsonArrayGet(jProgressed, i);
+        int nCurseId = JsonGetInt(JsonObjectGet(jP, "curse_id"));
+        int nNew     = JsonGetInt(JsonObjectGet(jP, "new_stage"));
+
+        CrsRemoveEffects(oPC, nCurseId);
+        CrsApplyEffects(oPC, nCurseId, nNew);
+
+        string sMsg = "[Klątwa] " + CrsGetName(nCurseId)
+                      + " wzmocniła się do stadium " + IntToString(nNew) + "!";
+        FloatingTextStringOnCreature(sMsg, oPC, FALSE);
+        SendMessageToPC(oPC, sMsg + " " + CrsGetDesc(nCurseId, nNew));
+    }
+
+    // Refresh window if open
+    int nToken = NuiFindWindow(oPC, CRS_WINDOW);
+    if(nToken != 0)
+        CrsFeedList(oPC, nToken);
+
+    DelayCommand(CRS_TICK_INTERVAL, CrsTick(oPC));
+}
+
+void CrsStartTicking(object oPC)
+{
+    if(GetLocalInt(oPC, CRS_LVAR_TICKING)) return;
+    SetLocalInt(oPC, CRS_LVAR_TICKING, 1);
+    DelayCommand(CRS_TICK_INTERVAL, CrsTick(oPC));
+}
+
+// ----------------------------------------------------------------
+// NUI — window layout
+// ----------------------------------------------------------------
+
+json CrsBuildWindow(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 28.0);
+    float fRowH  = GetNuiScaleDimension(oPC, 66.0);
+    float fNameW = GetNuiScaleDimension(oPC, 180.0);
+    float fDotW  = GetNuiScaleDimension(oPC, 56.0);
+    float fBtnW  = GetNuiScaleDimension(oPC, 110.0);
+    float fListH = GetNuiScaleDimension(oPC, 360.0);
+    float fInfoH = GetNuiScaleDimension(oPC, 24.0);
+
+    // --- List row template ---
+    // Col: name + stage dots
+    json jNameLbl = NuiLabel(NuiBind(CRS_BIND_NAME), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_TOP));
+    jNameLbl = NuiStyleForegroundColor(jNameLbl, NuiBind(CRS_BIND_COLOR));
+    jNameLbl = NuiHeight(jNameLbl, GetNuiScaleDimension(oPC, 22.0));
+
+    json jDotLbl = NuiLabel(NuiBind(CRS_BIND_STAGE_DOT), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_TOP));
+    jDotLbl = NuiStyleForegroundColor(jDotLbl, NuiBind(CRS_BIND_COLOR));
+    jDotLbl = NuiHeight(jDotLbl, GetNuiScaleDimension(oPC, 22.0));
+    jDotLbl = NuiWidth(jDotLbl,  fDotW);
+
+    json jDescLbl = NuiLabel(NuiBind(CRS_BIND_DESC), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_TOP));
+    jDescLbl = NuiStyleForegroundColor(jDescLbl, NuiColor(200, 180, 150));
+    jDescLbl = NuiHeight(jDescLbl, GetNuiScaleDimension(oPC, 40.0));
+
+    json jLeftCol = JsonArray();
+    jLeftCol = JsonArrayInsert(jLeftCol, NuiRow(JsonArrayInsert(JsonArrayInsert(JsonArray(), jNameLbl), jDotLbl)));
+    jLeftCol = JsonArrayInsert(jLeftCol, jDescLbl);
+    json jLeft = NuiCol(jLeftCol);
+
+    // Cleanse button
+    json jBtn = NuiButton(NuiBind(CRS_BIND_BTN_LBL));
+    jBtn = NuiId(jBtn,      CRS_BTN_CLEANSE);
+    jBtn = NuiEnabled(jBtn, NuiBind(CRS_BIND_BTN_ENA));
+    jBtn = NuiWidth(jBtn,   fBtnW);
+    jBtn = NuiHeight(jBtn,  GetNuiScaleDimension(oPC, 44.0));
+    jBtn = NuiTooltip(jBtn, JsonString("Wymaga: Święty Olej + złoto"));
+
+    json jRowArr = JsonArray();
+    jRowArr = JsonArrayInsert(jRowArr, jLeft);
+    jRowArr = JsonArrayInsert(jRowArr, jBtn);
+    json jRowWidget = NuiGroup(NuiRow(jRowArr), FALSE, NUI_SCROLLBARS_NONE);
+
+    json jTmpl = JsonArray();
+    jTmpl = JsonArrayInsert(jTmpl, NuiListTemplateCell(jRowWidget, 0.0, TRUE));
+
+    json jList = NuiList(jTmpl, NuiBind(CRS_BIND_ROWCOUNT), fRowH);
+    jList = NuiHeight(jList, fListH);
+
+    // Empty-state label (shown when no curses active)
+    json jEmptyLbl = NuiLabel(
+        JsonString("Nie masz aktywnych klątw."),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jEmptyLbl = NuiVisible(jEmptyLbl, NuiBind(CRS_BIND_EMPTY_VIS));
+    jEmptyLbl = NuiHeight(jEmptyLbl, GetNuiScaleDimension(oPC, 40.0));
+
+    // Info bar at bottom
+    json jInfoLbl = NuiLabel(NuiBind(CRS_BIND_INFO), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jInfoLbl = NuiStyleForegroundColor(jInfoLbl, NuiColor(220, 190, 100));
+    jInfoLbl = NuiHeight(jInfoLbl, fInfoH);
+
+    // Close button
+    json jClose = NuiButton(JsonString("Zamknij"));
+    jClose = NuiId(jClose,    CRS_BTN_CLOSE);
+    jClose = NuiWidth(jClose, GetNuiScaleDimension(oPC, 80.0));
+    jClose = NuiHeight(jClose, fBtnH);
+
+    json jBotRow = JsonArray();
+    jBotRow = JsonArrayInsert(jBotRow, jInfoLbl);
+    jBotRow = JsonArrayInsert(jBotRow, NuiSpacer());
+    jBotRow = JsonArrayInsert(jBotRow, jClose);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jEmptyLbl);
+    jCol = JsonArrayInsert(jCol, jList);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBotRow));
+
+    json jSide    = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    float fContW  = GetNuiScaleDimension(oPC, 558.0);
+    json jMainRow = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiCol(jCol), fContW));
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+
+    return NuiRow(jMainRow);
+}
+
+// ----------------------------------------------------------------
+// NUI — feed data
+// ----------------------------------------------------------------
+
+void CrsFeedList(object oPC, int nToken)
+{
+    json jAll   = CrsGetAllCurses(oPC);
+    int  nCount = JsonGetLength(jAll);
+
+    // Store row->curse_id map on PC for event handler lookup
+    json jRowMap = JsonArray();
+
+    json jNames  = JsonArray();
+    json jDots   = JsonArray();
+    json jDescs  = JsonArray();
+    json jColors = JsonArray();
+    json jBtnEna = JsonArray();
+    json jBtnLbl = JsonArray();
+
+    int bHasOil = (GetItemPossessedBy(oPC, CRS_ITEM_HOLY_OIL) != OBJECT_INVALID);
+    int nGold   = GetGold(oPC);
+
+    json jRed    = NuiColor(220,  60,  60);
+    json jOrange = NuiColor(230, 130,  40);
+    json jCrimson= NuiColor(160,  20,  20);
+
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jRow    = JsonArrayGet(jAll, i);
+        int nCurseId = JsonGetInt(JsonObjectGet(jRow, "curse_id"));
+        int nStage   = JsonGetInt(JsonObjectGet(jRow, "stage"));
+
+        string sDots;
+        switch(nStage)
+        {
+            case 1:  sDots = "\xe2\x97\x8f\xe2\x97\x8b\xe2\x97\x8b"; break; // ●○○
+            case 2:  sDots = "\xe2\x97\x8f\xe2\x97\x8f\xe2\x97\x8b"; break; // ●●○
+            default: sDots = "\xe2\x97\x8f\xe2\x97\x8f\xe2\x97\x8f"; break; // ●●●
+        }
+
+        int nCost    = CrsGetCleanseCost(nCurseId, nStage);
+        int bCanClns = bHasOil && (nGold >= nCost);
+
+        json jColor;
+        switch(nStage)
+        {
+            case 1:  jColor = jOrange;  break;
+            case 2:  jColor = jRed;     break;
+            default: jColor = jCrimson; break;
+        }
+
+        jRowMap  = JsonArrayInsert(jRowMap,  JsonInt(nCurseId));
+        jNames   = JsonArrayInsert(jNames,   JsonString(CrsGetName(nCurseId)));
+        jDots    = JsonArrayInsert(jDots,    JsonString(sDots));
+        jDescs   = JsonArrayInsert(jDescs,   JsonString(CrsGetDesc(nCurseId, nStage)));
+        jColors  = JsonArrayInsert(jColors,  jColor);
+        jBtnEna  = JsonArrayInsert(jBtnEna,  JsonBool(bCanClns));
+        jBtnLbl  = JsonArrayInsert(jBtnLbl,  JsonString("Zdjąć (" + IntToString(nCost) + "z)"));
+    }
+
+    SetLocalJson(oPC, CRS_LVAR_CURSE_ROW, jRowMap);
+
+    NuiSetBind(oPC, nToken, CRS_BIND_ROWCOUNT,  JsonInt(nCount));
+    NuiSetBind(oPC, nToken, CRS_BIND_NAME,       jNames);
+    NuiSetBind(oPC, nToken, CRS_BIND_STAGE_DOT,  jDots);
+    NuiSetBind(oPC, nToken, CRS_BIND_DESC,        jDescs);
+    NuiSetBind(oPC, nToken, CRS_BIND_COLOR,       jColors);
+    NuiSetBind(oPC, nToken, CRS_BIND_BTN_ENA,     jBtnEna);
+    NuiSetBind(oPC, nToken, CRS_BIND_BTN_LBL,     jBtnLbl);
+    NuiSetBind(oPC, nToken, CRS_BIND_EMPTY_VIS,   JsonBool(nCount == 0));
+
+    string sOilInfo = bHasOil ? "Masz Święty Olej." : "Brak Świętego Oleju — nie możesz zdjąć klątwy.";
+    NuiSetBind(oPC, nToken, CRS_BIND_INFO, JsonString(sOilInfo));
+}
+
+// ----------------------------------------------------------------
+// NUI — open window
+// ----------------------------------------------------------------
+
+void CrsOpenWindow(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, CRS_WINDOW);
+    if(nToken != 0)
+    {
+        CrsFeedList(oPC, nToken);
+        return;
+    }
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))
+                 - GetNuiScaleDimension(oPC, CRS_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT))
+                 - GetNuiScaleDimension(oPC, CRS_H)) / 2.0;
+    json jGeom = NuiRect(fCX, fCY,
+                         GetNuiScaleDimension(oPC, CRS_W),
+                         GetNuiScaleDimension(oPC, CRS_H));
+
+    json jWin = NuiWindow(
+        CrsBuildWindow(oPC),
+        JsonString("Klątwy"),
+        NuiBind(CRS_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    nToken = NuiCreate(oPC, jWin, CRS_WINDOW, CRS_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, CRS_WIN_GEOM, jGeom);
+    CrsFeedList(oPC, nToken);
+}

--- a/Curse System/Scripts/lib_crs_def.nss
+++ b/Curse System/Scripts/lib_crs_def.nss
@@ -1,0 +1,199 @@
+#include "lib_nui"
+#include "sql_crs"
+
+void CrsOpenWindow(object oPC);
+void CrsFeedList(object oPC, int nToken);
+void CrsApplyEffects(object oPC, int nCurseId, int nStage);
+void CrsRemoveEffects(object oPC, int nCurseId);
+void CrsApplyAllEffects(object oPC);
+void CrsRemoveAllEffects(object oPC);
+void CrsInflict(object oPC, int nCurseId);
+void CrsCleanse(object oPC, int nCurseId);
+void CrsStartTicking(object oPC);
+void CrsTick(object oPC);
+
+// ----------------------------------------------------------------
+// Window identity
+// ----------------------------------------------------------------
+
+const string CRS_WINDOW     = "CRS_WINDOW";
+const string CRS_EV_SCRIPT  = "lib_crs_ev";
+const string CRS_WIN_GEOM   = "crs_win_geom";
+
+const float CRS_W           = 600.0;
+const float CRS_H           = 500.0;
+
+// ----------------------------------------------------------------
+// Bind names (parallel arrays for NuiList)
+// ----------------------------------------------------------------
+
+const string CRS_BIND_ROWCOUNT  = "crs_row_cnt";
+const string CRS_BIND_NAME      = "crs_row_name";
+const string CRS_BIND_STAGE_DOT = "crs_row_dot";
+const string CRS_BIND_DESC      = "crs_row_desc";
+const string CRS_BIND_COLOR     = "crs_row_color";
+const string CRS_BIND_BTN_ENA   = "crs_row_btn_ena";
+const string CRS_BIND_BTN_LBL   = "crs_row_btn_lbl";
+const string CRS_BIND_INFO      = "crs_info_lbl";
+const string CRS_BIND_EMPTY_VIS = "crs_empty_vis";
+
+// ----------------------------------------------------------------
+// Buttons
+// ----------------------------------------------------------------
+
+const string CRS_BTN_CLOSE   = "crs_btn_close";
+const string CRS_BTN_CLEANSE = "crs_btn_clns";   // + IntToString(row index)
+
+// ----------------------------------------------------------------
+// Local variables on PC
+// ----------------------------------------------------------------
+
+const string CRS_LVAR_TICKING    = "CRS_TICKING";
+const string CRS_LVAR_CURSE_ROW  = "CRS_CURSE_ROW";  // json array: curse_id per visible row
+
+// ----------------------------------------------------------------
+// Items / consumables
+// ----------------------------------------------------------------
+
+// Tag of the item required for cleansing; must exist in the HAK or module palette.
+const string CRS_ITEM_HOLY_OIL   = "crs_hol_oil";
+
+// ----------------------------------------------------------------
+// Progression timing
+// ----------------------------------------------------------------
+
+// Every CRS_TICK_INTERVAL real seconds the tick function fires.
+const float CRS_TICK_INTERVAL    = 60.0;
+
+// After CRS_TICKS_PER_STAGE ticks a curse advances one stage (max 3).
+const int   CRS_TICKS_PER_STAGE  = 10;
+
+// ----------------------------------------------------------------
+// Curse IDs
+// ----------------------------------------------------------------
+
+const int CRS_CURSE_ROTTING_HAND   = 1;
+const int CRS_CURSE_PLAGUE_BRAND   = 2;
+const int CRS_CURSE_SHADOW_DESPAIR = 3;
+const int CRS_CURSE_TREMBLING      = 4;
+const int CRS_CURSE_SOUL_FROST     = 5;
+const int CRS_CURSE_BLOOD_SEAL     = 6;
+
+// ----------------------------------------------------------------
+// Effect tag prefix (used with TagEffect for identification)
+// ----------------------------------------------------------------
+
+const string CRS_EFF_TAG_PREFIX = "CRS_EFF_";
+
+// ----------------------------------------------------------------
+// Curse name lookup
+// ----------------------------------------------------------------
+
+string CrsGetName(int nCurseId)
+{
+    switch(nCurseId)
+    {
+        case CRS_CURSE_ROTTING_HAND:    return "Gnijąca Dłoń";
+        case CRS_CURSE_PLAGUE_BRAND:    return "Piętno Zarazy";
+        case CRS_CURSE_SHADOW_DESPAIR:  return "Cień Rozpaczy";
+        case CRS_CURSE_TREMBLING:       return "Klątwa Drżenia";
+        case CRS_CURSE_SOUL_FROST:      return "Mróz Duszy";
+        case CRS_CURSE_BLOOD_SEAL:      return "Pieczęć Krwi";
+    }
+    return "Nieznana klątwa";
+}
+
+// ----------------------------------------------------------------
+// Stage description lookup  (flavor text, Polish)
+// ----------------------------------------------------------------
+
+string CrsGetDesc(int nCurseId, int nStage)
+{
+    switch(nCurseId)
+    {
+        case CRS_CURSE_ROTTING_HAND:
+            switch(nStage)
+            {
+                case 1: return "Dłoń powoli więdnie. Ból przeszywa kości przy każdym zamachu.";
+                case 2: return "Palce czernieją. Chwyt słabnie, a oręż wypada z rąk bez ostrzeżenia.";
+                case 3: return "Ręka to zbutwiały kikut. Dotknięcie śmierci sączy się ku ramienion.";
+            }
+            break;
+        case CRS_CURSE_PLAGUE_BRAND:
+            switch(nStage)
+            {
+                case 1: return "Czarne znamię na skórze pulsuje ciepłem. Ciało traci siły.";
+                case 2: return "Znamię rozszerza się. Wnętrzności gnią od środka. Każdy oddech kosztuje.";
+                case 3: return "Skóra odpada płatami. Śmierć zbliża się powoli, nieubłaganie.";
+            }
+            break;
+        case CRS_CURSE_SHADOW_DESPAIR:
+            switch(nStage)
+            {
+                case 1: return "Czarny cień przylgnął do duszy. Słowa stają się puste i pozbawione sensu.";
+                case 2: return "Dusza kruszy się pod ciężarem rozpaczy. Inni wyczuwają obcość i stronią.";
+                case 3: return "Pustka wewnątrz jest nieodwracalna. Bogowie nie słyszą już modlitw.";
+            }
+            break;
+        case CRS_CURSE_TREMBLING:
+            switch(nStage)
+            {
+                case 1: return "Ręce drżą bez ustanku. Cel wydaje się daleki, a strzały chybią.";
+                case 2: return "Całe ciało trzęsie się konwulsyjnie. Każdy krok to walka z własnymi nogami.";
+                case 3: return "Kości szczękają. Ciało odmawia posłuszeństwa. Ucieczka staje się niemożliwa.";
+            }
+            break;
+        case CRS_CURSE_SOUL_FROST:
+            switch(nStage)
+            {
+                case 1: return "Zimno skuło duszę. Myśli są jak lód, zaklęcia wymykają się z umysłu.";
+                case 2: return "Lód wkrada się do żył. Pamięć blednie. Słowa zaklęć znikają przed wymówieniem.";
+                case 3: return "Dusza zamarznięta. Magia odpycha czarodzieja jak ciało odtrąca metal.";
+            }
+            break;
+        case CRS_CURSE_BLOOD_SEAL:
+            switch(nStage)
+            {
+                case 1: return "Krwawa pieczęć na piersi pulsuje słabo. Krew spływa bez widocznej rany.";
+                case 2: return "Pieczęć rozszerza się. Siły witalne opadają z każdym biciem serca.";
+                case 3: return "Pieczęć pochłania życie. Ciało umiera za życia, krok po kroku.";
+            }
+            break;
+    }
+    return "";
+}
+
+// ----------------------------------------------------------------
+// Gold cost to cleanse (per stage)
+// ----------------------------------------------------------------
+
+int CrsGetCleanseCost(int nCurseId, int nStage)
+{
+    // Base cost scales with stage; some curses cost more
+    int nBase;
+    switch(nCurseId)
+    {
+        case CRS_CURSE_BLOOD_SEAL:  nBase = 300; break;
+        case CRS_CURSE_PLAGUE_BRAND: nBase = 250; break;
+        default:                     nBase = 150; break;
+    }
+    return nBase * nStage;
+}
+
+// ----------------------------------------------------------------
+// HP drain per tick (0 = none)
+// ----------------------------------------------------------------
+
+int CrsGetDrainPerTick(int nCurseId, int nStage)
+{
+    switch(nCurseId)
+    {
+        case CRS_CURSE_PLAGUE_BRAND:
+            switch(nStage) { case 1: return 3; case 2: return 7; case 3: return 14; }
+            break;
+        case CRS_CURSE_BLOOD_SEAL:
+            switch(nStage) { case 1: return 2; case 2: return 6; case 3: return 12; }
+            break;
+    }
+    return 0;
+}

--- a/Curse System/Scripts/lib_crs_ev.nss
+++ b/Curse System/Scripts/lib_crs_ev.nss
@@ -1,0 +1,38 @@
+#include "lib_crs"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    if(nToken != NuiFindWindow(oPC, CRS_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalJson(oPC, CRS_LVAR_CURSE_ROW);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == CRS_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        if(sElem == CRS_BTN_CLEANSE)
+        {
+            json jMap = GetLocalJson(oPC, CRS_LVAR_CURSE_ROW);
+            if(JsonGetType(jMap) != JSON_TYPE_ARRAY) return;
+            if(nIdx < 0 || nIdx >= JsonGetLength(jMap)) return;
+
+            int nCurseId = JsonGetInt(JsonArrayGet(jMap, nIdx));
+            CrsCleanse(oPC, nCurseId);
+            return;
+        }
+    }
+}

--- a/Curse System/Scripts/lib_nui.nss
+++ b/Curse System/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Curse System/Scripts/lib_nui_utility.nss
+++ b/Curse System/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Curse System/Scripts/sql_crs.nss
+++ b/Curse System/Scripts/sql_crs.nss
@@ -1,0 +1,153 @@
+// Persistent curse storage.
+// One row per (char_uuid, curse_id) pair; unique constraint prevents duplicates.
+// tick_count drives stage progression: after CRS_TICKS_PER_STAGE ticks stage++, max 3.
+
+void CrsCreateTables()
+{
+    sqlquery sql = SqlPrepareQueryCampaign("curses",
+        "CREATE TABLE IF NOT EXISTS crs_active ("
+        "  id         INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "  char_uuid  TEXT    NOT NULL,"
+        "  curse_id   INTEGER NOT NULL,"
+        "  stage      INTEGER NOT NULL DEFAULT 1,"
+        "  tick_count INTEGER NOT NULL DEFAULT 0,"
+        "  applied_at INTEGER NOT NULL,"
+        "  UNIQUE(char_uuid, curse_id)"
+        ");"
+    );
+    SqlStep(sql);
+}
+
+// Returns TRUE if oPC already has nCurseId active.
+int CrsHasCurse(object oPC, int nCurseId)
+{
+    string sUUID = GetObjectUUID(oPC);
+    sqlquery sql = SqlPrepareQueryCampaign("curses",
+        "SELECT id FROM crs_active WHERE char_uuid=@uuid AND curse_id=@cid LIMIT 1;"
+    );
+    SqlBindString(sql, "@uuid", sUUID);
+    SqlBindInt   (sql, "@cid",  nCurseId);
+    return SqlStep(sql);
+}
+
+// Adds the curse at stage 1. If already present, does nothing.
+void CrsAddCurse(object oPC, int nCurseId)
+{
+    string sUUID = GetObjectUUID(oPC);
+    int nNow     = GetCalendarYear() * 525600
+                   + GetCalendarMonth() * 43800
+                   + GetCalendarDay()   * 1440
+                   + GetTimeHour()      * 60
+                   + GetTimeMinute();
+    sqlquery sql = SqlPrepareQueryCampaign("curses",
+        "INSERT OR IGNORE INTO crs_active (char_uuid, curse_id, stage, tick_count, applied_at)"
+        " VALUES (@uuid, @cid, 1, 0, @ts);"
+    );
+    SqlBindString(sql, "@uuid", sUUID);
+    SqlBindInt   (sql, "@cid",  nCurseId);
+    SqlBindInt   (sql, "@ts",   nNow);
+    SqlStep(sql);
+}
+
+// Removes the curse record for oPC.
+void CrsDeleteCurse(object oPC, int nCurseId)
+{
+    sqlquery sql = SqlPrepareQueryCampaign("curses",
+        "DELETE FROM crs_active WHERE char_uuid=@uuid AND curse_id=@cid;"
+    );
+    SqlBindString(sql, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (sql, "@cid",  nCurseId);
+    SqlStep(sql);
+}
+
+// Returns json array of {curse_id, stage, tick_count}, sorted by curse_id.
+json CrsGetAllCurses(object oPC)
+{
+    sqlquery sql = SqlPrepareQueryCampaign("curses",
+        "SELECT curse_id, stage, tick_count FROM crs_active"
+        " WHERE char_uuid=@uuid ORDER BY curse_id ASC;"
+    );
+    SqlBindString(sql, "@uuid", GetObjectUUID(oPC));
+
+    json jResult = JsonArray();
+    while(SqlStep(sql))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "curse_id",   JsonInt(SqlGetInt(sql, 0)));
+        jRow = JsonObjectSet(jRow, "stage",      JsonInt(SqlGetInt(sql, 1)));
+        jRow = JsonObjectSet(jRow, "tick_count", JsonInt(SqlGetInt(sql, 2)));
+        jResult = JsonArrayInsert(jResult, jRow);
+    }
+    return jResult;
+}
+
+// Returns {curse_id, stage, tick_count} for a specific curse, or JSON_NULL if absent.
+json CrsGetCurse(object oPC, int nCurseId)
+{
+    sqlquery sql = SqlPrepareQueryCampaign("curses",
+        "SELECT curse_id, stage, tick_count FROM crs_active"
+        " WHERE char_uuid=@uuid AND curse_id=@cid LIMIT 1;"
+    );
+    SqlBindString(sql, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (sql, "@cid",  nCurseId);
+
+    if(!SqlStep(sql)) return JsonNull();
+
+    json jRow = JsonObject();
+    jRow = JsonObjectSet(jRow, "curse_id",   JsonInt(SqlGetInt(sql, 0)));
+    jRow = JsonObjectSet(jRow, "stage",      JsonInt(SqlGetInt(sql, 1)));
+    jRow = JsonObjectSet(jRow, "tick_count", JsonInt(SqlGetInt(sql, 2)));
+    return jRow;
+}
+
+// Increments tick_count for all of oPC's curses.
+// Returns json array of {curse_id, old_stage, new_stage} for curses that progressed.
+json CrsTickAllCurses(object oPC, int nTicksPerStage)
+{
+    json jProgressed = JsonArray();
+    json jAll = CrsGetAllCurses(oPC);
+    int nCount = JsonGetLength(jAll);
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jRow      = JsonArrayGet(jAll, i);
+        int nCurseId   = JsonGetInt(JsonObjectGet(jRow, "curse_id"));
+        int nStage     = JsonGetInt(JsonObjectGet(jRow, "stage"));
+        int nTicks     = JsonGetInt(JsonObjectGet(jRow, "tick_count"));
+
+        if(nStage >= 3)
+        {
+            // Already at max stage; keep ticking so UI still fires, but no DB write needed
+            continue;
+        }
+
+        int nNewTicks = nTicks + 1;
+        int nNewStage = nStage;
+        if(nNewTicks >= nTicksPerStage)
+        {
+            nNewTicks = 0;
+            nNewStage = nStage + 1;
+            if(nNewStage > 3) nNewStage = 3;
+        }
+
+        sqlquery sql = SqlPrepareQueryCampaign("curses",
+            "UPDATE crs_active SET tick_count=@tc, stage=@st"
+            " WHERE char_uuid=@uuid AND curse_id=@cid;"
+        );
+        SqlBindInt   (sql, "@tc",   nNewTicks);
+        SqlBindInt   (sql, "@st",   nNewStage);
+        SqlBindString(sql, "@uuid", GetObjectUUID(oPC));
+        SqlBindInt   (sql, "@cid",  nCurseId);
+        SqlStep(sql);
+
+        if(nNewStage != nStage)
+        {
+            json jProg = JsonObject();
+            jProg = JsonObjectSet(jProg, "curse_id",  JsonInt(nCurseId));
+            jProg = JsonObjectSet(jProg, "old_stage", JsonInt(nStage));
+            jProg = JsonObjectSet(jProg, "new_stage", JsonInt(nNewStage));
+            jProgressed = JsonArrayInsert(jProgressed, jProg);
+        }
+    }
+    return jProgressed;
+}

--- a/Curse System/Scripts/sys_on_enter.nss
+++ b/Curse System/Scripts/sys_on_enter.nss
@@ -1,0 +1,18 @@
+#include "lib_crs"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC) || GetIsDMPossessed(oPC)) return;
+
+    // Re-apply curse effects lost on logout
+    CrsApplyAllEffects(oPC);
+
+    // Start the per-PC tick chain (idempotent guard inside)
+    CrsStartTicking(oPC);
+
+    // Notify if any curses are active
+    json jAll = CrsGetAllCurses(oPC);
+    if(JsonGetLength(jAll) > 0)
+        SendMessageToPC(oPC, "[Klątwy] Masz aktywne klątwy. Wpisz !klątwy lub użyj placeable by otworzyć panel.");
+}

--- a/Curse System/Scripts/sys_on_leave.nss
+++ b/Curse System/Scripts/sys_on_leave.nss
@@ -1,0 +1,10 @@
+#include "lib_crs_def"
+
+void main()
+{
+    object oPC = GetExitingObject();
+    if(!GetIsPC(oPC)) return;
+
+    // Clear ticking flag so CrsStartTicking works correctly on next login
+    DeleteLocalInt(oPC, CRS_LVAR_TICKING);
+}

--- a/Curse System/Scripts/sys_on_load.nss
+++ b/Curse System/Scripts/sys_on_load.nss
@@ -1,0 +1,6 @@
+#include "sql_crs"
+
+void main()
+{
+    CrsCreateTables();
+}

--- a/Curse System/Scripts/test_crs.nss
+++ b/Curse System/Scripts/test_crs.nss
@@ -1,0 +1,34 @@
+// OnUsed on a placeable.
+// First click:  inflicts all 6 curses on the using PC (for demo).
+// Second click: opens the Curse Panel so the player can cleanse.
+// Spawn the placeable, give yourself a crs_hol_oil item + gold to test cleansing.
+
+#include "lib_crs"
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    // If any curse already active, just open the panel
+    if(JsonGetLength(CrsGetAllCurses(oPC)) > 0)
+    {
+        CrsOpenWindow(oPC);
+        return;
+    }
+
+    // Give the PC one of each curse for demonstration
+    CrsInflict(oPC, CRS_CURSE_ROTTING_HAND);
+    CrsInflict(oPC, CRS_CURSE_PLAGUE_BRAND);
+    CrsInflict(oPC, CRS_CURSE_SHADOW_DESPAIR);
+    CrsInflict(oPC, CRS_CURSE_TREMBLING);
+    CrsInflict(oPC, CRS_CURSE_SOUL_FROST);
+    CrsInflict(oPC, CRS_CURSE_BLOOD_SEAL);
+
+    // Give a holy oil for test cleansing
+    CreateItemOnObject(CRS_ITEM_HOLY_OIL, oPC, 3);
+
+    SendMessageToPC(oPC, "[Test] Nałożono wszystkie klątwy. Kliknij ponownie, by otworzyć panel klątw.");
+
+    CrsStartTicking(oPC);
+}


### PR DESCRIPTION
## Co to robi

System klątw dla dark-fantasy CRPG. Gracz może być dotknięty jedną lub wieloma spośród 6 nazwanych klątw. Każda klątwa ma 3 stadia nasilenia, które postępują automatycznie w czasie. Zdjęcie klątwy wymaga przedmiotu i złota.

## Mechanika

- **6 klątw**: Gnijąca Dłoń (STR/DEX/attack), Piętno Zarazy (CON + HP drain), Cień Rozpaczy (CHA/WIS/spell failure), Klątwa Drżenia (DEX/attack/ruch), Mróz Duszy (WIS/INT/ruch/spell failure), Pieczęć Krwi (CON/STR + HP drain).
- **Stadia 1–3**: co 10 minut realnego czasu klątwa wzmacnia się (więcej kar, mocniejszy HP drain). Stadium 3 to stan krytyczny — pełny zestaw efektów i maksymalny drain.
- **Efekty**: `SupernaturalEffect` + `TagEffect("CRS_EFF_N")` — po wylogowaniu tracone, przywracane w `sys_on_enter`. Usuwanie przez iterację `GetFirstEffect/GetNextEffect` po tagu.
- **HP drain**: Piętno Zarazy i Pieczęć Krwi odejmują HP co 60s (nie poniżej 1 HP), poprzez `DURATION_TYPE_INSTANT EffectDamage(DAMAGE_TYPE_MAGICAL)`.
- **Zdjęcie klątwy**: wymaga `crs_hol_oil` (Święty Olej) w ekwipunku + złota. Koszt rośnie ze stadium (150–2000g zależnie od klątwy).
- **NUI panel**: lista aktywnych klątw z dotowym wskaźnikiem stadium (●◌◌/●●◌/●●●), flavor-textem i przyciskiem „Zdjąć (Xz)". Przycisk jest wyłączony gdy brak oleju lub złota.
- **SQLite**: kampania `curses`, tabela `crs_active` z `UNIQUE(char_uuid, curse_id)` — brak duplikatów nawet przy równoczesnym inflict.

## Pliki

| Plik | Rola |
|---|---|
| `Scripts/lib_crs_def.nss` | Stałe, lookup nazw/opisów/kosztów, forward decl |
| `Scripts/sql_crs.nss` | CREATE TABLE + CRUD + tick progression |
| `Scripts/lib_crs.nss` | Efekty TagEffect, tick chain, NUI build + feed |
| `Scripts/lib_crs_ev.nss` | NUI event handler |
| `Scripts/sys_on_load.nss` | Inicjalizacja tabel |
| `Scripts/sys_on_enter.nss` | Restore efektów + start tick |
| `Scripts/sys_on_leave.nss` | Cleanup flagi tick |
| `Scripts/test_crs.nss` | Placeable OnUsed — demo wszystkich 6 klątw |
| `INTEGRATION.md` | Tabela hooków, API, opis przedmiotu |

## Zależności

- **NWNX**: brak — tylko natywne NWN:EE API (build 8193.36+).
- **SQLite**: kampania `curses` — tworzona automatycznie przez `SqlPrepareQueryCampaign`.
- **Przedmiot**: `crs_hol_oil` — twórca modułu musi dodać do palety/sprzedawcy (dowolny item z tym tagiem).

## Jak włączyć w istniejącym module

1. Skopiuj folder `Scripts/` do swojego modułu.
2. W `OnModuleLoad` wywołaj `CrsCreateTables()` (lub include `sys_on_load.nss`).
3. W `OnClientEnter` wywołaj `CrsApplyAllEffects(oPC)` i `CrsStartTicking(oPC)`.
4. W `OnClientLeave` wywołaj `DeleteLocalInt(oPC, CRS_LVAR_TICKING)`.
5. Dodaj item `crs_hol_oil` do modułu.
6. Nadawaj klątwy przez `CrsInflict(oPC, CRS_CURSE_*)` z dowolnego skryptu.

## Co celowo pominięto

- **DM panel** — brak osobnego okna; DM nadaje klątwy przez konsoler lub własny skrypt.
- **Chat command** `!klątwy` — wzmiankowany w `sys_on_enter`, nie zaimplementowany; podepnij samodzielnie przez `OnPlayerChat`.
- **HAK z ikoną** — brak custom ikon, używa domyślnych NWN.
- **Odporności rasowe/klasowe** — klątwy działają na wszystkich; filtrowanie zostaw twórcy modułu.
- **Plik `.mod`** — środowisko nie pozwala pakować `.mod`; patrz `INTEGRATION.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_011h5kT3odPMTP8SdnshfdQ3)_