### PR TITLE
feat: Blood Altar

### DIFF
--- a/Blood Altar/INTEGRATION.md
+++ b/Blood Altar/INTEGRATION.md
@@ -1,0 +1,78 @@
+# Blood Altar — Instrukcja integracji
+
+## Co to robi
+
+Gracze mogą składać ofiary przy ołtarzach (złoto, przedmiot z ekwipunku lub własna krew)
+w zamian za tymczasowe wzmocnienia. Każda ciemna ofiara zwiększa wskaźnik **skalania duszy**
+(0–100), przechowywany w SQLite. Przy progach 33% i 66% na postaci pojawiają się stałe
+efekty aury; przy 100% (Soul Riven) gracz traci 4 punkty Charyzmy dopóki nie odejdzie od mroku.
+
+## Hooki modułowe
+
+| Zdarzenie modułu | Skrypt        | Uwagi                                    |
+|------------------|---------------|------------------------------------------|
+| OnModuleLoad     | `sys_on_load` | Tworzy tabele SQLite                     |
+| OnClientEnter    | `sys_on_enter`| Odświeża VFX korupcji, liczy decay      |
+| OnPlayerTarget   | `sys_on_target`| Obsługuje ofiarę z przedmiotu           |
+
+Skrypt `sys_on_use.nss` podepnij jako **OnUsed** na każdym placeablu ołtarza.
+
+## Tagi placeabli
+
+Ustaw `Tag` placeabla na jeden z poniższych (dokładna wielkość liter):
+
+| Tag            | Ołtarz          | Korupcja ofiar     |
+|----------------|-----------------|-------------------|
+| `ALTAR_BLOOD`  | Ołtarz Krwi     | 8 / 15 / 25       |
+| `ALTAR_BONE`   | Ołtarz Kości    | 5 / 12 / 20       |
+| `ALTAR_EARTH`  | Ołtarz Ziemi    | 0 / 0 / 0         |
+| `ALTAR_SHADOW` | Ołtarz Cienia   | 10 / 15 / 30      |
+
+## NWNX
+
+Brak twardych zależności od NWNX. Wszystkie efekty i VFX używają standardowego NWScript i NWN:EE.
+
+## Baza danych SQLite
+
+Kampania: **`blood_altar`**. Tabele tworzone automatycznie przez `sys_on_load`.
+
+```
+balt_corruption  — skalanie per gracz (player_uuid, corruption, last_sacrifice)
+balt_log         — historia ofiar (player_uuid, altar_tag, sac_idx, epoch)
+```
+
+## Typy ofiar
+
+Każdy ołtarz oferuje 3 poziomy:
+
+| Poziom | Koszt           | Mechanika                                  |
+|--------|-----------------|--------------------------------------------|
+| Drobna | Złoto (stała kwota) | Natychmiastowe odjęcie złota, buff     |
+| Ciała  | Przedmiot z ekwipunku | Targeting mode → wybierz przedmiot, zniszczenie, buff |
+| Krwi   | % maks. PW      | Popup potwierdzenia → obrażenia magiczne, buff |
+
+## Korupcja duszy
+
+- **0–32%** — brak efektów wizualnych
+- **33–65%** — `VFX_DUR_AURA_EVIL` (stały, odfiltrowywany przez BALT_VFX_TAG_LOW)
+- **66–99%** — jak wyżej + `VFX_DUR_AURA_NEGATIVE_ENERGY` (BALT_VFX_TAG_HIGH)
+- **100%** — oba aury + `-4 Charyzmy` (BALT_VFX_TAG_RIVEN) + wiadomość narracyjna
+
+Korupcja powoli spada przy każdym logowaniu jeśli minęło odpowiednio dużo czasu
+od ostatniej ciemnej ofiary (3 pkt po 12h, 8 po 24h, 15 po 48h).
+
+## Test
+
+1. Umieść dowolny placeable (np. Altar Generic).
+2. Ustaw `OnUsed = test_balt`.
+3. Klikaj — okno będzie cyklować przez wszystkie 4 typy ołtarzy.
+
+Alternatywnie:
+- Ustaw tag placeabla na `ALTAR_BLOOD` i `OnUsed = sys_on_use`.
+
+## Co celowo pominięto
+
+- **Brak .mod** — środowisko CLI nie pozwala pakować plików .mod; użyj Toolsetu.
+- **Brak cooldownu per ofiara** — można składać wielokrotnie; tryb PW może wymagać CD.
+- **Brak ograniczeń klasowych/rasowych** — każdy może korzystać z każdego ołtarza.
+- **Brak redukcji korupcji przez modlitwę/kapłanów** — extension point dla późniejszej integracji z Pantheon.

--- a/Blood Altar/Scripts/lib_balt.nss
+++ b/Blood Altar/Scripts/lib_balt.nss
@@ -1,0 +1,566 @@
+// lib_balt.nss — Blood Altar: dane oltarzy, UI NUI, aplikacja boonow, VFX korupcji
+#include "lib_balt_def"
+
+// ================================================================
+// Pomocnicy do budowania danych ofiar (JSON)
+// ================================================================
+
+json BaltMakeSac(string sName, string sCostDesc, string sEffDesc,
+                  int nCostType, int nCostVal,
+                  int nCorrupt, float fDuration, json jEffs)
+{
+    json j = JsonObject();
+    j = JsonObjectSet(j, "name",      JsonString(sName));
+    j = JsonObjectSet(j, "cost_desc", JsonString(sCostDesc));
+    j = JsonObjectSet(j, "eff_desc",  JsonString(sEffDesc));
+    j = JsonObjectSet(j, "cost_type", JsonInt(nCostType));
+    j = JsonObjectSet(j, "cost_val",  JsonInt(nCostVal));
+    j = JsonObjectSet(j, "corrupt",   JsonInt(nCorrupt));
+    j = JsonObjectSet(j, "duration",  JsonFloat(fDuration));
+    j = JsonObjectSet(j, "eff",       jEffs);
+    return j;
+}
+
+json BaltEffAbility(int nAbility, int nVal)
+{
+    json e = JsonObject();
+    e = JsonObjectSet(e, "t",   JsonInt(BALT_EFF_ABILITY));
+    e = JsonObjectSet(e, "sub", JsonInt(nAbility));
+    e = JsonObjectSet(e, "val", JsonInt(nVal));
+    return e;
+}
+
+json BaltEffVal(int nType, int nVal)
+{
+    json e = JsonObject();
+    e = JsonObjectSet(e, "t",   JsonInt(nType));
+    e = JsonObjectSet(e, "val", JsonInt(nVal));
+    return e;
+}
+
+json BaltEffNoParam(int nType)
+{
+    json e = JsonObject();
+    e = JsonObjectSet(e, "t", JsonInt(nType));
+    return e;
+}
+
+// ================================================================
+// Dane statyczne: nazwa i klimatyczny opis oltarza
+// ================================================================
+
+string BaltGetAltarName(string sAltarTag)
+{
+    if(sAltarTag == BALT_TAG_BLOOD)  return "Oltarz Krwi";
+    if(sAltarTag == BALT_TAG_BONE)   return "Oltarz Kosci";
+    if(sAltarTag == BALT_TAG_EARTH)  return "Oltarz Ziemi";
+    if(sAltarTag == BALT_TAG_SHADOW) return "Oltarz Cienia";
+    return "Oltarz";
+}
+
+string BaltGetAltarLore(string sAltarTag)
+{
+    if(sAltarTag == BALT_TAG_BLOOD)
+        return "Kamien pulsuje ciemna czerwienia. Krew i moc ida w parze — "
+             + "lecz kazda ofiara zostawia slad na duszy skladajacego. "
+             + "Tych, co składaja tu zbyt wiele, mroczna moc poślębia.";
+
+    if(sAltarTag == BALT_TAG_BONE)
+        return "Kosci układają się w starożytny wzor. Pochłaniający patron "
+             + "tego miejsca czeka na należną mu daninę. Martwa magia "
+             + "wzmacnia ciało — kosztem duszy.";
+
+    if(sAltarTag == BALT_TAG_EARTH)
+        return "Zielony mech okrywa kamien. Duch lasu i gor nie zada duszy — "
+             + "jedynie holdu. Natura daje i bierze, lecz nie kazi. "
+             + "Tu mozna czynic ofiary bez ryzyka skalania.";
+
+    if(sAltarTag == BALT_TAG_SHADOW)
+        return "Ciemnosc przy oltarzu nie znika nawet w poludnie. Pan Cieni "
+             + "nagradza skrytosc — lecz cena jest wyzsza niz sie zdaje. "
+             + "Kazda ofiara przybiza do zatracenia.";
+
+    return "";
+}
+
+// ================================================================
+// Definicje ofiar per typ oltarza
+// ================================================================
+
+json BaltGetSacrifices(string sAltarTag)
+{
+    json jList = JsonArray();
+
+    if(sAltarTag == BALT_TAG_BLOOD)
+    {
+        // --- Minor: zloto -> Sila +2 na 1h ---
+        json jE0 = JsonArrayInsert(JsonArray(), BaltEffAbility(ABILITY_STRENGTH, 2));
+        jList = JsonArrayInsert(jList, BaltMakeSac(
+            "Drobna danica krwi",
+            "300 zlota",
+            "Sila +2 na 1 godzine",
+            0, 300, 8, 3600.0, jE0));
+
+        // --- Flesh: przedmiot -> Przyspieszenie na 15 min ---
+        json jE1 = JsonArrayInsert(JsonArray(), BaltEffNoParam(BALT_EFF_HASTE));
+        jList = JsonArrayInsert(jList, BaltMakeSac(
+            "Ofiara z ciala",
+            "Przedmiot z ekwipunku",
+            "Przyspieszenie na 15 minut",
+            1, 0, 15, 900.0, jE1));
+
+        // --- Blood: 25% maks. PW -> Sila +4 + 20 PW tymczasowych na 3h ---
+        json jE2 = JsonArray();
+        jE2 = JsonArrayInsert(jE2, BaltEffAbility(ABILITY_STRENGTH, 4));
+        jE2 = JsonArrayInsert(jE2, BaltEffVal(BALT_EFF_TEMP_HP, 20));
+        jList = JsonArrayInsert(jList, BaltMakeSac(
+            "Wielka danica krwi",
+            "25% maks. PW",
+            "Sila +4, +20 PW tymcz. na 3 godziny",
+            2, 25, 25, 10800.0, jE2));
+    }
+    else if(sAltarTag == BALT_TAG_BONE)
+    {
+        // --- Minor: zloto -> Kondycja +2 na 1h ---
+        json jE0 = JsonArrayInsert(JsonArray(), BaltEffAbility(ABILITY_CONSTITUTION, 2));
+        jList = JsonArrayInsert(jList, BaltMakeSac(
+            "Proszek z kosci",
+            "250 zlota",
+            "Kondycja +2 na 1 godzine",
+            0, 250, 5, 3600.0, jE0));
+
+        // --- Flesh: przedmiot -> Odpornosc na Czary +10 na 1h ---
+        json jE1 = JsonArrayInsert(JsonArray(), BaltEffVal(BALT_EFF_SPELL_RES, 10));
+        jList = JsonArrayInsert(jList, BaltMakeSac(
+            "Ofiara ze schronienia",
+            "Przedmiot z ekwipunku",
+            "Odpornosc na czary +10 na 1 godzine",
+            1, 0, 12, 3600.0, jE1));
+
+        // --- Blood: 20% maks. PW -> Rzuty obronne +3 na 3h ---
+        json jE2 = JsonArrayInsert(JsonArray(), BaltEffVal(BALT_EFF_SAVES, 3));
+        jList = JsonArrayInsert(jList, BaltMakeSac(
+            "Danica kosci i krwi",
+            "20% maks. PW",
+            "Rzuty obronne +3 na 3 godziny",
+            2, 20, 20, 10800.0, jE2));
+    }
+    else if(sAltarTag == BALT_TAG_EARTH)
+    {
+        // --- Minor: zloto -> Zwinnosc +2 na 1h ---
+        json jE0 = JsonArrayInsert(JsonArray(), BaltEffAbility(ABILITY_DEXTERITY, 2));
+        jList = JsonArrayInsert(jList, BaltMakeSac(
+            "Holdownicze ziarno",
+            "100 zlota",
+            "Zwinnosc +2 na 1 godzine",
+            0, 100, 0, 3600.0, jE0));
+
+        // --- Flesh: przedmiot -> Regeneracja 2 PW/6s na 1h ---
+        json jE1 = JsonArrayInsert(JsonArray(), BaltEffVal(BALT_EFF_REGEN, 2));
+        jList = JsonArrayInsert(jList, BaltMakeSac(
+            "Ofiara z plonow",
+            "Przedmiot z ekwipunku",
+            "Regeneracja 2 PW co 6 sekund, 1h",
+            1, 0, 0, 3600.0, jE1));
+
+        // --- Blood: 15% maks. PW -> Kondycja +4 na 2h ---
+        json jE2 = JsonArrayInsert(JsonArray(), BaltEffAbility(ABILITY_CONSTITUTION, 4));
+        jList = JsonArrayInsert(jList, BaltMakeSac(
+            "Ucisc ziemi",
+            "15% maks. PW",
+            "Kondycja +4 na 2 godziny",
+            2, 15, 0, 7200.0, jE2));
+    }
+    else if(sAltarTag == BALT_TAG_SHADOW)
+    {
+        // --- Minor: zloto -> Ulepszona Niewidzialnosc na 10 min ---
+        json jE0 = JsonArrayInsert(JsonArray(), BaltEffNoParam(BALT_EFF_INVIS));
+        jList = JsonArrayInsert(jList, BaltMakeSac(
+            "Ofiarowanie mroku",
+            "400 zlota",
+            "Ulepszona Niewidzialnosc na 10 min.",
+            0, 400, 10, 600.0, jE0));
+
+        // --- Flesh: przedmiot -> Zwinnosc +4 + rzuty obronne +2 na 2h ---
+        json jE1 = JsonArray();
+        jE1 = JsonArrayInsert(jE1, BaltEffAbility(ABILITY_DEXTERITY, 4));
+        jE1 = JsonArrayInsert(jE1, BaltEffVal(BALT_EFF_SAVES, 2));
+        jList = JsonArrayInsert(jList, BaltMakeSac(
+            "Serce z cienia",
+            "Przedmiot z ekwipunku",
+            "Zwinnosc +4, Rzuty +2 na 2 godziny",
+            1, 0, 15, 7200.0, jE1));
+
+        // --- Blood: 30% maks. PW -> Sila +4, Zwinnosc +4 na 2h ---
+        json jE2 = JsonArray();
+        jE2 = JsonArrayInsert(jE2, BaltEffAbility(ABILITY_STRENGTH, 4));
+        jE2 = JsonArrayInsert(jE2, BaltEffAbility(ABILITY_DEXTERITY, 4));
+        jList = JsonArrayInsert(jList, BaltMakeSac(
+            "Pakt Cienia",
+            "30% maks. PW",
+            "Sila +4, Zwinnosc +4 na 2 godziny",
+            2, 30, 30, 7200.0, jE2));
+    }
+
+    return jList;
+}
+
+// ================================================================
+// Aplikacja boonow (efektow)
+// ================================================================
+
+void BaltApplyBoon(object oPC, json jSac)
+{
+    float fDuration = JsonGetFloat(JsonObjectGet(jSac, "duration"));
+    json  jEffs     = JsonObjectGet(jSac, "eff");
+    int   nCount    = JsonGetLength(jEffs);
+    int   i;
+
+    for(i = 0; i < nCount; i++)
+    {
+        json jE   = JsonArrayGet(jEffs, i);
+        int  nT   = JsonGetInt(JsonObjectGet(jE, "t"));
+        int  nSub = JsonGetInt(JsonObjectGet(jE, "sub"));
+        int  nVal = JsonGetInt(JsonObjectGet(jE, "val"));
+
+        effect eBoon;
+        int    bApply = TRUE;
+
+        switch(nT)
+        {
+            case BALT_EFF_ABILITY:
+                eBoon = EffectAbilityIncrease(nSub, nVal);
+                break;
+            case BALT_EFF_TEMP_HP:
+                eBoon = EffectTemporaryHitpoints(nVal);
+                break;
+            case BALT_EFF_INVIS:
+                eBoon = EffectInvisibility(INVISIBILITY_TYPE_IMPROVED);
+                break;
+            case BALT_EFF_HASTE:
+                eBoon = EffectHaste();
+                break;
+            case BALT_EFF_REGEN:
+                eBoon = EffectRegenerate(nVal, 6.0);
+                break;
+            case BALT_EFF_SPELL_RES:
+                eBoon = EffectSpellResistanceIncrease(nVal);
+                break;
+            case BALT_EFF_SAVES:
+                eBoon = EffectSavingThrowIncrease(SAVING_THROW_ALL, nVal, SAVING_THROW_TYPE_ALL);
+                break;
+            default:
+                bApply = FALSE;
+                break;
+        }
+
+        if(bApply)
+        {
+            eBoon = TagEffect(eBoon, "BALT_BOON");
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eBoon, oPC, fDuration);
+        }
+    }
+
+    // Natychmiastowy efekt wizualny w miejscu gracza
+    ApplyEffectAtLocation(DURATION_TYPE_INSTANT,
+        EffectVisualEffect(VFX_IMP_LIGHTNING_M), GetLocation(oPC));
+}
+
+// ================================================================
+// Korupcja: VFX i debuffs
+// ================================================================
+
+void BaltRemoveCorruptionVFX(object oPC)
+{
+    effect e = GetFirstEffect(oPC);
+    while(GetIsEffectValid(e))
+    {
+        string sTag = GetEffectTag(e);
+        if(sTag == BALT_VFX_TAG_LOW || sTag == BALT_VFX_TAG_HIGH || sTag == BALT_VFX_TAG_RIVEN)
+            RemoveEffect(oPC, e);
+        e = GetNextEffect(oPC);
+    }
+}
+
+void BaltApplyCorruptionVFX(object oPC, int nCorruption)
+{
+    BaltRemoveCorruptionVFX(oPC);
+
+    if(nCorruption >= BALT_CORRUPT_LOW)
+    {
+        effect eAura = EffectVisualEffect(VFX_DUR_AURA_EVIL);
+        eAura = TagEffect(eAura, BALT_VFX_TAG_LOW);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eAura, oPC);
+    }
+
+    if(nCorruption >= BALT_CORRUPT_HIGH)
+    {
+        effect eAura2 = EffectVisualEffect(VFX_DUR_AURA_NEGATIVE_ENERGY);
+        eAura2 = TagEffect(eAura2, BALT_VFX_TAG_HIGH);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eAura2, oPC);
+    }
+
+    if(nCorruption >= BALT_CORRUPT_MAX)
+    {
+        // "Dusza rozerwana" — staly debuff charyzmy; zdejmowany gdy korupcja spadnie
+        effect eRiven = EffectAbilityDecrease(ABILITY_CHARISMA, 4);
+        eRiven = TagEffect(eRiven, BALT_VFX_TAG_RIVEN);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eRiven, oPC);
+
+        FloatingTextStringOnCreature(
+            "Twoja dusza jest rozdarta... Mroczna moc cie konsumuje.",
+            oPC, FALSE);
+    }
+}
+
+// ================================================================
+// Popup potwierdzenia ofiary z krwi
+// ================================================================
+
+void BaltShowBloodConfirm(object oPC, int nHPCost, string sAltarName)
+{
+    if(NuiFindWindow(oPC, BALT_WIN_CONFIRM) != 0)
+        NuiDestroy(oPC, NuiFindWindow(oPC, BALT_WIN_CONFIRM));
+
+    float fW = GetNuiScaleDimension(oPC, 380.0);
+    float fH = GetNuiScaleDimension(oPC, 170.0);
+    float fX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - fW) / 2.0;
+    float fY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - fH) / 2.0;
+
+    string sMsg = "Czy poswieccisz " + IntToString(nHPCost) + " Punktow Wytrzymalosci"
+                + " ku chwale " + sAltarName + "?\n\nTego nie da sie cofnac.";
+
+    json jMsg = NuiLabel(JsonString(sMsg), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jMsg = NuiHeight(jMsg, GetNuiScaleDimension(oPC, 70.0));
+
+    json jYes = NuiButton(JsonString("Skladam offare"));
+    jYes = NuiId(jYes, BALT_BTN_CONFIRM);
+    jYes = NuiWidth(jYes, GetNuiScaleDimension(oPC, 150.0));
+
+    json jNo = NuiButton(JsonString("Odstepuje"));
+    jNo = NuiId(jNo, BALT_BTN_CANCEL);
+    jNo = NuiWidth(jNo, GetNuiScaleDimension(oPC, 100.0));
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jYes);
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jNo);
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jMsg);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+
+    json jWin = NuiWindow(NuiCol(jCol),
+        JsonString("Ofiara krwi"),
+        NuiRect(fX, fY, fW, fH),
+        JsonBool(FALSE), JsonBool(FALSE), JsonBool(FALSE),
+        JsonBool(FALSE), JsonBool(TRUE));
+
+    NuiCreate(oPC, jWin, BALT_WIN_CONFIRM, BALT_EV_SCRIPT);
+}
+
+// ================================================================
+// Budowanie okna NUI
+// ================================================================
+
+json BaltBuildWindow(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 30.0);
+    float fRowH  = GetNuiScaleDimension(oPC, 36.0);
+    float fProgH = GetNuiScaleDimension(oPC, 20.0);
+    float fLoreH = GetNuiScaleDimension(oPC, 58.0);
+
+    // -- Tekst klimatyczny --
+    json jLore = NuiText(NuiBind(BALT_BIND_LORE), FALSE);
+    jLore = NuiHeight(jLore, fLoreH);
+
+    // -- Wiersz korupcji: etykieta + pasek postepu --
+    json jCorrLbl = NuiLabel(NuiBind(BALT_BIND_CORR_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jCorrLbl = NuiWidth(jCorrLbl, GetNuiScaleDimension(oPC, 200.0));
+    jCorrLbl = NuiStyleForegroundColor(jCorrLbl, NuiBind(BALT_BIND_CORR_COLOR));
+
+    json jProg = NuiProgress(NuiBind(BALT_BIND_CORRUPTION));
+    jProg = NuiHeight(jProg, fProgH);
+
+    json jCorrRow = JsonArray();
+    jCorrRow = JsonArrayInsert(jCorrRow, jCorrLbl);
+    jCorrRow = JsonArrayInsert(jCorrRow, jProg);
+
+    // -- Lista ofiar (NuiList) --
+    float fNameW = GetNuiScaleDimension(oPC, 165.0);
+    float fCostW = GetNuiScaleDimension(oPC, 155.0);
+    float fSacBW = GetNuiScaleDimension(oPC, 120.0);
+
+    json jNameLbl = NuiLabel(NuiBind(BALT_BIND_SAC_NAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jNameLbl = NuiStyleForegroundColor(jNameLbl, NuiBind(BALT_BIND_SAC_COLOR));
+
+    json jCostLbl = NuiLabel(NuiBind(BALT_BIND_SAC_COST),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jCostLbl = NuiStyleForegroundColor(jCostLbl, NuiBind(BALT_BIND_SAC_COLOR));
+
+    json jEffLbl = NuiLabel(NuiBind(BALT_BIND_SAC_EFF),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jEffLbl = NuiStyleForegroundColor(jEffLbl, NuiBind(BALT_BIND_SAC_COLOR));
+
+    json jSacBtn = NuiButton(JsonString("Zloz ofiare"));
+    jSacBtn = NuiId(jSacBtn, BALT_BTN_SACRIFICE);
+    jSacBtn = NuiEnabled(jSacBtn, NuiBind(BALT_BIND_SAC_ENA));
+    jSacBtn = NuiWidth(jSacBtn, fSacBW);
+    jSacBtn = NuiHeight(jSacBtn, fRowH - GetNuiScaleDimension(oPC, 4.0));
+
+    json jTmpl = JsonArray();
+    jTmpl = JsonArrayInsert(jTmpl,
+        NuiListTemplateCell(NuiWidth(NuiCol(JsonArrayInsert(JsonArray(), jNameLbl)), fNameW), fNameW, FALSE));
+    jTmpl = JsonArrayInsert(jTmpl,
+        NuiListTemplateCell(NuiWidth(NuiCol(JsonArrayInsert(JsonArray(), jCostLbl)), fCostW), fCostW, FALSE));
+    jTmpl = JsonArrayInsert(jTmpl,
+        NuiListTemplateCell(NuiCol(JsonArrayInsert(JsonArray(), jEffLbl)), 0.0, TRUE));
+    jTmpl = JsonArrayInsert(jTmpl,
+        NuiListTemplateCell(NuiWidth(NuiCol(JsonArrayInsert(JsonArray(), jSacBtn)), fSacBW), fSacBW, FALSE));
+
+    float fListH = GetNuiScaleDimension(oPC, 160.0);
+    json jList = NuiList(jTmpl, NuiBind(BALT_BIND_ROWCOUNT), fRowH);
+    jList = NuiHeight(jList, fListH);
+
+    // -- Przycisk zamknij --
+    json jCloseBtn = NuiButton(JsonString("Zamknij"));
+    jCloseBtn = NuiId(jCloseBtn, BALT_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, GetNuiScaleDimension(oPC, 100.0));
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jBotRow = JsonArray();
+    jBotRow = JsonArrayInsert(jBotRow, NuiSpacer());
+    jBotRow = JsonArrayInsert(jBotRow, jCloseBtn);
+
+    // -- Sklej kolumne --
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jLore);
+    jCol = JsonArrayInsert(jCol, NuiRow(jCorrRow));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jList);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBotRow));
+
+    json jSide    = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    float fContW  = GetNuiScaleDimension(oPC, BALT_W - 40.0);
+    json jMainRow = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiCol(jCol), fContW));
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+
+    json jWin = NuiWindow(NuiRow(jMainRow),
+        NuiBind(BALT_BIND_TITLE),
+        NuiBind(BALT_BIND_WIN_GEOM),
+        JsonBool(FALSE), JsonBool(FALSE), JsonBool(FALSE),
+        JsonBool(TRUE),  JsonBool(FALSE));
+
+    return jWin;
+}
+
+// ================================================================
+// Wypelnianie bindow
+// ================================================================
+
+void BaltFeedWindow(object oPC, int nToken, string sAltarTag)
+{
+    int nCorruption = BaltGetCorruption(oPC);
+
+    NuiSetBind(oPC, nToken, BALT_BIND_TITLE, JsonString(BaltGetAltarName(sAltarTag)));
+    NuiSetBind(oPC, nToken, BALT_BIND_LORE,  JsonString(BaltGetAltarLore(sAltarTag)));
+
+    // Pasek i kolor korupcji
+    float fCorr = IntToFloat(nCorruption) / 100.0;
+    NuiSetBind(oPC, nToken, BALT_BIND_CORRUPTION,
+        JsonFloat(fCorr < 0.0 ? 0.0 : (fCorr > 1.0 ? 1.0 : fCorr)));
+    NuiSetBind(oPC, nToken, BALT_BIND_CORR_LBL,
+        JsonString("Skalanie duszy: " + IntToString(nCorruption) + "%"));
+
+    json jCorrColor;
+    if(nCorruption >= BALT_CORRUPT_HIGH)
+        jCorrColor = NuiColor(210, 30, 30);
+    else if(nCorruption >= BALT_CORRUPT_LOW)
+        jCorrColor = NuiColor(210, 120, 20);
+    else
+        jCorrColor = NuiColor(170, 170, 160);
+    NuiSetBind(oPC, nToken, BALT_BIND_CORR_COLOR, jCorrColor);
+
+    // Dane listy ofiar
+    json jSacs   = BaltGetSacrifices(sAltarTag);
+    int  nCount  = JsonGetLength(jSacs);
+    int  nGold   = GetGold(oPC);
+    int  nHP     = GetCurrentHitPoints(oPC);
+    int  nMaxHP  = GetMaxHitPoints(oPC);
+
+    json jNames  = JsonArray();
+    json jCosts  = JsonArray();
+    json jEffs   = JsonArray();
+    json jEnas   = JsonArray();
+    json jColors = JsonArray();
+
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jSac     = JsonArrayGet(jSacs, i);
+        int  nCostT   = JsonGetInt(JsonObjectGet(jSac, "cost_type"));
+        int  nCostV   = JsonGetInt(JsonObjectGet(jSac, "cost_val"));
+        int  bAfford;
+
+        if(nCostT == 0)
+            bAfford = (nGold >= nCostV);
+        else if(nCostT == 1)
+            bAfford = TRUE;
+        else
+        {
+            int nHPCost = nMaxHP * nCostV / 100;
+            bAfford = (nHP > nHPCost + 5);
+        }
+
+        json jColor = bAfford ? NuiColor(220, 200, 150) : NuiColor(100, 85, 65);
+
+        jNames  = JsonArrayInsert(jNames,  JsonString(JsonGetString(JsonObjectGet(jSac, "name"))));
+        jCosts  = JsonArrayInsert(jCosts,  JsonString(JsonGetString(JsonObjectGet(jSac, "cost_desc"))));
+        jEffs   = JsonArrayInsert(jEffs,   JsonString(JsonGetString(JsonObjectGet(jSac, "eff_desc"))));
+        jEnas   = JsonArrayInsert(jEnas,   JsonBool(bAfford));
+        jColors = JsonArrayInsert(jColors, jColor);
+    }
+
+    NuiSetBind(oPC, nToken, BALT_BIND_SAC_NAME,  jNames);
+    NuiSetBind(oPC, nToken, BALT_BIND_SAC_COST,  jCosts);
+    NuiSetBind(oPC, nToken, BALT_BIND_SAC_EFF,   jEffs);
+    NuiSetBind(oPC, nToken, BALT_BIND_SAC_ENA,   jEnas);
+    NuiSetBind(oPC, nToken, BALT_BIND_SAC_COLOR, jColors);
+    NuiSetBind(oPC, nToken, BALT_BIND_ROWCOUNT,  JsonInt(nCount));
+}
+
+// ================================================================
+// Otwieranie okna
+// ================================================================
+
+void BaltOpenWindow(object oPC, string sAltarTag)
+{
+    SetLocalString(oPC, BALT_LVAR_ALTAR_TAG, sAltarTag);
+
+    int nToken = NuiFindWindow(oPC, BALT_WINDOW);
+    if(nToken != 0)
+    {
+        BaltFeedWindow(oPC, nToken, sAltarTag);
+        return;
+    }
+
+    SetLocalInt(oPC, BALT_LVAR_ITEM_IDX, -1);  // -1 = brak aktywnego celowania
+
+    json jWin = BaltBuildWindow(oPC);
+    nToken = NuiCreate(oPC, jWin, BALT_WINDOW, BALT_EV_SCRIPT);
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - GetNuiScaleDimension(oPC, BALT_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - GetNuiScaleDimension(oPC, BALT_H)) / 2.0;
+    NuiSetBind(oPC, nToken, BALT_BIND_WIN_GEOM,
+        NuiRect(fCX, fCY, GetNuiScaleDimension(oPC, BALT_W), GetNuiScaleDimension(oPC, BALT_H)));
+
+    BaltFeedWindow(oPC, nToken, sAltarTag);
+}

--- a/Blood Altar/Scripts/lib_balt_def.nss
+++ b/Blood Altar/Scripts/lib_balt_def.nss
@@ -1,0 +1,86 @@
+// lib_balt_def.nss — Blood Altar: stale, ID bindow, ID przyciskow
+#include "lib_nui"
+#include "sql_balt"
+
+// Forward declarations (implementacja w lib_balt.nss)
+void BaltOpenWindow(object oPC, string sAltarTag);
+void BaltFeedWindow(object oPC, int nToken, string sAltarTag);
+void BaltShowBloodConfirm(object oPC, int nHPCost, string sAltarName);
+
+// ---------------------------------------------------------------
+// Identyfikatory okien NUI
+// ---------------------------------------------------------------
+const string BALT_WINDOW      = "BALT_WINDOW";
+const string BALT_WIN_CONFIRM = "BALT_WIN_CONFIRM";
+const string BALT_EV_SCRIPT   = "lib_balt_ev";
+
+// ---------------------------------------------------------------
+// Nazwy bindow (BALT_BIND_*)
+// ---------------------------------------------------------------
+const string BALT_BIND_TITLE      = "balt_title";
+const string BALT_BIND_LORE       = "balt_lore";
+const string BALT_BIND_CORRUPTION = "balt_corruption";  // float 0..1 dla NuiProgress
+const string BALT_BIND_CORR_LBL   = "balt_corr_lbl";
+const string BALT_BIND_CORR_COLOR  = "balt_corr_color";
+const string BALT_BIND_SAC_NAME   = "balt_sac_name";
+const string BALT_BIND_SAC_COST   = "balt_sac_cost";
+const string BALT_BIND_SAC_EFF    = "balt_sac_eff";
+const string BALT_BIND_SAC_ENA    = "balt_sac_ena";
+const string BALT_BIND_SAC_COLOR  = "balt_sac_color";
+const string BALT_BIND_ROWCOUNT   = "balt_rowcount";
+const string BALT_BIND_WIN_GEOM   = "balt_win_geom";
+
+// ---------------------------------------------------------------
+// Identyfikatory przyciskow (BALT_BTN_*)
+// ---------------------------------------------------------------
+const string BALT_BTN_CLOSE     = "balt_btn_close";
+const string BALT_BTN_SACRIFICE = "balt_btn_sac";   // w szablonie listy
+const string BALT_BTN_CONFIRM   = "balt_btn_confirm";
+const string BALT_BTN_CANCEL    = "balt_btn_cancel";
+
+// ---------------------------------------------------------------
+// Zmienne lokalne na PC (BALT_LVAR_*)
+// ---------------------------------------------------------------
+const string BALT_LVAR_ALTAR_TAG   = "BALT_ALTAR_TAG";
+const string BALT_LVAR_PENDING_IDX = "BALT_PENDING_IDX";  // indeks ofiary czekajacy na potwierdzenie
+const string BALT_LVAR_PENDING_HP  = "BALT_PENDING_HP";   // koszt HP czekajacy na potwierdzenie
+const string BALT_LVAR_ITEM_IDX    = "BALT_ITEM_IDX";     // indeks ofiary przy celowaniu w przedmiot
+
+// ---------------------------------------------------------------
+// Tagi placeable'i oltarzy (ustawiane w toolsecie jako Tag)
+// ---------------------------------------------------------------
+const string BALT_TAG_BLOOD  = "ALTAR_BLOOD";
+const string BALT_TAG_BONE   = "ALTAR_BONE";
+const string BALT_TAG_EARTH  = "ALTAR_EARTH";
+const string BALT_TAG_SHADOW = "ALTAR_SHADOW";
+
+// ---------------------------------------------------------------
+// Typy efektow boonow (uzywane w tablicy "eff" JSON ofiary)
+// ---------------------------------------------------------------
+const int BALT_EFF_ABILITY   = 0; // sub = ABILITY_*, val = ilosc
+const int BALT_EFF_TEMP_HP   = 1; // val = ilosc PW tymczasowych
+const int BALT_EFF_INVIS     = 2; // Ulepszona Niewidzialnosc (bez sub/val)
+const int BALT_EFF_HASTE     = 3; // Przyspieszenie (bez sub/val)
+const int BALT_EFF_REGEN     = 4; // val = HP/tick (co 6s)
+const int BALT_EFF_SPELL_RES = 5; // val = wzrost Odpornosci na Czary
+const int BALT_EFF_SAVES     = 6; // val = wzrost rzutow obronnych (wszystkie)
+
+// ---------------------------------------------------------------
+// Tagi efektow korupcji (TagEffect, pozwalaja na usuwanie)
+// ---------------------------------------------------------------
+const string BALT_VFX_TAG_LOW   = "BALT_VFX_LOW";
+const string BALT_VFX_TAG_HIGH  = "BALT_VFX_HIGH";
+const string BALT_VFX_TAG_RIVEN = "BALT_VFX_RIVEN";
+
+// ---------------------------------------------------------------
+// Progi korupcji
+// ---------------------------------------------------------------
+const int BALT_CORRUPT_LOW  = 33;
+const int BALT_CORRUPT_HIGH = 66;
+// BALT_CORRUPT_MAX = 100 zdefiniowany w sql_balt.nss
+
+// ---------------------------------------------------------------
+// Wymiary okna
+// ---------------------------------------------------------------
+const float BALT_W = 620.0;
+const float BALT_H = 460.0;

--- a/Blood Altar/Scripts/lib_balt_ev.nss
+++ b/Blood Altar/Scripts/lib_balt_ev.nss
@@ -1,0 +1,173 @@
+// lib_balt_ev.nss — Blood Altar: glowny handler eventow NUI
+#include "lib_balt"
+
+// ---------------------------------------------------------------
+// Obsluga klikniecia "Zloz ofiare" dla danego indeksu
+// ---------------------------------------------------------------
+
+void BaltHandleSacrificeClick(object oPC, int nToken, int nIdx)
+{
+    string sAltarTag = GetLocalString(oPC, BALT_LVAR_ALTAR_TAG);
+    if(sAltarTag == "") return;
+
+    json jSacs = BaltGetSacrifices(sAltarTag);
+    if(nIdx < 0 || nIdx >= JsonGetLength(jSacs)) return;
+    json jSac = JsonArrayGet(jSacs, nIdx);
+
+    int nCostType = JsonGetInt(JsonObjectGet(jSac, "cost_type"));
+    int nCostVal  = JsonGetInt(JsonObjectGet(jSac, "cost_val"));
+    int nCorrupt  = JsonGetInt(JsonObjectGet(jSac, "corrupt"));
+
+    if(nCostType == 0)
+    {
+        // --- Ofiara zlotem ---
+        if(GetGold(oPC) < nCostVal)
+        {
+            SendMessageToPC(oPC, "[Oltarz] Nie masz wystarczajaco zlota.");
+            return;
+        }
+        AssignCommand(oPC, TakeGoldFromCreature(nCostVal, oPC, TRUE));
+
+        BaltApplyBoon(oPC, jSac);
+        int nNewCorr = BaltAddCorruption(oPC, nCorrupt);
+        BaltLogSacrifice(oPC, sAltarTag, nIdx);
+        BaltApplyCorruptionVFX(oPC, nNewCorr);
+        BaltFeedWindow(oPC, nToken, sAltarTag);
+
+        SendMessageToPC(oPC, "[Oltarz] Ofiara przyjeta. "
+                      + JsonGetString(JsonObjectGet(jSac, "eff_desc")));
+
+        if(nCorrupt > 0 && nNewCorr >= BALT_CORRUPT_HIGH)
+            FloatingTextStringOnCreature(
+                "Pieczen krwi pulsuje slabo... Mroczna moc sie budzi.", oPC, FALSE);
+    }
+    else if(nCostType == 1)
+    {
+        // --- Ofiara z przedmiotu: wejdz w tryb celowania ---
+        // -1 = nieaktywny; sys_on_target.nss sprawdza ta wartosc
+        SetLocalInt(oPC, BALT_LVAR_ITEM_IDX, nIdx);
+        EnterTargetingMode(oPC, OBJECT_TYPE_ITEM);
+        SendMessageToPC(oPC, "[Oltarz] Wybierz przedmiot z ekwipunku, ktory zostanie poswiecony.");
+    }
+    else if(nCostType == 2)
+    {
+        // --- Ofiara z krwi: sprawdz HP i pokaz potwierdzenie ---
+        int nMaxHP  = GetMaxHitPoints(oPC);
+        int nHPCost = nMaxHP * nCostVal / 100;
+        if(nHPCost < 1) nHPCost = 1;
+
+        if(GetCurrentHitPoints(oPC) <= nHPCost + 5)
+        {
+            SendMessageToPC(oPC, "[Oltarz] Zbyt malo zywotnosci. Smierc to nie ofiara.");
+            return;
+        }
+
+        SetLocalInt(oPC, BALT_LVAR_PENDING_IDX, nIdx);
+        SetLocalInt(oPC, BALT_LVAR_PENDING_HP,  nHPCost);
+        BaltShowBloodConfirm(oPC, nHPCost, BaltGetAltarName(sAltarTag));
+    }
+}
+
+// ---------------------------------------------------------------
+// Wykonanie zatwierdzonej ofiary z krwi
+// ---------------------------------------------------------------
+
+void BaltHandleBloodConfirm(object oPC)
+{
+    int nIdx    = GetLocalInt(oPC, BALT_LVAR_PENDING_IDX);
+    int nHPCost = GetLocalInt(oPC, BALT_LVAR_PENDING_HP);
+
+    DeleteLocalInt(oPC, BALT_LVAR_PENDING_IDX);
+    DeleteLocalInt(oPC, BALT_LVAR_PENDING_HP);
+
+    string sAltarTag = GetLocalString(oPC, BALT_LVAR_ALTAR_TAG);
+    json jSacs = BaltGetSacrifices(sAltarTag);
+    if(nIdx < 0 || nIdx >= JsonGetLength(jSacs)) return;
+    json jSac = JsonArrayGet(jSacs, nIdx);
+
+    if(GetCurrentHitPoints(oPC) <= nHPCost + 5)
+    {
+        SendMessageToPC(oPC, "[Oltarz] Zbyt malo zywotnosci — ofiara niemozliwa.");
+        return;
+    }
+
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectDamage(nHPCost, DAMAGE_TYPE_MAGICAL), oPC);
+
+    BaltApplyBoon(oPC, jSac);
+
+    int nCorrupt = JsonGetInt(JsonObjectGet(jSac, "corrupt"));
+    int nNewCorr = BaltAddCorruption(oPC, nCorrupt);
+    BaltLogSacrifice(oPC, sAltarTag, nIdx);
+    BaltApplyCorruptionVFX(oPC, nNewCorr);
+
+    int nToken = NuiFindWindow(oPC, BALT_WINDOW);
+    if(nToken != 0)
+        BaltFeedWindow(oPC, nToken, sAltarTag);
+
+    SendMessageToPC(oPC, "[Oltarz] Krew zlożona. "
+                  + JsonGetString(JsonObjectGet(jSac, "eff_desc")));
+
+    if(nNewCorr >= BALT_CORRUPT_MAX)
+        FloatingTextStringOnCreature(
+            "Twoja dusza peka... Jestes narzedziem mroku.", oPC, FALSE);
+    else if(nNewCorr >= BALT_CORRUPT_HIGH)
+        FloatingTextStringOnCreature(
+            "Pieczen krwi pulsuje mroczna moca...", oPC, FALSE);
+}
+
+// ---------------------------------------------------------------
+// Glowny handler (skrypt NUI event)
+// ---------------------------------------------------------------
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    // --- Popup potwierdzenia krwi ---
+    if(nToken == NuiFindWindow(oPC, BALT_WIN_CONFIRM))
+    {
+        if(sEvent == EVENT_TYPE_CLICK)
+        {
+            if(sElem == BALT_BTN_CONFIRM)
+            {
+                NuiDestroy(oPC, nToken);
+                BaltHandleBloodConfirm(oPC);
+            }
+            else if(sElem == BALT_BTN_CANCEL)
+            {
+                DeleteLocalInt(oPC, BALT_LVAR_PENDING_IDX);
+                DeleteLocalInt(oPC, BALT_LVAR_PENDING_HP);
+                NuiDestroy(oPC, nToken);
+            }
+        }
+        return;
+    }
+
+    if(nToken != NuiFindWindow(oPC, BALT_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalString(oPC, BALT_LVAR_ALTAR_TAG);
+        SetLocalInt(oPC, BALT_LVAR_ITEM_IDX, -1);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == BALT_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+        if(sElem == BALT_BTN_SACRIFICE)
+        {
+            BaltHandleSacrificeClick(oPC, nToken, nIdx);
+            return;
+        }
+    }
+}

--- a/Blood Altar/Scripts/lib_nui.nss
+++ b/Blood Altar/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Blood Altar/Scripts/lib_nui_utility.nss
+++ b/Blood Altar/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Blood Altar/Scripts/sql_balt.nss
+++ b/Blood Altar/Scripts/sql_balt.nss
@@ -1,0 +1,92 @@
+// sql_balt.nss — Blood Altar: SQLite schema i zapytania
+
+const string BALT_DB          = "blood_altar";
+const int    BALT_CORRUPT_MAX = 100;
+
+void BaltCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign(BALT_DB,
+        "CREATE TABLE IF NOT EXISTS balt_corruption "
+        "(player_uuid TEXT PRIMARY KEY, corruption INTEGER DEFAULT 0, "
+        "last_sacrifice INTEGER DEFAULT 0)");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign(BALT_DB,
+        "CREATE TABLE IF NOT EXISTS balt_log "
+        "(id INTEGER PRIMARY KEY AUTOINCREMENT, player_uuid TEXT NOT NULL, "
+        "altar_tag TEXT NOT NULL, sac_idx INTEGER NOT NULL, "
+        "epoch INTEGER DEFAULT (strftime('%s','now')))");
+    SqlStep(q);
+}
+
+int BaltGetCorruption(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign(BALT_DB,
+        "SELECT corruption FROM balt_corruption WHERE player_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+void BaltSetCorruption(object oPC, int nCorruption)
+{
+    if(nCorruption < 0)             nCorruption = 0;
+    if(nCorruption > BALT_CORRUPT_MAX) nCorruption = BALT_CORRUPT_MAX;
+
+    sqlquery q = SqlPrepareQueryCampaign(BALT_DB,
+        "INSERT INTO balt_corruption (player_uuid, corruption, last_sacrifice) "
+        "VALUES (@uuid, @corr, strftime('%s','now')) "
+        "ON CONFLICT(player_uuid) DO UPDATE SET corruption = @corr, "
+        "last_sacrifice = strftime('%s','now')");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@corr", nCorruption);
+    SqlStep(q);
+}
+
+// Adds nDelta to corruption (clamped 0..BALT_CORRUPT_MAX), returns new value.
+int BaltAddCorruption(object oPC, int nDelta)
+{
+    int nCurrent = BaltGetCorruption(oPC);
+    int nNew     = nCurrent + nDelta;
+    if(nNew < 0)                 nNew = 0;
+    if(nNew > BALT_CORRUPT_MAX)  nNew = BALT_CORRUPT_MAX;
+    BaltSetCorruption(oPC, nNew);
+    return nNew;
+}
+
+// Called on OnClientEnter — decays corruption if enough time passed since last sacrifice.
+void BaltDecayOnEnter(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign(BALT_DB,
+        "SELECT corruption, last_sacrifice FROM balt_corruption WHERE player_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(!SqlStep(q)) return;
+
+    int nCorruption    = SqlGetInt(q, 0);
+    int nLastSacrifice = SqlGetInt(q, 1);
+    if(nCorruption <= 0) return;
+
+    sqlquery qNow = SqlPrepareQueryCampaign(BALT_DB, "SELECT strftime('%s','now')");
+    if(!SqlStep(qNow)) return;
+    int nNow        = StringToInt(SqlGetString(qNow, 0));
+    int nSecondsAgo = nNow - nLastSacrifice;
+
+    int nDecay = 0;
+    if(nSecondsAgo >= 172800)     nDecay = 15; // 48h+
+    else if(nSecondsAgo >= 86400) nDecay =  8; // 24h+
+    else if(nSecondsAgo >= 43200) nDecay =  3; // 12h+
+
+    if(nDecay > 0)
+        BaltSetCorruption(oPC, nCorruption - nDecay);
+}
+
+void BaltLogSacrifice(object oPC, string sAltarTag, int nSacIdx)
+{
+    sqlquery q = SqlPrepareQueryCampaign(BALT_DB,
+        "INSERT INTO balt_log (player_uuid, altar_tag, sac_idx) "
+        "VALUES (@uuid, @tag, @idx)");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindString(q, "@tag",  sAltarTag);
+    SqlBindInt   (q, "@idx",  nSacIdx);
+    SqlStep(q);
+}

--- a/Blood Altar/Scripts/sys_on_enter.nss
+++ b/Blood Altar/Scripts/sys_on_enter.nss
@@ -1,0 +1,16 @@
+// sys_on_enter.nss — Blood Altar: odswiezanie VFX korupcji przy logowaniu (OnClientEnter)
+#include "lib_balt"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC) || GetIsDMPossessed(oPC)) return;
+
+    BaltDecayOnEnter(oPC);
+    int nCorruption = BaltGetCorruption(oPC);
+    BaltApplyCorruptionVFX(oPC, nCorruption);
+
+    if(nCorruption >= BALT_CORRUPT_HIGH)
+        SendMessageToPC(oPC, "[Oltarz] Skalanie twojej duszy jest wysokie ("
+                      + IntToString(nCorruption) + "%). Unikaj ciemnych oltarzy.");
+}

--- a/Blood Altar/Scripts/sys_on_load.nss
+++ b/Blood Altar/Scripts/sys_on_load.nss
@@ -1,0 +1,7 @@
+// sys_on_load.nss — Blood Altar: inicjalizacja bazy (OnModuleLoad)
+#include "lib_balt_def"
+
+void main()
+{
+    BaltCreateTables();
+}

--- a/Blood Altar/Scripts/sys_on_target.nss
+++ b/Blood Altar/Scripts/sys_on_target.nss
@@ -1,0 +1,49 @@
+// sys_on_target.nss — Blood Altar: obsluga celowania przy ofierze z przedmiotu (OnPlayerTarget)
+#include "lib_balt"
+
+void main()
+{
+    object oPC = GetLastPlayerToSelectTarget();
+    if(!GetIsObjectValid(oPC)) return;
+
+    // Ignoruj, jesli okno oltarza nie jest otwarte lub nie ma indeksu ofiary
+    int nToken = NuiFindWindow(oPC, BALT_WINDOW);
+    if(nToken == 0) return;
+
+    string sAltarTag = GetLocalString(oPC, BALT_LVAR_ALTAR_TAG);
+    if(sAltarTag == "") return;
+
+    int nSacIdx = GetLocalInt(oPC, BALT_LVAR_ITEM_IDX);
+    // Wartosc 0 to tez poprawny indeks; rozrozniamy przez BALT_LVAR_ITEM_IDX = -1 gdy nieaktywny
+    if(nSacIdx < 0) return;
+    SetLocalInt(oPC, BALT_LVAR_ITEM_IDX, -1);  // kasuj, zeby nie przetworzyc dwukrotnie
+
+    object oItem = GetTargetingModeSelectedObject();
+    if(!GetIsObjectValid(oItem) || GetItemPossessor(oItem) != oPC)
+    {
+        SendMessageToPC(oPC, "[Oltarz] Mozesz poswiecic tylko przedmiot ze swojego ekwipunku.");
+        return;
+    }
+
+    json jSacs = BaltGetSacrifices(sAltarTag);
+    if(nSacIdx >= JsonGetLength(jSacs)) return;
+    json jSac = JsonArrayGet(jSacs, nSacIdx);
+
+    string sItemName = GetName(oItem);
+    DestroyObject(oItem);
+
+    BaltApplyBoon(oPC, jSac);
+
+    int nCorrupt = JsonGetInt(JsonObjectGet(jSac, "corrupt"));
+    int nNewCorr = BaltAddCorruption(oPC, nCorrupt);
+    BaltLogSacrifice(oPC, sAltarTag, nSacIdx);
+    BaltApplyCorruptionVFX(oPC, nNewCorr);
+    BaltFeedWindow(oPC, nToken, sAltarTag);
+
+    SendMessageToPC(oPC, "[Oltarz] Poswiecono: " + sItemName + ". "
+                  + JsonGetString(JsonObjectGet(jSac, "eff_desc")));
+
+    if(nCorrupt > 0 && nNewCorr >= BALT_CORRUPT_HIGH)
+        FloatingTextStringOnCreature(
+            "Pieczen krwi pulsuje mroczna moca...", oPC, FALSE);
+}

--- a/Blood Altar/Scripts/sys_on_use.nss
+++ b/Blood Altar/Scripts/sys_on_use.nss
@@ -1,0 +1,21 @@
+// sys_on_use.nss — Blood Altar: OnUsed placeabla oltarza
+// Ustaw ten skrypt jako OnUsed na obiektach z tagami ALTAR_BLOOD/BONE/EARTH/SHADOW
+#include "lib_balt"
+
+void main()
+{
+    object oPC    = GetLastUsedBy();
+    object oAltar = OBJECT_SELF;
+
+    if(!GetIsPC(oPC) || GetIsDMPossessed(oPC)) return;
+
+    string sTag = GetTag(oAltar);
+    if(sTag != BALT_TAG_BLOOD  && sTag != BALT_TAG_BONE &&
+       sTag != BALT_TAG_EARTH  && sTag != BALT_TAG_SHADOW)
+    {
+        SendMessageToPC(oPC, "[Oltarz] Ten oltarz nie jest skonfigurowany (nieprawidlowy tag).");
+        return;
+    }
+
+    BaltOpenWindow(oPC, sTag);
+}

--- a/Blood Altar/Scripts/test_balt.nss
+++ b/Blood Altar/Scripts/test_balt.nss
@@ -1,0 +1,27 @@
+// test_balt.nss — Blood Altar: skrypt testowy (OnUsed na placeable demonstracyjnym)
+// Klika kolejno cykluje przez wszystkie 4 typy oltarzy.
+// Dodaj ten skrypt jako OnUsed na dowolnym placeablu w DEMO module.
+#include "lib_balt"
+
+void main()
+{
+    object oPC   = GetLastUsedBy();
+    object oSelf = OBJECT_SELF;
+
+    if(!GetIsPC(oPC)) return;
+
+    int nType = GetLocalInt(oSelf, "BALT_TEST_CYCLE");
+    string sTag;
+    switch(nType % 4)
+    {
+        case 0: sTag = BALT_TAG_BLOOD;  break;
+        case 1: sTag = BALT_TAG_BONE;   break;
+        case 2: sTag = BALT_TAG_EARTH;  break;
+        default: sTag = BALT_TAG_SHADOW; break;
+    }
+    SetLocalInt(oSelf, "BALT_TEST_CYCLE", nType + 1);
+
+    SendMessageToPC(oPC, "[Test-Oltarz] Otwieranie: " + BaltGetAltarName(sTag)
+                  + "  |  Skalanie: " + IntToString(BaltGetCorruption(oPC)) + "%");
+    BaltOpenWindow(oPC, sTag);
+}


### PR DESCRIPTION
## Co to robi

System ołtarzy ofiarnych — gracz podchodzi do jednego z 4 typów ołtarzy i składa ofiarę (złoto, przedmiot z ekwipunku lub własną krew) w zamian za tymczasowe wzmocnienia. Każda ciemna ofiara kumuluje **skalanie duszy** (0–100) trwale przechowywane w SQLite per postać.

## Mechanika

**4 typy ołtarzy** (tag na placeablu): `ALTAR_BLOOD`, `ALTAR_BONE`, `ALTAR_EARTH`, `ALTAR_SHADOW`

Każdy oferuje 3 poziomy ofiary:

| Poziom | Koszt | Przykład efektu |
|--------|-------|-----------------|
| Drobna | Stała kwota złota | Siła +2 / DEX +2 / Niewidzialność 10 min |
| Ciała  | Przedmiot z ekwipunku (targeting mode) | Haste 15 min / Regen / Odporność na czary |
| Krwi   | X% maks. PW (popup potwierdzenia) | Siła +4 + 20 PW tymcz. / Rzuty +3 / STR+DEX +4 |

**Korupcja duszy** (tylko ciemne ołtarze):
- **0–32%** — brak efektów
- **33–65%** — `VFX_DUR_AURA_EVIL` (trwały, tagowany, usuwalny)
- **66–99%** — powyższe + `VFX_DUR_AURA_NEGATIVE_ENERGY`
- **100% (Soul Riven)** — oba aury + `-4 Charyzmy` jako trwały efekt

Korupcja samoistnie spada przy logowaniu (3/8/15 pkt po 12h/24h/48h od ostatniej ofiary). Ołtarz Ziemi nie generuje korupcji.

## Pliki

```
Blood Altar/
  Scripts/
    lib_nui.nss            — helper NUI (skopiowany wzorzec z repo)
    lib_nui_utility.nss    — helper NUI utility
    sql_balt.nss           — schemat SQLite + zapytania
    lib_balt_def.nss       — stałe, ID bindów, LVAR, forward decls
    lib_balt.nss           — definicje ofiar (4x3), UI NUI, ApplyBoon, VFX korupcji
    lib_balt_ev.nss        — handler eventów NUI (główne okno + popup krwi)
    sys_on_load.nss        — init tabel (OnModuleLoad)
    sys_on_enter.nss       — decay + reapply VFX (OnClientEnter)
    sys_on_target.nss      — ofiara z przedmiotu (OnPlayerTarget)
    sys_on_use.nss         — otwarcie okna z placeabla (OnUsed)
    test_balt.nss          — skrypt demonstracyjny cyklujący przez 4 ołtarze
  INTEGRATION.md           — tabela hooków, tagi, opis korupcji
```

## Zależności (NWNX? SQL?)

- **Brak NWNX** — wyłącznie standardowy NWScript + NWN:EE NUI
- **SQLite**: kampania `blood_altar`, tabele `balt_corruption` i `balt_log`, tworzone idempotentnie przez `sys_on_load`

## Jak włączyć w istniejącym module

1. Skopiuj folder `Blood Altar/Scripts/` do swojego haka lub nadpisz skryptami modułu
2. Podepnij hooki:
   - `OnModuleLoad` → `sys_on_load`
   - `OnClientEnter` → `sys_on_enter`
   - `OnPlayerTarget` → `sys_on_target`
3. Na placeablach ołtarzy: ustaw `Tag` na jeden z czterech tagów i `OnUsed` → `sys_on_use`
4. Test: placeable z `OnUsed = test_balt` — cykluje przez wszystkie 4 typy

## Co celowo pominięto

- **Plik .mod** — środowisko CLI nie pozwala pakować .mod; zamiast tego `INTEGRATION.md`
- **Cooldown per ofiara** — można składać wielokrotnie; serwer PW może wymagać dodania
- **Ograniczenia klasowe/rasowe** — każda postać może korzystać; extension point
- **Redukcja korupcji przez kapłanów/modlitwę** — gotowy extension point dla integracji z modułem Pantheon
- **Dedykowane grafiki/hak** — efekty VFX opierają się na standardowych zasobach NWN:EE

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNEkE9m1thr8U2AFgchetz)_