### PR TITLE
feat: Korupcja Duszy (Soul Corruption)

### DIFF
--- a/Corruption/INTEGRATION.md
+++ b/Corruption/INTEGRATION.md
@@ -1,0 +1,140 @@
+# Corruption – Integration Guide
+
+## Opis modułu
+
+System Korupcji Duszy śledzi stopień moralnego zepsucia każdej postaci graczy
+jako wartość 0–100 przechowaną w SQLite. Pięć stadiów (Nieskażony → Potępiony)
+aplikuje narastające kary atrybutów i efekty wizualne. Gracze mogą oczyścić
+duszę przez rytuał pokuty w oknie NUI, Święconą Wodę lub odpoczynek
+w uświęconym miejscu.
+
+---
+
+## Hooki do podpięcia
+
+| Zdarzenie modułu | Skrypt z modułu | Uwagi |
+|---|---|---|
+| **OnModuleLoad** | `sys_on_load` | Tworzy tabelę SQLite `cor_chars`. |
+| **OnClientEnter** | `sys_on_enter` | Wczytuje korupcję z DB, re-aplikuje efekty. |
+| **OnPlayerRest** | `sys_on_rest` | Sanctuary bonus + nightmare flavor. |
+| **OnActivateItem** | `sys_on_activate` | Święcona woda (`cor_holy_water`) i mroczne artefakty. |
+| **OnPlayerDeath** | `sys_on_death` | Opcjonalny flavor dla Potępionych. |
+
+Jeśli Twój moduł ma już skrypty dla tych zdarzeń, wstaw wywołanie
+`ExecuteScript("sys_on_enter", OBJECT_SELF)` (lub odpowiedni skrypt)
+**na końcu** istniejącego handlera.
+
+---
+
+## NWNX
+
+Moduł **nie wymaga NWNX**. Używa wyłącznie standardowego NWScript + NUI +
+`SqlPrepareQueryCampaign`.
+
+---
+
+## Baza danych
+
+Kampania: **`corruption`** (plik `corruption.sqlite3` obok modułu lub w katalogu
+kampanii, zależnie od konfiguracji serwera).
+
+```sql
+CREATE TABLE IF NOT EXISTS cor_chars (
+    uuid        TEXT    PRIMARY KEY,
+    char_name   TEXT    DEFAULT '',
+    corruption  INTEGER DEFAULT 0,
+    last_ritual INTEGER DEFAULT 0
+);
+```
+
+Tabela jest tworzona idempotentnie przy każdym starcie modułu.
+
+---
+
+## Jak nadać korupcję z zewnętrznego skryptu
+
+```nss
+#include "lib_cor"
+
+// Przykład: NPC zabity przez gracza podnosi korupcję, jeśli był neutralny/przyjazny.
+// Umieść ten fragment w OnCreatureDeath lub własnym OnPlayerKillTarget.
+
+void main()
+{
+    object oVictim = OBJECT_SELF;        // martwy NPC
+    object oKiller = GetLastKiller();
+
+    if(!GetIsPC(oKiller)) return;
+
+    int nRep = GetReputation(oVictim, oKiller);
+    if(nRep >= 70)  // neutralny lub przyjazny
+    {
+        CorGainCorruption(oKiller, COR_NEUTRAL_KILL_GAIN,
+            "Poczucie winy przenika twoje ciało. Zabiłeś kogoś, kto ci nie zagrażał.");
+    }
+}
+```
+
+---
+
+## Mroczne artefakty
+
+Ustaw zmienną lokalną na dowolnym item:
+
+```
+LVAR name : COR_DARK_ARTIFACT   (string)
+LVAR type : int
+LVAR value: 5    (lub inna wartość — tyle pkt korupcji doda aktywacja)
+```
+
+Kiedy gracz aktywuje item, `sys_on_activate` dodaje wskazaną liczbę punktów
+korupcji i usuwa zmienną (by item mógł aktywować efekt tylko raz per sesję).
+
+---
+
+## Sanctuary (miejsce uświęcone)
+
+Ustaw zmienną lokalną na obiekcie **Area** w Toolsecie:
+
+```
+LVAR name : COR_AREA_SANCTUARY   (string)
+LVAR type : int
+LVAR value: 1
+```
+
+Odpoczynek w tej lokacji usuwa `COR_SANCTUARY_REDUCTION` (domyślnie 3) punktów
+korupcji zamiast wywoływania koszmarów.
+
+---
+
+## Przedmiot: Święcona Woda
+
+Stwórz item z tagiem `cor_holy_water`. Aktywacja (Activate Item) zużywa item
+i usuwa `COR_HWATER_REDUCTION` (domyślnie 10) punktów korupcji.
+
+---
+
+## Demo (test w module)
+
+1. Umieść dowolny placeable (np. Campfire) w obszarze testowym.
+2. Ustaw skrypt `test_cor` jako **OnUsed**.
+3. Uruchom moduł, podejdź do placeable i użyj go:
+   - 1. użycie → otwiera okno NUI Korupcji Duszy.
+   - 2. użycie → +15 pkt korupcji.
+   - 3. użycie → -15 pkt korupcji.
+   - Cykl się powtarza.
+
+---
+
+## Co celowo pominięto (v1)
+
+- **Wizualne zmiany appearance** — wymagałyby ingerencji w moduł Appearance
+  lub NWNX:Player (zmiana modelu postaci). Można dodać w v2.
+- **Reakcje NPC** (SetReputation) — pominięte, by uniknąć konfliktów
+  z istniejącymi systemami reputacji.
+- **Automatyczne przyrosty korupcji** (heartbeat za każdą godzinę online
+  z mrocznym przedmiotem) — pominięte; architektura to umożliwia przez
+  `sys_module_hb.nss`.
+- **Kurator/wyznawca** jako NPC potrzebny do rytuału — rytuał jest
+  samoobsługowy w NUI; builder może go wymagać wyłącznie przez NPC
+  ustawiając zmienną modułową.

--- a/Corruption/Scripts/lib_cor.nss
+++ b/Corruption/Scripts/lib_cor.nss
@@ -1,0 +1,379 @@
+// lib_cor.nss  –  Corruption: core logic, effect management, NUI building
+
+#include "lib_cor_def"
+
+// ================================================================
+// Effect management
+// ================================================================
+
+void CorRemoveEffects(object oPC)
+{
+    effect eEff = GetFirstEffect(oPC);
+    while(GetIsEffectValid(eEff))
+    {
+        if(GetEffectTag(eEff) == COR_EFFECT_TAG)
+            RemoveEffect(oPC, eEff);
+        eEff = GetNextEffect(oPC);
+    }
+}
+
+void CorApplyEffects(object oPC)
+{
+    CorRemoveEffects(oPC);
+
+    int nCorruption = GetLocalInt(oPC, COR_LVAR_CORRUPTION);
+    int nStage      = CorGetStage(nCorruption);
+
+    if(nStage == COR_STAGE_PURE) return;
+
+    effect eCHA, eWIS, eSTR, eAura;
+
+    switch(nStage)
+    {
+        case COR_STAGE_TAINTED:
+            eCHA = TagEffect(EffectAbilityDecrease(ABILITY_CHARISMA, 1), COR_EFFECT_TAG);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, eCHA, oPC);
+            break;
+
+        case COR_STAGE_FALLEN:
+            eCHA = TagEffect(EffectAbilityDecrease(ABILITY_CHARISMA, 2), COR_EFFECT_TAG);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, eCHA, oPC);
+
+            eWIS = TagEffect(EffectAbilityDecrease(ABILITY_WISDOM, 1), COR_EFFECT_TAG);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, eWIS, oPC);
+            break;
+
+        case COR_STAGE_CURSED:
+            eCHA = TagEffect(EffectAbilityDecrease(ABILITY_CHARISMA, 4), COR_EFFECT_TAG);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, eCHA, oPC);
+
+            eWIS = TagEffect(EffectAbilityDecrease(ABILITY_WISDOM, 2), COR_EFFECT_TAG);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, eWIS, oPC);
+
+            eAura = TagEffect(EffectVisualEffect(VFX_DUR_AURA_PULSE_RED_BLACK), COR_EFFECT_TAG);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, eAura, oPC);
+            break;
+
+        case COR_STAGE_DAMNED:
+            eCHA = TagEffect(EffectAbilityDecrease(ABILITY_CHARISMA, 6), COR_EFFECT_TAG);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, eCHA, oPC);
+
+            eWIS = TagEffect(EffectAbilityDecrease(ABILITY_WISDOM, 4), COR_EFFECT_TAG);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, eWIS, oPC);
+
+            eSTR = TagEffect(EffectAbilityDecrease(ABILITY_STRENGTH, 2), COR_EFFECT_TAG);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, eSTR, oPC);
+
+            eAura = TagEffect(EffectVisualEffect(VFX_DUR_AURA_PULSE_RED_BLACK), COR_EFFECT_TAG);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, eAura, oPC);
+            break;
+    }
+}
+
+// ================================================================
+// Corruption modification (public API used by other systems)
+// ================================================================
+
+void CorGainCorruption(object oPC, int nAmount, string sFlavor)
+{
+    int nOld   = GetLocalInt(oPC, COR_LVAR_CORRUPTION);
+    int nNew   = nOld + nAmount;
+    if(nNew > 100) nNew = 100;
+    if(nNew == nOld) return;
+
+    SetLocalInt(oPC, COR_LVAR_CORRUPTION, nNew);
+    CorDbSetCorruption(oPC, nNew);
+
+    int nOldStage = CorGetStage(nOld);
+    int nNewStage = CorGetStage(nNew);
+
+    CorApplyEffects(oPC);
+
+    if(sFlavor != "")
+        SendMessageToPC(oPC, "[Korupcja] " + sFlavor);
+
+    if(nNewStage > nOldStage)
+    {
+        FloatingTextStringOnCreature(
+            "Twoja dusza osuwa się głębiej w mrok... [" + CorStageName(nNewStage) + "]",
+            oPC, FALSE);
+        SendMessageToPC(oPC,
+            "[Korupcja] Nowe stadium: " + CorStageName(nNewStage) + ".");
+    }
+
+    int nToken = NuiFindWindow(oPC, COR_WINDOW);
+    if(nToken != 0) CorRefreshWindow(oPC);
+}
+
+void CorReduceCorruption(object oPC, int nAmount)
+{
+    int nOld = GetLocalInt(oPC, COR_LVAR_CORRUPTION);
+    int nNew = nOld - nAmount;
+    if(nNew < 0) nNew = 0;
+    if(nNew == nOld) return;
+
+    SetLocalInt(oPC, COR_LVAR_CORRUPTION, nNew);
+    CorDbSetCorruption(oPC, nNew);
+
+    int nOldStage = CorGetStage(nOld);
+    int nNewStage = CorGetStage(nNew);
+
+    CorApplyEffects(oPC);
+
+    if(nNewStage < nOldStage)
+    {
+        FloatingTextStringOnCreature(
+            "Część ciemności odpłynęła... [" + CorStageName(nNewStage) + "]",
+            oPC, FALSE);
+    }
+
+    int nToken = NuiFindWindow(oPC, COR_WINDOW);
+    if(nToken != 0) CorRefreshWindow(oPC);
+}
+
+// ================================================================
+// Ritual (NUI-triggered): requires gold, has 24-h cooldown
+// ================================================================
+
+void CorPerformRitual(object oPC)
+{
+    int nNow      = CorDbNow();
+    int nLast     = CorDbGetLastRitual(oPC);
+    int nCooldown = COR_RITUAL_COOLDOWN - (nNow - nLast);
+
+    if(nCooldown > 0)
+    {
+        int nHours = nCooldown / 3600;
+        int nMins  = (nCooldown % 3600) / 60;
+        SendMessageToPC(oPC,
+            "[Korupcja] Rytuał wymaga skupienia. Odczekaj jeszcze " +
+            IntToString(nHours) + "h " + IntToString(nMins) + "min.");
+        return;
+    }
+
+    int nGold = GetGold(oPC);
+    if(nGold < COR_RITUAL_GOLD_COST)
+    {
+        SendMessageToPC(oPC,
+            "[Korupcja] Rytuał wymaga " +
+            IntToString(COR_RITUAL_GOLD_COST) + " sztuk złota jako ofiary.");
+        return;
+    }
+
+    int nCorruption = GetLocalInt(oPC, COR_LVAR_CORRUPTION);
+    if(nCorruption == 0)
+    {
+        SendMessageToPC(oPC, "[Korupcja] Twoja dusza jest czysta — rytuał nie jest potrzebny.");
+        return;
+    }
+
+    AssignCommand(oPC, TakeGoldFromCreature(COR_RITUAL_GOLD_COST, oPC, TRUE));
+    CorDbSetLastRitual(oPC);
+
+    effect eLight = EffectVisualEffect(VFX_IMP_SUNSTRIKE);
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, eLight, oPC);
+
+    SendMessageToPC(oPC,
+        "[Korupcja] Wypowiadasz słowa pokuty. Pieczęć mroku słabnie...");
+
+    CorReduceCorruption(oPC, COR_RITUAL_REDUCTION);
+
+    int nToken = NuiFindWindow(oPC, COR_WINDOW);
+    if(nToken != 0) CorRefreshWindow(oPC);
+}
+
+// ================================================================
+// Holy water item use
+// ================================================================
+
+void CorUseHolyWater(object oPC, object oItem)
+{
+    int nCorruption = GetLocalInt(oPC, COR_LVAR_CORRUPTION);
+    if(nCorruption == 0)
+    {
+        SendMessageToPC(oPC,
+            "[Korupcja] Święcona woda nic nie robi — twoja dusza jest czysta.");
+        return;
+    }
+
+    DestroyObject(oItem);
+
+    effect eHoly = EffectVisualEffect(VFX_IMP_HOLY_AID);
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, eHoly, oPC);
+
+    SendMessageToPC(oPC,
+        "[Korupcja] Święcona woda paruje na twojej skórze. Mrok cofa się odrobinę.");
+
+    CorReduceCorruption(oPC, COR_HWATER_REDUCTION);
+}
+
+// ================================================================
+// NUI – populate binds after window creation / refresh
+// ================================================================
+
+void CorRefreshWindow(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, COR_WINDOW);
+    if(nToken == 0) return;
+
+    int nCorruption = GetLocalInt(oPC, COR_LVAR_CORRUPTION);
+    int nStage      = CorGetStage(nCorruption);
+
+    NuiSetBind(oPC, nToken, COR_BIND_STAGE_LBL,
+        JsonString(CorStageName(nStage) + "  (" + IntToString(nCorruption) + "/100)"));
+
+    NuiSetBind(oPC, nToken, COR_BIND_VALUE_LBL,
+        JsonString(IntToString(nCorruption) + " / 100"));
+
+    NuiSetBind(oPC, nToken, COR_BIND_BAR_VAL,
+        JsonFloat(IntToFloat(nCorruption) / 100.0));
+
+    NuiSetBind(oPC, nToken, COR_BIND_FLAVOR_LBL,
+        JsonString(CorStageFlavor(nStage)));
+
+    NuiSetBind(oPC, nToken, COR_BIND_PENALTY_LBL,
+        JsonString(CorStagePenalties(nStage)));
+
+    // Ritual button state
+    int nNow     = CorDbNow();
+    int nLast    = CorDbGetLastRitual(oPC);
+    int nCooldownSec = COR_RITUAL_COOLDOWN - (nNow - nLast);
+    int bCanRitual   = (nCooldownSec <= 0 && nCorruption > 0);
+
+    NuiSetBind(oPC, nToken, COR_BIND_RITUAL_ENA, JsonBool(bCanRitual));
+
+    if(bCanRitual)
+        NuiSetBind(oPC, nToken, COR_BIND_RITUAL_LBL,
+            JsonString("Odpokutuj (" + IntToString(COR_RITUAL_GOLD_COST) + " zł)"));
+    else if(nCorruption == 0)
+        NuiSetBind(oPC, nToken, COR_BIND_RITUAL_LBL,
+            JsonString("Dusza czysta"));
+    else
+    {
+        int nH = nCooldownSec / 3600;
+        int nM = (nCooldownSec % 3600) / 60;
+        NuiSetBind(oPC, nToken, COR_BIND_RITUAL_LBL,
+            JsonString("Cooldown: " + IntToString(nH) + "h " + IntToString(nM) + "m"));
+    }
+}
+
+// ================================================================
+// NUI – build layout
+// ================================================================
+
+json CorBuildLayout(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 30.0);
+    float fBarH  = GetNuiScaleDimension(oPC, 18.0);
+    float fLblH  = GetNuiScaleDimension(oPC, 24.0);
+    float fTextH = GetNuiScaleDimension(oPC, 66.0);
+    float fPenH  = GetNuiScaleDimension(oPC, 88.0);
+    float fContentW = GetNuiScaleDimension(oPC, 380.0);
+
+    // Stage label (large, centered)
+    json jStageLbl = NuiHeight(
+        NuiLabel(NuiBind(COR_BIND_STAGE_LBL),
+            JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE)),
+        GetNuiScaleDimension(oPC, 32.0));
+
+    // Progress bar
+    json jBar = NuiHeight(NuiProgress(NuiBind(COR_BIND_BAR_VAL)), fBarH);
+
+    // Flavor text (multi-line)
+    json jFlavor = NuiHeight(
+        NuiText(NuiBind(COR_BIND_FLAVOR_LBL), FALSE),
+        fTextH);
+
+    // Separator label
+    json jPenHdr = NuiHeight(
+        NuiLabel(JsonString("Aktywne kary:"),
+            JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)),
+        fLblH);
+
+    // Penalties (multi-line text, read-only)
+    json jPen = NuiHeight(
+        NuiText(NuiBind(COR_BIND_PENALTY_LBL), FALSE),
+        fPenH);
+
+    // Ritual button
+    json jRitualBtn = NuiButton(NuiBind(COR_BIND_RITUAL_LBL));
+    jRitualBtn = NuiId(jRitualBtn, COR_BTN_RITUAL);
+    jRitualBtn = NuiEnabled(jRitualBtn, NuiBind(COR_BIND_RITUAL_ENA));
+    jRitualBtn = NuiWidth(jRitualBtn, GetNuiScaleDimension(oPC, 220.0));
+    jRitualBtn = NuiHeight(jRitualBtn, fBtnH);
+    jRitualBtn = NuiTooltip(jRitualBtn,
+        JsonString("Wykonaj rytuał pokuty — usuwa " +
+            IntToString(COR_RITUAL_REDUCTION) + " pkt korupcji. Odnawia się co 24h."));
+
+    // Close button
+    json jClose = NuiButton(JsonString("Zamknij"));
+    jClose = NuiId(jClose, COR_BTN_CLOSE);
+    jClose = NuiWidth(jClose, GetNuiScaleDimension(oPC, 100.0));
+    jClose = NuiHeight(jClose, fBtnH);
+
+    // Bottom row
+    json jBotRow = JsonArray();
+    jBotRow = JsonArrayInsert(jBotRow, jRitualBtn);
+    jBotRow = JsonArrayInsert(jBotRow, NuiSpacer());
+    jBotRow = JsonArrayInsert(jBotRow, jClose);
+
+    // Assemble column
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jStageLbl);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, jBar);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, jFlavor);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, jPenHdr);
+    jCol = JsonArrayInsert(jCol, jPen);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBotRow));
+
+    // Wrap in centering side columns (Mailbox/LFG pattern)
+    json jSide    = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    json jMainRow = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiCol(jCol), fContentW));
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    return NuiRow(jMainRow);
+}
+
+// ================================================================
+// Window open / reopen
+// ================================================================
+
+void CorOpenWindow(object oPC)
+{
+    int nExisting = NuiFindWindow(oPC, COR_WINDOW);
+    if(nExisting != 0)
+    {
+        CorRefreshWindow(oPC);
+        return;
+    }
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))
+                 - GetNuiScaleDimension(oPC, COR_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT))
+                 - GetNuiScaleDimension(oPC, COR_H)) / 2.0;
+    json jGeom = NuiRect(fCX, fCY,
+                         GetNuiScaleDimension(oPC, COR_W),
+                         GetNuiScaleDimension(oPC, COR_H));
+
+    json jRoot = CorBuildLayout(oPC);
+
+    json jWin = NuiWindow(
+        jRoot,
+        JsonString("Korupcja Duszy"),
+        NuiBind(COR_WIN_GEOM),
+        JsonBool(FALSE),   // resizable
+        JsonBool(FALSE),   // collapsed
+        JsonBool(TRUE),    // closable
+        JsonBool(TRUE),    // transparent
+        JsonBool(FALSE));  // border
+
+    int nToken = NuiCreate(oPC, jWin, COR_WINDOW, COR_EV);
+    NuiSetBind(oPC, nToken, COR_WIN_GEOM, jGeom);
+
+    CorRefreshWindow(oPC);
+}

--- a/Corruption/Scripts/lib_cor_def.nss
+++ b/Corruption/Scripts/lib_cor_def.nss
@@ -1,0 +1,167 @@
+// lib_cor_def.nss  –  Corruption: constants, stage definitions, bind IDs
+
+#include "lib_nui"
+#include "sql_cor"
+
+// Forward declarations (implemented in lib_cor.nss)
+void CorOpenWindow(object oPC);
+void CorRefreshWindow(object oPC);
+void CorApplyEffects(object oPC);
+void CorRemoveEffects(object oPC);
+void CorGainCorruption(object oPC, int nAmount, string sFlavor);
+void CorReduceCorruption(object oPC, int nAmount);
+
+// ================================================================
+// Stage constants
+// ================================================================
+
+const int COR_STAGE_PURE    = 0;  //  0-19
+const int COR_STAGE_TAINTED = 1;  // 20-39
+const int COR_STAGE_FALLEN  = 2;  // 40-59
+const int COR_STAGE_CURSED  = 3;  // 60-79
+const int COR_STAGE_DAMNED  = 4;  // 80-100
+
+// ================================================================
+// NUI window / group / event script IDs
+// ================================================================
+
+const string COR_WINDOW   = "COR_WINDOW";
+const string COR_EV       = "lib_cor_ev";
+const string COR_WIN_GEOM = "cor_win_geom";
+const string COR_GRP_MAIN = "cor_grp_main";
+
+// ================================================================
+// Bind names
+// ================================================================
+
+const string COR_BIND_STAGE_LBL   = "cor_stage_lbl";
+const string COR_BIND_VALUE_LBL   = "cor_value_lbl";
+const string COR_BIND_BAR_VAL     = "cor_bar_val";
+const string COR_BIND_FLAVOR_LBL  = "cor_flavor";
+const string COR_BIND_PENALTY_LBL = "cor_penalty";
+const string COR_BIND_RITUAL_ENA  = "cor_ritual_ena";
+const string COR_BIND_RITUAL_LBL  = "cor_ritual_lbl";
+const string COR_BIND_COOLDOWN_LBL= "cor_cooldown";
+
+// ================================================================
+// Button IDs
+// ================================================================
+
+const string COR_BTN_RITUAL = "cor_btn_ritual";
+const string COR_BTN_CLOSE  = "cor_btn_close";
+const string COR_BTN_HWATER = "cor_btn_hwater";
+
+// ================================================================
+// Local variables on PC
+// ================================================================
+
+const string COR_LVAR_CORRUPTION = "COR_VALUE";    // cached int (synced from DB on enter)
+const string COR_LVAR_DIRTY      = "COR_DIRTY";    // 1 = effects need reapplication
+
+// ================================================================
+// Item / area tags recognised by the module
+// ================================================================
+
+// Usable item that reduces corruption by COR_HWATER_REDUCTION points.
+const string COR_TAG_HOLY_WATER = "cor_holy_water";
+// Area variable name: set LVAR = 1 on area to treat it as a sanctuary for rest.
+const string COR_LVAR_AREA_SANCTUARY = "COR_AREA_SANCTUARY";
+// Item variable name: set this LVAR to a positive int on any item to make it
+// a "dark artifact" that raises corruption when acquired/equipped.
+const string COR_IVAR_DARK_ARTIFACT  = "COR_DARK_ARTIFACT";
+
+// ================================================================
+// Tuning constants
+// ================================================================
+
+const int COR_RITUAL_GOLD_COST   = 500;   // gp to perform cleansing ritual
+const int COR_RITUAL_COOLDOWN    = 86400; // seconds (24 h)
+const int COR_RITUAL_REDUCTION   = 15;
+const int COR_HWATER_REDUCTION   = 10;
+const int COR_SANCTUARY_REDUCTION= 3;     // per rest in sanctuary area
+const int COR_NEUTRAL_KILL_GAIN  = 8;     // killing neutral/friendly NPC
+const int COR_DARK_ARTIFACT_GAIN = 5;     // per dark artifact picked up
+
+// ================================================================
+// Layout dimensions
+// ================================================================
+
+const float COR_W = 420.0;
+const float COR_H = 390.0;
+
+// ================================================================
+// Effect tag
+// ================================================================
+
+const string COR_EFFECT_TAG = "COR_EFFECT";
+
+// ================================================================
+// Stage helpers
+// ================================================================
+
+int CorGetStage(int nCorruption)
+{
+    if(nCorruption >= 80) return COR_STAGE_DAMNED;
+    if(nCorruption >= 60) return COR_STAGE_CURSED;
+    if(nCorruption >= 40) return COR_STAGE_FALLEN;
+    if(nCorruption >= 20) return COR_STAGE_TAINTED;
+    return COR_STAGE_PURE;
+}
+
+string CorStageName(int nStage)
+{
+    switch(nStage)
+    {
+        case COR_STAGE_PURE:    return "Nieskażony";
+        case COR_STAGE_TAINTED: return "Skażony";
+        case COR_STAGE_FALLEN:  return "Upadły";
+        case COR_STAGE_CURSED:  return "Przeklęty";
+        case COR_STAGE_DAMNED:  return "Potępiony";
+    }
+    return "-";
+}
+
+string CorStageFlavor(int nStage)
+{
+    switch(nStage)
+    {
+        case COR_STAGE_PURE:
+            return "Twoja dusza płonie słabym, lecz czystym światłem.\nDemony cię omijają.";
+        case COR_STAGE_TAINTED:
+            return "Cień zagościł w twoim sercu.\nNocami śnią ci się twarze tych, których skrzywdziłeś.";
+        case COR_STAGE_FALLEN:
+            return "Mrok wypełnił połowę twego jestestwa.\nKapłani odwracają wzrok gdy przechodzisz obok.";
+        case COR_STAGE_CURSED:
+            return "Twoja obecność mrozi krew w żyłach przechodniów.\nAnioły nie słyszą już twoich próśb.";
+        case COR_STAGE_DAMNED:
+            return "Dusza twoja jest przegniła do cna.\nZbawienie wymaga cudu albo ofiary, jakiej jeszcze nie złożyłeś.";
+    }
+    return "";
+}
+
+string CorStagePenalties(int nStage)
+{
+    switch(nStage)
+    {
+        case COR_STAGE_PURE:    return "Brak kar.";
+        case COR_STAGE_TAINTED: return "• -1 do Charyzmy";
+        case COR_STAGE_FALLEN:  return "• -2 do Charyzmy\n• -1 do Mądrości";
+        case COR_STAGE_CURSED:  return "• -4 do Charyzmy\n• -2 do Mądrości\n• Aura nieczystości (efekt wizualny)";
+        case COR_STAGE_DAMNED:  return "• -6 do Charyzmy\n• -4 do Mądrości\n• -2 do Siły\n• Aura grozy (efekt wizualny)";
+    }
+    return "";
+}
+
+// Returns a NuiColor representing the stage (dark-to-red palette).
+json CorStageColor(int nStage)
+{
+    switch(nStage)
+    {
+        case COR_STAGE_PURE:    return NuiColor(160, 200, 255, 255);
+        case COR_STAGE_TAINTED: return NuiColor(210, 180,  80, 255);
+        case COR_STAGE_FALLEN:  return NuiColor(210, 110,  40, 255);
+        case COR_STAGE_CURSED:  return NuiColor(190,  50, 190, 255);
+        case COR_STAGE_DAMNED:  return NuiColor(230,  30,  30, 255);
+    }
+    return NuiColor(180, 180, 180, 255);
+}

--- a/Corruption/Scripts/lib_cor_ev.nss
+++ b/Corruption/Scripts/lib_cor_ev.nss
@@ -1,0 +1,37 @@
+// lib_cor_ev.nss  –  Corruption: NUI event handler (OnNUIWindowRoutine)
+
+#include "lib_cor"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+
+    if(nToken != NuiFindWindow(oPC, COR_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+        return; // no cleanup needed — effects are persistent
+
+    if(sEvent == EVENT_TYPE_OPEN)
+    {
+        CorRefreshWindow(oPC);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == COR_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        if(sElem == COR_BTN_RITUAL)
+        {
+            CorPerformRitual(oPC);
+            return;
+        }
+    }
+}

--- a/Corruption/Scripts/lib_nui.nss
+++ b/Corruption/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Corruption/Scripts/lib_nui_utility.nss
+++ b/Corruption/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Corruption/Scripts/sql_cor.nss
+++ b/Corruption/Scripts/sql_cor.nss
@@ -1,0 +1,64 @@
+// sql_cor.nss  –  Corruption: SQLite schema and queries
+// Campaign DB: "corruption"
+
+void CorCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("corruption",
+        "CREATE TABLE IF NOT EXISTS cor_chars ("
+        "uuid         TEXT    PRIMARY KEY, "
+        "char_name    TEXT    DEFAULT '', "
+        "corruption   INTEGER DEFAULT 0, "
+        "last_ritual  INTEGER DEFAULT 0"
+        ")");
+    SqlStep(q);
+}
+
+// Returns stored corruption (0 if not yet registered).
+int CorDbGetCorruption(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("corruption",
+        "SELECT corruption FROM cor_chars WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// Writes corruption (clamped to 0-100 by caller).
+void CorDbSetCorruption(object oPC, int nValue)
+{
+    sqlquery q = SqlPrepareQueryCampaign("corruption",
+        "INSERT INTO cor_chars (uuid, char_name, corruption, last_ritual) "
+        "VALUES (@uuid, @name, @val, 0) "
+        "ON CONFLICT(uuid) DO UPDATE SET char_name = @name, corruption = @val");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindString(q, "@name", GetName(oPC));
+    SqlBindInt   (q, "@val",  nValue);
+    SqlStep(q);
+}
+
+// Returns unix timestamp of last cleansing ritual (0 if none).
+int CorDbGetLastRitual(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("corruption",
+        "SELECT last_ritual FROM cor_chars WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+void CorDbSetLastRitual(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("corruption",
+        "UPDATE cor_chars SET last_ritual = strftime('%s','now') WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+// Returns current unix timestamp via SQLite (avoids NWN time API quirks).
+int CorDbNow()
+{
+    sqlquery q = SqlPrepareQueryCampaign("corruption",
+        "SELECT CAST(strftime('%s','now') AS INTEGER)");
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}

--- a/Corruption/Scripts/sys_on_activate.nss
+++ b/Corruption/Scripts/sys_on_activate.nss
@@ -1,0 +1,33 @@
+// sys_on_activate.nss  –  Corruption: OnActivateItem hook
+// Handles holy water and dark artifact items.
+
+#include "lib_cor"
+
+void main()
+{
+    object oPC   = GetItemActivator();
+    object oItem = GetItemActivated();
+
+    if(!GetIsPC(oPC) || !GetIsObjectValid(oItem)) return;
+
+    string sTag = GetTag(oItem);
+
+    // Holy water: reduce corruption
+    if(sTag == COR_TAG_HOLY_WATER)
+    {
+        CorUseHolyWater(oPC, oItem);
+        return;
+    }
+
+    // Dark artifact: gain corruption when activated/first picked up
+    int nDarkPower = GetLocalInt(oItem, COR_IVAR_DARK_ARTIFACT);
+    if(nDarkPower > 0)
+    {
+        SendMessageToPC(oPC,
+            "[Korupcja] Mroczna moc artefaktu przesącza się przez twoje palce...");
+        CorGainCorruption(oPC, nDarkPower,
+            "Dotknąłeś " + GetName(oItem) + " — pieczęć mroku się wzmacnia.");
+        // Remove the variable so the item can only corrupt once per activation
+        DeleteLocalInt(oItem, COR_IVAR_DARK_ARTIFACT);
+    }
+}

--- a/Corruption/Scripts/sys_on_death.nss
+++ b/Corruption/Scripts/sys_on_death.nss
@@ -1,0 +1,23 @@
+// sys_on_death.nss  –  Corruption: OnPlayerDeath hook
+// Potępiony (Damned) characters bleed corruption on death —
+// a faint warning before possible permanent consequences.
+
+#include "lib_cor"
+
+void main()
+{
+    object oPC = GetLastPlayerDied();
+    if(!GetIsObjectValid(oPC)) return;
+
+    int nCorruption = GetLocalInt(oPC, COR_LVAR_CORRUPTION);
+    int nStage      = CorGetStage(nCorruption);
+
+    if(nStage == COR_STAGE_DAMNED)
+    {
+        SendMessageToPC(oPC,
+            "[Korupcja] W chwili śmierci twa dusza krzyczy. "
+            "Demony tańczą wokół twojego ciała.");
+        // Purely atmospheric — no extra penalty on death to avoid frustrating players.
+        // Builders can add penalties here (e.g., permanent stat loss, XP drain).
+    }
+}

--- a/Corruption/Scripts/sys_on_enter.nss
+++ b/Corruption/Scripts/sys_on_enter.nss
@@ -1,0 +1,21 @@
+// sys_on_enter.nss  –  Corruption: OnClientEnter hook
+// Restores cached corruption value and reapplies permanent effects.
+
+#include "lib_cor"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC) || GetIsDMPossessed(oPC)) return;
+
+    int nCorruption = CorDbGetCorruption(oPC);
+    SetLocalInt(oPC, COR_LVAR_CORRUPTION, nCorruption);
+
+    CorApplyEffects(oPC);
+
+    int nStage = CorGetStage(nCorruption);
+    if(nStage >= COR_STAGE_TAINTED)
+        SendMessageToPC(oPC,
+            "[Korupcja] Twoja dusza nosi piętno " + CorStageName(nStage) +
+            " (" + IntToString(nCorruption) + "/100).");
+}

--- a/Corruption/Scripts/sys_on_load.nss
+++ b/Corruption/Scripts/sys_on_load.nss
@@ -1,0 +1,9 @@
+// sys_on_load.nss  –  Corruption: OnModuleLoad hook
+// Call this from the module's OnModuleLoad event script.
+
+#include "lib_cor_def"
+
+void main()
+{
+    CorCreateTables();
+}

--- a/Corruption/Scripts/sys_on_rest.nss
+++ b/Corruption/Scripts/sys_on_rest.nss
@@ -1,0 +1,57 @@
+// sys_on_rest.nss  –  Corruption: OnPlayerRest (FINISHED) hook
+// Two effects on rest:
+//   1. Sanctuary area: resting here cleanses COR_SANCTUARY_REDUCTION points.
+//   2. Nightmare: corrupted characters (stage >= FALLEN) may receive a vivid
+//      description of their soul's state as a lore moment.
+
+#include "lib_cor"
+
+void main()
+{
+    object oPC = GetLastPCRested();
+    if(!GetIsObjectValid(oPC)) return;
+    if(GetLastRestEventType() != REST_EVENTTYPE_REST_FINISHED) return;
+
+    int nCorruption = GetLocalInt(oPC, COR_LVAR_CORRUPTION);
+    int nStage      = CorGetStage(nCorruption);
+
+    // Sanctuary bonus
+    object oArea = GetArea(oPC);
+    if(GetLocalInt(oArea, COR_LVAR_AREA_SANCTUARY))
+    {
+        if(nCorruption > 0)
+        {
+            SendMessageToPC(oPC,
+                "[Korupcja] Święte miejsce łagodzi ciemność twej duszy.");
+            CorReduceCorruption(oPC, COR_SANCTUARY_REDUCTION);
+        }
+        return;
+    }
+
+    // Nightmare messages for corrupted PCs (flavor only, no mechanical effect)
+    if(nStage >= COR_STAGE_FALLEN)
+    {
+        string sNightmare;
+        switch(nStage)
+        {
+            case COR_STAGE_FALLEN:
+                sNightmare =
+                    "Budzisz się pokryty zimnym potem. Twoje sny były ciemne "
+                    "i pełne twarzy, którym wyrządziłeś krzywdę.";
+                break;
+            case COR_STAGE_CURSED:
+                sNightmare =
+                    "Sen nie przyniósł ukojenia — widziałeś siebie jako cień, "
+                    "bezgłośnie krzyczący w pustce. Coś obserwowało cię z ciemności.";
+                break;
+            case COR_STAGE_DAMNED:
+                sNightmare =
+                    "Obudziłeś się z krzykiem, który nie wydostał się z twoich ust. "
+                    "Wokół ciebie przez chwilę wisiały sylwetki potępionych. "
+                    "Ich twarze były twoją twarzą.";
+                break;
+        }
+        if(sNightmare != "")
+            SendMessageToPC(oPC, "[Korupcja] " + sNightmare);
+    }
+}

--- a/Corruption/Scripts/test_cor.nss
+++ b/Corruption/Scripts/test_cor.nss
@@ -1,0 +1,48 @@
+// test_cor.nss  –  Corruption: OnUsed script for a demonstration placeable
+//
+// Placeable tag: "test_corruption"
+//
+// First use:  opens the Corruption Soul panel for the activating PC.
+// Second use (within same session): adds 15 corruption points for testing.
+// Third use:  subtracts 15 corruption points.
+// Cycles through gain / reduce so testers can walk through all stages.
+//
+// Place a campfire or shrine placeable in your test area, assign this
+// script to its OnUsed event, and give the placeable the tag "test_corruption".
+
+#include "lib_cor"
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    int nMode = GetLocalInt(OBJECT_SELF, "TEST_COR_MODE");
+
+    switch(nMode % 3)
+    {
+        case 0:
+            // Open the soul panel
+            CorOpenWindow(oPC);
+            SendMessageToPC(oPC,
+                "[Test Korupcja] Panel otwarty. Użyj ponownie by dodać 15 pkt korupcji.");
+            break;
+
+        case 1:
+            // Gain corruption
+            CorGainCorruption(oPC, 15,
+                "Mroczna energia z obiektu testowego przenika przez twoje ciało.");
+            SendMessageToPC(oPC,
+                "[Test Korupcja] +15 korupcji. Użyj ponownie by odjąć 15 pkt.");
+            break;
+
+        case 2:
+            // Reduce corruption
+            CorReduceCorruption(oPC, 15);
+            SendMessageToPC(oPC,
+                "[Test Korupcja] -15 korupcji. Użyj ponownie by otworzyć panel.");
+            break;
+    }
+
+    SetLocalInt(OBJECT_SELF, "TEST_COR_MODE", (nMode + 1) % 3);
+}


### PR DESCRIPTION
## Co to robi

System Korupcji Duszy śledzi moralne zepsucie postaci graczy jako wartość 0–100 (per postać, persystentna w SQLite). Pięć stadiów — Nieskażony, Skażony, Upadły, Przeklęty, Potępiony — aplikuje narastające kary atrybutów i efekty wizualne. Gracz może oczyścić duszę przez rytuał pokuty w oknie NUI, użycie Święconej Wody lub odpoczynek w uświęconym miejscu.

## Mechanika

- **Skala:** 0–100 (SQL campaign DB `corruption`). Każde stadium zaczyna się co 20 punktów.
- **Kary:**
  - Skażony (20–39): −1 CHA
  - Upadły (40–59): −2 CHA, −1 WIS
  - Przeklęty (60–79): −4 CHA, −2 WIS + aura wizualna
  - Potępiony (80–100): −6 CHA, −4 WIS, −2 STR + aura wizualna
- **Przyrost:** `CorGainCorruption(oPC, nAmount, sFlavor)` — wywoływana z zewnątrz (OnCreatureDeath, ciemne artefakty z LVAR `COR_DARK_ARTIFACT`, itd.).
- **Redukcja:** rytuał NUI (500 zł, cooldown 24h, −15 pkt); Święcona Woda (tag `cor_holy_water`, −10 pkt); odpoczynek w sanctuary area (LVAR `COR_AREA_SANCTUARY=1`, −3 pkt).
- **Efekty permanentne** są tagowane `COR_EFFECT` — usuwane i re-aplikowane przy każdej zmianie stadium; przywracane przy OnClientEnter.
- **Koszmary** — narracyjne wiadomości dla Upadłych/Przeklętych/Potępionych po odpoczynku poza sanctuary.

## Pliki

```
Corruption/
├── INTEGRATION.md
└── Scripts/
    ├── sql_cor.nss          — schemat SQLite + CRUD
    ├── lib_cor_def.nss      — stałe, stadium-data, bind IDs
    ├── lib_cor.nss          — rdzeń: efekty, API, NUI layout, okno
    ├── lib_cor_ev.nss       — handler NUI eventów
    ├── lib_nui.nss          — (kopiowany z innych modułów)
    ├── lib_nui_utility.nss  — (kopiowany z innych modułów)
    ├── sys_on_load.nss      — OnModuleLoad: CREATE TABLE IF NOT EXISTS
    ├── sys_on_enter.nss     — OnClientEnter: wczytaj DB, re-aplikuj efekty
    ├── sys_on_rest.nss      — OnPlayerRest: sanctuary bonus / koszmary
    ├── sys_on_activate.nss  — OnActivateItem: święcona woda + mroczne artefakty
    ├── sys_on_death.nss     — OnPlayerDeath: opcjonalny flavor dla Potępionych
    └── test_cor.nss         — OnUsed demo (cykluje open / +15 / -15)
```

**LOC własnego NWScript:** 838 linii (bez skopiowanych lib_nui).

## Zależności (NWNX? SQL?)

- **NWNX:** nie wymagany.
- **SQLite:** `SqlPrepareQueryCampaign("corruption", ...)` — standardowy NWN EE API.
- Campaign DB `corruption` tworzona automatycznie przez silnik.

## Jak włączyć w istniejącym module

1. Skopiuj folder `Corruption/Scripts/` do katalogu skryptów modułu w toolsecie.
2. Podepnij hooki (szczegóły w `INTEGRATION.md`):
   - `sys_on_load` → OnModuleLoad
   - `sys_on_enter` → OnClientEnter
   - `sys_on_rest` → OnPlayerRest
   - `sys_on_activate` → OnActivateItem
   - `sys_on_death` → OnPlayerDeath (opcjonalnie)
3. Wywołuj `CorGainCorruption(oPC, nAmount, sFlavor)` z własnych skryptów (zabójstwa, ciemna magia).
4. Taguj mroczne artefakty (LVAR `COR_DARK_ARTIFACT = N`) i sanctuary areas (LVAR `COR_AREA_SANCTUARY = 1`).
5. Utwórz item z tagiem `cor_holy_water` jako konsumable.
6. (Opcjonalnie) Umieść placeable z `test_cor` jako OnUsed do testowania.

## Co celowo pominięto

- **Zmiany appearance** — wymagałyby NWNX:Player lub ingerencji w moduł Appearance; pozostawiono jako extension point.
- **Reakcje NPC** (SetReputation) — pominięte by uniknąć konfliktów z istniejącymi systemami reputacji i fakcji.
- **Heartbeat-based przyrost** — architektura to wspiera (`CorGainCorruption` jest public API), ale automatyczny przyrost co N sekund pominięto na rzecz event-driven triggering.
- **Kurator NPC** do rytuału — rytuał jest samoobsługowy w NUI; builder może wymagać obecności NPC przez własne warunki.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PNaFJX91iM4chzxbuG3VC6)_