### PR TITLE
feat: Czarne Targowisko (Black Market)

### DIFF
--- a/Black Market/INTEGRATION.md
+++ b/Black Market/INTEGRATION.md
@@ -1,0 +1,77 @@
+# Czarne Targowisko — Integracja
+
+## Zależności skryptowe
+
+Moduł wymaga `lib_nui.nss` i `lib_nui_utility.nss` (dostarczone w module **Mailbox** lub dowolnym innym module korzystającym z NUI helpers). Dodaj te pliki do modułu jeśli jeszcze tam nie są.
+
+## Hooki modułu
+
+| Zdarzenie modułu | Skrypt           | Co robi                                     |
+|------------------|------------------|---------------------------------------------|
+| OnModuleLoad     | `sys_on_load`    | Tworzy tabele SQLite, seeduje katalog, rotuje stock |
+| OnClientEnter    | `sys_on_enter`   | Rejestruje gracza, opada gorąco, sprawdza strażników |
+| OnPlayerTarget   | `sys_on_target`  | Obsługuje wybranie przedmiotu do sprzedaży  |
+
+Każdy skrypt może być wywołany z istniejącego hooka:
+```nss
+// W twoim sys_on_load.nss:
+ExecuteScript("sys_on_load", GetModule());   // lub #include + wywołanie funkcji
+```
+
+## Placeable do testu
+
+1. W toolsecie utwórz `Placeable` (np. drzwi / skrzynię).
+2. Ustaw skrypt `OnUsed` na `test_bmt`.
+3. Umieść placeable w obszarze.
+
+Gracz klika placeable → otwiera się okno Czarnego Targowiska.
+
+## Baza danych SQLite
+
+Dane globalne (stock, katalog, gracze) trzymane w kampanii o nazwie `blackmarket`.  
+Plik SQLite: `<server_data>/campaign_blackmarket.sqlite`.
+
+Schemat jest idempotentny — `CREATE TABLE IF NOT EXISTS` — bezpieczny przy restarcie.
+
+## Dodawanie własnych przedmiotów do katalogu
+
+Metoda 1 — SQL ręczny (DM/admin):
+```sql
+INSERT INTO bmt_catalog (resref, item_name, flavor, base_gold, max_stack)
+VALUES ('moj_resref', 'Nazwa dla gracza', 'Klimatyczny opis.', 300, 2);
+```
+
+Metoda 2 — edycja `BmtSeedCatalog()` w `sql_bmt.nss` przed pierwszym uruchomieniem (przed seedem).
+
+Aby wymusić odświeżenie stocku (np. po dodaniu nowych itemów):
+```sql
+DELETE FROM bmt_stock;
+```
+Przy kolejnym wejściu gracza/restarcie moduł dobierze nowy losowy zestaw.
+
+## Flagi wystawione dla innych systemów
+
+| Zmienna lokalna na PC | Typ | Znaczenie                          |
+|-----------------------|-----|------------------------------------|
+| `BMT_WANTED`          | int | 1 = gracz jest aktywnie śledzony   |
+
+Inne systemy (straże, NPC, sklepy) mogą sprawdzać `GetLocalInt(oPC, "BMT_WANTED")`.
+
+## Konfiguracja (lib_bmt_def.nss)
+
+| Stała              | Domyślnie | Opis                               |
+|--------------------|-----------|------------------------------------|
+| `BMT_REFRESH_SECS` | 21600     | Rotacja stocku (sekundy; 6h)       |
+| `BMT_STOCK_COUNT`  | 8         | Liczba slotów w rotującym stocku   |
+| `BMT_FENCE_RATE`   | 40        | % wartości wypłacane przy sprzedaży |
+| `BMT_HEAT_PER_BUY` | 6         | Gorąco za zakup                    |
+| `BMT_HEAT_PER_SELL`| 4         | Gorąco za sprzedaż                 |
+| `BMT_HEAT_WARN`    | 70        | Próg dla efektów strażniczych      |
+| `BMT_HEAT_DECAY_HOUR`| 2       | Utrata gorąca na realną godzinę    |
+
+## Co celowo pominięto
+
+- **Spawn strażników jako NPC** — wymaga resrefa z haka; zamiast tego system wystawia flagę `BMT_WANTED` i efekt VFX jako placeholder; integracja z AI straży należy do twórcy modułu.
+- **Okno historii transakcji** — tabela `bmt_transactions` i widok historii nie zostały dodane, żeby nie komplikować UI; można dołożyć jako rozszerzenie.
+- **Limit zakupów na postać** — stock jest globalny (wszyscy gracze dzielą ten sam pool qty); per-PC limit można dodać przez tabelę `bmt_purchase_log`.
+- **Animacja NPC Passura** — flirt/dialog z NPC wymaga skryptu konwersacji; `test_bmt.nss` otwiera okno bezpośrednio z placeable.

--- a/Black Market/Scripts/lib_bmt.nss
+++ b/Black Market/Scripts/lib_bmt.nss
@@ -1,0 +1,492 @@
+#include "lib_bmt_def"
+
+// ----------------------------------------------------------------
+// Heat display helpers
+// ----------------------------------------------------------------
+
+json BmtHeatColor(int nHeat)
+{
+    if(nHeat < 30)           return NuiColor( 80, 200,  80);
+    if(nHeat < 60)           return NuiColor(220, 200,  60);
+    if(nHeat < BMT_HEAT_WARN) return NuiColor(230, 140,  40);
+    return                          NuiColor(220,  60,  60);
+}
+
+string BmtHeatLabel(int nHeat)
+{
+    if(nHeat == 0)            return "Poszukiwany: Nikt cie nie szuka";
+    if(nHeat < 30)            return "Poszukiwany: Wzbudzasz ciekawosc (" + IntToString(nHeat) + ")";
+    if(nHeat < 60)            return "Poszukiwany: Kilka par oczu sledzi (" + IntToString(nHeat) + ")";
+    if(nHeat < BMT_HEAT_WARN) return "Poszukiwany: Listy goncze kraza (" + IntToString(nHeat) + ")";
+    return                           "!! WYJATKOWO GORACY !! (" + IntToString(nHeat) + ")";
+}
+
+string BmtRefreshLabel()
+{
+    int nSecs = BmtGetSecondsToRefresh();
+    if(nSecs <= 0) return "Towar wlasnie sie odnawia...";
+    int nH = nSecs / 3600;
+    int nM = (nSecs % 3600) / 60;
+    return "Oferta zmienia sie za: " + IntToString(nH) + "h " + IntToString(nM) + "m";
+}
+
+// ----------------------------------------------------------------
+// Guard consequence
+// ----------------------------------------------------------------
+
+// Called with a delay after area entry when heat is high.
+// Sets a WANTED flag and applies a visual paranoia cue.
+// Dependent systems (guard AI, NPC dialogue) can read BMT_WANTED.
+void BmtCheckGuards(object oPC)
+{
+    string sUuid = GetObjectUUID(oPC);
+    int nHeat    = BmtGetHeat(sUuid);
+    if(nHeat < BMT_HEAT_WARN) return;
+
+    // Probability scales linearly: 0% at threshold, 25% at max.
+    int nChance = (nHeat - BMT_HEAT_WARN) * 25 / (BMT_HEAT_MAX - BMT_HEAT_WARN);
+    if(d100() > nChance) return;
+
+    SetLocalInt(oPC, "BMT_WANTED", 1);
+    SendMessageToPC(oPC, "[Targowisko] Czujesz na sobie ciezki wzrok straznikow...");
+    FloatingTextStringOnCreature("Poszukiwany!", oPC, FALSE);
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectVisualEffect(VFX_IMP_DOOM), oPC);
+}
+
+// ----------------------------------------------------------------
+// NUI Layout — Buy tab
+// ----------------------------------------------------------------
+
+json BmtBuildBuyView(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 30.0);
+    float fRowH  = GetNuiScaleDimension(oPC, 26.0);
+    float fFlvH  = GetNuiScaleDimension(oPC, 75.0);
+    float fListH = GetNuiScaleDimension(oPC, 210.0);
+
+    // Tab bar
+    json jTabBuy = NuiButton(JsonString("[ Kup ]"));
+    jTabBuy = NuiId(jTabBuy, BMT_BTN_TAB_BUY);
+    jTabBuy = NuiWidth(jTabBuy, GetNuiScaleDimension(oPC, 110.0));
+    jTabBuy = NuiHeight(jTabBuy, fBtnH);
+    jTabBuy = NuiEncouraged(jTabBuy, JsonBool(TRUE));
+
+    json jTabSell = NuiButton(JsonString("Sprzedaj"));
+    jTabSell = NuiId(jTabSell, BMT_BTN_TAB_SELL);
+    jTabSell = NuiWidth(jTabSell, GetNuiScaleDimension(oPC, 110.0));
+    jTabSell = NuiHeight(jTabSell, fBtnH);
+
+    json jHeatLbl = NuiLabel(NuiBind(BMT_BIND_HEAT_LBL),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jHeatLbl = NuiStyleForegroundColor(jHeatLbl, NuiBind(BMT_BIND_HEAT_COLOR));
+
+    json jTabRow = JsonArray();
+    jTabRow = JsonArrayInsert(jTabRow, jTabBuy);
+    jTabRow = JsonArrayInsert(jTabRow, jTabSell);
+    jTabRow = JsonArrayInsert(jTabRow, NuiSpacer());
+    jTabRow = JsonArrayInsert(jTabRow, jHeatLbl);
+
+    // Refresh info
+    json jRefreshLbl = NuiLabel(NuiBind(BMT_BIND_REFRESH_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRefreshLbl = NuiHeight(jRefreshLbl, GetNuiScaleDimension(oPC, 20.0));
+
+    // Item list — columns: name (elastic) | price (80) | qty (50)
+    float fPriceW = GetNuiScaleDimension(oPC, 80.0);
+    float fQtyW   = GetNuiScaleDimension(oPC, 50.0);
+
+    json jNameLbl  = NuiLabel(NuiBind(BMT_BIND_ROW_NAME),
+        JsonInt(NUI_HALIGN_LEFT),   JsonInt(NUI_VALIGN_MIDDLE));
+    json jPriceLbl = NuiLabel(NuiBind(BMT_BIND_ROW_PRICE),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jPriceLbl = NuiWidth(jPriceLbl, fPriceW);
+    json jQtyLbl   = NuiLabel(NuiBind(BMT_BIND_ROW_QTY),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jQtyLbl = NuiWidth(jQtyLbl, fQtyW);
+
+    json jCellCols = JsonArray();
+    jCellCols = JsonArrayInsert(jCellCols, jNameLbl);
+    jCellCols = JsonArrayInsert(jCellCols, jPriceLbl);
+    jCellCols = JsonArrayInsert(jCellCols, jQtyLbl);
+
+    json jCell = NuiGroup(NuiRow(jCellCols), TRUE, NUI_SCROLLBARS_NONE);
+    jCell = NuiId(jCell, BMT_BTN_ROW);
+    jCell = NuiEncouraged(jCell, NuiBind(BMT_BIND_ROW_ENC));
+
+    json jTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jCell, 0.0, TRUE));
+    json jList = NuiList(jTmpl, NuiBind(BMT_BIND_ROWCNT), fRowH);
+    jList = NuiHeight(jList, fListH);
+
+    // Flavor text
+    json jFlavor = NuiGroup(NuiText(NuiBind(BMT_BIND_FLAVOR), FALSE),
+        TRUE, NUI_SCROLLBARS_NONE);
+    jFlavor = NuiHeight(jFlavor, fFlvH);
+
+    // Buy button
+    json jBuyBtn = NuiButton(NuiBind(BMT_BIND_BUY_LBL));
+    jBuyBtn = NuiId(jBuyBtn, BMT_BTN_BUY);
+    jBuyBtn = NuiEnabled(jBuyBtn, NuiBind(BMT_BIND_BUY_ENA));
+    jBuyBtn = NuiWidth(jBuyBtn, GetNuiScaleDimension(oPC, 240.0));
+    jBuyBtn = NuiHeight(jBuyBtn, fBtnH);
+
+    json jBuyRow = JsonArray();
+    jBuyRow = JsonArrayInsert(jBuyRow, NuiSpacer());
+    jBuyRow = JsonArrayInsert(jBuyRow, jBuyBtn);
+    jBuyRow = JsonArrayInsert(jBuyRow, NuiSpacer());
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(jTabRow));
+    jCol = JsonArrayInsert(jCol, jRefreshLbl);
+    jCol = JsonArrayInsert(jCol, jList);
+    jCol = JsonArrayInsert(jCol, jFlavor);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBuyRow));
+
+    return NuiCol(jCol);
+}
+
+// ----------------------------------------------------------------
+// NUI Layout — Sell tab
+// ----------------------------------------------------------------
+
+json BmtBuildSellView(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 30.0);
+    float fInstrH= GetNuiScaleDimension(oPC, 90.0);
+    float fOfferH= GetNuiScaleDimension(oPC, 120.0);
+
+    // Tab bar
+    json jTabBuy = NuiButton(JsonString("Kup"));
+    jTabBuy = NuiId(jTabBuy, BMT_BTN_TAB_BUY);
+    jTabBuy = NuiWidth(jTabBuy, GetNuiScaleDimension(oPC, 110.0));
+    jTabBuy = NuiHeight(jTabBuy, fBtnH);
+
+    json jTabSell = NuiButton(JsonString("[ Sprzedaj ]"));
+    jTabSell = NuiId(jTabSell, BMT_BTN_TAB_SELL);
+    jTabSell = NuiWidth(jTabSell, GetNuiScaleDimension(oPC, 110.0));
+    jTabSell = NuiHeight(jTabSell, fBtnH);
+    jTabSell = NuiEncouraged(jTabSell, JsonBool(TRUE));
+
+    json jHeatLbl = NuiLabel(NuiBind(BMT_BIND_HEAT_LBL),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jHeatLbl = NuiStyleForegroundColor(jHeatLbl, NuiBind(BMT_BIND_HEAT_COLOR));
+
+    json jTabRow = JsonArray();
+    jTabRow = JsonArrayInsert(jTabRow, jTabBuy);
+    jTabRow = JsonArrayInsert(jTabRow, jTabSell);
+    jTabRow = JsonArrayInsert(jTabRow, NuiSpacer());
+    jTabRow = JsonArrayInsert(jTabRow, jHeatLbl);
+
+    // Instructions
+    string sInstr =
+        "Passur skupuje towar bez zbednych pytan.\n"
+        "Zaplaci " + IntToString(BMT_FENCE_RATE) + "% wartosci — reszte pochlopnie 'prowizja'.\n\n"
+        "Wybierz przedmiot z ekwipunku klikajac przycisk ponizej.";
+    json jInstrTxt = NuiGroup(NuiText(JsonString(sInstr), FALSE),
+        FALSE, NUI_SCROLLBARS_NONE);
+    jInstrTxt = NuiHeight(jInstrTxt, fInstrH);
+
+    // Pick button
+    json jPickBtn = NuiButton(JsonString("Wybierz przedmiot z ekwipunku"));
+    jPickBtn = NuiId(jPickBtn, BMT_BTN_PICK_ITEM);
+    jPickBtn = NuiHeight(jPickBtn, fBtnH);
+
+    // Offer display
+    json jOfferTxt = NuiGroup(NuiText(NuiBind(BMT_BIND_OFFER_LBL), FALSE),
+        FALSE, NUI_SCROLLBARS_NONE);
+    jOfferTxt = NuiHeight(jOfferTxt, fOfferH);
+
+    // Sell confirm button
+    json jSellBtn = NuiButton(JsonString("Sprzedaj Passurowi"));
+    jSellBtn = NuiId(jSellBtn, BMT_BTN_SELL_CONFIRM);
+    jSellBtn = NuiEnabled(jSellBtn, NuiBind(BMT_BIND_SELL_ENA));
+    jSellBtn = NuiWidth(jSellBtn, GetNuiScaleDimension(oPC, 220.0));
+    jSellBtn = NuiHeight(jSellBtn, fBtnH);
+
+    json jSellRow = JsonArray();
+    jSellRow = JsonArrayInsert(jSellRow, NuiSpacer());
+    jSellRow = JsonArrayInsert(jSellRow, jSellBtn);
+    jSellRow = JsonArrayInsert(jSellRow, NuiSpacer());
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(jTabRow));
+    jCol = JsonArrayInsert(jCol, jInstrTxt);
+    jCol = JsonArrayInsert(jCol, jPickBtn);
+    jCol = JsonArrayInsert(jCol, jOfferTxt);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jSellRow));
+
+    return NuiCol(jCol);
+}
+
+// ----------------------------------------------------------------
+// Window create / reopen
+// ----------------------------------------------------------------
+
+void BmtShowWindow(object oPC)
+{
+    BmtRefreshStock();
+
+    int nExisting = NuiFindWindow(oPC, BMT_WINDOW);
+    if(nExisting != 0)
+    {
+        NuiSetGroupLayout(oPC, nExisting, BMT_GRP_SWAP, BmtBuildBuyView(oPC));
+        SetLocalInt(oPC, BMT_LVAR_MODE, 0);
+        BmtFeedBuyTab(oPC, nExisting);
+        return;
+    }
+
+    float fW  = GetNuiScaleDimension(oPC, BMT_W);
+    float fH  = GetNuiScaleDimension(oPC, BMT_H);
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - fW) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - fH) / 2.0;
+    json jGeom = NuiRect(fCX, fCY, fW, fH);
+
+    float fBtnH = GetNuiScaleDimension(oPC, 30.0);
+    json jCloseBtn = NuiButton(JsonString("X"));
+    jCloseBtn = NuiId(jCloseBtn, BMT_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, GetNuiScaleDimension(oPC, 30.0));
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+    json jTopBarRow = JsonArray();
+    jTopBarRow = JsonArrayInsert(jTopBarRow, NuiSpacer());
+    jTopBarRow = JsonArrayInsert(jTopBarRow, jCloseBtn);
+
+    json jSwapGrp = NuiGroup(BmtBuildBuyView(oPC), FALSE, NUI_SCROLLBARS_NONE);
+    jSwapGrp = NuiId(jSwapGrp, BMT_GRP_SWAP);
+
+    json jRootChildren = JsonArray();
+    jRootChildren = JsonArrayInsert(jRootChildren, NuiRow(jTopBarRow));
+    jRootChildren = JsonArrayInsert(jRootChildren, jSwapGrp);
+    json jRoot = NuiCol(jRootChildren);
+
+    json jWin = NuiWindow(jRoot,
+        JsonString("Czarne Targowisko"),
+        NuiBind(BMT_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    int nToken = NuiCreate(oPC, jWin, BMT_WINDOW, BMT_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, BMT_WIN_GEOM, jGeom);
+
+    SetLocalInt(oPC, BMT_LVAR_MODE, 0);
+    BmtFeedBuyTab(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Feed — Buy tab
+// ----------------------------------------------------------------
+
+void BmtFeedBuyTab(object oPC, int nToken)
+{
+    json jStock = BmtGetStock();
+    int  nCount = JsonGetLength(jStock);
+    int  nSelId = GetLocalInt(oPC, BMT_LVAR_SEL_STOCK);
+
+    json jNames  = JsonArray();
+    json jPrices = JsonArray();
+    json jQtys   = JsonArray();
+    json jEncs   = JsonArray();
+    string sFlavor = "";
+
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jRow  = JsonArrayGet(jStock, i);
+        int  nId   = JsonGetInt   (JsonObjectGet(jRow, "id"));
+        string sNm = JsonGetString(JsonObjectGet(jRow, "item_name"));
+        int  nGold = JsonGetInt   (JsonObjectGet(jRow, "base_gold"));
+        int  nQty  = JsonGetInt   (JsonObjectGet(jRow, "qty"));
+
+        jNames  = JsonArrayInsert(jNames,  JsonString(sNm));
+        jPrices = JsonArrayInsert(jPrices, JsonString(IntToString(nGold) + " sz."));
+        jQtys   = JsonArrayInsert(jQtys,   JsonString("x" + IntToString(nQty)));
+        jEncs   = JsonArrayInsert(jEncs,   JsonBool(nSelId > 0 && nId == nSelId));
+
+        if(nSelId > 0 && nId == nSelId)
+            sFlavor = JsonGetString(JsonObjectGet(jRow, "flavor"));
+    }
+
+    NuiSetBind(oPC, nToken, BMT_BIND_ROW_NAME,    jNames);
+    NuiSetBind(oPC, nToken, BMT_BIND_ROW_PRICE,   jPrices);
+    NuiSetBind(oPC, nToken, BMT_BIND_ROW_QTY,     jQtys);
+    NuiSetBind(oPC, nToken, BMT_BIND_ROW_ENC,     jEncs);
+    NuiSetBind(oPC, nToken, BMT_BIND_ROWCNT,      JsonInt(nCount));
+    NuiSetBind(oPC, nToken, BMT_BIND_REFRESH_LBL, JsonString(BmtRefreshLabel()));
+    NuiSetBind(oPC, nToken, BMT_BIND_FLAVOR,       JsonString(sFlavor));
+
+    string sBuyLbl = nSelId > 0
+        ? "Kup — " + GetLocalString(oPC, BMT_LVAR_SEL_NAME)
+            + " (" + IntToString(GetLocalInt(oPC, BMT_LVAR_SEL_PRICE)) + " sz.)"
+        : "Wybierz towar";
+    NuiSetBind(oPC, nToken, BMT_BIND_BUY_LBL, JsonString(sBuyLbl));
+    NuiSetBind(oPC, nToken, BMT_BIND_BUY_ENA, JsonBool(nSelId > 0));
+
+    int nHeat = BmtGetHeat(GetObjectUUID(oPC));
+    NuiSetBind(oPC, nToken, BMT_BIND_HEAT_LBL,   JsonString(BmtHeatLabel(nHeat)));
+    NuiSetBind(oPC, nToken, BMT_BIND_HEAT_COLOR,  BmtHeatColor(nHeat));
+}
+
+// ----------------------------------------------------------------
+// Feed — Sell tab
+// ----------------------------------------------------------------
+
+void BmtFeedSellTab(object oPC, int nToken)
+{
+    string sSellName = GetLocalString(oPC, BMT_LVAR_SELL_NAME);
+    int    nOffer    = GetLocalInt   (oPC, BMT_LVAR_SELL_PRICE);
+    int    bHasOffer = (sSellName != "");
+
+    string sOfferTxt;
+    if(bHasOffer)
+        sOfferTxt =
+            "Passur zważył w dłoni " + sSellName + " i wydał wyrok:\n\n"
+            "„" + IntToString(nOffer) + " monet. Nie targujemy sie."\n\n"
+            "Polowa trafi w zapomniane kieszenie — to koszt milczenia.";
+    else
+        sOfferTxt =
+            "Zadnego towaru jeszcze nie wyceniono.\n\n"
+            "Wcisnij przycisk powyzej i wsknaz przedmiot z ekwipunku.";
+
+    NuiSetBind(oPC, nToken, BMT_BIND_OFFER_LBL, JsonString(sOfferTxt));
+    NuiSetBind(oPC, nToken, BMT_BIND_SELL_ENA,  JsonBool(bHasOffer));
+
+    int nHeat = BmtGetHeat(GetObjectUUID(oPC));
+    NuiSetBind(oPC, nToken, BMT_BIND_HEAT_LBL,   JsonString(BmtHeatLabel(nHeat)));
+    NuiSetBind(oPC, nToken, BMT_BIND_HEAT_COLOR,  BmtHeatColor(nHeat));
+}
+
+// ----------------------------------------------------------------
+// Action: Buy
+// ----------------------------------------------------------------
+
+void BmtHandleBuy(object oPC, int nToken)
+{
+    int nStockId = GetLocalInt(oPC, BMT_LVAR_SEL_STOCK);
+    if(nStockId <= 0) return;
+
+    json jItem = BmtGetStockItem(nStockId);
+    if(JsonGetType(jItem) == JSON_TYPE_NULL || JsonGetInt(JsonObjectGet(jItem, "qty")) <= 0)
+    {
+        SendMessageToPC(oPC, "[Targowisko] Towar właśnie się wyczerpał.");
+        DeleteLocalInt(oPC, BMT_LVAR_SEL_STOCK);
+        DeleteLocalString(oPC, BMT_LVAR_SEL_NAME);
+        DeleteLocalInt(oPC, BMT_LVAR_SEL_PRICE);
+        BmtFeedBuyTab(oPC, nToken);
+        return;
+    }
+
+    int    nCost = JsonGetInt   (JsonObjectGet(jItem, "base_gold"));
+    string sRes  = JsonGetString(JsonObjectGet(jItem, "resref"));
+    string sNm   = JsonGetString(JsonObjectGet(jItem, "item_name"));
+
+    if(GetGold(oPC) < nCost)
+    {
+        SendMessageToPC(oPC, "[Targowisko] „Nie masz dość monet, przyjacielu."");
+        return;
+    }
+
+    AssignCommand(oPC, TakeGoldFromCreature(nCost, oPC, TRUE));
+
+    object oItem = CreateItemOnObject(sRes, oPC);
+    if(!GetIsObjectValid(oItem))
+    {
+        // Resref missing — refund; this is a builder configuration error
+        GiveGoldToCreature(oPC, nCost);
+        SendMessageToPC(oPC,
+            "[Targowisko] Predmiot niedostepny — skontaktuj sie z zarzadca modulu.");
+        return;
+    }
+
+    BmtDeductStock(nStockId);
+    BmtAddHeat(GetObjectUUID(oPC), BMT_HEAT_PER_BUY);
+
+    SendMessageToPC(oPC,
+        "[Targowisko] Kupiles " + sNm + " za " + IntToString(nCost) + " sz.");
+    FloatingTextStringOnCreature("Transakcja zawarta.", oPC, FALSE);
+
+    DeleteLocalInt(oPC, BMT_LVAR_SEL_STOCK);
+    DeleteLocalString(oPC, BMT_LVAR_SEL_NAME);
+    DeleteLocalInt(oPC, BMT_LVAR_SEL_PRICE);
+    BmtFeedBuyTab(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Action: Sell (confirm after item was already taken and serialized)
+// ----------------------------------------------------------------
+
+void BmtHandleSell(object oPC, int nToken)
+{
+    string sSellName = GetLocalString(oPC, BMT_LVAR_SELL_NAME);
+    int    nOffer    = GetLocalInt   (oPC, BMT_LVAR_SELL_PRICE);
+    if(sSellName == "" || nOffer <= 0) return;
+
+    GiveGoldToCreature(oPC, nOffer);
+    BmtAddHeat(GetObjectUUID(oPC), BMT_HEAT_PER_SELL);
+
+    SendMessageToPC(oPC,
+        "[Targowisko] Passur przyjal " + sSellName
+        + " i odliczyl " + IntToString(nOffer) + " sz.");
+    FloatingTextStringOnCreature("Gotowka. Bez pokwitowania.", oPC, FALSE);
+
+    DeleteLocalString(oPC, BMT_LVAR_SELL_NAME);
+    DeleteLocalInt   (oPC, BMT_LVAR_SELL_PRICE);
+    DeleteLocalString(oPC, BMT_LVAR_SELL_SERIAL);
+
+    BmtFeedSellTab(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Action: Handle player targeting (called from sys_on_target)
+// ----------------------------------------------------------------
+
+void BmtHandleTarget(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, BMT_WINDOW);
+    if(nToken == 0) return;
+    if(GetLocalInt(oPC, BMT_LVAR_MODE) != 1) return;
+
+    object oItem = GetTargetingModeSelectedObject();
+    if(!GetIsObjectValid(oItem) || GetItemPossessor(oItem) != oPC)
+    {
+        SendMessageToPC(oPC,
+            "[Targowisko] Możesz sprzedać tylko przedmiot ze swojego ekwipunku.");
+        return;
+    }
+
+    int nBaseValue = GetGoldPieceValue(oItem);
+    int nOffer     = (nBaseValue * BMT_FENCE_RATE) / 100;
+    if(nOffer <= 0) nOffer = 1;
+
+    string sName  = GetName(oItem);
+    json   jSerial = ObjectToJson(oItem, TRUE);
+
+    SetLocalString(oPC, BMT_LVAR_SELL_NAME,   sName);
+    SetLocalInt   (oPC, BMT_LVAR_SELL_PRICE,  nOffer);
+    SetLocalString(oPC, BMT_LVAR_SELL_SERIAL, JsonDump(jSerial));
+
+    DestroyObject(oItem);
+
+    BmtFeedSellTab(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Cleanup: restore pending sell item, clear all LVARs
+// ----------------------------------------------------------------
+
+void BmtCleanupPC(object oPC)
+{
+    string sSerial = GetLocalString(oPC, BMT_LVAR_SELL_SERIAL);
+    if(sSerial != "")
+        JsonToObject(JsonParse(sSerial), GetLocation(oPC), oPC, TRUE);
+
+    DeleteLocalString(oPC, BMT_LVAR_SELL_NAME);
+    DeleteLocalInt   (oPC, BMT_LVAR_SELL_PRICE);
+    DeleteLocalString(oPC, BMT_LVAR_SELL_SERIAL);
+    DeleteLocalInt   (oPC, BMT_LVAR_SEL_STOCK);
+    DeleteLocalString(oPC, BMT_LVAR_SEL_NAME);
+    DeleteLocalInt   (oPC, BMT_LVAR_SEL_PRICE);
+    DeleteLocalInt   (oPC, BMT_LVAR_MODE);
+}

--- a/Black Market/Scripts/lib_bmt_def.nss
+++ b/Black Market/Scripts/lib_bmt_def.nss
@@ -1,0 +1,94 @@
+#include "lib_nui"
+
+// ----------------------------------------------------------------
+// Configuration — defined before sql_bmt include so sql functions
+// can reference these constants directly.
+// ----------------------------------------------------------------
+
+const int    BMT_REFRESH_SECS    = 21600;  // stock rotation period: 6 real hours
+const int    BMT_STOCK_COUNT     = 8;      // items in rotating stock
+const int    BMT_FENCE_RATE      = 40;     // percent of gold value paid when fencing
+const int    BMT_HEAT_PER_BUY    = 6;      // heat gained per purchase
+const int    BMT_HEAT_PER_SELL   = 4;      // heat gained per fenced item
+const int    BMT_HEAT_MAX        = 100;
+const int    BMT_HEAT_WARN       = 70;     // threshold for guard consequences
+const int    BMT_HEAT_DECAY_HOUR = 2;      // heat lost per real hour offline/idle
+
+// ----------------------------------------------------------------
+// Layout
+// ----------------------------------------------------------------
+
+const float  BMT_W   = 580.0;
+const float  BMT_H   = 500.0;
+
+#include "sql_bmt"
+
+// ----------------------------------------------------------------
+// Window / group IDs
+// ----------------------------------------------------------------
+
+const string BMT_WINDOW     = "BMT_WINDOW";
+const string BMT_EV_SCRIPT  = "lib_bmt_ev";
+const string BMT_GRP_SWAP   = "BMT_GRP_SWAP";
+const string BMT_WIN_GEOM   = "bmt_win_geom";
+
+// ----------------------------------------------------------------
+// Bind names — buy tab
+// ----------------------------------------------------------------
+
+const string BMT_BIND_ROW_NAME    = "bmt_row_name";
+const string BMT_BIND_ROW_PRICE   = "bmt_row_price";
+const string BMT_BIND_ROW_QTY     = "bmt_row_qty";
+const string BMT_BIND_ROW_ENC     = "bmt_row_enc";
+const string BMT_BIND_ROWCNT      = "bmt_rowcnt";
+const string BMT_BIND_FLAVOR      = "bmt_flavor";
+const string BMT_BIND_BUY_ENA     = "bmt_buy_ena";
+const string BMT_BIND_BUY_LBL     = "bmt_buy_lbl";
+const string BMT_BIND_REFRESH_LBL = "bmt_refresh_lbl";
+
+// ----------------------------------------------------------------
+// Bind names — sell tab
+// ----------------------------------------------------------------
+
+const string BMT_BIND_OFFER_LBL   = "bmt_offer_lbl";
+const string BMT_BIND_SELL_ENA    = "bmt_sell_ena";
+
+// ----------------------------------------------------------------
+// Bind names — shared
+// ----------------------------------------------------------------
+
+const string BMT_BIND_HEAT_LBL    = "bmt_heat_lbl";
+const string BMT_BIND_HEAT_COLOR  = "bmt_heat_color";
+
+// ----------------------------------------------------------------
+// Button IDs
+// ----------------------------------------------------------------
+
+const string BMT_BTN_CLOSE        = "bmt_btn_close";
+const string BMT_BTN_ROW          = "bmt_btn_row";
+const string BMT_BTN_BUY          = "bmt_btn_buy";
+const string BMT_BTN_TAB_BUY      = "bmt_btn_tab_buy";
+const string BMT_BTN_TAB_SELL     = "bmt_btn_tab_sell";
+const string BMT_BTN_PICK_ITEM    = "bmt_btn_pick";
+const string BMT_BTN_SELL_CONFIRM = "bmt_btn_sellcfm";
+
+// ----------------------------------------------------------------
+// Local variables stored on the PC object
+// ----------------------------------------------------------------
+
+const string BMT_LVAR_SEL_STOCK   = "BMT_SEL_STOCK";   // selected bmt_stock.id
+const string BMT_LVAR_SEL_NAME    = "BMT_SEL_NAME";    // name of selected item
+const string BMT_LVAR_SEL_PRICE   = "BMT_SEL_PRICE";   // gold cost of selected
+const string BMT_LVAR_SELL_NAME   = "BMT_SELL_NAME";   // name of item being fenced
+const string BMT_LVAR_SELL_PRICE  = "BMT_SELL_PRICE";  // gold offered by Passur
+const string BMT_LVAR_SELL_SERIAL = "BMT_SELL_SERIAL"; // JsonDump of serialized item
+const string BMT_LVAR_MODE        = "BMT_MODE";        // 0 = buy, 1 = sell
+
+// ----------------------------------------------------------------
+// Forward declarations
+// ----------------------------------------------------------------
+
+void BmtShowWindow(object oPC);
+void BmtFeedBuyTab(object oPC, int nToken);
+void BmtFeedSellTab(object oPC, int nToken);
+void BmtHandleTarget(object oPC);

--- a/Black Market/Scripts/lib_bmt_ev.nss
+++ b/Black Market/Scripts/lib_bmt_ev.nss
@@ -1,0 +1,108 @@
+#include "lib_bmt"
+
+// ----------------------------------------------------------------
+// Main NUI event handler — set as EventScript on BMT_WINDOW
+// ----------------------------------------------------------------
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    if(nToken != NuiFindWindow(oPC, BMT_WINDOW)) return;
+
+    // ---- Window closed by OS chrome ----
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        BmtCleanupPC(oPC);
+        return;
+    }
+
+    // ---- Row click (mousedown so row highlight fires immediately) ----
+    if(sEvent == EVENT_TYPE_MOUSEDOWN && sElem == BMT_BTN_ROW)
+    {
+        if(GetLocalInt(oPC, BMT_LVAR_MODE) != 0) return;
+
+        json jStock = BmtGetStock();
+        if(nIdx < 0 || nIdx >= JsonGetLength(jStock)) return;
+
+        json jRow  = JsonArrayGet(jStock, nIdx);
+        int  nId   = JsonGetInt   (JsonObjectGet(jRow, "id"));
+        string sNm = JsonGetString(JsonObjectGet(jRow, "item_name"));
+        int  nGold = JsonGetInt   (JsonObjectGet(jRow, "base_gold"));
+
+        SetLocalInt   (oPC, BMT_LVAR_SEL_STOCK, nId);
+        SetLocalString(oPC, BMT_LVAR_SEL_NAME,  sNm);
+        SetLocalInt   (oPC, BMT_LVAR_SEL_PRICE, nGold);
+
+        BmtFeedBuyTab(oPC, nToken);
+        return;
+    }
+
+    if(sEvent != EVENT_TYPE_CLICK) return;
+
+    // ---- Close button ----
+    if(sElem == BMT_BTN_CLOSE)
+    {
+        BmtCleanupPC(oPC);
+        NuiDestroy(oPC, nToken);
+        return;
+    }
+
+    // ---- Tab: switch to Buy ----
+    if(sElem == BMT_BTN_TAB_BUY)
+    {
+        if(GetLocalInt(oPC, BMT_LVAR_MODE) == 0) return;
+        SetLocalInt(oPC, BMT_LVAR_MODE, 0);
+        NuiSetGroupLayout(oPC, nToken, BMT_GRP_SWAP, BmtBuildBuyView(oPC));
+        BmtFeedBuyTab(oPC, nToken);
+        return;
+    }
+
+    // ---- Tab: switch to Sell ----
+    if(sElem == BMT_BTN_TAB_SELL)
+    {
+        if(GetLocalInt(oPC, BMT_LVAR_MODE) == 1) return;
+        SetLocalInt(oPC, BMT_LVAR_MODE, 1);
+        NuiSetGroupLayout(oPC, nToken, BMT_GRP_SWAP, BmtBuildSellView(oPC));
+        BmtFeedSellTab(oPC, nToken);
+        return;
+    }
+
+    // ---- Buy: execute purchase of selected item ----
+    if(sElem == BMT_BTN_BUY)
+    {
+        BmtHandleBuy(oPC, nToken);
+        return;
+    }
+
+    // ---- Sell: pick item from inventory (enters targeting mode) ----
+    if(sElem == BMT_BTN_PICK_ITEM)
+    {
+        // Clear any previously serialized item so the old offer stays visible
+        // but is invalidated — user must pick again if they changed their mind.
+        string sOldSerial = GetLocalString(oPC, BMT_LVAR_SELL_SERIAL);
+        if(sOldSerial != "")
+        {
+            // Restore the previously taken item before picking a new one
+            JsonToObject(JsonParse(sOldSerial), GetLocation(oPC), oPC, TRUE);
+            DeleteLocalString(oPC, BMT_LVAR_SELL_SERIAL);
+            DeleteLocalString(oPC, BMT_LVAR_SELL_NAME);
+            DeleteLocalInt   (oPC, BMT_LVAR_SELL_PRICE);
+        }
+        EnterTargetingMode(oPC, OBJECT_TYPE_ITEM);
+        SendMessageToPC(oPC,
+            "[Targowisko] Kliknij przedmiot w ekwipunku, który chcesz sprzedać.");
+        return;
+    }
+
+    // ---- Sell: confirm and exchange ----
+    if(sElem == BMT_BTN_SELL_CONFIRM)
+    {
+        BmtHandleSell(oPC, nToken);
+        return;
+    }
+}

--- a/Black Market/Scripts/sql_bmt.nss
+++ b/Black Market/Scripts/sql_bmt.nss
@@ -1,0 +1,240 @@
+// ----------------------------------------------------------------
+// Schema
+// ----------------------------------------------------------------
+
+void BmtCreateTables()
+{
+    sqlquery q;
+
+    q = SqlPrepareQueryCampaign("blackmarket",
+        "CREATE TABLE IF NOT EXISTS bmt_catalog ("
+        "id        INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "resref    TEXT    NOT NULL, "
+        "item_name TEXT    NOT NULL, "
+        "flavor    TEXT    DEFAULT '', "
+        "base_gold INTEGER DEFAULT 100, "
+        "max_stack INTEGER DEFAULT 1)");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("blackmarket",
+        "CREATE TABLE IF NOT EXISTS bmt_stock ("
+        "id             INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "catalog_id     INTEGER NOT NULL, "
+        "qty_available  INTEGER DEFAULT 1, "
+        "expires_at     INTEGER DEFAULT 0)");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("blackmarket",
+        "CREATE TABLE IF NOT EXISTS bmt_player ("
+        "uuid       TEXT    PRIMARY KEY, "
+        "heat       INTEGER DEFAULT 0, "
+        "last_decay INTEGER DEFAULT 0)");
+    SqlStep(q);
+}
+
+// Populates bmt_catalog with starter items; idempotent (skips if already seeded).
+// All resrefs below are from standard NWN — replace with hak items as needed.
+void BmtSeedCatalog()
+{
+    sqlquery qc = SqlPrepareQueryCampaign("blackmarket",
+        "SELECT COUNT(*) FROM bmt_catalog");
+    if(SqlStep(qc) && SqlGetInt(qc, 0) > 0) return;
+
+    sqlquery q;
+    q = SqlPrepareQueryCampaign("blackmarket",
+        "INSERT INTO bmt_catalog (resref,item_name,flavor,base_gold,max_stack) VALUES "
+        "('nw_it_mpotion001','Wywar z Czarnego Lotosu',"
+        "'Zostawia ciemna plame na ustach. Nikt nie pyta po co.',80,3)");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("blackmarket",
+        "INSERT INTO bmt_catalog (resref,item_name,flavor,base_gold,max_stack) VALUES "
+        "('nw_it_mpotion002','Eliksir Nocnego Widzenia',"
+        "'Zrenice rozszerzaja sie jak przepasc. Dzialanie kilka godzin.',60,5)");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("blackmarket",
+        "INSERT INTO bmt_catalog (resref,item_name,flavor,base_gold,max_stack) VALUES "
+        "('nw_it_mpotion007','Wywar Zelaznej Woli',"
+        "'Smakuje jak rdza i krew wrogow.',120,2)");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("blackmarket",
+        "INSERT INTO bmt_catalog (resref,item_name,flavor,base_gold,max_stack) VALUES "
+        "('nw_it_mpotion010','Mikstura Czarnej Krwi',"
+        "'Lepka. Gesta. Obiecuje rzeczy, ktorych legalny handel nie moze.',150,3)");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("blackmarket",
+        "INSERT INTO bmt_catalog (resref,item_name,flavor,base_gold,max_stack) VALUES "
+        "('nw_it_mpotion014','Wyciag z Pajaka Cieni',"
+        "'Bol mija. Refleks zostaje.',110,4)");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("blackmarket",
+        "INSERT INTO bmt_catalog (resref,item_name,flavor,base_gold,max_stack) VALUES "
+        "('nw_it_mpotion018','Eliksir Odwagi Tchórza',"
+        "'Dziala przez piec minut. Czasem.',50,5)");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("blackmarket",
+        "INSERT INTO bmt_catalog (resref,item_name,flavor,base_gold,max_stack) VALUES "
+        "('nw_it_sparscr009','Zwoj Lewitacji',"
+        "'Skradzione z biblioteki klasztornej. Pieczen jeszcze niemal nienaruszona.',70,2)");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("blackmarket",
+        "INSERT INTO bmt_catalog (resref,item_name,flavor,base_gold,max_stack) VALUES "
+        "('nw_it_sparscr010','Zwoj Niewidzialnosci',"
+        "'Nielegalny w dziewieciu miastach. W dziesiatym - drogi.',200,1)");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("blackmarket",
+        "INSERT INTO bmt_catalog (resref,item_name,flavor,base_gold,max_stack) VALUES "
+        "('nw_it_sparscr013','Zwoj Ciemnosci',"
+        "'Mrok mozna kupic za odpowiednia cene.',90,2)");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("blackmarket",
+        "INSERT INTO bmt_catalog (resref,item_name,flavor,base_gold,max_stack) VALUES "
+        "('nw_it_sparscr503','Zwoj Przywolania Cienia',"
+        "'Pergamin drzacy. Atrament brazowy od rdzy lub czegos gorszego.',180,1)");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("blackmarket",
+        "INSERT INTO bmt_catalog (resref,item_name,flavor,base_gold,max_stack) VALUES "
+        "('nw_it_mpotion019','Antidotum Plemienna',"
+        "'Warzone przez wioskowego szamana. Skuteczne. Bez certyfikatu.',65,4)");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("blackmarket",
+        "INSERT INTO bmt_catalog (resref,item_name,flavor,base_gold,max_stack) VALUES "
+        "('nw_it_mpotion008','Trunek Szepczacego Boga',"
+        "'Smak popiolu i obietnicy. Kaplani protestowali.',250,1)");
+    SqlStep(q);
+}
+
+// Fills bmt_stock with a random draw from catalog; noop if stock is still valid.
+void BmtRefreshStock()
+{
+    sqlquery qExp = SqlPrepareQueryCampaign("blackmarket",
+        "SELECT COUNT(*) FROM bmt_stock "
+        "WHERE qty_available > 0 AND expires_at > strftime('%s','now')");
+    if(SqlStep(qExp) && SqlGetInt(qExp, 0) > 0) return;
+
+    SqlStep(SqlPrepareQueryCampaign("blackmarket", "DELETE FROM bmt_stock"));
+
+    sqlquery qFill = SqlPrepareQueryCampaign("blackmarket",
+        "INSERT INTO bmt_stock (catalog_id, qty_available, expires_at) "
+        "SELECT id, max_stack, strftime('%s','now') + @secs "
+        "FROM bmt_catalog ORDER BY RANDOM() LIMIT @cnt");
+    SqlBindInt(qFill, "@secs", BMT_REFRESH_SECS);
+    SqlBindInt(qFill, "@cnt",  BMT_STOCK_COUNT);
+    SqlStep(qFill);
+}
+
+// Returns JsonArray [{id, item_name, flavor, base_gold, qty}, ...] for current stock.
+json BmtGetStock()
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("blackmarket",
+        "SELECT s.id, c.item_name, c.flavor, c.base_gold, s.qty_available "
+        "FROM bmt_stock s JOIN bmt_catalog c ON s.catalog_id = c.id "
+        "WHERE s.qty_available > 0 AND s.expires_at > strftime('%s','now') "
+        "ORDER BY s.id");
+    while(SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "id",        JsonInt   (SqlGetInt   (q, 0)));
+        jRow = JsonObjectSet(jRow, "item_name", JsonString(SqlGetString(q, 1)));
+        jRow = JsonObjectSet(jRow, "flavor",    JsonString(SqlGetString(q, 2)));
+        jRow = JsonObjectSet(jRow, "base_gold", JsonInt   (SqlGetInt   (q, 3)));
+        jRow = JsonObjectSet(jRow, "qty",       JsonInt   (SqlGetInt   (q, 4)));
+        jRows = JsonArrayInsert(jRows, jRow);
+    }
+    return jRows;
+}
+
+// Returns JsonObject {id, resref, item_name, base_gold, qty} or JsonNull.
+json BmtGetStockItem(int nStockId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("blackmarket",
+        "SELECT s.id, c.resref, c.item_name, c.base_gold, s.qty_available "
+        "FROM bmt_stock s JOIN bmt_catalog c ON s.catalog_id = c.id "
+        "WHERE s.id = @id");
+    SqlBindInt(q, "@id", nStockId);
+    if(!SqlStep(q)) return JsonNull();
+    json j = JsonObject();
+    j = JsonObjectSet(j, "id",        JsonInt   (SqlGetInt   (q, 0)));
+    j = JsonObjectSet(j, "resref",    JsonString(SqlGetString(q, 1)));
+    j = JsonObjectSet(j, "item_name", JsonString(SqlGetString(q, 2)));
+    j = JsonObjectSet(j, "base_gold", JsonInt   (SqlGetInt   (q, 3)));
+    j = JsonObjectSet(j, "qty",       JsonInt   (SqlGetInt   (q, 4)));
+    return j;
+}
+
+void BmtDeductStock(int nStockId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("blackmarket",
+        "UPDATE bmt_stock SET qty_available = qty_available - 1 WHERE id = @id");
+    SqlBindInt(q, "@id", nStockId);
+    SqlStep(q);
+}
+
+// Returns seconds until stock expires; negative if already expired.
+int BmtGetSecondsToRefresh()
+{
+    sqlquery q = SqlPrepareQueryCampaign("blackmarket",
+        "SELECT CAST(MAX(expires_at) - strftime('%s','now') AS INTEGER) FROM bmt_stock");
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+void BmtRegisterPlayer(string sUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign("blackmarket",
+        "INSERT OR IGNORE INTO bmt_player (uuid, heat, last_decay) "
+        "VALUES (@uuid, 0, strftime('%s','now'))");
+    SqlBindString(q, "@uuid", sUuid);
+    SqlStep(q);
+}
+
+int BmtGetHeat(string sUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign("blackmarket",
+        "SELECT heat FROM bmt_player WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", sUuid);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+void BmtAddHeat(string sUuid, int nAmount)
+{
+    sqlquery q = SqlPrepareQueryCampaign("blackmarket",
+        "UPDATE bmt_player SET heat = MIN(100, heat + @amt) WHERE uuid = @uuid");
+    SqlBindInt   (q, "@amt",  nAmount);
+    SqlBindString(q, "@uuid", sUuid);
+    SqlStep(q);
+}
+
+// Calculates real hours elapsed since last_decay, removes that heat, advances timestamp.
+void BmtDecayHeat(string sUuid)
+{
+    sqlquery qEl = SqlPrepareQueryCampaign("blackmarket",
+        "SELECT CAST((strftime('%s','now') - last_decay) / 3600 AS INTEGER) "
+        "FROM bmt_player WHERE uuid = @uuid");
+    SqlBindString(qEl, "@uuid", sUuid);
+    if(!SqlStep(qEl)) return;
+    int nHours = SqlGetInt(qEl, 0);
+    if(nHours <= 0) return;
+
+    sqlquery q = SqlPrepareQueryCampaign("blackmarket",
+        "UPDATE bmt_player "
+        "SET heat       = MAX(0, heat - @decay), "
+        "    last_decay = last_decay + @hours * 3600 "
+        "WHERE uuid = @uuid");
+    SqlBindInt   (q, "@decay", nHours * BMT_HEAT_DECAY_HOUR);
+    SqlBindInt   (q, "@hours", nHours);
+    SqlBindString(q, "@uuid",  sUuid);
+    SqlStep(q);
+}

--- a/Black Market/Scripts/sys_on_enter.nss
+++ b/Black Market/Scripts/sys_on_enter.nss
@@ -1,0 +1,16 @@
+#include "lib_bmt"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC)) return;
+
+    string sUuid = GetObjectUUID(oPC);
+    BmtRegisterPlayer(sUuid);
+    BmtDecayHeat(sUuid);
+
+    // Guard check fires after the PC finishes loading into the area
+    int nHeat = BmtGetHeat(sUuid);
+    if(nHeat >= BMT_HEAT_WARN)
+        DelayCommand(5.0, BmtCheckGuards(oPC));
+}

--- a/Black Market/Scripts/sys_on_load.nss
+++ b/Black Market/Scripts/sys_on_load.nss
@@ -1,0 +1,8 @@
+#include "lib_bmt_def"
+
+void main()
+{
+    BmtCreateTables();
+    BmtSeedCatalog();
+    BmtRefreshStock();
+}

--- a/Black Market/Scripts/sys_on_target.nss
+++ b/Black Market/Scripts/sys_on_target.nss
@@ -1,0 +1,10 @@
+#include "lib_bmt"
+
+void main()
+{
+    object oPC = GetLastPlayerToSelectTarget();
+    if(!GetIsPC(oPC)) return;
+    if(NuiFindWindow(oPC, BMT_WINDOW) == 0) return;
+
+    BmtHandleTarget(oPC);
+}

--- a/Black Market/Scripts/test_bmt.nss
+++ b/Black Market/Scripts/test_bmt.nss
@@ -1,0 +1,26 @@
+#include "lib_bmt"
+
+// Attach to OnUsed of a placeable named "Czarne Targowisko" in the toolset.
+// Simulates knocking on the fence's door.
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    string sUuid = GetObjectUUID(oPC);
+    BmtRegisterPlayer(sUuid);
+    BmtDecayHeat(sUuid);
+
+    int nHeat = BmtGetHeat(sUuid);
+    string sIntro;
+
+    if(nHeat < BMT_HEAT_WARN)
+        sIntro = "Drzwi uchylają się. Wnętrze pachnie pleśnią i starymi tajemnicami.";
+    else
+        sIntro =
+            "Passur mierzy cię długim spojrzeniem. "
+            "„Gorące paluchy, co? Wejdź. Szybko."";
+
+    FloatingTextStringOnCreature(sIntro, oPC, FALSE);
+    BmtShowWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

System czarnego rynku prowadzonego przez fencera „Passura". Gracz otwiera okno NUI z dwiema zakładkami: **Kup** (obracający się co 6h asortyment nielegalnego towaru) i **Sprzedaj** (fence skupuje dowolny przedmiot z ekwipunku gracza za 40% wartości). Każda transakcja podnosi „gorąco" gracza, które powoli opada w czasie rzeczywistym — przy przekroczeniu progu 70/100 pojawiają się fabularne konsekwencje.

## Mechanika

- **Obracający się stock**: baza `bmt_stock` uzupełniana z losowego wyboru `bmt_catalog` co `BMT_REFRESH_SECS` (domyślnie 6h). Licznik odświeżenia widoczny w UI.
- **Zakup**: gracz klika wiersz na liście → podświetlenie + tekst fabularny → przycisk `Kup (X sz.)`. Transakcja odejmuje złoto, dodaje przedmiot przez `CreateItemOnObject(resref, oPC)`, dekrementuje `qty_available`. Brak resrefa w haku = automatyczny zwrot (komunikat dla buildera).
- **Sprzedaż (fencing)**: gracz klika „Wybierz przedmiot" → `EnterTargetingMode` → `sys_on_target` serializuje item przez `ObjectToJson` i go niszczy. Wycena = `GetGoldPieceValue(oItem) * 40 / 100`. Potwierdzenie daje złoto i kasuje serial. Anulowanie (zamknięcie okna) odtwarza item przez `JsonToObject`.
- **Gorąco (heat 0–100)**: przyrasta za każdą transakcję, opada o `BMT_HEAT_DECAY_HOUR` za każdą realną godzinę (obliczane przy wejściu gracza z diff timestampów). Przy heat ≥ 70: losowa szansa na efekt VFX + wiadomość + flaga `BMT_WANTED` dla innych systemów.

## Pliki

| Plik | Rola |
|------|------|
| `lib_bmt_def.nss` | Stałe, ID bindów/przycisków, LVARy, konfiguracja, forward decls |
| `sql_bmt.nss` | Schemat SQLite + wszystkie zapytania (catalog, stock, player heat) |
| `lib_bmt.nss` | Logika NUI (dwie zakładki), feed funkcje, BmtHandleBuy/Sell/Target, BmtCheckGuards |
| `lib_bmt_ev.nss` | Handler eventów NUI: klik rzędu, zakładki, kupno, sprzedaż, zamknięcie |
| `sys_on_load.nss` | OnModuleLoad: CreateTables + SeedCatalog + RefreshStock |
| `sys_on_enter.nss` | OnClientEnter: rejestracja gracza, decay heata, sprawdzenie strażników |
| `sys_on_target.nss` | OnPlayerTarget: serializacja i wycena wybranego przedmiotu |
| `test_bmt.nss` | OnUsed na placeable — demo otwierające okno z intro flavor text |
| `INTEGRATION.md` | Tabela hooków, instrukcja rozszerzania katalogu, flagi dla innych systemów |

## Zależności

- **SQL**: `SqlPrepareQueryCampaign("blackmarket", ...)` — plik kampanii `campaign_blackmarket.sqlite`. Brak NWNX.
- **Shared NUI lib**: `lib_nui.nss` + `lib_nui_utility.nss` — dostarczone przez moduł **Mailbox** (lub inny NUI helper). Nie duplikowane tutaj.
- **Brak NWNX** — moduł działa na czystym NWN:EE.

## Jak włączyć w istniejącym module

```nss
// sys_on_load — dodaj wywołanie:
ExecuteScript("sys_on_load", GetModule());

// sys_on_enter — dodaj:
ExecuteScript("sys_on_enter", GetEnteringObject());

// OnPlayerTarget modułu:
ExecuteScript("sys_on_target", GetModule());
```

Alternatywnie: `#include "lib_bmt"` / `#include "lib_bmt_def"` i wywołaj funkcje bezpośrednio z istniejących hooków.

Placeable do testu: nowy placeable z `OnUsed = test_bmt`.

Rozszerzanie katalogu — SQL:
```sql
INSERT INTO bmt_catalog (resref, item_name, flavor, base_gold, max_stack)
VALUES ('moj_resref', 'Nazwa', 'Opis fabularny.', 300, 2);
```

## Co celowo pominięto

- **Spawn NPC strażników** — wymaga resrefa z haka twórcy modułu; zamiast tego system wystawia flagę `BMT_WANTED` i efekt VFX jako placeholder.
- **Historia transakcji per-PC** — tabela `bmt_purchase_log` i widok historii nie dodane, żeby nie rozbudowywać UI; trivialny addon.
- **Limit zakupów per-PC** — stock jest globalny (wszyscy gracze dzielą pool qty); per-PC limit to oddzielna tabela.
- **Animacja/dialog NPC Passura** — system otwiera UI bezpośrednio z placeable; konwersacja NWN to oddzielny plik `.dlg`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9t15dMmKSiKGYWrfuWVmF)_