### PR TITLE
feat: Blood Tracker (Ślady Krwi)

### DIFF
--- a/Blood Tracker/INTEGRATION.md
+++ b/Blood Tracker/INTEGRATION.md
@@ -1,0 +1,72 @@
+# Blood Tracker — Instrukcja integracji
+
+## Hooki wymagane
+
+| Zdarzenie modułu | Skrypt         | Uwagi |
+|------------------|----------------|-------|
+| OnModuleLoad     | sys_on_load    | Tworzy tabele SQLite |
+| OnHeartbeat      | sys_on_hb      | Śledzi HP graczy, odpada stare ślady, odświeża UI |
+
+## Otwieranie UI
+
+Wywołaj `BtrkOpen(oPC)` z dowolnego skryptu (np. OnUsed na placeable, rozmowa z NPC):
+
+```nwscript
+#include "lib_btrk"
+void main()
+{
+    BtrkOpen(GetPCSpeaker());
+}
+```
+
+## Ślady NPC
+
+**Bez NWNX:** Przypisz `sys_on_dmg` jako `OnDamaged` na wybranych kreaturach
+(przez Toolset lub spawn-script). Krew zostawiana jest tylko przez te stworzenia.
+
+**Z NWNX_Events:** W `sys_on_load.nss` dodaj globalną rejestrację zdarzenia:
+
+```nwscript
+#include "nwnx_events"
+void main()
+{
+    BtrkCreateTables();
+    NWNX_Events_SubscribeEvent("NWNX_ON_CREATURE_DAMAGE_AFTER", "sys_on_dmg_nx");
+}
+```
+
+Stwórz `sys_on_dmg_nx.nss`:
+
+```nwscript
+#include "lib_btrk"
+#include "nwnx_events"
+void main()
+{
+    object oTarget = OBJECT_SELF;
+    if(GetIsPC(oTarget)) return;
+    int nDmg = StringToInt(NWNX_Events_GetEventData("DAMAGE_TOTAL"));
+    BtrkDropTrail(oTarget, nDmg);
+}
+```
+
+## SQL — baza danych
+
+Dane zapisywane są w kampanii `blood_tracker` (dwa pliki: `blood_tracker.sqlite`
+w katalogu `<module>/` lub standardowym katalogu kampanii NWN).
+
+Tabele:
+- `blood_trails` — aktywne ślady z lokalizacją, źródłem, TTL
+- `btrk_discoveries` — historia odkryć per gracz (żeby nie liczyć tego samego śladu dwa razy)
+
+## Testowanie
+
+1. Umieść placeable z `OnUsed = test_btrk` w module.
+2. Uruchom moduł, kliknij placeable — pojawi się UI i 3 testowe ślady.
+3. Aktywuj tropienie → Szukaj Śladów → sprawdź kierunek i wpisy dziennika.
+4. Zranij postać (strata ≥ 5 HP) — heartbeat po ≤6 s wstawi ślad do bazy.
+
+## Co celowo pominięto
+
+- Wizualne markery 3D (efekty VFX na ziemi) — wymagają haka z animowanym placeable lub NWNX_Object
+- Reagowanie na wejście w odległość śladu automatycznie (bez kliknięcia) — wymagałoby persistentnego AoE lub tick-based proximity check per tracker
+- Persistentne statystyki (liczba odkrytych śladów, rekordy) — łatwe do dodania przez kolejną tabelę SQL

--- a/Blood Tracker/Scripts/lib_btrk.nss
+++ b/Blood Tracker/Scripts/lib_btrk.nss
@@ -1,0 +1,411 @@
+#include "sql_btrk"
+#include "nw_inc_nui"
+
+void BtrkOpen(object oPC);
+void BtrkFeedDisplay(object oPC, int nToken);
+void BtrkAddLog(object oPC, string sEntry);
+void BtrkSearchTrails(object oPC, int nToken);
+void BtrkRefreshTrackerUI(object oPC);
+
+// ----------------------------------------------------------------
+// Compass / text helpers
+// ----------------------------------------------------------------
+
+// VectorToAngle returns 0=East, 90=North (NWN convention).
+string BtrkCompassLabel(float fAngle)
+{
+    if(fAngle >= 337.5 || fAngle < 22.5)  return "WSCHÓD";
+    if(fAngle < 67.5)                      return "PÓŁNOCNY-WSCHÓD";
+    if(fAngle < 112.5)                     return "PÓŁNOC";
+    if(fAngle < 157.5)                     return "PÓŁNOCNY-ZACHÓD";
+    if(fAngle < 202.5)                     return "ZACHÓD";
+    if(fAngle < 247.5)                     return "POŁUDNIOWY-ZACHÓD";
+    if(fAngle < 292.5)                     return "POŁUDNIE";
+    return "POŁUDNIOWY-WSCHÓD";
+}
+
+string BtrkDistanceLabel(float fDist)
+{
+    if(fDist < 4.0)  return "bardzo blisko (poniżej 4 m)";
+    if(fDist < 12.0) return "blisko (ok. " + IntToString(FloatToInt(fDist)) + " m)";
+    if(fDist < 28.0) return "w pobliżu (ok. " + IntToString(FloatToInt(fDist)) + " m)";
+    return "daleko (ok. " + IntToString(FloatToInt(fDist)) + " m)";
+}
+
+string BtrkFreshnessLabel(int nAgeSeconds)
+{
+    if(nAgeSeconds < BTRK_DECAY_FRESH) return "Świeże";
+    if(nAgeSeconds < BTRK_DECAY_STALE) return "Stare";
+    return "Lodowate";
+}
+
+int BtrkFreshnessDC(int nAgeSeconds)
+{
+    if(nAgeSeconds < BTRK_DECAY_FRESH) return BTRK_DC_FRESH;
+    if(nAgeSeconds < BTRK_DECAY_STALE) return BTRK_DC_STALE;
+    return BTRK_DC_COLD;
+}
+
+string BtrkFreshnessColor(int nAgeSeconds)
+{
+    // Colour prefix tags for log entries only — not used in NUI color binds
+    if(nAgeSeconds < BTRK_DECAY_FRESH) return "<c=red>";
+    if(nAgeSeconds < BTRK_DECAY_STALE) return "<c=orange>";
+    return "<c=gray>";
+}
+
+// ----------------------------------------------------------------
+// NUI layout builder
+// ----------------------------------------------------------------
+
+json BtrkBuildWindow(object oPC)
+{
+    float fW    = GetNuiScaleDimension(oPC, 310.0);
+    float fH    = GetNuiScaleDimension(oPC, 460.0);
+    float fBtnH = GetNuiScaleDimension(oPC, 30.0);
+    float fRowH = GetNuiScaleDimension(oPC, 22.0);
+    float fLblH = GetNuiScaleDimension(oPC, 20.0);
+
+    // ---- Header row ----
+    json jTitle = NuiLabel(JsonString("Tropiciel Krwi"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitle = NuiHeight(jTitle, fBtnH);
+
+    json jCloseBtn = NuiButton(JsonString("X"));
+    jCloseBtn = NuiId(jCloseBtn, BTRK_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, fBtnH);
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jHdrElems = JsonArray();
+    jHdrElems = JsonArrayInsert(jHdrElems, jTitle);
+    jHdrElems = JsonArrayInsert(jHdrElems, jCloseBtn);
+    json jHeader = NuiRow(jHdrElems);
+
+    // ---- Status row ----
+    json jStatusLbl = NuiLabel(NuiBind(BTRK_BIND_STATUS_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jStatusLbl = NuiStyleForegroundColor(jStatusLbl, NuiBind(BTRK_BIND_STATUS_COL));
+    jStatusLbl = NuiHeight(jStatusLbl, fBtnH);
+
+    json jActBtn = NuiButton(NuiBind(BTRK_BIND_ACT_LBL));
+    jActBtn = NuiId(jActBtn, BTRK_BTN_ACTIVATE);
+    jActBtn = NuiWidth(jActBtn, GetNuiScaleDimension(oPC, 120.0));
+    jActBtn = NuiHeight(jActBtn, fBtnH);
+
+    json jStatusElems = JsonArray();
+    jStatusElems = JsonArrayInsert(jStatusElems, jStatusLbl);
+    jStatusElems = JsonArrayInsert(jStatusElems, jActBtn);
+    json jStatusRow = NuiRow(jStatusElems);
+
+    // ---- Divider ----
+    json jDiv1 = NuiLabel(JsonString("────────── Ślad ──────────────────"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jDiv1 = NuiHeight(jDiv1, fLblH);
+
+    // ---- Trail direction ----
+    json jDirLbl = NuiLabel(NuiBind(BTRK_BIND_DIR_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jDirLbl = NuiHeight(jDirLbl, fRowH);
+
+    // ---- Freshness ----
+    json jFreshLbl = NuiLabel(NuiBind(BTRK_BIND_FRESH_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jFreshLbl = NuiHeight(jFreshLbl, fRowH);
+
+    // ---- Distance ----
+    json jDistLbl = NuiLabel(NuiBind(BTRK_BIND_DIST_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jDistLbl = NuiHeight(jDistLbl, fRowH);
+
+    // ---- Source ----
+    json jSrcLbl = NuiLabel(NuiBind(BTRK_BIND_SRC_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jSrcLbl = NuiHeight(jSrcLbl, fRowH);
+
+    // ---- Search button ----
+    json jSearchBtn = NuiButton(JsonString("Szukaj Śladów"));
+    jSearchBtn = NuiId(jSearchBtn, BTRK_BTN_SEARCH);
+    jSearchBtn = NuiEnabled(jSearchBtn, NuiBind(BTRK_BIND_SEARCH_ENA));
+    jSearchBtn = NuiHeight(jSearchBtn, fBtnH);
+
+    // ---- Log divider ----
+    json jDiv2 = NuiLabel(JsonString("────────── Dziennik ──────────────"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jDiv2 = NuiHeight(jDiv2, fLblH);
+
+    // ---- Log list ----
+    json jLogLbl = NuiLabel(NuiBind(BTRK_BIND_LOG_ROW),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    json jLogCell = NuiListTemplateCell(jLogLbl, 0.0, TRUE);
+    json jLogTmpl = JsonArrayInsert(JsonArray(), jLogCell);
+    json jLogList = NuiList(jLogTmpl, NuiBind(BTRK_BIND_LOG_COUNT), fRowH);
+    jLogList = NuiHeight(jLogList, fRowH * BTRK_LOG_MAX + 4.0);
+
+    // ---- Clear log button ----
+    json jClearBtn = NuiButton(JsonString("Wyczyść Dziennik"));
+    jClearBtn = NuiId(jClearBtn, BTRK_BTN_CLEAR_LOG);
+    jClearBtn = NuiHeight(jClearBtn, fBtnH);
+
+    // ---- Assemble root column ----
+    json jRootElems = JsonArray();
+    jRootElems = JsonArrayInsert(jRootElems, jHeader);
+    jRootElems = JsonArrayInsert(jRootElems, jStatusRow);
+    jRootElems = JsonArrayInsert(jRootElems, jDiv1);
+    jRootElems = JsonArrayInsert(jRootElems, jDirLbl);
+    jRootElems = JsonArrayInsert(jRootElems, jFreshLbl);
+    jRootElems = JsonArrayInsert(jRootElems, jDistLbl);
+    jRootElems = JsonArrayInsert(jRootElems, jSrcLbl);
+    jRootElems = JsonArrayInsert(jRootElems, jSearchBtn);
+    jRootElems = JsonArrayInsert(jRootElems, jDiv2);
+    jRootElems = JsonArrayInsert(jRootElems, jLogList);
+    jRootElems = JsonArrayInsert(jRootElems, jClearBtn);
+    json jRoot = NuiCol(jRootElems);
+
+    json jWin = NuiWindow(jRoot,
+        JsonBool(FALSE),
+        NuiBind(BTRK_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    return jWin;
+}
+
+// ----------------------------------------------------------------
+// Window open / feed
+// ----------------------------------------------------------------
+
+void BtrkOpen(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, BTRK_WINDOW);
+    if(nToken != 0)
+    {
+        BtrkFeedDisplay(oPC, nToken);
+        return;
+    }
+
+    float fGuiW = IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH));
+    float fGuiH = IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT));
+    float fWinW = GetNuiScaleDimension(oPC, 310.0);
+    float fWinH = GetNuiScaleDimension(oPC, 460.0);
+    json jGeom  = NuiRect(
+        (fGuiW - fWinW) / 2.0,
+        (fGuiH - fWinH) / 2.0,
+        fWinW, fWinH);
+
+    json jWin = BtrkBuildWindow(oPC);
+    nToken = NuiCreate(oPC, jWin, BTRK_WINDOW, BTRK_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, BTRK_WIN_GEOM, jGeom);
+
+    BtrkFeedDisplay(oPC, nToken);
+}
+
+// Pushes all data-binds for the current state of oPC.
+void BtrkFeedDisplay(object oPC, int nToken)
+{
+    int bActive = GetLocalInt(oPC, BTRK_LVAR_ACTIVE);
+
+    // Status + activate button
+    if(bActive)
+    {
+        NuiSetBind(oPC, nToken, BTRK_BIND_STATUS_LBL, JsonString("Tryb: AKTYWNY"));
+        NuiSetBind(oPC, nToken, BTRK_BIND_STATUS_COL, NuiColor(180, 60, 60));
+        NuiSetBind(oPC, nToken, BTRK_BIND_ACT_LBL,    JsonString("Dezaktywuj"));
+    }
+    else
+    {
+        NuiSetBind(oPC, nToken, BTRK_BIND_STATUS_LBL, JsonString("Tryb: NIEAKTYWNY"));
+        NuiSetBind(oPC, nToken, BTRK_BIND_STATUS_COL, NuiColor(120, 120, 120));
+        NuiSetBind(oPC, nToken, BTRK_BIND_ACT_LBL,    JsonString("Aktywuj"));
+    }
+
+    NuiSetBind(oPC, nToken, BTRK_BIND_SEARCH_ENA, JsonBool(bActive));
+
+    // Trail panel — refresh from stored tracked id if active
+    int nTrackedId = GetLocalInt(oPC, BTRK_LVAR_TRACKED_ID);
+    if(bActive && nTrackedId > 0)
+    {
+        json jTrail = BtrkGetTrailById(nTrackedId);
+        if(JsonGetType(jTrail) != JSON_TYPE_NULL)
+        {
+            float fTX  = JsonGetFloat(JsonObjectGet(jTrail, "pos_x"));
+            float fTY  = JsonGetFloat(JsonObjectGet(jTrail, "pos_y"));
+            vector vPC = GetPosition(oPC);
+            float fDX  = fTX - vPC.x;
+            float fDY  = fTY - vPC.y;
+            float fDist = sqrt(fDX * fDX + fDY * fDY);
+            float fAngle = VectorToAngle(Vector(fDX, fDY, 0.0));
+
+            int nAge      = BtrkGetAgeSeconds(JsonGetInt(JsonObjectGet(jTrail, "created_at")));
+            string sFresh = BtrkFreshnessLabel(nAge);
+            string sName  = JsonGetString(JsonObjectGet(jTrail, "source_name"));
+            int nAmt      = JsonGetInt(JsonObjectGet(jTrail, "blood_amt"));
+
+            NuiSetBind(oPC, nToken, BTRK_BIND_DIR_LBL,
+                JsonString("Kierunek: " + BtrkCompassLabel(fAngle)));
+            NuiSetBind(oPC, nToken, BTRK_BIND_FRESH_LBL,
+                JsonString("Świeżość: " + sFresh));
+            NuiSetBind(oPC, nToken, BTRK_BIND_DIST_LBL,
+                JsonString("Odległość: " + BtrkDistanceLabel(fDist)));
+            string sBleed = nAmt >= 30 ? " (ciężka rana)" : "";
+            NuiSetBind(oPC, nToken, BTRK_BIND_SRC_LBL,
+                JsonString("Ofiara: " + sName + sBleed));
+        }
+        else
+        {
+            // Trail expired
+            DeleteLocalInt(oPC, BTRK_LVAR_TRACKED_ID);
+            NuiSetBind(oPC, nToken, BTRK_BIND_DIR_LBL,   JsonString("Ślad wystygł..."));
+            NuiSetBind(oPC, nToken, BTRK_BIND_FRESH_LBL, JsonString(""));
+            NuiSetBind(oPC, nToken, BTRK_BIND_DIST_LBL,  JsonString(""));
+            NuiSetBind(oPC, nToken, BTRK_BIND_SRC_LBL,   JsonString(""));
+        }
+    }
+    else if(!bActive)
+    {
+        NuiSetBind(oPC, nToken, BTRK_BIND_DIR_LBL,   JsonString("Aktywuj tropienie, by szukać śladów."));
+        NuiSetBind(oPC, nToken, BTRK_BIND_FRESH_LBL, JsonString(""));
+        NuiSetBind(oPC, nToken, BTRK_BIND_DIST_LBL,  JsonString(""));
+        NuiSetBind(oPC, nToken, BTRK_BIND_SRC_LBL,   JsonString(""));
+    }
+    else
+    {
+        NuiSetBind(oPC, nToken, BTRK_BIND_DIR_LBL,   JsonString("Brak tropionego śladu. Użyj Szukaj."));
+        NuiSetBind(oPC, nToken, BTRK_BIND_FRESH_LBL, JsonString(""));
+        NuiSetBind(oPC, nToken, BTRK_BIND_DIST_LBL,  JsonString(""));
+        NuiSetBind(oPC, nToken, BTRK_BIND_SRC_LBL,   JsonString(""));
+    }
+
+    // Log
+    json jLog  = GetLocalJson(oPC, BTRK_LVAR_LOG);
+    if(JsonGetType(jLog) != JSON_TYPE_ARRAY) jLog = JsonArray();
+    NuiSetBind(oPC, nToken, BTRK_BIND_LOG_ROW,   jLog);
+    NuiSetBind(oPC, nToken, BTRK_BIND_LOG_COUNT, JsonInt(JsonGetLength(jLog)));
+}
+
+// ----------------------------------------------------------------
+// Log management
+// ----------------------------------------------------------------
+
+void BtrkAddLog(object oPC, string sEntry)
+{
+    json jLog = GetLocalJson(oPC, BTRK_LVAR_LOG);
+    if(JsonGetType(jLog) != JSON_TYPE_ARRAY) jLog = JsonArray();
+
+    // Prepend newest entry so list shows most recent at top
+    json jNew = JsonArray();
+    jNew = JsonArrayInsert(jNew, JsonString(sEntry));
+    int i;
+    int nCount = JsonGetLength(jLog);
+    for(i = 0; i < nCount && i < BTRK_LOG_MAX - 1; i++)
+        jNew = JsonArrayInsert(jNew, JsonArrayGet(jLog, i));
+
+    SetLocalJson(oPC, BTRK_LVAR_LOG, jNew);
+}
+
+// ----------------------------------------------------------------
+// Trail search (skill check + nearest trail lookup)
+// ----------------------------------------------------------------
+
+void BtrkSearchTrails(object oPC, int nToken)
+{
+    string sArea  = GetTag(GetArea(oPC));
+    vector vPC    = GetPosition(oPC);
+    string sUUID  = GetObjectUUID(oPC);
+
+    json jTrail = BtrkFindNearest(sArea, vPC.x, vPC.y, sUUID);
+
+    if(JsonGetType(jTrail) == JSON_TYPE_NULL)
+    {
+        SendMessageToPC(oPC, "[Tropiciel] Nie znaleziono żadnych śladów w pobliżu.");
+        BtrkAddLog(oPC, "Brak śladów w pobliżu.");
+        BtrkFeedDisplay(oPC, nToken);
+        return;
+    }
+
+    int nCreatedAt = JsonGetInt(JsonObjectGet(jTrail, "created_at"));
+    int nAge       = BtrkGetAgeSeconds(nCreatedAt);
+    int nDC        = BtrkFreshnessDC(nAge);
+    int nSkill     = GetSkillRank(SKILL_SEARCH, oPC) + d20();
+
+    if(nSkill < nDC)
+    {
+        // Failed — vague or wrong direction as flavor
+        string sWrong = "Ślady zacierają się... nie możesz ich odczytać. (DC " +
+            IntToString(nDC) + ", rzut: " + IntToString(nSkill) + ")";
+        SendMessageToPC(oPC, "[Tropiciel] " + sWrong);
+        BtrkAddLog(oPC, "Rzut nieudany — DC " + IntToString(nDC) + ".");
+        BtrkFeedDisplay(oPC, nToken);
+        return;
+    }
+
+    // Success
+    int nId        = JsonGetInt(JsonObjectGet(jTrail, "id"));
+    string sName   = JsonGetString(JsonObjectGet(jTrail, "source_name"));
+    float fDist    = JsonGetFloat(JsonObjectGet(jTrail, "dist"));
+    float fTX      = JsonGetFloat(JsonObjectGet(jTrail, "pos_x"));
+    float fTY      = JsonGetFloat(JsonObjectGet(jTrail, "pos_y"));
+    float fAngle   = VectorToAngle(Vector(fTX - vPC.x, fTY - vPC.y, 0.0));
+    string sFresh  = BtrkFreshnessLabel(nAge);
+    int nBlood     = JsonGetInt(JsonObjectGet(jTrail, "blood_amt"));
+
+    SetLocalInt(oPC, BTRK_LVAR_TRACKED_ID, nId);
+    BtrkMarkDiscovered(sUUID, nId);
+    GiveXPToCreature(oPC, BTRK_XP_PER_TRAIL);
+
+    string sLog = sFresh + " ślad — " + BtrkCompassLabel(fAngle)
+        + " (" + IntToString(FloatToInt(fDist)) + "m)"
+        + (nBlood >= 30 ? " [ciężki]" : "");
+    BtrkAddLog(oPC, sLog);
+
+    string sMsg = "[Tropiciel] Odnalazłeś ślad " + sName + "! "
+        + sFresh + ", kierunek: " + BtrkCompassLabel(fAngle)
+        + ", " + BtrkDistanceLabel(fDist) + ". (DC " + IntToString(nDC)
+        + ", rzut: " + IntToString(nSkill) + ")";
+    SendMessageToPC(oPC, sMsg);
+
+    BtrkFeedDisplay(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Heartbeat refresh — called from sys_on_hb for each active tracker
+// ----------------------------------------------------------------
+
+void BtrkRefreshTrackerUI(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, BTRK_WINDOW);
+    if(nToken == 0) return;
+    BtrkFeedDisplay(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Trail drop — called from sys_on_dmg (NPCs) or sys_on_hb (PCs)
+// ----------------------------------------------------------------
+
+void BtrkClearBleedLock(object oCreature)
+{
+    DeleteLocalInt(oCreature, "BTRK_BLEED_LOCK");
+}
+
+void BtrkDropTrail(object oCreature, int nDamage)
+{
+    if(nDamage < BTRK_MIN_BLEED_DMG) return;
+
+    // Per-creature cooldown: one trail entry per BTRK_BLEED_COOLDOWN seconds max.
+    // DelayCommand resets the lock after the cooldown — no tick arithmetic needed.
+    if(GetLocalInt(oCreature, "BTRK_BLEED_LOCK")) return;
+    SetLocalInt(oCreature, "BTRK_BLEED_LOCK", 1);
+    DelayCommand(IntToFloat(BTRK_BLEED_COOLDOWN), BtrkClearBleedLock(oCreature));
+
+    object oArea = GetArea(oCreature);
+    if(!GetIsObjectValid(oArea)) return;
+
+    string sArea = GetTag(oArea);
+    vector vPos  = GetPosition(oCreature);
+    string sUUID = GetIsPC(oCreature) ? GetObjectUUID(oCreature) : "";
+    string sName = GetName(oCreature);
+
+    BtrkInsertTrail(sArea, vPos.x, vPos.y, vPos.z, sUUID, sName, nDamage);
+}

--- a/Blood Tracker/Scripts/lib_btrk_def.nss
+++ b/Blood Tracker/Scripts/lib_btrk_def.nss
@@ -1,0 +1,51 @@
+// Blood Tracker — constants and NUI bind identifiers.
+
+// ---- Window IDs ----
+const string BTRK_WINDOW           = "BTRK_WINDOW";
+const string BTRK_EV_SCRIPT        = "lib_btrk_ev";
+const string BTRK_WIN_GEOM         = "btrk_win_geom";
+
+// ---- NUI bind names ----
+const string BTRK_BIND_STATUS_LBL  = "btrk_status_lbl";
+const string BTRK_BIND_STATUS_COL  = "btrk_status_col";
+const string BTRK_BIND_ACT_LBL     = "btrk_act_lbl";
+const string BTRK_BIND_SEARCH_ENA  = "btrk_search_ena";
+const string BTRK_BIND_DIR_LBL     = "btrk_dir_lbl";
+const string BTRK_BIND_FRESH_LBL   = "btrk_fresh_lbl";
+const string BTRK_BIND_DIST_LBL    = "btrk_dist_lbl";
+const string BTRK_BIND_SRC_LBL     = "btrk_src_lbl";
+const string BTRK_BIND_LOG_ROW     = "btrk_log_row";
+const string BTRK_BIND_LOG_COUNT   = "btrk_log_count";
+
+// ---- Button IDs ----
+const string BTRK_BTN_CLOSE        = "btrk_btn_close";
+const string BTRK_BTN_ACTIVATE     = "btrk_btn_activate";
+const string BTRK_BTN_SEARCH       = "btrk_btn_search";
+const string BTRK_BTN_CLEAR_LOG    = "btrk_btn_clearlog";
+
+// ---- Local variables on PC object ----
+const string BTRK_LVAR_ACTIVE      = "BTRK_ACTIVE";        // 1 when tracking mode on
+const string BTRK_LVAR_TRACKED_ID  = "BTRK_TRACKED_ID";    // trail id currently tracked
+const string BTRK_LVAR_LOG         = "BTRK_LOG";            // JsonArray of log entry strings
+const string BTRK_LVAR_HB_TICK     = "BTRK_HB_TICK";       // heartbeat tick counter on MODULE
+
+// ---- Tuning ----
+const float  BTRK_SEARCH_RANGE     = 45.0;   // meters — max trail search radius
+const int    BTRK_DECAY_FRESH      = 300;    // seconds until stale
+const int    BTRK_DECAY_STALE      = 900;    // seconds until cold
+const int    BTRK_DECAY_COLD       = 1800;   // seconds until expiry
+const int    BTRK_DC_FRESH         = 10;     // Search DC for fresh trail
+const int    BTRK_DC_STALE         = 16;     // Search DC for stale trail
+const int    BTRK_DC_COLD          = 22;     // Search DC for cold trail
+const int    BTRK_LOG_MAX          = 7;      // visible rows in log list
+const int    BTRK_XP_PER_TRAIL     = 20;    // XP per newly discovered trail
+const int    BTRK_MIN_BLEED_DMG    = 5;      // min damage to leave a trail
+
+// Creatures bleed at most once per interval (seconds) to avoid spam
+const int    BTRK_BLEED_COOLDOWN   = 8;
+
+// Heartbeat ticks between UI refreshes for active trackers
+const int    BTRK_REFRESH_TICKS    = 2;
+
+// SQLite campaign database name
+const string BTRK_CAMPAIGN_DB      = "blood_tracker";

--- a/Blood Tracker/Scripts/lib_btrk_ev.nss
+++ b/Blood Tracker/Scripts/lib_btrk_ev.nss
@@ -1,0 +1,64 @@
+#include "lib_btrk"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+
+    if(nToken != NuiFindWindow(oPC, BTRK_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        // Tracking mode persists across window closes — intentional.
+        // The PC must explicitly press Dezaktywuj to stop leaving trails.
+        return;
+    }
+
+    if(sEvent != EVENT_TYPE_CLICK) return;
+
+    if(sElem == BTRK_BTN_CLOSE)
+    {
+        NuiDestroy(oPC, nToken);
+        return;
+    }
+
+    if(sElem == BTRK_BTN_ACTIVATE)
+    {
+        int bActive = GetLocalInt(oPC, BTRK_LVAR_ACTIVE);
+        if(bActive)
+        {
+            DeleteLocalInt(oPC, BTRK_LVAR_ACTIVE);
+            DeleteLocalInt(oPC, BTRK_LVAR_TRACKED_ID);
+            SendMessageToPC(oPC, "[Tropiciel] Tryb tropienia dezaktywowany.");
+            BtrkAddLog(oPC, "--- Tropienie wyłączone ---");
+        }
+        else
+        {
+            SetLocalInt(oPC, BTRK_LVAR_ACTIVE, 1);
+            SendMessageToPC(oPC, "[Tropiciel] Tryb tropienia aktywowany. Pieczęć krwi pulsuje słabo...");
+            BtrkAddLog(oPC, "--- Tropienie włączone ---");
+        }
+        BtrkFeedDisplay(oPC, nToken);
+        return;
+    }
+
+    if(sElem == BTRK_BTN_SEARCH)
+    {
+        if(!GetLocalInt(oPC, BTRK_LVAR_ACTIVE))
+        {
+            SendMessageToPC(oPC, "[Tropiciel] Najpierw aktywuj tryb tropienia.");
+            return;
+        }
+        BtrkSearchTrails(oPC, nToken);
+        return;
+    }
+
+    if(sElem == BTRK_BTN_CLEAR_LOG)
+    {
+        DeleteLocalJson(oPC, BTRK_LVAR_LOG);
+        BtrkFeedDisplay(oPC, nToken);
+        return;
+    }
+}

--- a/Blood Tracker/Scripts/sql_btrk.nss
+++ b/Blood Tracker/Scripts/sql_btrk.nss
@@ -1,0 +1,150 @@
+#include "lib_btrk_def"
+
+void BtrkCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign(BTRK_CAMPAIGN_DB,
+        "CREATE TABLE IF NOT EXISTS blood_trails ("
+        "  id          INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "  area_tag    TEXT    NOT NULL DEFAULT '',"
+        "  pos_x       REAL    NOT NULL DEFAULT 0,"
+        "  pos_y       REAL    NOT NULL DEFAULT 0,"
+        "  pos_z       REAL    NOT NULL DEFAULT 0,"
+        "  source_uuid TEXT    NOT NULL DEFAULT '',"
+        "  source_name TEXT    NOT NULL DEFAULT '',"
+        "  blood_amt   INTEGER NOT NULL DEFAULT 0,"
+        "  created_at  INTEGER NOT NULL DEFAULT (strftime('%s','now')),"
+        "  expires_at  INTEGER NOT NULL DEFAULT 0"
+        ")");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign(BTRK_CAMPAIGN_DB,
+        "CREATE INDEX IF NOT EXISTS idx_btrk_area ON blood_trails (area_tag, expires_at)");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign(BTRK_CAMPAIGN_DB,
+        "CREATE TABLE IF NOT EXISTS btrk_discoveries ("
+        "  tracker_uuid TEXT    NOT NULL,"
+        "  trail_id     INTEGER NOT NULL,"
+        "  found_at     INTEGER NOT NULL DEFAULT (strftime('%s','now')),"
+        "  PRIMARY KEY (tracker_uuid, trail_id)"
+        ")");
+    SqlStep(q);
+}
+
+void BtrkInsertTrail(string sAreaTag, float fX, float fY, float fZ,
+                     string sUUID, string sName, int nDamage)
+{
+    sqlquery q = SqlPrepareQueryCampaign(BTRK_CAMPAIGN_DB,
+        "INSERT INTO blood_trails (area_tag, pos_x, pos_y, pos_z, source_uuid, source_name, blood_amt, expires_at) "
+        "VALUES (@area, @x, @y, @z, @uuid, @name, @dmg, strftime('%s','now') + @exp)");
+    SqlBindString(q, "@area", sAreaTag);
+    SqlBindFloat (q, "@x",    fX);
+    SqlBindFloat (q, "@y",    fY);
+    SqlBindFloat (q, "@z",    fZ);
+    SqlBindString(q, "@uuid", sUUID);
+    SqlBindString(q, "@name", sName);
+    SqlBindInt   (q, "@dmg",  nDamage);
+    SqlBindInt   (q, "@exp",  BTRK_DECAY_COLD);
+    SqlStep(q);
+}
+
+void BtrkDecayExpired()
+{
+    sqlquery q = SqlPrepareQueryCampaign(BTRK_CAMPAIGN_DB,
+        "DELETE FROM blood_trails WHERE expires_at < strftime('%s','now')");
+    SqlStep(q);
+
+    // Orphaned discovery records after trail deletion
+    q = SqlPrepareQueryCampaign(BTRK_CAMPAIGN_DB,
+        "DELETE FROM btrk_discoveries "
+        "WHERE trail_id NOT IN (SELECT id FROM blood_trails)");
+    SqlStep(q);
+}
+
+// Returns JSON object for nearest undiscovered trail in area within BTRK_SEARCH_RANGE.
+// Adds "dist" float field. Returns JsonNull() when nothing found.
+json BtrkFindNearest(string sAreaTag, float fPX, float fPY, string sTrackerUUID)
+{
+    sqlquery q = SqlPrepareQueryCampaign(BTRK_CAMPAIGN_DB,
+        "SELECT id, pos_x, pos_y, pos_z, source_name, source_uuid, blood_amt, created_at, "
+        "       ((pos_x - @px) * (pos_x - @px) + (pos_y - @py) * (pos_y - @py)) AS dist2 "
+        "FROM blood_trails "
+        "WHERE area_tag = @area "
+        "  AND expires_at > strftime('%s','now') "
+        "  AND id NOT IN (SELECT trail_id FROM btrk_discoveries WHERE tracker_uuid = @tuuid) "
+        "ORDER BY dist2 ASC "
+        "LIMIT 1");
+    SqlBindString(q, "@area",  sAreaTag);
+    SqlBindFloat (q, "@px",    fPX);
+    SqlBindFloat (q, "@py",    fPY);
+    SqlBindString(q, "@tuuid", sTrackerUUID);
+
+    if(!SqlStep(q)) return JsonNull();
+
+    float fDX   = SqlGetFloat(q, 1) - fPX;
+    float fDY   = SqlGetFloat(q, 2) - fPY;
+    float fDist = sqrt(fDX * fDX + fDY * fDY);
+
+    if(fDist > BTRK_SEARCH_RANGE) return JsonNull();
+
+    json j = JsonObject();
+    j = JsonObjectSet(j, "id",          JsonInt   (SqlGetInt   (q, 0)));
+    j = JsonObjectSet(j, "pos_x",       JsonFloat (SqlGetFloat (q, 1)));
+    j = JsonObjectSet(j, "pos_y",       JsonFloat (SqlGetFloat (q, 2)));
+    j = JsonObjectSet(j, "pos_z",       JsonFloat (SqlGetFloat (q, 3)));
+    j = JsonObjectSet(j, "source_name", JsonString(SqlGetString(q, 4)));
+    j = JsonObjectSet(j, "source_uuid", JsonString(SqlGetString(q, 5)));
+    j = JsonObjectSet(j, "blood_amt",   JsonInt   (SqlGetInt   (q, 6)));
+    j = JsonObjectSet(j, "created_at",  JsonInt   (SqlGetInt   (q, 7)));
+    j = JsonObjectSet(j, "dist",        JsonFloat (fDist));
+    return j;
+}
+
+json BtrkGetTrailById(int nId)
+{
+    sqlquery q = SqlPrepareQueryCampaign(BTRK_CAMPAIGN_DB,
+        "SELECT id, pos_x, pos_y, pos_z, source_name, source_uuid, blood_amt, created_at, area_tag "
+        "FROM blood_trails WHERE id = @id AND expires_at > strftime('%s','now')");
+    SqlBindInt(q, "@id", nId);
+    if(!SqlStep(q)) return JsonNull();
+
+    json j = JsonObject();
+    j = JsonObjectSet(j, "id",          JsonInt   (SqlGetInt   (q, 0)));
+    j = JsonObjectSet(j, "pos_x",       JsonFloat (SqlGetFloat (q, 1)));
+    j = JsonObjectSet(j, "pos_y",       JsonFloat (SqlGetFloat (q, 2)));
+    j = JsonObjectSet(j, "pos_z",       JsonFloat (SqlGetFloat (q, 3)));
+    j = JsonObjectSet(j, "source_name", JsonString(SqlGetString(q, 4)));
+    j = JsonObjectSet(j, "source_uuid", JsonString(SqlGetString(q, 5)));
+    j = JsonObjectSet(j, "blood_amt",   JsonInt   (SqlGetInt   (q, 6)));
+    j = JsonObjectSet(j, "created_at",  JsonInt   (SqlGetInt   (q, 7)));
+    j = JsonObjectSet(j, "area_tag",    JsonString(SqlGetString(q, 8)));
+    return j;
+}
+
+void BtrkMarkDiscovered(string sTrackerUUID, int nTrailId)
+{
+    sqlquery q = SqlPrepareQueryCampaign(BTRK_CAMPAIGN_DB,
+        "INSERT OR IGNORE INTO btrk_discoveries (tracker_uuid, trail_id) VALUES (@uuid, @tid)");
+    SqlBindString(q, "@uuid", sTrackerUUID);
+    SqlBindInt   (q, "@tid",  nTrailId);
+    SqlStep(q);
+}
+
+// Returns age in seconds using server-side SQLite clock for consistency.
+int BtrkGetAgeSeconds(int nCreatedAt)
+{
+    sqlquery q = SqlPrepareQueryCampaign(BTRK_CAMPAIGN_DB,
+        "SELECT CAST(strftime('%s','now') AS INTEGER) - @ts");
+    SqlBindInt(q, "@ts", nCreatedAt);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+int BtrkTrailCountInArea(string sAreaTag)
+{
+    sqlquery q = SqlPrepareQueryCampaign(BTRK_CAMPAIGN_DB,
+        "SELECT COUNT(*) FROM blood_trails WHERE area_tag = @area AND expires_at > strftime('%s','now')");
+    SqlBindString(q, "@area", sAreaTag);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}

--- a/Blood Tracker/Scripts/sys_on_dmg.nss
+++ b/Blood Tracker/Scripts/sys_on_dmg.nss
@@ -1,0 +1,15 @@
+#include "lib_btrk"
+
+// Assign this script as the OnDamaged event of any NPC whose blood trails
+// you want tracked. For PCs the module heartbeat handles trail dropping;
+// this script is only needed for non-PC creatures.
+// With NWNX_Events you can register it globally — see INTEGRATION.md.
+
+void main()
+{
+    object oCreature = OBJECT_SELF;
+    if(GetIsPC(oCreature)) return;  // PCs handled by sys_on_hb
+
+    int nDmg = GetTotalDamageDealt();
+    BtrkDropTrail(oCreature, nDmg);
+}

--- a/Blood Tracker/Scripts/sys_on_hb.nss
+++ b/Blood Tracker/Scripts/sys_on_hb.nss
@@ -1,0 +1,44 @@
+#include "lib_btrk"
+
+// Module OnHeartbeat fires every ~6 seconds.
+// Every tick: drop PC trails if they took damage since last tick.
+// Every BTRK_REFRESH_TICKS ticks: decay expired trails + refresh active tracker UIs.
+
+void main()
+{
+    object oMod = GetModule();
+    int nTick   = GetLocalInt(oMod, BTRK_LVAR_HB_TICK) + 1;
+    SetLocalInt(oMod, BTRK_LVAR_HB_TICK, nTick);
+
+    // ---- PC damage trail check (every tick) ----
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        int nCurHP  = GetCurrentHitPoints(oPC);
+        int nLastHP = GetLocalInt(oPC, "BTRK_LAST_HP");
+
+        if(nLastHP > 0)
+        {
+            int nDmg = nLastHP - nCurHP;
+            if(nDmg >= BTRK_MIN_BLEED_DMG)
+                BtrkDropTrail(oPC, nDmg);
+        }
+        SetLocalInt(oPC, "BTRK_LAST_HP", nCurHP);
+
+        oPC = GetNextPC();
+    }
+
+    if(nTick % BTRK_REFRESH_TICKS != 0) return;
+
+    // ---- Decay expired trails ----
+    BtrkDecayExpired();
+
+    // ---- Refresh UI for active trackers ----
+    oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        if(GetLocalInt(oPC, BTRK_LVAR_ACTIVE))
+            BtrkRefreshTrackerUI(oPC);
+        oPC = GetNextPC();
+    }
+}

--- a/Blood Tracker/Scripts/sys_on_load.nss
+++ b/Blood Tracker/Scripts/sys_on_load.nss
@@ -1,0 +1,6 @@
+#include "sql_btrk"
+
+void main()
+{
+    BtrkCreateTables();
+}

--- a/Blood Tracker/Scripts/test_btrk.nss
+++ b/Blood Tracker/Scripts/test_btrk.nss
@@ -1,0 +1,39 @@
+#include "lib_btrk"
+
+// OnUsed script for a test placeable.
+// Demonstrates the Blood Tracker UI and optionally seeds fake trail data.
+
+void SeedTestTrails(object oPC)
+{
+    object oArea  = GetArea(oPC);
+    string sArea  = GetTag(oArea);
+    vector vBase  = GetPosition(oPC);
+
+    // Three test trails at different freshness ages (simulated by expires_at offsets)
+    // Trail 1 — fresh, 8m NE
+    BtrkInsertTrail(sArea, vBase.x + 6.0, vBase.y + 6.0, vBase.z,
+        "", "Zraniony Goblin",  18);
+
+    // Trail 2 — stale-ish, 20m South
+    BtrkInsertTrail(sArea, vBase.x,        vBase.y - 20.0, vBase.z,
+        "", "Zbrojny Rycerz",   42);
+
+    // Trail 3 — old, 35m West
+    BtrkInsertTrail(sArea, vBase.x - 34.0, vBase.y + 2.0,  vBase.z,
+        "", "Nieznane Stworzenie", 9);
+
+    SendMessageToPC(oPC, "[Tropiciel] Zasiano 3 testowe ślady w okolicy.");
+}
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    // Seed trails on first use if area has none
+    string sArea = GetTag(GetArea(oPC));
+    if(BtrkTrailCountInArea(sArea) == 0)
+        SeedTestTrails(oPC);
+
+    BtrkOpen(oPC);
+}


### PR DESCRIPTION
## Co to robi

Moduł **Blood Tracker** (Ślady Krwi) pozwala graczom wchodzić w tryb tropiciela i śledzić ślady krwi zostawiane przez ranne stworzenia. Panel NUI pokazuje kierunek do najbliższego nieodkrytego śladu, jego świeżość i szacowaną odległość. Każde odkrycie nagradza XP i ląduje w Dzienniku Tropiciela.

## Mechanika

1. **Ślady krwi** — ranne stworzenia (≥5 HP straty) zostawiają marker w SQLite z pozycją, nazwą źródła i wagą obrażeń. Ślad ma TTL 30 minut; co 2 heartbeaty system usuwa wygasłe.
2. **Rzut na Przeszukiwanie** — DC zależy od świeżości śladu: Świeże DC 10, Stare DC 16, Lodowate DC 22. Sukces ujawnia kierunek kompasowy (8 stron) i odległość; porażka to brak wyników.
3. **Dziennik i XP** — każdy nowo odkryty ślad zapisuje się w dzienniku NUI (prepend, max 7 wpisów) i przyznaje 20 XP. Ten sam ślad można odkryć tylko raz (tabela `btrk_discoveries`).

## Pliki

| Plik | Rola |
|------|------|
| `Scripts/lib_btrk_def.nss` | Stałe, ID bindów, parametry tuningu |
| `Scripts/sql_btrk.nss` | Schemat SQLite + CRUD (create, insert, nearest, decay) |
| `Scripts/lib_btrk.nss` | Rdzeń: NUI layout builder, BtrkOpen, BtrkFeedDisplay, BtrkSearchTrails, BtrkDropTrail |
| `Scripts/lib_btrk_ev.nss` | Handler zdarzeń NUI (activate, search, clear-log, close) |
| `Scripts/sys_on_load.nss` | OnModuleLoad — tworzy tabele SQL |
| `Scripts/sys_on_hb.nss` | OnHeartbeat — delta HP gracza → ślad, decay, refresh UI |
| `Scripts/sys_on_dmg.nss` | OnDamaged NPC — woła BtrkDropTrail |
| `Scripts/test_btrk.nss` | Placeable OnUsed — zasiew testowych śladów + otwiera UI |
| `INTEGRATION.md` | Instrukcja podpięcia hooków, NWNX, test |

## Zależności (NWNX? SQL?)

- **SQL:** Kampania `blood_tracker` (SQLite). Dwie tabele: `blood_trails`, `btrk_discoveries`. Pełne `CREATE TABLE IF NOT EXISTS`, idempotentna migracja.
- **NWNX:** Opcjonalne — bez NWNX ślady NPC wymagają ręcznego przypisania `sys_on_dmg` jako `OnDamaged` na kreaturach. Z `NWNX_Events` można zarejestrować globalnie (przykład w `INTEGRATION.md`). Ślady graczy działają bez NWNX (heartbeat).

## Jak włączyć w istniejącym module

1. Skopiuj folder `Scripts/` do swojego modułu (lub hak).
2. W `OnModuleLoad` dodaj: `ExecuteScript("sys_on_load", GetModule());`
3. W `OnHeartbeat` dodaj: `ExecuteScript("sys_on_hb", GetModule());`
4. Otwieraj UI wywołując `BtrkOpen(oPC)` z dowolnego skryptu.
5. (Opcja) Przypisz `sys_on_dmg` na `OnDamaged` wybranych NPC.

## Co celowo pominięto

- **Wizualne markery VFX** (plamy krwi na ziemi) — wymagają haka z placeable lub NWNX_Object; dodanie możliwe jako rozszerzenie.
- **Automatyczne wykrycie przy wejściu w zasięg** — wymagałoby AoE trigger lub per-tracker proximity check w heartbeat; celowo uproszczono do kliknięcia.
- **Statystyki persistentne** (ranking tropicieli) — łatwe do dodania przez kolejną tabelę SQL.

---
_Generated by [Claude Code](https://claude.ai/code/session_016D484UC2cM1TW7B6rMhVFW)_