### PR TITLE
feat: Nekromancja — Słudzy Ciemności

### DIFF
--- a/Necromancy/INTEGRATION.md
+++ b/Necromancy/INTEGRATION.md
@@ -1,0 +1,126 @@
+# Necromancy — Instrukcja integracji
+
+## Co to robi
+
+System nekromancji umożliwia graczom przywoływanie poległych stworów jako
+nieumarłych sług (Szkielet / Zombie / Cień / Wight). Słudzy są persystentni
+(baza SQL), zużywają Esencję Dusz i towarzyszą graczowi na mapie. Panel NUI
+pozwala zarządzać listą sług, dokarmiać ich esencją i rozwiązywać więzy.
+
+## Mechanika — skrót
+
+| Element | Opis |
+|---|---|
+| Esencja Dusz | Waluta zdobywana z zabijania stworów; koszt przywołania: 60 pkt |
+| Typy sług | Szkielet (CR<5), Zombie (CR 5–9), Cień (undead→Cień), Wight (CR≥10) |
+| Limit sług | 1–5 (rośnie co 5 poziomów postaci) |
+| Rozpad | Co ~6 s odejmowany jest drain (2–6 pkt/tick); sługa ginie przy 0 esencji |
+| Persystencja | Sluga i jego esencja zapisywane są w kampanijnej bazie "nec" |
+
+## Pliki
+
+| Plik | Rola |
+|---|---|
+| `sql_nec.nss` | Schema SQLite, CRUD — jedyne miejsce z zapytaniami |
+| `lib_nec_def.nss` | Stałe, ID bindów, pomocniki typów |
+| `lib_nec.nss` | Budowanie okna NUI, cały gameplay (bind/feed/dismiss/spawn/decay) |
+| `lib_nec_ev.nss` | Handler eventów NUI — podepnij jako `nui_script` |
+| `sys_on_load.nss` | `CREATE TABLE IF NOT EXISTS` przy starcie modułu |
+| `sys_on_enter.nss` | Rejestracja gracza + respawn sług po zalogowaniu |
+| `sys_on_leave.nss` | Zapis HP i usunięcie obiektów przy wylogowaniu |
+| `sys_module_hb.nss` | Tick decay + sync HP (co 6 s / co 30 s) |
+| `sys_on_target.nss` | Odbiór targetu z trybu wybierania celu (wiązanie zwłok) |
+| `test_nec.nss` | OnUsed na placeable — otwiera panel + daje 200 esencji testowo |
+
+## Zależności
+
+- **NWNX**: nie wymagane.
+- **Kampanijne SQLite**: tak — baza o nazwie `"nec"` (plik `nec.sqlite` lub
+  kampania o takiej nazwie). Tabele tworzone są automatycznie przy
+  `OnModuleLoad`.
+- **Blueprinty stworów** (resrefs w `lib_nec_def.nss`):
+
+  | Typ | Domyślny resref | Uwaga |
+  |---|---|---|
+  | Szkielet | `nw_s_skelwar` | stock NWN |
+  | Zombie | `nw_zombie01` | stock NWN |
+  | Cień | `nw_s_shadow` | stock NWN |
+  | Wight | `nw_s_wight` | stock NWN |
+
+  Jeśli te resrefy nie istnieją w twoim hak, zaktualizuj stałe
+  `NEC_RESREF_*` w `lib_nec_def.nss`.
+
+## Jak włączyć w istniejącym module
+
+### 1. Module OnModuleLoad
+```
+// Jeśli masz już skrypt:
+#include "lib_nec_def"
+// ...gdzieś w main():
+NecCreateTables();
+
+// Lub ustaw sys_on_load.nss bezpośrednio jako skrypt OnModuleLoad
+```
+
+### 2. Module OnClientEnter
+```
+#include "lib_nec"
+// w main():
+object oPC = GetEnteringObject();
+if (GetIsPC(oPC) && !GetIsDMPossessed(oPC)) {
+    NecRegisterPC(oPC);
+    DelayCommand(2.0, NecSpawnServants(oPC));
+}
+```
+
+### 3. Module OnClientLeave
+```
+#include "lib_nec"
+// w main():
+object oPC = GetExitingObject();
+if (GetIsPC(oPC) && !GetIsDMPossessed(oPC))
+    NecDespawnServants(oPC);
+```
+
+### 4. Module OnHeartbeat
+```
+#include "lib_nec"
+// Wywołaj w istniejącym heartbeacie lub ustaw sys_module_hb.nss:
+NecHeartbeat();
+```
+
+### 5. Module OnPlayerTarget
+```
+#include "lib_nec"
+// w main() — sprawdź tylko jeśli jest ustawiona flaga NEC_LVAR_TARGETING:
+object oPC = GetLastPlayerToSelectTarget();
+if (GetIsPC(oPC) && GetLocalInt(oPC, NEC_LVAR_TARGETING)) {
+    DeleteLocalInt(oPC, NEC_LVAR_TARGETING);
+    NecBindCorpse(oPC, GetTargetingModeSelectedObject());
+}
+// lub użyj sys_on_target.nss bezpośrednio
+```
+
+### 6. Esencja z zabijanych stworów (opcjonalne)
+Wstaw do skryptu OnDeath każdego obszaru/stwora:
+```
+#include "lib_nec"
+// w main() (np. z nw_c2_default7.nss):
+NecOnCreatureDeath(GetLastKiller(), OBJECT_SELF);
+```
+
+### 7. Otwieranie panelu przez gracza
+Ustaw `test_nec.nss` (lub własny skrypt z `NecOpenWindow(oPC)`) jako OnUsed
+na placeable (np. „Trupie Archiwum", „Nekronomikon" — item z OnActivate).
+
+## Co celowo pominięto
+
+- **Komendy sług** (Atakuj / Stój / Cofnij) — wymagałyby oddzielnego sub-menu
+  NUI lub chatu; można dodać jako rozszerzenie przez panel szczegółów.
+- **Unikalny wygląd sług** (zmiana koloru/modelu) — wymaga NWNX_Appearance lub
+  przypisania blueprintów HAK per typ; szkielet/zombie/cień/wight z NWN stock
+  wyglądają odpowiednio bez modyfikacji.
+- **Atak zarażenia** sług (odradzanie nowych nieumarłych z wrogów) — celowo
+  pominięty, by uniknąć lawinowego rozrostu stworów w grze multiplayer.
+- **Przekraczanie limitu przez talenty/featy** — mechanizm skalowania przez
+  poziom jest celowo prosty; builder może nadpisać `NecGetMaxServants`.

--- a/Necromancy/Scripts/lib_nec.nss
+++ b/Necromancy/Scripts/lib_nec.nss
@@ -1,0 +1,686 @@
+// lib_nec.nss — Necromancy: NUI construction, servant lifecycle, essence economy
+
+#include "lib_nec_def"
+
+// ----------------------------------------------------------------
+// Forward declarations
+// ----------------------------------------------------------------
+
+json  NecBuildWindow(object oPC);
+void  NecOpenWindow(object oPC);
+void  NecFeedRoster(object oPC, int nToken);
+void  NecFeedDetail(object oPC, int nToken, int nServantId);
+void  NecClearDetail(object oPC, int nToken);
+void  NecFeedEssencePool(object oPC, int nToken);
+void  NecUpdateBindState(object oPC, int nToken);
+void  NecBindCorpse(object oPC, object oCorpse);
+void  NecDoFeed(object oPC, int nToken, int nServantId);
+void  NecDoDismiss(object oPC, int nToken, int nServantId);
+object NecSpawnServant(object oPC, json jRow);
+void  NecSpawnServants(object oPC);
+void  NecDespawnServants(object oPC);
+void  NecProcessDecay(object oPC);
+void  NecSyncServantHP(object oPC);
+void  NecOnCreatureDeath(object oKiller, object oCorpse);
+
+// ----------------------------------------------------------------
+// NUI — window construction
+// ----------------------------------------------------------------
+
+json NecBuildWindow(object oPC)
+{
+    float fScale = GetNuiScaleDimension(oPC, 1.0);
+
+    // ---- List template ----
+    json jCells = JsonArray();
+
+    json jCellName = NuiListTemplateCell(
+        NuiLabel(NuiBind(NEC_BIND_ROW_NAME), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)),
+        165.0, FALSE);
+    jCells = JsonArrayInsert(jCells, jCellName);
+
+    json jCellType = NuiListTemplateCell(
+        NuiLabel(NuiBind(NEC_BIND_ROW_TYPE), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE)),
+        72.0, FALSE);
+    jCells = JsonArrayInsert(jCells, jCellType);
+
+    json jCellHP = NuiListTemplateCell(
+        NuiProgressBar(NuiBind(NEC_BIND_ROW_HP)),
+        80.0, FALSE);
+    jCells = JsonArrayInsert(jCells, jCellHP);
+
+    json jCellEss = NuiListTemplateCell(
+        NuiProgressBar(NuiBind(NEC_BIND_ROW_ESS)),
+        80.0, FALSE);
+    jCells = JsonArrayInsert(jCells, jCellEss);
+
+    json jRowBtn = NuiId(NuiButton(JsonString("▶")), NEC_BTN_ROW);
+    jRowBtn = NuiEnabled(jRowBtn, JsonBool(TRUE));
+    jCells = JsonArrayInsert(jCells, NuiListTemplateCell(jRowBtn, 48.0, FALSE));
+
+    json jTemplate = NuiListTemplate(jCells, 40.0, TRUE);
+    json jList     = NuiList(jTemplate, NuiBind(NEC_BIND_ROW_COUNT), 40.0);
+
+    // ---- Left panel: header + list ----
+    json jRosterHeader = JsonArray();
+    jRosterHeader = JsonArrayInsert(jRosterHeader,
+        NuiLabel(NuiBind(NEC_BIND_SLOT_LBL), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)));
+    json jRosterHeaderRow = NuiRow(jRosterHeader);
+
+    json jRosterCol = JsonArray();
+    jRosterCol = JsonArrayInsert(jRosterCol, jRosterHeaderRow);
+    jRosterCol = JsonArrayInsert(jRosterCol, jList);
+    json jLeftGroup = NuiGroup(NuiCol(jRosterCol), TRUE, NUI_SCROLLBARS_NONE);
+    jLeftGroup = NuiWidth(jLeftGroup, 460.0);
+
+    // ---- Right panel: servant detail ----
+    json jDetTitle = NuiLabel(JsonString("SZCZEGÓŁY"), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jDetTitle = NuiForegroundColor(jDetTitle, GetNuiColorNwnGold());
+    jDetTitle = NuiHeight(jDetTitle, 24.0);
+
+    json jDetName = NuiLabel(NuiBind(NEC_BIND_DET_NAME),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jDetName = NuiHeight(jDetName, 22.0);
+
+    json jDetInfo = NuiLabel(NuiBind(NEC_BIND_DET_INFO),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_TOP));
+    jDetInfo = NuiHeight(jDetInfo, 40.0);
+
+    // HP bar row
+    json jDetHPRow = JsonArray();
+    jDetHPRow = JsonArrayInsert(jDetHPRow,
+        NuiWidth(NuiLabel(JsonString("PW:"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)), 28.0));
+    jDetHPRow = JsonArrayInsert(jDetHPRow, NuiProgressBar(NuiBind(NEC_BIND_DET_HP_BAR)));
+
+    // Essence bar row
+    json jDetEssRow = JsonArray();
+    jDetEssRow = JsonArrayInsert(jDetEssRow,
+        NuiWidth(NuiLabel(JsonString("Esn:"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)), 28.0));
+    jDetEssRow = JsonArrayInsert(jDetEssRow, NuiProgressBar(NuiBind(NEC_BIND_DET_ESS_BAR)));
+
+    // Feed row
+    json jFeedInput = NuiTextEdit(JsonString("25"), NuiBind(NEC_BIND_FEED_AMT), 5, FALSE);
+    jFeedInput = NuiWidth(jFeedInput, 52.0);
+    json jFeedBtn = NuiId(
+        NuiEnabled(NuiButton(JsonString("Nakarm")), NuiBind(NEC_BIND_FEED_ENA)),
+        NEC_BTN_FEED);
+    json jFeedRow = JsonArray();
+    jFeedRow = JsonArrayInsert(jFeedRow, jFeedInput);
+    jFeedRow = JsonArrayInsert(jFeedRow, jFeedBtn);
+
+    // Dismiss button
+    json jDismissBtn = NuiId(
+        NuiEnabled(NuiButton(JsonString("Pożegnaj sługę")), NuiBind(NEC_BIND_DISMISS_ENA)),
+        NEC_BTN_DISMISS);
+
+    json jDetCol = JsonArray();
+    jDetCol = JsonArrayInsert(jDetCol, NuiHeight(jDetTitle, 28.0));
+    jDetCol = JsonArrayInsert(jDetCol, NuiHeight(jDetName, 26.0));
+    jDetCol = JsonArrayInsert(jDetCol, NuiHeight(jDetInfo, 44.0));
+    jDetCol = JsonArrayInsert(jDetCol, NuiHeight(NuiRow(jDetHPRow), 28.0));
+    jDetCol = JsonArrayInsert(jDetCol, NuiHeight(NuiRow(jDetEssRow), 28.0));
+    jDetCol = JsonArrayInsert(jDetCol, CreateEmptyRow(oPC, 6.0));
+    jDetCol = JsonArrayInsert(jDetCol,
+        NuiHeight(NuiLabel(JsonString("Nakarm esencją:"),
+            JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)), 20.0));
+    jDetCol = JsonArrayInsert(jDetCol, NuiHeight(NuiRow(jFeedRow), 32.0));
+    jDetCol = JsonArrayInsert(jDetCol, NuiSpacer());
+    jDetCol = JsonArrayInsert(jDetCol, NuiHeight(jDismissBtn, 32.0));
+
+    json jRightGroup = NuiGroup(NuiCol(jDetCol), TRUE, NUI_SCROLLBARS_NONE);
+
+    // ---- Body row ----
+    json jBody = JsonArray();
+    jBody = JsonArrayInsert(jBody, jLeftGroup);
+    jBody = JsonArrayInsert(jBody, jRightGroup);
+
+    // ---- Footer row ----
+    json jEssLbl = NuiLabel(NuiBind(NEC_BIND_ESSENCE_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+
+    json jBindBtn = NuiId(
+        NuiEnabled(NuiButton(JsonString("Przywołaj Umarłych")), NuiBind(NEC_BIND_BIND_ENA)),
+        NEC_BTN_BIND);
+    jBindBtn = NuiWidth(jBindBtn, 160.0);
+
+    json jCloseBtn = NuiId(NuiButton(JsonString("Zamknij")), NEC_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, 80.0);
+
+    json jFooter = JsonArray();
+    jFooter = JsonArrayInsert(jFooter, jEssLbl);
+    jFooter = JsonArrayInsert(jFooter, NuiSpacer());
+    jFooter = JsonArrayInsert(jFooter, jBindBtn);
+    jFooter = JsonArrayInsert(jFooter, jCloseBtn);
+
+    // ---- Root layout ----
+    json jRoot = JsonArray();
+    jRoot = JsonArrayInsert(jRoot, NuiHeight(NuiRow(jBody), 420.0));
+    jRoot = JsonArrayInsert(jRoot, NuiHeight(NuiRow(jFooter), 38.0));
+
+    json jGeom = NuiRect(
+        GetNuiScaleDimension(oPC, 50.0),
+        GetNuiScaleDimension(oPC, 50.0),
+        GetNuiScaleDimension(oPC, NEC_W),
+        GetNuiScaleDimension(oPC, NEC_H));
+
+    return NuiWindow(
+        NuiCol(jRoot),
+        JsonString("Nekromancja — Słudzy Ciemności"),
+        NuiBind(NEC_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        NEC_EV_SCRIPT);
+}
+
+// ----------------------------------------------------------------
+// Open / refresh window
+// ----------------------------------------------------------------
+
+void NecOpenWindow(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, NEC_WINDOW);
+    if (nToken != 0)
+    {
+        NuiSetGroupLayout(oPC, nToken, "root", NecBuildWindow(oPC));
+        NecFeedRoster(oPC, nToken);
+        NecClearDetail(oPC, nToken);
+        NecFeedEssencePool(oPC, nToken);
+        NecUpdateBindState(oPC, nToken);
+        return;
+    }
+
+    nToken = NuiCreate(oPC, NecBuildWindow(oPC), NEC_WINDOW);
+    if (nToken == 0) return;
+
+    NuiSetBind(oPC, nToken, NEC_WIN_GEOM,
+        NuiRect(50.0, 50.0,
+            GetNuiScaleDimension(oPC, NEC_W),
+            GetNuiScaleDimension(oPC, NEC_H)));
+
+    NecFeedRoster(oPC, nToken);
+    NecClearDetail(oPC, nToken);
+    NecFeedEssencePool(oPC, nToken);
+    NecUpdateBindState(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Data feed helpers
+// ----------------------------------------------------------------
+
+void NecFeedRoster(object oPC, int nToken)
+{
+    json jServants = NecGetServants(oPC);
+    int  nCount    = JsonGetLength(jServants);
+    int  nMax      = NecGetMaxServants(oPC);
+
+    NuiSetBind(oPC, nToken, NEC_BIND_SLOT_LBL,
+        JsonString("Słudzy: " + IntToString(nCount) + " / " + IntToString(nMax)));
+    NuiSetBind(oPC, nToken, NEC_BIND_ROW_COUNT, JsonInt(nCount));
+
+    json jNames = JsonArray();
+    json jTypes = JsonArray();
+    json jHPs   = JsonArray();
+    json jEsses = JsonArray();
+    json jEncs  = JsonArray();
+
+    int nSelId = GetLocalInt(oPC, NEC_LVAR_SEL_ID);
+    int i;
+    for (i = 0; i < nCount; i++)
+    {
+        json jRow   = JsonArrayGet(jServants, i);
+        int  nId    = JsonGetInt   (JsonObjectGet(jRow, "id"));
+        int  nHPCur = JsonGetInt   (JsonObjectGet(jRow, "hp_current"));
+        int  nHPMax = JsonGetInt   (JsonObjectGet(jRow, "hp_max"));
+        int  nEss   = JsonGetInt   (JsonObjectGet(jRow, "essence"));
+        int  nType  = JsonGetInt   (JsonObjectGet(jRow, "servant_type"));
+        string sName = JsonGetString(JsonObjectGet(jRow, "servant_name"));
+
+        jNames = JsonArrayInsert(jNames, JsonString(sName));
+        jTypes = JsonArrayInsert(jTypes, JsonString(NecTypeName(nType)));
+
+        float fHP  = (nHPMax > 0) ? IntToFloat(nHPCur) / IntToFloat(nHPMax) : 0.0;
+        float fEss = IntToFloat(nEss) / IntToFloat(NEC_MAX_ESSENCE);
+        jHPs  = JsonArrayInsert(jHPs,  JsonFloat(fHP));
+        jEsses = JsonArrayInsert(jEsses, JsonFloat(fEss));
+        jEncs  = JsonArrayInsert(jEncs,  JsonBool(nId == nSelId));
+    }
+
+    NuiSetBind(oPC, nToken, NEC_BIND_ROW_NAME, jNames);
+    NuiSetBind(oPC, nToken, NEC_BIND_ROW_TYPE, jTypes);
+    NuiSetBind(oPC, nToken, NEC_BIND_ROW_HP,   jHPs);
+    NuiSetBind(oPC, nToken, NEC_BIND_ROW_ESS,  jEsses);
+    NuiSetBind(oPC, nToken, NEC_BIND_ROW_ENC,  jEncs);
+}
+
+void NecFeedDetail(object oPC, int nToken, int nServantId)
+{
+    json jRow = NecGetServant(nServantId);
+    if (JsonGetType(jRow) == JSON_TYPE_NULL)
+    {
+        NecClearDetail(oPC, nToken);
+        return;
+    }
+
+    string sName = JsonGetString(JsonObjectGet(jRow, "servant_name"));
+    int    nType = JsonGetInt   (JsonObjectGet(jRow, "servant_type"));
+    int    nHPCur= JsonGetInt   (JsonObjectGet(jRow, "hp_current"));
+    int    nHPMax= JsonGetInt   (JsonObjectGet(jRow, "hp_max"));
+    int    nEss  = JsonGetInt   (JsonObjectGet(jRow, "essence"));
+
+    NuiSetBind(oPC, nToken, NEC_BIND_DET_NAME, JsonString(sName));
+    NuiSetBind(oPC, nToken, NEC_BIND_DET_INFO,
+        JsonString("Typ: " + NecTypeName(nType) +
+                   "   PW: " + IntToString(nHPCur) + "/" + IntToString(nHPMax) +
+                   "   Esn: " + IntToString(nEss) + "/" + IntToString(NEC_MAX_ESSENCE)));
+
+    float fHP  = (nHPMax > 0) ? IntToFloat(nHPCur) / IntToFloat(nHPMax) : 0.0;
+    float fEss = IntToFloat(nEss) / IntToFloat(NEC_MAX_ESSENCE);
+    NuiSetBind(oPC, nToken, NEC_BIND_DET_HP_BAR,  JsonFloat(fHP));
+    NuiSetBind(oPC, nToken, NEC_BIND_DET_ESS_BAR, JsonFloat(fEss));
+
+    NuiSetBind(oPC, nToken, NEC_BIND_FEED_AMT, JsonString(IntToString(NEC_FEED_DEFAULT)));
+    NuiSetBind(oPC, nToken, NEC_BIND_FEED_ENA,    JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NEC_BIND_DISMISS_ENA, JsonBool(TRUE));
+}
+
+void NecClearDetail(object oPC, int nToken)
+{
+    NuiSetBind(oPC, nToken, NEC_BIND_DET_NAME,    JsonString("— brak wybranego sługi —"));
+    NuiSetBind(oPC, nToken, NEC_BIND_DET_INFO,    JsonString(""));
+    NuiSetBind(oPC, nToken, NEC_BIND_DET_HP_BAR,  JsonFloat(0.0));
+    NuiSetBind(oPC, nToken, NEC_BIND_DET_ESS_BAR, JsonFloat(0.0));
+    NuiSetBind(oPC, nToken, NEC_BIND_FEED_ENA,    JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NEC_BIND_DISMISS_ENA, JsonBool(FALSE));
+}
+
+void NecFeedEssencePool(object oPC, int nToken)
+{
+    int nEss = NecGetEssencePool(oPC);
+    NuiSetBind(oPC, nToken, NEC_BIND_ESSENCE_LBL,
+        JsonString("Esencja Dusz: " + IntToString(nEss)));
+}
+
+// Recompute which interactive controls are enabled.
+void NecUpdateBindState(object oPC, int nToken)
+{
+    int nCount = NecGetServantCount(oPC);
+    int nMax   = NecGetMaxServants(oPC);
+    int nPool  = NecGetEssencePool(oPC);
+
+    int bCanBind = (nCount < nMax) && (nPool >= NEC_BIND_COST);
+    NuiSetBind(oPC, nToken, NEC_BIND_BIND_ENA, JsonBool(bCanBind));
+}
+
+// ----------------------------------------------------------------
+// Bind corpse (raise undead servant)
+// ----------------------------------------------------------------
+
+void NecBindCorpse(object oPC, object oCorpse)
+{
+    int nToken = NuiFindWindow(oPC, NEC_WINDOW);
+
+    if (!GetIsObjectValid(oCorpse) ||
+        GetObjectType(oCorpse) != OBJECT_TYPE_CREATURE ||
+        !GetIsDead(oCorpse) ||
+        GetIsPC(oCorpse))
+    {
+        SendMessageToPC(oPC, "[Nekromancja] Cel musi być zwłokami poległego stwora.");
+        NecUpdateBindState(oPC, nToken);
+        return;
+    }
+
+    if (GetDistanceBetween(oPC, oCorpse) > 5.0)
+    {
+        SendMessageToPC(oPC, "[Nekromancja] Zbliż się do zwłok, by nałożyć Pieczęć Krwi.");
+        NecUpdateBindState(oPC, nToken);
+        return;
+    }
+
+    int nCount = NecGetServantCount(oPC);
+    int nMax   = NecGetMaxServants(oPC);
+    if (nCount >= nMax)
+    {
+        SendMessageToPC(oPC, "[Nekromancja] Osiągnąłeś limit sług. Pożegnaj jednego, by przywołać nowego.");
+        NecUpdateBindState(oPC, nToken);
+        return;
+    }
+
+    if (!NecSpendEssenceFromPool(oPC, NEC_BIND_COST))
+    {
+        SendMessageToPC(oPC, "[Nekromancja] Niewystarczająca Esencja Dusz. Potrzebujesz " +
+            IntToString(NEC_BIND_COST) + " punktów.");
+        NecUpdateBindState(oPC, nToken);
+        return;
+    }
+
+    int    nType   = NecGetServantType(oCorpse);
+    int    nHPMax  = NecTypeBaseHP(nType);
+    string sName   = GetName(oCorpse);
+
+    // Placeholder tag; will be updated with the real DB id after insert.
+    int    nId     = NecInsertServant(oPC, "NEC_PENDING", sName, nType, nHPMax, NEC_START_ESSENCE);
+    if (nId == 0)
+    {
+        SendMessageToPC(oPC, "[Nekromancja] Błąd bazy danych — nie udało się zapisać sługi.");
+        NecAddEssenceToPool(oPC, NEC_BIND_COST); // refund
+        return;
+    }
+
+    string sTag  = NecServantTag(GetObjectUUID(oPC), nId);
+    // Update the tag now that we have the real id.
+    sqlquery qTag = SqlPrepareQueryCampaign("nec",
+        "UPDATE nec_servants SET servant_tag = @tag WHERE id = @id");
+    SqlBindString(qTag, "@tag", sTag);
+    SqlBindInt(qTag,    "@id",  nId);
+    SqlStep(qTag);
+
+    // Spawn creature near PC.
+    location lLoc   = GetLocation(oPC);
+    string sResRef  = NecTypeResRef(nType);
+    object oServant = CreateObject(OBJECT_TYPE_CREATURE, sResRef, lLoc, FALSE, sTag);
+
+    if (!GetIsObjectValid(oServant))
+    {
+        SendMessageToPC(oPC, "[Nekromancja] Nie można wezwać stwora — sprawdź resref w hak.");
+        NecDismissServant(nId);
+        NecAddEssenceToPool(oPC, NEC_BIND_COST);
+        return;
+    }
+
+    // Ally faction, follow PC.
+    SetFaction(oServant, GetFaction(oPC));
+    AssignCommand(oServant, ActionFollow(oPC, 2.0));
+
+    // VFX on the corpse to mark it as bound.
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectVisualEffect(VFX_IMP_DEATH), oCorpse);
+
+    FloatingTextStringOnCreature(
+        "Pieczęć Krwi pulsuje słabo... " + sName + " powstaje z martwych.",
+        oPC, FALSE);
+
+    if (nToken != 0)
+    {
+        NecFeedRoster(oPC, nToken);
+        NecFeedEssencePool(oPC, nToken);
+        NecUpdateBindState(oPC, nToken);
+    }
+}
+
+// ----------------------------------------------------------------
+// Feed essence to selected servant
+// ----------------------------------------------------------------
+
+void NecDoFeed(object oPC, int nToken, int nServantId)
+{
+    if (nServantId <= 0) return;
+
+    string sAmtStr = JsonGetString(NuiGetBind(oPC, nToken, NEC_BIND_FEED_AMT));
+    int    nAmount = StringToInt(sAmtStr);
+    if (nAmount <= 0)
+    {
+        SendMessageToPC(oPC, "[Nekromancja] Podaj dodatnią liczbę punktów esencji.");
+        return;
+    }
+
+    int nPool = NecGetEssencePool(oPC);
+    if (nPool < nAmount)
+    {
+        SendMessageToPC(oPC, "[Nekromancja] Masz tylko " + IntToString(nPool) + " Esencji Dusz.");
+        return;
+    }
+
+    json jRow = NecGetServant(nServantId);
+    if (JsonGetType(jRow) == JSON_TYPE_NULL) return;
+
+    int nCurrentEss = JsonGetInt(JsonObjectGet(jRow, "essence"));
+    int nHeadroom   = NEC_MAX_ESSENCE - nCurrentEss;
+    if (nHeadroom <= 0)
+    {
+        SendMessageToPC(oPC, "[Nekromancja] Sługa jest już nasycony esencją.");
+        return;
+    }
+
+    int nActual = (nAmount > nHeadroom) ? nHeadroom : nAmount;
+    if (!NecSpendEssenceFromPool(oPC, nActual))
+    {
+        SendMessageToPC(oPC, "[Nekromancja] Błąd przy pobieraniu esencji z puli.");
+        return;
+    }
+
+    NecFeedServantEssence(nServantId, nActual, NEC_MAX_ESSENCE);
+
+    string sServantName = JsonGetString(JsonObjectGet(jRow, "servant_name"));
+    FloatingTextStringOnCreature(
+        sServantName + " pochłania " + IntToString(nActual) + " pkt Esencji.",
+        oPC, FALSE);
+
+    NecFeedRoster(oPC, nToken);
+    NecFeedDetail(oPC, nToken, nServantId);
+    NecFeedEssencePool(oPC, nToken);
+    NecUpdateBindState(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Dismiss servant
+// ----------------------------------------------------------------
+
+void NecDoDismiss(object oPC, int nToken, int nServantId)
+{
+    if (nServantId <= 0) return;
+
+    json jRow = NecGetServant(nServantId);
+    if (JsonGetType(jRow) == JSON_TYPE_NULL) return;
+
+    string sTag     = JsonGetString(JsonObjectGet(jRow, "servant_tag"));
+    string sName    = JsonGetString(JsonObjectGet(jRow, "servant_name"));
+    object oServant = GetObjectByTag(sTag);
+
+    NecDismissServant(nServantId);
+
+    if (GetIsObjectValid(oServant))
+    {
+        ApplyEffectToObject(DURATION_TYPE_INSTANT,
+            EffectVisualEffect(VFX_IMP_DEATH), oServant);
+        DestroyObject(oServant, 1.0);
+    }
+
+    FloatingTextStringOnCreature(
+        sName + " rozpada się w pył. Wasze więzi zostają zerwane.",
+        oPC, FALSE);
+
+    DeleteLocalInt(oPC, NEC_LVAR_SEL_ID);
+    NecFeedRoster(oPC, nToken);
+    NecClearDetail(oPC, nToken);
+    NecFeedEssencePool(oPC, nToken);
+    NecUpdateBindState(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Servant lifecycle — spawn / despawn
+// ----------------------------------------------------------------
+
+object NecSpawnServant(object oPC, json jRow)
+{
+    string sTag    = JsonGetString(JsonObjectGet(jRow, "servant_tag"));
+    int    nType   = JsonGetInt   (JsonObjectGet(jRow, "servant_type"));
+    string sResRef = NecTypeResRef(nType);
+    location lLoc  = GetLocation(oPC);
+
+    object oServant = CreateObject(OBJECT_TYPE_CREATURE, sResRef, lLoc, FALSE, sTag);
+    if (!GetIsObjectValid(oServant)) return OBJECT_INVALID;
+
+    SetFaction(oServant, GetFaction(oPC));
+    AssignCommand(oServant, ActionFollow(oPC, 2.0));
+    return oServant;
+}
+
+// Restores all active servants when a PC logs in.
+void NecSpawnServants(object oPC)
+{
+    json jServants = NecGetServants(oPC);
+    int  nCount    = JsonGetLength(jServants);
+    int  i;
+    for (i = 0; i < nCount; i++)
+    {
+        json   jRow  = JsonArrayGet(jServants, i);
+        string sTag  = JsonGetString(JsonObjectGet(jRow, "servant_tag"));
+        int    nId   = JsonGetInt   (JsonObjectGet(jRow, "id"));
+
+        // Only spawn if not already in the world.
+        if (!GetIsObjectValid(GetObjectByTag(sTag)))
+            NecSpawnServant(oPC, jRow);
+    }
+}
+
+// Saves live HP and destroys creature objects when a PC logs out.
+void NecDespawnServants(object oPC)
+{
+    json jServants = NecGetServants(oPC);
+    int  nCount    = JsonGetLength(jServants);
+    int  i;
+    for (i = 0; i < nCount; i++)
+    {
+        json   jRow     = JsonArrayGet(jServants, i);
+        int    nId      = JsonGetInt   (JsonObjectGet(jRow, "id"));
+        string sTag     = JsonGetString(JsonObjectGet(jRow, "servant_tag"));
+        object oServant = GetObjectByTag(sTag);
+
+        if (GetIsObjectValid(oServant))
+        {
+            int nHP = GetCurrentHitPoints(oServant);
+            NecUpdateServantHP(nId, (nHP < 0) ? 0 : nHP);
+            DestroyObject(oServant);
+        }
+    }
+}
+
+// ----------------------------------------------------------------
+// Heartbeat: decay and HP sync
+// ----------------------------------------------------------------
+
+// Called once per module heartbeat for a single PC.
+void NecProcessDecay(object oPC)
+{
+    json jServants = NecGetServants(oPC);
+    int  nCount    = JsonGetLength(jServants);
+    int  i;
+    for (i = 0; i < nCount; i++)
+    {
+        json   jRow  = JsonArrayGet(jServants, i);
+        int    nId   = JsonGetInt(JsonObjectGet(jRow, "id"));
+        int    nType = JsonGetInt(JsonObjectGet(jRow, "servant_type"));
+        int    nEss  = JsonGetInt(JsonObjectGet(jRow, "essence"));
+        string sTag  = JsonGetString(JsonObjectGet(jRow, "servant_tag"));
+        string sName = JsonGetString(JsonObjectGet(jRow, "servant_name"));
+
+        int nDrain = NecTypeDrain(nType);
+        int nNew   = nEss - nDrain;
+
+        if (nNew <= 0)
+        {
+            // Essence depleted: servant collapses.
+            NecDismissServant(nId);
+            object oServant = GetObjectByTag(sTag);
+            if (GetIsObjectValid(oServant))
+            {
+                ApplyEffectToObject(DURATION_TYPE_INSTANT,
+                    EffectVisualEffect(VFX_IMP_DEATH), oServant);
+                DestroyObject(oServant, 0.5);
+            }
+            FloatingTextStringOnCreature(
+                sName + " obraca się w proch — esencja wyczerpana.",
+                oPC, FALSE);
+
+            // Refresh open window.
+            int nToken = NuiFindWindow(oPC, NEC_WINDOW);
+            if (nToken != 0)
+            {
+                int nSelId = GetLocalInt(oPC, NEC_LVAR_SEL_ID);
+                NecFeedRoster(oPC, nToken);
+                if (nSelId == nId)
+                {
+                    DeleteLocalInt(oPC, NEC_LVAR_SEL_ID);
+                    NecClearDetail(oPC, nToken);
+                }
+                NecUpdateBindState(oPC, nToken);
+            }
+        }
+        else
+        {
+            NecUpdateServantEssence(nId, nNew);
+        }
+    }
+}
+
+// Syncs live HP of all servants with DB values and destroys dead ones.
+void NecSyncServantHP(object oPC)
+{
+    json jServants = NecGetServants(oPC);
+    int  nCount    = JsonGetLength(jServants);
+    int  i;
+    for (i = 0; i < nCount; i++)
+    {
+        json   jRow     = JsonArrayGet(jServants, i);
+        int    nId      = JsonGetInt   (JsonObjectGet(jRow, "id"));
+        string sTag     = JsonGetString(JsonObjectGet(jRow, "servant_tag"));
+        string sName    = JsonGetString(JsonObjectGet(jRow, "servant_name"));
+        object oServant = GetObjectByTag(sTag);
+
+        if (!GetIsObjectValid(oServant)) continue;
+
+        int nHP = GetCurrentHitPoints(oServant);
+        if (nHP <= 0)
+        {
+            NecDismissServant(nId);
+            DestroyObject(oServant);
+            FloatingTextStringOnCreature(
+                sName + " pada martwy po raz drugi. Krąg zostaje zamknięty.",
+                oPC, FALSE);
+
+            int nToken = NuiFindWindow(oPC, NEC_WINDOW);
+            if (nToken != 0)
+            {
+                int nSelId = GetLocalInt(oPC, NEC_LVAR_SEL_ID);
+                NecFeedRoster(oPC, nToken);
+                if (nSelId == nId)
+                {
+                    DeleteLocalInt(oPC, NEC_LVAR_SEL_ID);
+                    NecClearDetail(oPC, nToken);
+                }
+                NecUpdateBindState(oPC, nToken);
+            }
+        }
+        else
+        {
+            NecUpdateServantHP(nId, nHP);
+        }
+    }
+}
+
+// ----------------------------------------------------------------
+// Module integration hook — call from your OnCreatureDeath script
+// ----------------------------------------------------------------
+
+// Call this from the area/module OnCreatureDeath with oKiller = GetLastKiller()
+// and oCorpse = OBJECT_SELF. Adds essence to the killer's pool if they're a PC.
+void NecOnCreatureDeath(object oKiller, object oCorpse)
+{
+    if (!GetIsPC(oKiller)) return;
+    if (GetIsPC(oCorpse))  return;        // don't yield essence for player kills
+
+    int nAmount = NecEssenceForCR(oCorpse);
+    if (nAmount <= 0) return;
+
+    NecAddEssenceToPool(oKiller, nAmount);
+
+    int nToken = NuiFindWindow(oKiller, NEC_WINDOW);
+    if (nToken != 0)
+    {
+        NecFeedEssencePool(oKiller, nToken);
+        NecUpdateBindState(oKiller, nToken);
+    }
+}

--- a/Necromancy/Scripts/lib_nec_def.nss
+++ b/Necromancy/Scripts/lib_nec_def.nss
@@ -1,0 +1,205 @@
+// lib_nec_def.nss — Necromancy: constants, type helpers, servant meta-data
+
+#include "sql_nec"
+#include "lib_nui"
+
+// ----------------------------------------------------------------
+// Window / script identifiers
+// ----------------------------------------------------------------
+
+const string NEC_WINDOW     = "NEC_WINDOW";
+const string NEC_EV_SCRIPT  = "lib_nec_ev";
+const string NEC_WIN_GEOM   = "nec_win_geom";
+
+// ----------------------------------------------------------------
+// Bind names — roster list (array binds)
+// ----------------------------------------------------------------
+
+const string NEC_BIND_ROW_COUNT   = "nec_row_count";
+const string NEC_BIND_ROW_NAME    = "nec_row_name";
+const string NEC_BIND_ROW_TYPE    = "nec_row_type";
+const string NEC_BIND_ROW_HP      = "nec_row_hp";
+const string NEC_BIND_ROW_ESS     = "nec_row_ess";
+const string NEC_BIND_ROW_ENC     = "nec_row_enc";
+
+// ----------------------------------------------------------------
+// Bind names — header / footer
+// ----------------------------------------------------------------
+
+const string NEC_BIND_SLOT_LBL    = "nec_slot_lbl";
+const string NEC_BIND_ESSENCE_LBL = "nec_essence_lbl";
+const string NEC_BIND_BIND_ENA    = "nec_bind_ena";
+
+// ----------------------------------------------------------------
+// Bind names — detail panel
+// ----------------------------------------------------------------
+
+const string NEC_BIND_DET_NAME    = "nec_det_name";
+const string NEC_BIND_DET_INFO    = "nec_det_info";
+const string NEC_BIND_DET_HP_BAR  = "nec_det_hp_bar";
+const string NEC_BIND_DET_ESS_BAR = "nec_det_ess_bar";
+const string NEC_BIND_FEED_AMT    = "nec_feed_amt";
+const string NEC_BIND_FEED_ENA    = "nec_feed_ena";
+const string NEC_BIND_DISMISS_ENA = "nec_dismiss_ena";
+
+// ----------------------------------------------------------------
+// Button identifiers
+// ----------------------------------------------------------------
+
+const string NEC_BTN_CLOSE   = "nec_btn_close";
+const string NEC_BTN_BIND    = "nec_btn_bind";
+const string NEC_BTN_DISMISS = "nec_btn_dismiss";
+const string NEC_BTN_FEED    = "nec_btn_feed";
+const string NEC_BTN_ROW     = "nec_btn_row";
+
+// ----------------------------------------------------------------
+// Local variables on PC
+// ----------------------------------------------------------------
+
+const string NEC_LVAR_SEL_ID    = "NEC_SEL_ID";
+const string NEC_LVAR_TARGETING = "NEC_TARGETING";
+
+// ----------------------------------------------------------------
+// Servant type IDs
+// ----------------------------------------------------------------
+
+const int NEC_TYPE_SKELETON = 0;
+const int NEC_TYPE_ZOMBIE   = 1;
+const int NEC_TYPE_SHADE    = 2;
+const int NEC_TYPE_WIGHT    = 3;
+
+// ----------------------------------------------------------------
+// Servant blueprints
+// Stock NWN resrefs — verify/override for your HAK content.
+// Shade and Wight fall back to shadow/wight NWN defaults.
+// ----------------------------------------------------------------
+
+const string NEC_RESREF_SKELETON = "nw_s_skelwar";
+const string NEC_RESREF_ZOMBIE   = "nw_zombie01";
+const string NEC_RESREF_SHADE    = "nw_s_shadow";
+const string NEC_RESREF_WIGHT    = "nw_s_wight";
+
+// ----------------------------------------------------------------
+// Essence drain per heartbeat tick (~6 s)
+// ----------------------------------------------------------------
+
+const int NEC_DRAIN_SKELETON = 2;
+const int NEC_DRAIN_ZOMBIE   = 3;
+const int NEC_DRAIN_SHADE    = 4;
+const int NEC_DRAIN_WIGHT    = 6;
+
+// ----------------------------------------------------------------
+// Essence economy
+// ----------------------------------------------------------------
+
+const int NEC_MAX_ESSENCE     = 200;
+const int NEC_START_ESSENCE   = 100;   // essence a fresh servant starts with
+const int NEC_BIND_COST       = 60;    // pool cost to raise one servant
+const int NEC_FEED_DEFAULT    = 25;    // default feed amount shown in text field
+const int NEC_ESSENCE_LOW_CR  = 5;    // kills CR 1-5
+const int NEC_ESSENCE_MED_CR  = 15;   // kills CR 6-12
+const int NEC_ESSENCE_HIGH_CR = 30;   // kills CR 13+
+
+// ----------------------------------------------------------------
+// Servant base HP
+// ----------------------------------------------------------------
+
+const int NEC_HP_SKELETON = 20;
+const int NEC_HP_ZOMBIE   = 35;
+const int NEC_HP_SHADE    = 15;
+const int NEC_HP_WIGHT    = 50;
+
+// ----------------------------------------------------------------
+// Window geometry
+// ----------------------------------------------------------------
+
+const float NEC_W = 630.0;
+const float NEC_H = 510.0;
+
+// ----------------------------------------------------------------
+// Type helpers
+// ----------------------------------------------------------------
+
+// Maximum number of simultaneous servants, scaled by character level.
+int NecGetMaxServants(object oPC)
+{
+    int nLevel = GetHitDice(oPC);
+    if (nLevel >= 20) return 5;
+    if (nLevel >= 15) return 4;
+    if (nLevel >= 10) return 3;
+    if (nLevel >= 5)  return 2;
+    return 1;
+}
+
+// Infer best servant type from a freshly slain creature.
+int NecGetServantType(object oCorpse)
+{
+    int nCR = FloatToInt(GetChallengeRating(oCorpse));
+    if (GetRacialType(oCorpse) == RACIAL_TYPE_UNDEAD) return NEC_TYPE_SHADE;
+    if (nCR >= 10) return NEC_TYPE_WIGHT;
+    if (nCR >= 5)  return NEC_TYPE_ZOMBIE;
+    return NEC_TYPE_SKELETON;
+}
+
+string NecTypeName(int nType)
+{
+    switch (nType)
+    {
+        case NEC_TYPE_SKELETON: return "Szkielet";
+        case NEC_TYPE_ZOMBIE:   return "Zombie";
+        case NEC_TYPE_SHADE:    return "Cień";
+        case NEC_TYPE_WIGHT:    return "Wight";
+    }
+    return "Nieznany";
+}
+
+string NecTypeResRef(int nType)
+{
+    switch (nType)
+    {
+        case NEC_TYPE_SKELETON: return NEC_RESREF_SKELETON;
+        case NEC_TYPE_ZOMBIE:   return NEC_RESREF_ZOMBIE;
+        case NEC_TYPE_SHADE:    return NEC_RESREF_SHADE;
+        case NEC_TYPE_WIGHT:    return NEC_RESREF_WIGHT;
+    }
+    return NEC_RESREF_SKELETON;
+}
+
+int NecTypeDrain(int nType)
+{
+    switch (nType)
+    {
+        case NEC_TYPE_SKELETON: return NEC_DRAIN_SKELETON;
+        case NEC_TYPE_ZOMBIE:   return NEC_DRAIN_ZOMBIE;
+        case NEC_TYPE_SHADE:    return NEC_DRAIN_SHADE;
+        case NEC_TYPE_WIGHT:    return NEC_DRAIN_WIGHT;
+    }
+    return NEC_DRAIN_SKELETON;
+}
+
+int NecTypeBaseHP(int nType)
+{
+    switch (nType)
+    {
+        case NEC_TYPE_SKELETON: return NEC_HP_SKELETON;
+        case NEC_TYPE_ZOMBIE:   return NEC_HP_ZOMBIE;
+        case NEC_TYPE_SHADE:    return NEC_HP_SHADE;
+        case NEC_TYPE_WIGHT:    return NEC_HP_WIGHT;
+    }
+    return NEC_HP_SKELETON;
+}
+
+// Unique in-game tag derived from PC UUID + DB row id.
+string NecServantTag(string sOwnerUuid, int nId)
+{
+    return "NEC_" + GetStringLeft(sOwnerUuid, 8) + "_" + IntToString(nId);
+}
+
+// Essence yield from a single kill by the creature's CR.
+int NecEssenceForCR(object oCorpse)
+{
+    int nCR = FloatToInt(GetChallengeRating(oCorpse));
+    if (nCR >= 13) return NEC_ESSENCE_HIGH_CR;
+    if (nCR >= 6)  return NEC_ESSENCE_MED_CR;
+    return NEC_ESSENCE_LOW_CR;
+}

--- a/Necromancy/Scripts/lib_nec_ev.nss
+++ b/Necromancy/Scripts/lib_nec_ev.nss
@@ -1,0 +1,148 @@
+// lib_nec_ev.nss — Necromancy: NUI event handler
+// Set as the event script in NecBuildWindow (NEC_EV_SCRIPT).
+
+#include "lib_nec"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    if (nToken != NuiFindWindow(oPC, NEC_WINDOW)) return;
+
+    // ----------------------------------------------------------------
+    // Window lifecycle
+    // ----------------------------------------------------------------
+
+    if (sEvent == EVENT_TYPE_OPEN)
+    {
+        NecFeedRoster(oPC, nToken);
+        NecClearDetail(oPC, nToken);
+        NecFeedEssencePool(oPC, nToken);
+        NecUpdateBindState(oPC, nToken);
+        return;
+    }
+
+    if (sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalInt(oPC, NEC_LVAR_SEL_ID);
+        DeleteLocalInt(oPC, NEC_LVAR_TARGETING);
+        return;
+    }
+
+    // ----------------------------------------------------------------
+    // Watch events
+    // ----------------------------------------------------------------
+
+    if (sEvent == EVENT_TYPE_WATCH)
+    {
+        // Re-validate feed button when the amount field changes.
+        if (sElem == NEC_BIND_FEED_AMT)
+        {
+            string sVal = JsonGetString(NuiGetBind(oPC, nToken, NEC_BIND_FEED_AMT));
+            int    nVal = StringToInt(sVal);
+            int    nSel = GetLocalInt(oPC, NEC_LVAR_SEL_ID);
+            int    bOk  = (nVal > 0) && (nSel > 0) && (NecGetEssencePool(oPC) >= nVal);
+            NuiSetBind(oPC, nToken, NEC_BIND_FEED_ENA, JsonBool(bOk));
+        }
+        return;
+    }
+
+    // ----------------------------------------------------------------
+    // Click events
+    // ----------------------------------------------------------------
+
+    if (sEvent == EVENT_TYPE_CLICK)
+    {
+        // ---- Close button ----
+        if (sElem == NEC_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        // ---- Row selection ----
+        if (sElem == NEC_BTN_ROW)
+        {
+            json jServants = NecGetServants(oPC);
+            if (nIdx < 0 || nIdx >= JsonGetLength(jServants)) return;
+
+            json jRow  = JsonArrayGet(jServants, nIdx);
+            int  nId   = JsonGetInt(JsonObjectGet(jRow, "id"));
+
+            SetLocalInt(oPC, NEC_LVAR_SEL_ID, nId);
+
+            // Highlight selected row.
+            int  nCount  = JsonGetLength(jServants);
+            json jEncs   = JsonArray();
+            int  i;
+            for (i = 0; i < nCount; i++)
+                jEncs = JsonArrayInsert(jEncs, JsonBool(i == nIdx));
+            NuiSetBind(oPC, nToken, NEC_BIND_ROW_ENC, jEncs);
+
+            NecFeedDetail(oPC, nToken, nId);
+            return;
+        }
+
+        // ---- Feed button ----
+        if (sElem == NEC_BTN_FEED)
+        {
+            int nSel = GetLocalInt(oPC, NEC_LVAR_SEL_ID);
+            NecDoFeed(oPC, nToken, nSel);
+            return;
+        }
+
+        // ---- Dismiss button ----
+        if (sElem == NEC_BTN_DISMISS)
+        {
+            int nSel = GetLocalInt(oPC, NEC_LVAR_SEL_ID);
+            NecDoDismiss(oPC, nToken, nSel);
+            return;
+        }
+
+        // ---- Bind (raise undead) button ----
+        if (sElem == NEC_BTN_BIND)
+        {
+            int nCount = NecGetServantCount(oPC);
+            int nMax   = NecGetMaxServants(oPC);
+            if (nCount >= nMax)
+            {
+                SendMessageToPC(oPC, "[Nekromancja] Osiągnąłeś limit sług (" +
+                    IntToString(nMax) + "). Pożegnaj jednego, by móc przywołać nowego.");
+                return;
+            }
+            int nPool = NecGetEssencePool(oPC);
+            if (nPool < NEC_BIND_COST)
+            {
+                SendMessageToPC(oPC, "[Nekromancja] Za mało Esencji Dusz — potrzebujesz " +
+                    IntToString(NEC_BIND_COST) + ", masz " + IntToString(nPool) + ".");
+                return;
+            }
+
+            SetLocalInt(oPC, NEC_LVAR_TARGETING, 1);
+            NuiSetBind(oPC, nToken, NEC_BIND_BIND_ENA, JsonBool(FALSE));
+            EnterTargetingMode(oPC, OBJECT_TYPE_CREATURE);
+            SendMessageToPC(oPC, "[Nekromancja] Wskaż zwłoki stwora, by nałożyć Pieczęć Krwi.");
+            return;
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // Mousedown events (e.g., row selection via direct click area)
+    // ----------------------------------------------------------------
+
+    if (sEvent == EVENT_TYPE_MOUSEDOWN && sElem == NEC_BTN_ROW)
+    {
+        json jServants = NecGetServants(oPC);
+        if (nIdx < 0 || nIdx >= JsonGetLength(jServants)) return;
+
+        json jRow = JsonArrayGet(jServants, nIdx);
+        int  nId  = JsonGetInt(JsonObjectGet(jRow, "id"));
+
+        SetLocalInt(oPC, NEC_LVAR_SEL_ID, nId);
+        NecFeedDetail(oPC, nToken, nId);
+    }
+}

--- a/Necromancy/Scripts/sql_nec.nss
+++ b/Necromancy/Scripts/sql_nec.nss
@@ -1,0 +1,184 @@
+// sql_nec.nss — Necromancy: SQL schema and data-access layer
+// Campaign DB name: "nec"
+
+void NecCreateTables()
+{
+    sqlquery q;
+
+    q = SqlPrepareQueryCampaign("nec",
+        "CREATE TABLE IF NOT EXISTS nec_servants ("
+        "  id           INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "  owner_uuid   TEXT    NOT NULL,"
+        "  servant_tag  TEXT    NOT NULL,"
+        "  servant_name TEXT    NOT NULL DEFAULT 'Sługa',"
+        "  servant_type INTEGER NOT NULL DEFAULT 0,"
+        "  hp_current   INTEGER NOT NULL DEFAULT 10,"
+        "  hp_max       INTEGER NOT NULL DEFAULT 10,"
+        "  essence      INTEGER NOT NULL DEFAULT 100,"
+        "  raised_at    INTEGER NOT NULL DEFAULT 0,"
+        "  is_active    INTEGER NOT NULL DEFAULT 1"
+        ")");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("nec",
+        "CREATE TABLE IF NOT EXISTS nec_essence ("
+        "  owner_uuid   TEXT    PRIMARY KEY,"
+        "  essence      INTEGER NOT NULL DEFAULT 0,"
+        "  total_souls  INTEGER NOT NULL DEFAULT 0"
+        ")");
+    SqlStep(q);
+}
+
+void NecRegisterPC(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("nec",
+        "INSERT OR IGNORE INTO nec_essence (owner_uuid, essence, total_souls) "
+        "VALUES (@uuid, 0, 0)");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+int NecGetEssencePool(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("nec",
+        "SELECT essence FROM nec_essence WHERE owner_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if (SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+void NecAddEssenceToPool(object oPC, int nAmount)
+{
+    sqlquery q = SqlPrepareQueryCampaign("nec",
+        "UPDATE nec_essence "
+        "SET essence = MIN(essence + @amt, 9999), total_souls = total_souls + 1 "
+        "WHERE owner_uuid = @uuid");
+    SqlBindInt(q,    "@amt",  nAmount);
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+// Returns 1 if enough essence was available and was spent, 0 otherwise.
+int NecSpendEssenceFromPool(object oPC, int nAmount)
+{
+    sqlquery q = SqlPrepareQueryCampaign("nec",
+        "UPDATE nec_essence "
+        "SET essence = essence - @amt "
+        "WHERE owner_uuid = @uuid AND essence >= @amt");
+    SqlBindInt(q,    "@amt",  nAmount);
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+    return SqlGetAffectedRows(q);
+}
+
+json NecGetServants(object oPC)
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("nec",
+        "SELECT id, servant_tag, servant_name, servant_type, hp_current, hp_max, essence "
+        "FROM nec_servants "
+        "WHERE owner_uuid = @uuid AND is_active = 1 "
+        "ORDER BY id");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    while (SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "id",           JsonInt   (SqlGetInt   (q, 0)));
+        jRow = JsonObjectSet(jRow, "servant_tag",  JsonString(SqlGetString(q, 1)));
+        jRow = JsonObjectSet(jRow, "servant_name", JsonString(SqlGetString(q, 2)));
+        jRow = JsonObjectSet(jRow, "servant_type", JsonInt   (SqlGetInt   (q, 3)));
+        jRow = JsonObjectSet(jRow, "hp_current",   JsonInt   (SqlGetInt   (q, 4)));
+        jRow = JsonObjectSet(jRow, "hp_max",       JsonInt   (SqlGetInt   (q, 5)));
+        jRow = JsonObjectSet(jRow, "essence",      JsonInt   (SqlGetInt   (q, 6)));
+        jRows = JsonArrayInsert(jRows, jRow);
+    }
+    return jRows;
+}
+
+int NecGetServantCount(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("nec",
+        "SELECT COUNT(*) FROM nec_servants "
+        "WHERE owner_uuid = @uuid AND is_active = 1");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if (SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// Inserts a new servant row; returns the new row id (0 on failure).
+int NecInsertServant(object oPC, string sTag, string sName, int nType, int nHPMax, int nEssence)
+{
+    sqlquery q = SqlPrepareQueryCampaign("nec",
+        "INSERT INTO nec_servants "
+        "(owner_uuid, servant_tag, servant_name, servant_type, "
+        " hp_current, hp_max, essence, raised_at, is_active) "
+        "VALUES (@uuid, @tag, @name, @type, @hp, @hp, @ess, strftime('%s','now'), 1)");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindString(q, "@tag",  sTag);
+    SqlBindString(q, "@name", sName);
+    SqlBindInt(q,    "@type", nType);
+    SqlBindInt(q,    "@hp",   nHPMax);
+    SqlBindInt(q,    "@ess",  nEssence);
+    SqlStep(q);
+    sqlquery qId = SqlPrepareQueryCampaign("nec", "SELECT last_insert_rowid()");
+    if (SqlStep(qId)) return SqlGetInt(qId, 0);
+    return 0;
+}
+
+void NecDismissServant(int nId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("nec",
+        "UPDATE nec_servants SET is_active = 0 WHERE id = @id");
+    SqlBindInt(q, "@id", nId);
+    SqlStep(q);
+}
+
+void NecUpdateServantEssence(int nId, int nEssence)
+{
+    sqlquery q = SqlPrepareQueryCampaign("nec",
+        "UPDATE nec_servants SET essence = @ess WHERE id = @id");
+    SqlBindInt(q, "@ess", nEssence);
+    SqlBindInt(q, "@id",  nId);
+    SqlStep(q);
+}
+
+void NecUpdateServantHP(int nId, int nHP)
+{
+    // If hp reaches 0 the servant is also deactivated.
+    sqlquery q = SqlPrepareQueryCampaign("nec",
+        "UPDATE nec_servants "
+        "SET hp_current = @hp, "
+        "    is_active  = CASE WHEN @hp <= 0 THEN 0 ELSE is_active END "
+        "WHERE id = @id");
+    SqlBindInt(q, "@hp", nHP);
+    SqlBindInt(q, "@id", nId);
+    SqlStep(q);
+}
+
+void NecFeedServantEssence(int nId, int nAmount, int nCap)
+{
+    sqlquery q = SqlPrepareQueryCampaign("nec",
+        "UPDATE nec_servants SET essence = MIN(essence + @amt, @cap) WHERE id = @id");
+    SqlBindInt(q, "@amt", nAmount);
+    SqlBindInt(q, "@cap", nCap);
+    SqlBindInt(q, "@id",  nId);
+    SqlStep(q);
+}
+
+json NecGetServant(int nId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("nec",
+        "SELECT id, servant_tag, servant_name, servant_type, hp_current, hp_max, essence "
+        "FROM nec_servants WHERE id = @id");
+    SqlBindInt(q, "@id", nId);
+    if (!SqlStep(q)) return JsonNull();
+    json jRow = JsonObject();
+    jRow = JsonObjectSet(jRow, "id",           JsonInt   (SqlGetInt   (q, 0)));
+    jRow = JsonObjectSet(jRow, "servant_tag",  JsonString(SqlGetString(q, 1)));
+    jRow = JsonObjectSet(jRow, "servant_name", JsonString(SqlGetString(q, 2)));
+    jRow = JsonObjectSet(jRow, "servant_type", JsonInt   (SqlGetInt   (q, 3)));
+    jRow = JsonObjectSet(jRow, "hp_current",   JsonInt   (SqlGetInt   (q, 4)));
+    jRow = JsonObjectSet(jRow, "hp_max",       JsonInt   (SqlGetInt   (q, 5)));
+    jRow = JsonObjectSet(jRow, "essence",      JsonInt   (SqlGetInt   (q, 6)));
+    return jRow;
+}

--- a/Necromancy/Scripts/sys_module_hb.nss
+++ b/Necromancy/Scripts/sys_module_hb.nss
@@ -1,0 +1,51 @@
+// sys_module_hb.nss — Necromancy: module OnHeartbeat hook
+// Fires every ~6 seconds. Ticks essence decay and syncs servant HP for all online PCs.
+// If your module already has an OnHeartbeat script, call NecHeartbeat() from there
+// instead of replacing the script entirely.
+
+#include "lib_nec"
+
+// Essence decay runs every tick; HP sync runs every 5 ticks (~30 s) to reduce DB writes.
+const string NEC_LVAR_HB_TICK = "NEC_HB_TICK";
+
+void NecHeartbeat()
+{
+    object oPC = GetFirstPC();
+    while (GetIsObjectValid(oPC))
+    {
+        if (!GetIsDMPossessed(oPC))
+        {
+            NecProcessDecay(oPC);
+
+            int nTick = GetLocalInt(GetModule(), NEC_LVAR_HB_TICK + GetObjectUUID(oPC));
+            nTick++;
+            SetLocalInt(GetModule(), NEC_LVAR_HB_TICK + GetObjectUUID(oPC), nTick);
+
+            if (nTick >= 5)
+            {
+                SetLocalInt(GetModule(), NEC_LVAR_HB_TICK + GetObjectUUID(oPC), 0);
+                NecSyncServantHP(oPC);
+
+                // Also keep servants following their master (re-issue command if idle).
+                json jServants = NecGetServants(oPC);
+                int  nCount    = JsonGetLength(jServants);
+                int  i;
+                for (i = 0; i < nCount; i++)
+                {
+                    json   jRow     = JsonArrayGet(jServants, i);
+                    string sTag     = JsonGetString(JsonObjectGet(jRow, "servant_tag"));
+                    object oServant = GetObjectByTag(sTag);
+
+                    if (GetIsObjectValid(oServant) && !GetIsInCombat(oServant))
+                        AssignCommand(oServant, ActionFollow(oPC, 2.0));
+                }
+            }
+        }
+        oPC = GetNextPC();
+    }
+}
+
+void main()
+{
+    NecHeartbeat();
+}

--- a/Necromancy/Scripts/sys_on_enter.nss
+++ b/Necromancy/Scripts/sys_on_enter.nss
@@ -1,0 +1,15 @@
+// sys_on_enter.nss — Necromancy: module OnClientEnter hook
+// Registers the PC in the essence table and restores live servant objects.
+
+#include "lib_nec"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if (!GetIsPC(oPC) || GetIsDMPossessed(oPC)) return;
+
+    NecRegisterPC(oPC);
+
+    // Delay spawn so the PC's location is fully initialised before we place creatures.
+    DelayCommand(2.0, NecSpawnServants(oPC));
+}

--- a/Necromancy/Scripts/sys_on_leave.nss
+++ b/Necromancy/Scripts/sys_on_leave.nss
@@ -1,0 +1,12 @@
+// sys_on_leave.nss — Necromancy: module OnClientLeave hook
+// Saves current servant HP to DB and destroys their in-world objects.
+
+#include "lib_nec"
+
+void main()
+{
+    object oPC = GetExitingObject();
+    if (!GetIsPC(oPC) || GetIsDMPossessed(oPC)) return;
+
+    NecDespawnServants(oPC);
+}

--- a/Necromancy/Scripts/sys_on_load.nss
+++ b/Necromancy/Scripts/sys_on_load.nss
@@ -1,0 +1,9 @@
+// sys_on_load.nss — Necromancy: module OnModuleLoad hook
+// Creates persistent database tables if they don't exist yet.
+
+#include "lib_nec_def"
+
+void main()
+{
+    NecCreateTables();
+}

--- a/Necromancy/Scripts/sys_on_target.nss
+++ b/Necromancy/Scripts/sys_on_target.nss
@@ -1,0 +1,28 @@
+// sys_on_target.nss — Necromancy: module OnPlayerTarget hook
+// Handles the creature-targeting mode entered when "Przywołaj Umarłych" is clicked.
+
+#include "lib_nec"
+
+void main()
+{
+    object oPC = GetLastPlayerToSelectTarget();
+    if (!GetIsPC(oPC)) return;
+
+    // Only process if we are waiting for a necromancy bind target.
+    if (!GetLocalInt(oPC, NEC_LVAR_TARGETING)) return;
+    DeleteLocalInt(oPC, NEC_LVAR_TARGETING);
+
+    object oTarget = GetTargetingModeSelectedObject();
+
+    int nToken = NuiFindWindow(oPC, NEC_WINDOW);
+
+    if (!GetIsObjectValid(oTarget))
+    {
+        // Player cancelled targeting.
+        SendMessageToPC(oPC, "[Nekromancja] Anulowano przywoływanie.");
+        if (nToken != 0) NecUpdateBindState(oPC, nToken);
+        return;
+    }
+
+    NecBindCorpse(oPC, oTarget);
+}

--- a/Necromancy/Scripts/test_nec.nss
+++ b/Necromancy/Scripts/test_nec.nss
@@ -1,0 +1,20 @@
+// test_nec.nss — Necromancy: demo placeable OnUsed script
+// Place a "Księga Nekromancji" or similar placeable in your test area
+// and set its OnUsed script to test_nec. Using it opens the NUI panel
+// and grants 200 starting Essence for testing purposes.
+
+#include "lib_nec"
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if (!GetIsPC(oPC)) return;
+
+    NecRegisterPC(oPC);
+
+    // Grant essence for testing only — remove from production.
+    NecAddEssenceToPool(oPC, 200);
+    SendMessageToPC(oPC, "[Nekromancja] Otrzymujesz 200 pkt Esencji Dusz na potrzeby testów.");
+
+    NecOpenWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

Moduł **Nekromancja — Słudzy Ciemności** pozwala graczom-nekromantom przywoływać poległe stwory jako nieumarłych sług. Słudzy towarzyszą graczowi w świecie gry, są persystentni między sesjami (SQLite) i powoli zużywają Esencję Dusz — jeśli esencja się wyczerpie, sługa rozpada się w proch.

## Mechanika

- **Esencja Dusz** — waluta zdobywana przy zabijaniu stworów (5 / 15 / 30 pkt wg CR). Koszt przywołania: 60 pkt.
- **Cztery typy sług** — Szkielet (CR < 5), Zombie (CR 5–9), Cień (nieumarły → Cień), Wight (CR ≥ 10). Każdy typ ma inną bazę HP i szybkość zużycia esencji.
- **Limit sług** — 1–5 jednocześnie, rośnie co 5 poziomów postaci.
- **Decay** — co ~6 s odejmowany drain (2–6 pkt); przy 0 esencji sługa znika z efektem VFX.
- **Panel NUI** — lista sług (nazwa, typ, pasek HP, pasek esencji, przycisk wyboru) + panel szczegółów z karmeniem (pole tekstowe z kwotą) i przyciskiem pożegnania.
- **Bind Corpse** — przycisk „Przywołaj Umarłych" wchodzi w tryb targetowania → gracz wskazuje ciało (max 5 m) → system sprawdza warunki i spawna stwora.

## Pliki

| Plik | Rola |
|---|---|
| `sql_nec.nss` | Schema SQLite (`nec_servants`, `nec_essence`), CRUD |
| `lib_nec_def.nss` | Stałe, ID bindów NUI, helpery typów |
| `lib_nec.nss` | Budowanie okna NUI, cały gameplay |
| `lib_nec_ev.nss` | Handler eventów NUI |
| `sys_on_load.nss` | Tworzenie tabel (`OnModuleLoad`) |
| `sys_on_enter.nss` | Rejestracja PC + respawn sług (`OnClientEnter`) |
| `sys_on_leave.nss` | Zapis HP + usunięcie obiektów (`OnClientLeave`) |
| `sys_module_hb.nss` | Decay + sync HP + follow (`OnHeartbeat`) |
| `sys_on_target.nss` | Odbiór targetu do wiązania zwłok (`OnPlayerTarget`) |
| `test_nec.nss` | Demo OnUsed: otwiera UI + daje 200 esencji testowo |
| `INTEGRATION.md` | Instrukcja integracji z istniejącym modułem |

**Łącznie: 1358 LOC NWScript** w 10 plikach.

## Zależności (NWNX? SQL?)

- **NWNX**: nie wymagane.
- **Kampanijne SQLite**: tak — baza `"nec"` (tabele tworzone idempotentnie przez `sys_on_load.nss`).
- **Blueprinty stworów**: domyślnie stock NWN (`nw_s_skelwar`, `nw_zombie01`, `nw_s_shadow`, `nw_s_wight`). Resrefy konfigurowane przez stałe `NEC_RESREF_*` w `lib_nec_def.nss`.

## Jak włączyć w istniejącym module

1. Przypisz `sys_on_load.nss` do zdarzenia `OnModuleLoad` (lub wywołaj `NecCreateTables()` ze swojego istniejącego skryptu).
2. Z `OnClientEnter` wywołaj `NecRegisterPC(oPC)` + `DelayCommand(2.0, NecSpawnServants(oPC))`.
3. Z `OnClientLeave` wywołaj `NecDespawnServants(oPC)`.
4. Z `OnHeartbeat` wywołaj `NecHeartbeat()` (lub użyj `sys_module_hb.nss` bezpośrednio).
5. Z `OnPlayerTarget` wywołaj `NecBindCorpse` gdy `NEC_LVAR_TARGETING == 1` (lub użyj `sys_on_target.nss`).
6. Z `OnDeath` każdego obszaru wywołaj `NecOnCreatureDeath(GetLastKiller(), OBJECT_SELF)` — opcjonalne, ale potrzebne do zdobywania esencji.
7. Placeable z `test_nec.nss` jako OnUsed otwiera panel UI.

## Co celowo pominięto

- **Komendy sług** (Atakuj / Stój / Cofnij) — wymagałyby dodatkowego sub-menu NUI lub komend czatu; punkt rozszerzenia.
- **Własne blueprinty HAK** — moduł działa na stock NWN; do nadpisania przez `NEC_RESREF_*`.
- **Atak zarażenia** (odradzanie nieumarłych z wrogów) — pominięty celowo, by zapobiec lawinowemu rozrostowi stworów w MP.
- **Skala esencji przez talenty/featy** — `NecGetMaxServants()` jest trivialnie nadpisywalny przez buildera.

---
_Generated by [Claude Code](https://claude.ai/code/session_017oKHgALFhEESQGfBg3cwQg)_