### PR TITLE
feat: Ritual Circles

### DIFF
--- a/Ritual Circles/INTEGRATION.md
+++ b/Ritual Circles/INTEGRATION.md
@@ -1,0 +1,62 @@
+# Ritual Circles — Integration Guide
+
+## Co to robi
+
+System rytualnych kręgów grupowych. Gracze zbierają się przy specjalnym placeable (kręgu), wybierają rytuał, a lider inicjuje 60-sekundowe channelowanie. Po sukcesie wszyscy uczestnicy dostają potężne efekty grupowe; przerwanie powoduje backlash (2d6 obrażeń + ogłuszenie 6s).
+
+## Hooki do podpięcia
+
+| Zdarzenie modułu | Skrypt |
+|-----------------|--------|
+| OnModuleLoad | `sys_on_load` |
+| OnClientEnter | `sys_on_enter` |
+| OnHeartbeat | `sys_module_hb` |
+
+Jeśli moduł ma już własne skrypty tych zdarzeń, dołącz wywołania:
+- `RitCreateTables()` w OnModuleLoad
+- Blok z `sys_on_enter.nss` w OnClientEnter
+- `RitProcessHeartbeat()` w OnHeartbeat
+
+## Placeables — kręgi rytualne
+
+1. Umieść w świecie dowolny placeable (np. Brazier, Stone Circle, Altar).
+2. Nadaj mu unikalny **Tag**, np. `rit_circle_01`, `rit_circle_02`.
+3. Przypisz skrypt `test_rit` do zdarzenia **OnUsed**.
+
+Każdy placeable to oddzielny, niezależny krąg. Można mieć ich wiele jednocześnie.
+
+## Przedmioty rytualne (lider musi trzymać w ekwipunku)
+
+| Rytuał | Tag przedmiotu | Nazwa |
+|--------|---------------|-------|
+| Błogosławieństwo Mroku | `rit_candle_black` | Czarna świeca |
+| Pakt Krwi | `rit_vial_blood` | Fiolka krwi |
+| Przywołanie Ducha | `rit_soul_gem` | Klejnot duszy |
+| Splot Klątwy | `rit_effigy` | Kukła ofiarna |
+
+Stwórz odpowiednie przedmioty w HAK lub toolsecie z tymi tagami. Przedmiot jest niszczony przy inicjowaniu rytuału.
+
+## Efekty rytuałów
+
+| Rytuał | Min. uczestników | Efekt sukcesu |
+|--------|-----------------|---------------|
+| Błogosławieństwo Mroku | 2 | +2 do ataku i +2 magicznych obrażeń przez 1h (wszyscy) |
+| Pakt Krwi | 3 | Kosztuje 20% HP każdego → leczy wszystkich do 75% max HP |
+| Przywołanie Ducha | 4 | Lider przywołuje wrait (nw_shwraith) na 30 min |
+| Splot Klątwy | 2 | –2 do wszystkich rzutów obronnych przez 1h (wszyscy niosą klątwę) |
+
+## Baza danych
+
+Kampania SQLite: `"ritual"` (plik `ritual.sqlite` w katalogu modułu).  
+Tabela `rit_circles` — jeden wiersz per tag kręgu, tworzony automatycznie przy pierwszym użyciu.
+
+## Zależności NWNX
+
+Brak — moduł używa wyłącznie standardowego NWScript + NUI (NWN:EE 8193+).
+
+## Co celowo pominięto
+
+- Brak systemu rejestracji offline graczy (rytual wymaga obecności online).
+- Brak osobnego panelu DM do zarządzania kręgami (można dodać osobny script).
+- Przywołana zjawa (Soul Calling) korzysta ze standardowego `nw_shwraith`; zastąp własnym blueprintem, jeśli chcesz inny model.
+- Klątwa (Curse Weaving) daje debuff uczestnikom, a nie bezpośrednio wrogom — zamysłem jest RP „niosę klątwę"; opcjonalnie można dodać OnSpellHook dla efektu obszarowego.

--- a/Ritual Circles/scripts/lib_nui.nss
+++ b/Ritual Circles/scripts/lib_nui.nss
@@ -1,0 +1,89 @@
+// lib_nui.nss - minimal NUI helpers (open source, no NWNX dependency)
+//
+// Subset of LC's lib_nui without NWNX deps:
+//   - NUI event type string constants
+//   - Window property constants
+//   - Mouse button constants
+//   - GetNuiScaleDimension - GUI scale awareness
+//   - CreateEmptyRow - scale-aware fixed-height spacer row
+//   - GetNuiColorNwnGold - project standard gold color
+
+#include "nw_inc_nui"
+
+// ============================================================
+// NUI event types (NuiGetEventType returns one of these)
+// https://nwnlexicon.com/index.php/NuiGetEventType
+// ============================================================
+const string EVENT_TYPE_WATCH       = "watch";
+const string EVENT_TYPE_OPEN        = "open";
+const string EVENT_TYPE_CLOSE       = "close";
+const string EVENT_TYPE_CLICK       = "click";
+const string EVENT_TYPE_MOUSEUP     = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN   = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE       = "range";
+const string EVENT_TYPE_FOCUS       = "focus";
+const string EVENT_TYPE_BLUR        = "blur";
+
+// ============================================================
+// Window properties (bind names for NuiWindow params)
+// ============================================================
+const string WINDOW_TITLE       = "title";
+const string WINDOW_GEOMETRY    = "geometry";
+const string WINDOW_RESIZABLE   = "resizable";
+const string WINDOW_COLLAPSED   = "collapsed";
+const string WINDOW_CLOSABLE    = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER      = "border";
+
+// ============================================================
+// Mouse buttons (NuiGetEventPayload for click events)
+// ============================================================
+const int EVENT_BUTTON_LEFT   = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT  = 2;
+
+// ============================================================
+// Scale-aware helpers
+// ============================================================
+
+// Returns dimension scaled by player's GUI scale (capped at fScaleMax).
+// Use for widget sizes inside windows so layout looks consistent across resolutions.
+float GetNuiScaleDimension(object oPC, float fDimension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+
+    if(fScaleGui > fScaleMax) fScaleGui = fScaleMax;
+    if(fScaleGui <= 0.0)      fScaleGui = 1.0;
+
+    return (fDimension / fScaleGui);
+}
+
+// Scale-aware spacer row of given height. Pass fHeight=0 for elastic spacer.
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+
+    if(fHeight <= 0.0)
+    {
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    }
+    else
+    {
+        jRow = JsonArrayInsert(jRow, NuiHeight(
+            NuiSpacer(),
+            GetNuiScaleDimension(oPC, fHeight, fScaleMax)));
+    }
+
+    return NuiRow(jRow);
+}
+
+// ============================================================
+// Project color helpers
+// ============================================================
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}

--- a/Ritual Circles/scripts/lib_rit.nss
+++ b/Ritual Circles/scripts/lib_rit.nss
@@ -1,0 +1,749 @@
+// lib_rit.nss - Ritual Circles: NUI layout, window management, core game logic
+
+#include "lib_rit_def"
+
+// ============================================================
+// NUI layout
+// ============================================================
+
+json RitBuildLayout(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 32.0);
+    float fRowH  = GetNuiScaleDimension(oPC, 30.0);
+    float fTypeH = GetNuiScaleDimension(oPC, 36.0);
+
+    json jCol = JsonArray();
+
+    // Header label (ritual name or "Opuszczony Krąg")
+    {
+        json jLbl = NuiLabel(NuiBind(RIT_BIND_HEADER),
+            JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+        jLbl = NuiHeight(jLbl, GetNuiScaleDimension(oPC, 28.0));
+        jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jLbl)));
+    }
+
+    // State label (color: gold)
+    {
+        json jLbl = NuiLabel(NuiBind(RIT_BIND_STATUS),
+            JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+        jLbl = NuiStyleForegroundColor(jLbl, GetNuiColorNwnGold());
+        jLbl = NuiHeight(jLbl, GetNuiScaleDimension(oPC, 22.0));
+        jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jLbl)));
+    }
+
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+
+    // Ritual type list (hidden during CASTING / COOLDOWN)
+    {
+        // Template: one button per row showing the type name
+        json jTmpl = JsonArray();
+        json jBtn = NuiId(NuiButton(NuiBind(RIT_BIND_TYPE_NAMES)), RIT_BTN_TYPE_ROW);
+        jBtn = NuiEncouraged(jBtn, NuiBind(RIT_BIND_TYPE_ENC));
+        jBtn = NuiHeight(jBtn, fTypeH);
+        jTmpl = JsonArrayInsert(jTmpl, NuiListTemplateCell(jBtn, 0.0, TRUE));
+
+        json jList = NuiList(jTmpl, JsonInt(RIT_TYPE_COUNT), fTypeH);
+        float fListH = GetNuiScaleDimension(oPC, 160.0);
+        jList = NuiHeight(jList, fListH);
+
+        json jGrp = NuiGroup(NuiCol(JsonArrayInsert(JsonArray(), jList)), FALSE, NUI_SCROLLBARS_NONE);
+        jGrp = NuiVisible(jGrp, NuiBind(RIT_BIND_TYPE_VIS));
+        jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jGrp)));
+    }
+
+    // Flavor / description text
+    {
+        json jLbl = NuiLabel(NuiBind(RIT_BIND_FLAVOR),
+            JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_TOP));
+        jLbl = NuiHeight(jLbl, GetNuiScaleDimension(oPC, 72.0));
+        jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jLbl)));
+    }
+
+    // Requirements label
+    {
+        json jLbl = NuiLabel(NuiBind(RIT_BIND_REQ_LABEL),
+            JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+        jLbl = NuiHeight(jLbl, GetNuiScaleDimension(oPC, 22.0));
+        jLbl = NuiStyleForegroundColor(jLbl, NuiColor(200, 130, 80));
+        jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jLbl)));
+    }
+
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+
+    // Participants header
+    {
+        json jLbl = NuiLabel(NuiBind(RIT_BIND_PART_HEADER),
+            JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+        jLbl = NuiHeight(jLbl, GetNuiScaleDimension(oPC, 20.0));
+        jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jLbl)));
+    }
+
+    // Participants list
+    {
+        json jTmpl = JsonArray();
+        json jNameLbl = NuiLabel(NuiBind(RIT_BIND_PART_NAMES),
+            JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+        jNameLbl = NuiStyleForegroundColor(jNameLbl, NuiBind(RIT_BIND_PART_COLORS));
+        jTmpl = JsonArrayInsert(jTmpl, NuiListTemplateCell(jNameLbl, 0.0, TRUE));
+
+        json jList = NuiList(jTmpl, NuiBind(RIT_BIND_PART_LEN), fRowH);
+        jList = NuiHeight(jList, GetNuiScaleDimension(oPC, 120.0));
+        jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jList)));
+    }
+
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+
+    // Progress bar + time label (visible only during CASTING)
+    {
+        json jProg = NuiProgressBar(NuiBind(RIT_BIND_PROGRESS));
+        jProg = NuiVisible(jProg, NuiBind(RIT_BIND_PROG_VIS));
+        jProg = NuiHeight(jProg, GetNuiScaleDimension(oPC, 18.0));
+        jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jProg)));
+
+        json jTimeLbl = NuiLabel(NuiBind(RIT_BIND_PROG_LABEL),
+            JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+        jTimeLbl = NuiVisible(jTimeLbl, NuiBind(RIT_BIND_PROG_VIS));
+        jTimeLbl = NuiHeight(jTimeLbl, GetNuiScaleDimension(oPC, 18.0));
+        jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jTimeLbl)));
+    }
+
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 0.0)); // elastic spacer
+
+    // Action buttons
+    {
+        json jBtns = JsonArray();
+
+        json jJoin = NuiId(NuiButton(JsonString("Dołącz")), RIT_BTN_JOIN);
+        jJoin = NuiEnabled(jJoin, NuiBind(RIT_BIND_JOIN_ENA));
+        jJoin = NuiWidth(jJoin, GetNuiScaleDimension(oPC, 90.0));
+        jJoin = NuiHeight(jJoin, fBtnH);
+
+        json jLeave = NuiId(NuiButton(JsonString("Opuść")), RIT_BTN_LEAVE);
+        jLeave = NuiEnabled(jLeave, NuiBind(RIT_BIND_LEAVE_ENA));
+        jLeave = NuiWidth(jLeave, GetNuiScaleDimension(oPC, 90.0));
+        jLeave = NuiHeight(jLeave, fBtnH);
+
+        json jBegin = NuiId(NuiButton(JsonString("Zainicjuj Rytuał")), RIT_BTN_BEGIN);
+        jBegin = NuiEnabled(jBegin, NuiBind(RIT_BIND_BEGIN_ENA));
+        jBegin = NuiWidth(jBegin, GetNuiScaleDimension(oPC, 140.0));
+        jBegin = NuiHeight(jBegin, fBtnH);
+
+        json jCancel = NuiId(NuiButton(JsonString("Przerwij")), RIT_BTN_CANCEL);
+        jCancel = NuiEnabled(jCancel, NuiBind(RIT_BIND_CANCEL_ENA));
+        jCancel = NuiWidth(jCancel, GetNuiScaleDimension(oPC, 90.0));
+        jCancel = NuiHeight(jCancel, fBtnH);
+
+        jBtns = JsonArrayInsert(jBtns, jJoin);
+        jBtns = JsonArrayInsert(jBtns, jLeave);
+        jBtns = JsonArrayInsert(jBtns, NuiSpacer());
+        jBtns = JsonArrayInsert(jBtns, jBegin);
+        jBtns = JsonArrayInsert(jBtns, jCancel);
+
+        jCol = JsonArrayInsert(jCol, NuiRow(jBtns));
+    }
+
+    return NuiCol(jCol);
+}
+
+// ============================================================
+// Window open / feed
+// ============================================================
+
+void RitOpenWindow(object oPC, object oCircle)
+{
+    string sTag = GetTag(oCircle);
+    SetLocalString(oPC, RIT_LVAR_CIRCLE, sTag);
+
+    int nToken = NuiFindWindow(oPC, RIT_WINDOW);
+    if(nToken != 0)
+    {
+        RitFeedWindow(oPC, nToken, sTag);
+        return;
+    }
+
+    float fGuiW = IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH));
+    float fGuiH = IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT));
+    float fW    = GetNuiScaleDimension(oPC, RIT_W);
+    float fH    = GetNuiScaleDimension(oPC, RIT_H);
+    float fCX   = (fGuiW - fW) / 2.0;
+    float fCY   = (fGuiH - fH) / 2.0;
+
+    json jWin = NuiWindow(
+        RitBuildLayout(oPC),
+        JsonString("Krąg Rytuału"),
+        NuiRect(fCX, fCY, fW, fH),
+        JsonBool(FALSE),  // resizable
+        JsonBool(FALSE),  // collapsed
+        JsonBool(TRUE),   // closable (native X button)
+        JsonBool(FALSE),  // transparent
+        JsonBool(TRUE));  // border
+
+    nToken = NuiCreate(oPC, jWin, RIT_WINDOW, RIT_EV_SCRIPT);
+    RitFeedWindow(oPC, nToken, sTag);
+}
+
+void RitFeedWindow(object oPC, int nToken, string sTag)
+{
+    json jData = RitGetCircle(sTag);
+    if(JsonGetType(jData) == JSON_TYPE_NULL) return;
+
+    int    nState      = JsonGetInt   (JsonObjectGet(jData, "state"));
+    int    nType       = JsonGetInt   (JsonObjectGet(jData, "ritual_type"));
+    string sLeaderUUID = JsonGetString(JsonObjectGet(jData, "leader_uuid"));
+    json   jParts      = JsonParse(JsonGetString(JsonObjectGet(jData, "participants_json")));
+    int    nCastStart  = JsonGetInt   (JsonObjectGet(jData, "cast_start"));
+    int    nNow        = RitGetUnixTime();
+    int    nPartCount  = JsonGetLength(jParts);
+
+    int bIsParticipant = RitIsParticipant(oPC, sTag);
+    int bIsLeader      = (GetObjectUUID(oPC) == sLeaderUUID && sLeaderUUID != "");
+
+    // Header
+    string sHeader = (nType != RIT_TYPE_NONE && nState != RIT_STATE_IDLE)
+                   ? RitTypeName(nType)
+                   : "Opuszczony Krąg";
+    NuiSetBind(oPC, nToken, RIT_BIND_HEADER, JsonString(sHeader));
+
+    // State label
+    NuiSetBind(oPC, nToken, RIT_BIND_STATUS, JsonString(RitStateName(nState)));
+
+    // Flavor text
+    string sFlavor;
+    if(nState == RIT_STATE_IDLE)
+        sFlavor = "Kamienie kręgu są zimne. Czeka na tych, którzy przybędą z ofiarą w dłoniach.";
+    else if(nState == RIT_STATE_COOLDOWN)
+        sFlavor = "Krąg drży jeszcze od mocy ostatniego rytuału. Powietrze pachnie popiołem i krwią.";
+    else if(nType != RIT_TYPE_NONE)
+        sFlavor = RitTypeDesc(nType);
+    else
+        sFlavor = "Wybierz rytuał, by poznać jego opis.";
+    NuiSetBind(oPC, nToken, RIT_BIND_FLAVOR, JsonString(sFlavor));
+
+    // Requirements text (only when type is chosen and not on cooldown)
+    string sReq = "";
+    if(nType != RIT_TYPE_NONE && nState != RIT_STATE_COOLDOWN)
+    {
+        int nMin = RitTypeMinParts(nType);
+        sReq = "Min. " + IntToString(nMin) + " uczestników · Lider niesie: " + RitTypeItemName(nType);
+        if(bIsLeader && !RitLeaderHasItem(sTag))
+            sReq += "  [BRAK!]";
+    }
+    NuiSetBind(oPC, nToken, RIT_BIND_REQ_LABEL, JsonString(sReq));
+
+    // Type list visibility
+    int bTypeVis = (nState == RIT_STATE_IDLE || nState == RIT_STATE_GATHERING);
+    NuiSetBind(oPC, nToken, RIT_BIND_TYPE_VIS, JsonBool(bTypeVis));
+
+    // Ritual type list rows
+    {
+        json jNames = JsonArray();
+        json jEncs  = JsonArray();
+        int i;
+        for(i = 1; i <= RIT_TYPE_COUNT; i++)
+        {
+            string sEntry = RitTypeName(i)
+                + "  (min. " + IntToString(RitTypeMinParts(i)) + " os."
+                + ", wymaga: " + RitTypeItemName(i) + ")";
+            jNames = JsonArrayInsert(jNames, JsonString(sEntry));
+            jEncs  = JsonArrayInsert(jEncs,  JsonBool(i == nType));
+        }
+        NuiSetBind(oPC, nToken, RIT_BIND_TYPE_NAMES, jNames);
+        NuiSetBind(oPC, nToken, RIT_BIND_TYPE_ENC,   jEncs);
+    }
+
+    // Participants list
+    {
+        json jNames  = JsonArray();
+        json jColors = JsonArray();
+        int i;
+        for(i = 0; i < nPartCount; i++)
+        {
+            string sUUID = JsonGetString(JsonArrayGet(jParts, i));
+            string sName = RitGetNameByUUID(sUUID);
+            if(sUUID == sLeaderUUID)
+                sName = "[Lider] " + sName;
+            jNames  = JsonArrayInsert(jNames,  JsonString(sName));
+            json jColor = (sUUID == sLeaderUUID)
+                        ? NuiColor(210, 170, 60)
+                        : NuiColor(200, 200, 200);
+            jColors = JsonArrayInsert(jColors, jColor);
+        }
+        int nMin = (nType != RIT_TYPE_NONE) ? RitTypeMinParts(nType) : 2;
+        string sPartHdr = "Uczestnicy (" + IntToString(nPartCount) + " / " + IntToString(nMin) + " min.):";
+        NuiSetBind(oPC, nToken, RIT_BIND_PART_HEADER, JsonString(sPartHdr));
+        NuiSetBind(oPC, nToken, RIT_BIND_PART_NAMES,  jNames);
+        NuiSetBind(oPC, nToken, RIT_BIND_PART_COLORS, jColors);
+        NuiSetBind(oPC, nToken, RIT_BIND_PART_LEN,    JsonInt(nPartCount));
+    }
+
+    // Progress bar (CASTING only)
+    int bProgVis = (nState == RIT_STATE_CASTING);
+    NuiSetBind(oPC, nToken, RIT_BIND_PROG_VIS, JsonBool(bProgVis));
+    if(bProgVis)
+    {
+        int nElapsed  = nNow - nCastStart;
+        if(nElapsed < 0) nElapsed = 0;
+        float fProg   = IntToFloat(nElapsed) / IntToFloat(RIT_CASTING_SEC);
+        if(fProg > 1.0) fProg = 1.0;
+        int nRemaining = RIT_CASTING_SEC - nElapsed;
+        if(nRemaining < 0) nRemaining = 0;
+        NuiSetBind(oPC, nToken, RIT_BIND_PROGRESS,  JsonFloat(fProg));
+        NuiSetBind(oPC, nToken, RIT_BIND_PROG_LABEL,
+            JsonString(IntToString(nRemaining) + " sek. pozostało..."));
+    }
+    else
+    {
+        NuiSetBind(oPC, nToken, RIT_BIND_PROGRESS,  JsonFloat(0.0));
+        NuiSetBind(oPC, nToken, RIT_BIND_PROG_LABEL, JsonString(""));
+    }
+
+    // Button states
+    int bCanJoin   = !bIsParticipant
+                   && nState != RIT_STATE_CASTING
+                   && nState != RIT_STATE_COOLDOWN
+                   && nType  != RIT_TYPE_NONE;
+    int bCanLeave  = bIsParticipant && nState != RIT_STATE_CASTING;
+    int bCanBegin  = bIsLeader
+                   && nState == RIT_STATE_GATHERING
+                   && nPartCount >= RitTypeMinParts(nType)
+                   && RitLeaderHasItem(sTag);
+    int bCanCancel = bIsParticipant && nState == RIT_STATE_CASTING;
+
+    NuiSetBind(oPC, nToken, RIT_BIND_JOIN_ENA,   JsonBool(bCanJoin));
+    NuiSetBind(oPC, nToken, RIT_BIND_LEAVE_ENA,  JsonBool(bCanLeave));
+    NuiSetBind(oPC, nToken, RIT_BIND_BEGIN_ENA,  JsonBool(bCanBegin));
+    NuiSetBind(oPC, nToken, RIT_BIND_CANCEL_ENA, JsonBool(bCanCancel));
+}
+
+void RitUpdateAllWindows(string sTag)
+{
+    json jData = RitGetCircle(sTag);
+    if(JsonGetType(jData) == JSON_TYPE_NULL) return;
+    json jParts = JsonParse(JsonGetString(JsonObjectGet(jData, "participants_json")));
+    int i, n = JsonGetLength(jParts);
+    for(i = 0; i < n; i++)
+    {
+        object oMember = RitGetPCByUUID(JsonGetString(JsonArrayGet(jParts, i)));
+        if(!GetIsObjectValid(oMember)) continue;
+        int nToken = NuiFindWindow(oMember, RIT_WINDOW);
+        if(nToken != 0) RitFeedWindow(oMember, nToken, sTag);
+    }
+}
+
+void RitNotifyParticipants(string sTag, string sMsg)
+{
+    json jData = RitGetCircle(sTag);
+    if(JsonGetType(jData) == JSON_TYPE_NULL) return;
+    json jParts = JsonParse(JsonGetString(JsonObjectGet(jData, "participants_json")));
+    int i, n = JsonGetLength(jParts);
+    for(i = 0; i < n; i++)
+    {
+        object oMember = RitGetPCByUUID(JsonGetString(JsonArrayGet(jParts, i)));
+        if(GetIsObjectValid(oMember))
+            FloatingTextStringOnCreature(sMsg, oMember, FALSE);
+    }
+}
+
+// ============================================================
+// Core actions
+// ============================================================
+
+void RitJoin(object oPC, string sTag)
+{
+    json jData = RitGetCircle(sTag);
+    if(JsonGetType(jData) == JSON_TYPE_NULL) return;
+
+    int nState = JsonGetInt(JsonObjectGet(jData, "state"));
+    if(nState == RIT_STATE_CASTING || nState == RIT_STATE_COOLDOWN)
+    {
+        SendMessageToPC(oPC, "[Rytuał] Krąg jest w trakcie rytuału lub odpoczywa.");
+        return;
+    }
+    if(RitIsParticipant(oPC, sTag))
+    {
+        SendMessageToPC(oPC, "[Rytuał] Już uczestniczysz w tym rytuale.");
+        return;
+    }
+    int nType = JsonGetInt(JsonObjectGet(jData, "ritual_type"));
+    if(nType == RIT_TYPE_NONE)
+    {
+        SendMessageToPC(oPC, "[Rytuał] Najpierw wybierz typ rytuału.");
+        return;
+    }
+
+    string sUUID  = GetObjectUUID(oPC);
+    json jParts   = JsonParse(JsonGetString(JsonObjectGet(jData, "participants_json")));
+    jParts        = JsonArrayInsert(jParts, JsonString(sUUID));
+    jData         = JsonObjectSet(jData, "participants_json", JsonString(JsonDump(jParts)));
+
+    // First participant becomes leader
+    if(JsonGetString(JsonObjectGet(jData, "leader_uuid")) == "")
+        jData = JsonObjectSet(jData, "leader_uuid", JsonString(sUUID));
+
+    if(nState == RIT_STATE_IDLE)
+        jData = JsonObjectSet(jData, "state", JsonInt(RIT_STATE_GATHERING));
+
+    RitSetCircle(sTag, jData);
+    FloatingTextStringOnCreature("Stoisz w kręgu, gotów do rytuału.", oPC, FALSE);
+    RitUpdateAllWindows(sTag);
+}
+
+void RitLeave(object oPC, string sTag)
+{
+    if(!RitIsParticipant(oPC, sTag))
+    {
+        SendMessageToPC(oPC, "[Rytuał] Nie uczestniczysz w tym rytuale.");
+        return;
+    }
+    json jData = RitGetCircle(sTag);
+    int nState = JsonGetInt(JsonObjectGet(jData, "state"));
+    if(nState == RIT_STATE_CASTING)
+    {
+        SendMessageToPC(oPC, "[Rytuał] Nie możesz opuścić kręgu w trakcie rytuału — użyj 'Przerwij'.");
+        return;
+    }
+
+    string sUUID   = GetObjectUUID(oPC);
+    json jOld      = JsonParse(JsonGetString(JsonObjectGet(jData, "participants_json")));
+    json jNew      = JsonArray();
+    int i, n = JsonGetLength(jOld);
+    for(i = 0; i < n; i++)
+        if(JsonGetString(JsonArrayGet(jOld, i)) != sUUID)
+            jNew = JsonArrayInsert(jNew, JsonArrayGet(jOld, i));
+
+    jData = JsonObjectSet(jData, "participants_json", JsonString(JsonDump(jNew)));
+
+    // Reassign leader if the leaving PC was leader
+    string sLeader = JsonGetString(JsonObjectGet(jData, "leader_uuid"));
+    if(sLeader == sUUID)
+    {
+        if(JsonGetLength(jNew) > 0)
+            jData = JsonObjectSet(jData, "leader_uuid", JsonArrayGet(jNew, 0));
+        else
+        {
+            jData = JsonObjectSet(jData, "leader_uuid",   JsonString(""));
+            jData = JsonObjectSet(jData, "ritual_type",   JsonInt(RIT_TYPE_NONE));
+            jData = JsonObjectSet(jData, "state",         JsonInt(RIT_STATE_IDLE));
+        }
+    }
+    if(JsonGetLength(jNew) == 0)
+        jData = JsonObjectSet(jData, "state", JsonInt(RIT_STATE_IDLE));
+
+    RitSetCircle(sTag, jData);
+    DeleteLocalString(oPC, RIT_LVAR_CIRCLE);
+    FloatingTextStringOnCreature("Opuszczasz krąg.", oPC, FALSE);
+    RitUpdateAllWindows(sTag);
+}
+
+// Selecting a ritual type row also auto-joins the player as the first member.
+void RitSetType(object oPC, string sTag, int nType)
+{
+    if(nType < RIT_TYPE_DARK_BLESSING || nType > RIT_TYPE_COUNT) return;
+
+    json jData = RitGetCircle(sTag);
+    int nState = JsonGetInt(JsonObjectGet(jData, "state"));
+    if(nState == RIT_STATE_CASTING || nState == RIT_STATE_COOLDOWN)
+    {
+        SendMessageToPC(oPC, "[Rytuał] Nie można zmienić rytuału teraz.");
+        return;
+    }
+    // Only the current leader (or anyone if circle is idle) may change the type
+    string sLeaderUUID = JsonGetString(JsonObjectGet(jData, "leader_uuid"));
+    if(sLeaderUUID != "" && sLeaderUUID != GetObjectUUID(oPC))
+    {
+        SendMessageToPC(oPC, "[Rytuał] Tylko lider może zmienić typ rytuału.");
+        return;
+    }
+
+    jData = JsonObjectSet(jData, "ritual_type", JsonInt(nType));
+
+    // Auto-join as leader if not yet a participant
+    if(!RitIsParticipant(oPC, sTag))
+    {
+        string sUUID = GetObjectUUID(oPC);
+        json jParts  = JsonParse(JsonGetString(JsonObjectGet(jData, "participants_json")));
+        jParts       = JsonArrayInsert(jParts, JsonString(sUUID));
+        jData        = JsonObjectSet(jData, "participants_json", JsonString(JsonDump(jParts)));
+        jData        = JsonObjectSet(jData, "leader_uuid",       JsonString(sUUID));
+        jData        = JsonObjectSet(jData, "state",             JsonInt(RIT_STATE_GATHERING));
+        FloatingTextStringOnCreature("Przejmujesz inicjatywę. Jesteś liderem rytuału.", oPC, FALSE);
+    }
+
+    RitSetCircle(sTag, jData);
+    RitUpdateAllWindows(sTag);
+}
+
+void RitBegin(object oPC, string sTag)
+{
+    if(!RitIsLeader(oPC, sTag))
+    {
+        SendMessageToPC(oPC, "[Rytuał] Tylko lider może zainicjować rytuał.");
+        return;
+    }
+
+    json jData     = RitGetCircle(sTag);
+    int  nState    = JsonGetInt(JsonObjectGet(jData, "state"));
+    int  nType     = JsonGetInt(JsonObjectGet(jData, "ritual_type"));
+    json jParts    = JsonParse(JsonGetString(JsonObjectGet(jData, "participants_json")));
+    int  nCount    = JsonGetLength(jParts);
+    int  nMin      = RitTypeMinParts(nType);
+
+    if(nState != RIT_STATE_GATHERING)
+    {
+        SendMessageToPC(oPC, "[Rytuał] Krąg nie jest w trybie zbierania uczestników.");
+        return;
+    }
+    if(nCount < nMin)
+    {
+        SendMessageToPC(oPC, "[Rytuał] Za mało uczestników. Potrzeba co najmniej "
+            + IntToString(nMin) + ".");
+        return;
+    }
+    if(!RitLeaderHasItem(sTag))
+    {
+        SendMessageToPC(oPC, "[Rytuał] Musisz posiadać: " + RitTypeItemName(nType) + ".");
+        return;
+    }
+
+    // Consume the ritual item
+    string sItemTag = RitTypeItemTag(nType);
+    if(sItemTag != "")
+    {
+        object oItem = GetItemPossessedBy(oPC, sItemTag);
+        if(GetIsObjectValid(oItem)) DestroyObject(oItem);
+    }
+
+    // Blood Binding: drain 20% HP from every participant (min 1 HP, cannot kill)
+    if(nType == RIT_TYPE_BLOOD_BINDING)
+    {
+        int i;
+        for(i = 0; i < nCount; i++)
+        {
+            object oMember = RitGetPCByUUID(JsonGetString(JsonArrayGet(jParts, i)));
+            if(!GetIsObjectValid(oMember)) continue;
+            int nMax  = GetMaxHitPoints(oMember);
+            int nCost = nMax / 5;
+            int nCur  = GetCurrentHitPoints(oMember);
+            if(nCost >= nCur) nCost = nCur - 1;
+            if(nCost > 0)
+                ApplyEffectToObject(DURATION_TYPE_INSTANT,
+                    EffectDamage(nCost, DAMAGE_TYPE_MAGICAL), oMember);
+            FloatingTextStringOnCreature("Twoja krew spływa do kręgu...", oMember, FALSE);
+        }
+    }
+
+    int nNow = RitGetUnixTime();
+    jData = JsonObjectSet(jData, "state",      JsonInt(RIT_STATE_CASTING));
+    jData = JsonObjectSet(jData, "cast_start", JsonInt(nNow));
+    RitSetCircle(sTag, jData);
+
+    RitNotifyParticipants(sTag,
+        "Pieczęcie kręgu rozżarzają się krwistą czerwienią... Rytuał się rozpoczął.");
+    RitUpdateAllWindows(sTag);
+}
+
+void RitCancel(object oPC, string sTag)
+{
+    json jData = RitGetCircle(sTag);
+    if(JsonGetInt(JsonObjectGet(jData, "state")) != RIT_STATE_CASTING)
+    {
+        SendMessageToPC(oPC, "[Rytuał] Rytuał nie jest w toku.");
+        return;
+    }
+
+    json jParts = JsonParse(JsonGetString(JsonObjectGet(jData, "participants_json")));
+    int i, n = JsonGetLength(jParts);
+
+    // Backlash: 2d6 magical damage + 6s stun on every participant
+    for(i = 0; i < n; i++)
+    {
+        object oMember = RitGetPCByUUID(JsonGetString(JsonArrayGet(jParts, i)));
+        if(!GetIsObjectValid(oMember)) continue;
+        ApplyEffectToObject(DURATION_TYPE_INSTANT,
+            EffectDamage(d6(2), DAMAGE_TYPE_MAGICAL), oMember);
+        effect eStun = ExtraordinaryEffect(EffectStunned());
+        ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eStun, oMember, 6.0);
+        ApplyEffectToObject(DURATION_TYPE_INSTANT,
+            EffectVisualEffect(VFX_COM_CHUNK_BONE_MEDIUM), oMember);
+        FloatingTextStringOnCreature("Krąg wybucha! Niestabilna magia rani cię!", oMember, FALSE);
+    }
+
+    RitResetCircle(sTag);
+    RitEnsureCircle(sTag);
+
+    for(i = 0; i < n; i++)
+    {
+        object oMember = RitGetPCByUUID(JsonGetString(JsonArrayGet(jParts, i)));
+        if(GetIsObjectValid(oMember))
+        {
+            DeleteLocalString(oMember, RIT_LVAR_CIRCLE);
+            int nToken = NuiFindWindow(oMember, RIT_WINDOW);
+            if(nToken != 0) RitFeedWindow(oMember, nToken, sTag);
+        }
+    }
+}
+
+// ============================================================
+// Completion (called by heartbeat when channeling finishes)
+// ============================================================
+
+void RitComplete(string sTag, int nType, json jParts)
+{
+    int i;
+    int n = JsonGetLength(jParts);
+
+    // Fetch leader UUID before modifying the DB
+    json jDataPre   = RitGetCircle(sTag);
+    string sLeaderUUID = JsonGetString(JsonObjectGet(jDataPre, "leader_uuid"));
+
+    if(nType == RIT_TYPE_DARK_BLESSING)
+    {
+        // +2 attack, +2 magical damage for 1 hour — tagged so it can be stripped
+        for(i = 0; i < n; i++)
+        {
+            object oMember = RitGetPCByUUID(JsonGetString(JsonArrayGet(jParts, i)));
+            if(!GetIsObjectValid(oMember)) continue;
+            effect eAtk  = EffectAttackIncrease(2);
+            effect eDmg  = EffectDamageIncrease(2, DAMAGE_TYPE_MAGICAL);
+            effect eLink = TagEffect(EffectLinkEffects(eAtk, eDmg), "RIT_DARK_BLESSING");
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eLink, oMember, 3600.0);
+            ApplyEffectToObject(DURATION_TYPE_INSTANT,
+                EffectVisualEffect(VFX_IMP_EVIL_HELP), oMember);
+            FloatingTextStringOnCreature(
+                "Mrok cię przyjął. Poczujesz jego siłę w walce.", oMember, FALSE);
+        }
+    }
+    else if(nType == RIT_TYPE_BLOOD_BINDING)
+    {
+        // Heal every participant to 75% of their max HP
+        for(i = 0; i < n; i++)
+        {
+            object oMember = RitGetPCByUUID(JsonGetString(JsonArrayGet(jParts, i)));
+            if(!GetIsObjectValid(oMember)) continue;
+            int nMax  = GetMaxHitPoints(oMember);
+            int nCur  = GetCurrentHitPoints(oMember);
+            int nHeal = (nMax * 3 / 4) - nCur;
+            if(nHeal > 0)
+                ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectHeal(nHeal), oMember);
+            ApplyEffectToObject(DURATION_TYPE_INSTANT,
+                EffectVisualEffect(VFX_IMP_HEALING_L), oMember);
+            FloatingTextStringOnCreature(
+                "Pakt krwi zostaje zapieczętowany. Rany się goją.", oMember, FALSE);
+        }
+    }
+    else if(nType == RIT_TYPE_SOUL_CALLING)
+    {
+        // Summon a wraith that serves the leader for 30 minutes
+        object oLeader = RitGetPCByUUID(sLeaderUUID);
+        if(GetIsObjectValid(oLeader))
+        {
+            location lLdr = GetLocation(oLeader);
+            ApplyEffectAtLocation(DURATION_TYPE_INSTANT,
+                EffectVisualEffect(VFX_FNF_SUMMON_UNDEAD), lLdr);
+            object oWraith = CreateObject(OBJECT_TYPE_CREATURE, "nw_shwraith", lLdr,
+                FALSE, "RIT_WRAITH_SUMMON");
+            if(GetIsObjectValid(oWraith))
+            {
+                // DEFENDER faction: fights hostiles, friendly to the party
+                ChangeToStandardFaction(oWraith, STANDARD_FACTION_DEFENDER);
+                AssignCommand(oWraith, ActionForceFollowObject(oLeader, 3.0));
+                DelayCommand(1800.0, DestroyObject(oWraith));
+            }
+            FloatingTextStringOnCreature(
+                "Z zaświatów odpowiada duch — zjawa słucha twej woli.", oLeader, FALSE);
+        }
+        for(i = 0; i < n; i++)
+        {
+            string sUUID = JsonGetString(JsonArrayGet(jParts, i));
+            if(sUUID == sLeaderUUID) continue;
+            object oMember = RitGetPCByUUID(sUUID);
+            if(GetIsObjectValid(oMember))
+                FloatingTextStringOnCreature(
+                    "Rytuał przywołania zostaje spełniony.", oMember, FALSE);
+        }
+    }
+    else if(nType == RIT_TYPE_CURSE_WEAVING)
+    {
+        // Each participant carries the curse outward: -2 to all saving throws for 1h.
+        // Tagged "RIT_CURSE_WEAVING" so a server hook can strip it on demand.
+        for(i = 0; i < n; i++)
+        {
+            object oMember = RitGetPCByUUID(JsonGetString(JsonArrayGet(jParts, i)));
+            if(!GetIsObjectValid(oMember)) continue;
+            effect eCurse = TagEffect(
+                ExtraordinaryEffect(EffectSavingThrowDecrease(SAVING_THROW_ALL, 2)),
+                "RIT_CURSE_WEAVING");
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eCurse, oMember, 3600.0);
+            ApplyEffectToObject(DURATION_TYPE_INSTANT,
+                EffectVisualEffect(VFX_IMP_CURSE_STRIKE), oMember);
+            FloatingTextStringOnCreature(
+                "Klątwa przesiąka w twoje kości — staniesz się dla wrogów przekleństwem.", oMember, FALSE);
+        }
+    }
+
+    // Transition circle to cooldown, clear roster
+    int nNow = RitGetUnixTime();
+    json jUpd = RitGetCircle(sTag);
+    jUpd = JsonObjectSet(jUpd, "state",             JsonInt(RIT_STATE_COOLDOWN));
+    jUpd = JsonObjectSet(jUpd, "cooldown_end",      JsonInt(nNow + RIT_COOLDOWN_SEC));
+    jUpd = JsonObjectSet(jUpd, "participants_json", JsonString("[]"));
+    jUpd = JsonObjectSet(jUpd, "leader_uuid",       JsonString(""));
+    jUpd = JsonObjectSet(jUpd, "ritual_type",       JsonInt(RIT_TYPE_NONE));
+    RitSetCircle(sTag, jUpd);
+
+    // Clear participants' circle LVAR and refresh their open windows
+    for(i = 0; i < n; i++)
+    {
+        object oMember = RitGetPCByUUID(JsonGetString(JsonArrayGet(jParts, i)));
+        if(!GetIsObjectValid(oMember)) continue;
+        DeleteLocalString(oMember, RIT_LVAR_CIRCLE);
+        int nToken = NuiFindWindow(oMember, RIT_WINDOW);
+        if(nToken != 0) RitFeedWindow(oMember, nToken, sTag);
+    }
+}
+
+// ============================================================
+// Heartbeat processing (call from OnHeartbeat every tick)
+// ============================================================
+
+void RitProcessHeartbeat()
+{
+    int nNow = RitGetUnixTime();
+
+    // Advance any circles that have finished channeling
+    json jCasting = RitGetActiveCastingCircles();
+    int i, nC = JsonGetLength(jCasting);
+    for(i = 0; i < nC; i++)
+    {
+        json jEntry   = JsonArrayGet(jCasting, i);
+        string sTag   = JsonGetString(JsonObjectGet(jEntry, "tag"));
+        int nType     = JsonGetInt   (JsonObjectGet(jEntry, "ritual_type"));
+        int nStart    = JsonGetInt   (JsonObjectGet(jEntry, "cast_start"));
+        json jParts   = JsonParse(JsonGetString(JsonObjectGet(jEntry, "participants_json")));
+
+        if(nNow - nStart >= RIT_CASTING_SEC)
+        {
+            RitComplete(sTag, nType, jParts);
+        }
+        else
+        {
+            // Refresh progress bars for all participants
+            RitUpdateAllWindows(sTag);
+        }
+    }
+
+    // Expire circles whose cooldown has elapsed
+    json jCooldown = RitGetCooldownCircles();
+    int nD = JsonGetLength(jCooldown);
+    for(i = 0; i < nD; i++)
+    {
+        json jEntry  = JsonArrayGet(jCooldown, i);
+        string sTag  = JsonGetString(JsonObjectGet(jEntry, "tag"));
+        int nCoolEnd = JsonGetInt   (JsonObjectGet(jEntry, "cooldown_end"));
+        if(nNow >= nCoolEnd)
+        {
+            RitResetCircle(sTag);
+            RitEnsureCircle(sTag);
+        }
+    }
+}

--- a/Ritual Circles/scripts/lib_rit_def.nss
+++ b/Ritual Circles/scripts/lib_rit_def.nss
@@ -1,0 +1,254 @@
+// lib_rit_def.nss - Ritual Circles: constants, ritual data, participant helpers
+
+#include "lib_nui"
+#include "sql_rit"
+
+// ============================================================
+// Forward declarations
+// ============================================================
+
+void RitOpenWindow(object oPC, object oCircle);
+void RitFeedWindow(object oPC, int nToken, string sTag);
+void RitUpdateAllWindows(string sTag);
+void RitNotifyParticipants(string sTag, string sMsg);
+void RitJoin(object oPC, string sTag);
+void RitLeave(object oPC, string sTag);
+void RitSetType(object oPC, string sTag, int nType);
+void RitBegin(object oPC, string sTag);
+void RitCancel(object oPC, string sTag);
+void RitComplete(string sTag, int nType, json jParts);
+void RitProcessHeartbeat();
+
+// ============================================================
+// Window / event IDs
+// ============================================================
+
+const string RIT_WINDOW    = "RIT_WINDOW";
+const string RIT_EV_SCRIPT = "lib_rit_ev";
+
+// ============================================================
+// NUI bind names
+// ============================================================
+
+const string RIT_BIND_HEADER       = "rit_header";      // window title label
+const string RIT_BIND_STATUS       = "rit_status";      // state label
+const string RIT_BIND_FLAVOR       = "rit_flavor";      // flavor text
+const string RIT_BIND_REQ_LABEL    = "rit_req_lbl";     // requirements text
+const string RIT_BIND_TYPE_NAMES   = "rit_type_names";  // JsonArray<string> for type list
+const string RIT_BIND_TYPE_ENC     = "rit_type_enc";    // JsonArray<bool>  for type list
+const string RIT_BIND_TYPE_VIS     = "rit_type_vis";    // bool: show type list group
+const string RIT_BIND_PART_HEADER  = "rit_part_hdr";    // "Uczestnicy (n/min):"
+const string RIT_BIND_PART_NAMES   = "rit_part_names";  // JsonArray<string>
+const string RIT_BIND_PART_COLORS  = "rit_part_colors"; // JsonArray<json NuiColor>
+const string RIT_BIND_PART_LEN     = "rit_part_len";    // JsonInt row count
+const string RIT_BIND_PROGRESS     = "rit_progress";    // float 0.0-1.0
+const string RIT_BIND_PROG_VIS     = "rit_prog_vis";    // bool
+const string RIT_BIND_PROG_LABEL   = "rit_prog_lbl";    // "X sek. pozostało"
+const string RIT_BIND_JOIN_ENA     = "rit_join_ena";
+const string RIT_BIND_LEAVE_ENA    = "rit_leave_ena";
+const string RIT_BIND_BEGIN_ENA    = "rit_begin_ena";
+const string RIT_BIND_CANCEL_ENA   = "rit_cancel_ena";
+
+// ============================================================
+// Button / element IDs
+// ============================================================
+
+const string RIT_BTN_CLOSE    = "rit_close";
+const string RIT_BTN_JOIN     = "rit_join";
+const string RIT_BTN_LEAVE    = "rit_leave";
+const string RIT_BTN_BEGIN    = "rit_begin";
+const string RIT_BTN_CANCEL   = "rit_cancel";
+const string RIT_BTN_TYPE_ROW = "rit_type_row"; // NuiList row button
+
+// ============================================================
+// PC local variables
+// ============================================================
+
+const string RIT_LVAR_CIRCLE = "RIT_CIRCLE"; // tag of currently tracked circle
+
+// ============================================================
+// Window dimensions
+// ============================================================
+
+const float RIT_W = 480.0;
+const float RIT_H = 560.0;
+
+// ============================================================
+// Timing
+// ============================================================
+
+const int RIT_CASTING_SEC  = 60;  // channeling duration
+const int RIT_COOLDOWN_SEC = 600; // cooldown after completion
+
+// ============================================================
+// Ritual type IDs  (0 = none/unset)
+// ============================================================
+
+const int RIT_TYPE_NONE          = 0;
+const int RIT_TYPE_DARK_BLESSING = 1;
+const int RIT_TYPE_BLOOD_BINDING = 2;
+const int RIT_TYPE_SOUL_CALLING  = 3;
+const int RIT_TYPE_CURSE_WEAVING = 4;
+const int RIT_TYPE_COUNT         = 4;
+
+// ============================================================
+// Circle state IDs
+// ============================================================
+
+const int RIT_STATE_IDLE      = 0;
+const int RIT_STATE_GATHERING = 1;
+const int RIT_STATE_CASTING   = 2;
+const int RIT_STATE_COOLDOWN  = 3;
+
+// ============================================================
+// Ritual data
+// ============================================================
+
+string RitTypeName(int nType)
+{
+    switch(nType)
+    {
+        case RIT_TYPE_DARK_BLESSING: return "Błogosławieństwo Mroku";
+        case RIT_TYPE_BLOOD_BINDING: return "Pakt Krwi";
+        case RIT_TYPE_SOUL_CALLING:  return "Przywołanie Ducha";
+        case RIT_TYPE_CURSE_WEAVING: return "Splot Klątwy";
+    }
+    return "—";
+}
+
+string RitTypeDesc(int nType)
+{
+    switch(nType)
+    {
+        case RIT_TYPE_DARK_BLESSING:
+            return "Ciemność zstępuje na uczestników. Wszyscy przez godzinę uderzają celniej "
+                 + "i silniej — jak drapieżniki czerpiące moc ze zmroku.";
+        case RIT_TYPE_BLOOD_BINDING:
+            return "Krew zebranych miesza się w kręgu. Ból staje się siłą — rytuał leczy "
+                 + "uczestników do 75% HP, kosztem 20% życia każdego z nich.";
+        case RIT_TYPE_SOUL_CALLING:
+            return "Głos lekceważących żywych dociera do zaświatów. Zjawa o niepojętej sile "
+                 + "zostaje przywołana i służy liderowi przez pół godziny.";
+        case RIT_TYPE_CURSE_WEAVING:
+            return "Zbiorowa nienawiść uczestników zostaje spleciона w klątwę. "
+                 + "Każdy niesie ją w sobie — wrogowie w pobliżu rzucają słabiej.";
+    }
+    return "";
+}
+
+int RitTypeMinParts(int nType)
+{
+    switch(nType)
+    {
+        case RIT_TYPE_DARK_BLESSING: return 2;
+        case RIT_TYPE_BLOOD_BINDING: return 3;
+        case RIT_TYPE_SOUL_CALLING:  return 4;
+        case RIT_TYPE_CURSE_WEAVING: return 2;
+    }
+    return 2;
+}
+
+// Tag of item the leader must hold (consumed on ritual begin).
+string RitTypeItemTag(int nType)
+{
+    switch(nType)
+    {
+        case RIT_TYPE_DARK_BLESSING: return "rit_candle_black";
+        case RIT_TYPE_BLOOD_BINDING: return "rit_vial_blood";
+        case RIT_TYPE_SOUL_CALLING:  return "rit_soul_gem";
+        case RIT_TYPE_CURSE_WEAVING: return "rit_effigy";
+    }
+    return "";
+}
+
+string RitTypeItemName(int nType)
+{
+    switch(nType)
+    {
+        case RIT_TYPE_DARK_BLESSING: return "Czarna świeca";
+        case RIT_TYPE_BLOOD_BINDING: return "Fiolka krwi";
+        case RIT_TYPE_SOUL_CALLING:  return "Klejnot duszy";
+        case RIT_TYPE_CURSE_WEAVING: return "Kukła ofiarna";
+    }
+    return "—";
+}
+
+string RitStateName(int nState)
+{
+    switch(nState)
+    {
+        case RIT_STATE_IDLE:      return "Krąg oczekuje";
+        case RIT_STATE_GATHERING: return "Zbieranie uczestników";
+        case RIT_STATE_CASTING:   return "Rytuał w toku";
+        case RIT_STATE_COOLDOWN:  return "Krąg odpoczywa";
+    }
+    return "—";
+}
+
+// ============================================================
+// Participant helpers
+// ============================================================
+
+int RitIsParticipant(object oPC, string sTag)
+{
+    json jData = RitGetCircle(sTag);
+    if(JsonGetType(jData) == JSON_TYPE_NULL) return FALSE;
+    json jParts = JsonParse(JsonGetString(JsonObjectGet(jData, "participants_json")));
+    string sUUID = GetObjectUUID(oPC);
+    int i, n = JsonGetLength(jParts);
+    for(i = 0; i < n; i++)
+        if(JsonGetString(JsonArrayGet(jParts, i)) == sUUID) return TRUE;
+    return FALSE;
+}
+
+int RitIsLeader(object oPC, string sTag)
+{
+    json jData = RitGetCircle(sTag);
+    if(JsonGetType(jData) == JSON_TYPE_NULL) return FALSE;
+    return JsonGetString(JsonObjectGet(jData, "leader_uuid")) == GetObjectUUID(oPC);
+}
+
+int RitPartCount(string sTag)
+{
+    json jData = RitGetCircle(sTag);
+    if(JsonGetType(jData) == JSON_TYPE_NULL) return 0;
+    return JsonGetLength(JsonParse(JsonGetString(JsonObjectGet(jData, "participants_json"))));
+}
+
+// Resolve UUID to a name, checking online PCs first.
+string RitGetNameByUUID(string sUUID)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        if(GetObjectUUID(oPC) == sUUID) return GetName(oPC);
+        oPC = GetNextPC();
+    }
+    return "Nieobecny";
+}
+
+object RitGetPCByUUID(string sUUID)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        if(GetObjectUUID(oPC) == sUUID) return oPC;
+        oPC = GetNextPC();
+    }
+    return OBJECT_INVALID;
+}
+
+// Returns TRUE if the leader is online and holds the required ritual item.
+int RitLeaderHasItem(string sTag)
+{
+    json jData = RitGetCircle(sTag);
+    if(JsonGetType(jData) == JSON_TYPE_NULL) return FALSE;
+    string sLeaderUUID = JsonGetString(JsonObjectGet(jData, "leader_uuid"));
+    if(sLeaderUUID == "") return FALSE;
+    object oLeader = RitGetPCByUUID(sLeaderUUID);
+    if(!GetIsObjectValid(oLeader)) return FALSE;
+    int nType = JsonGetInt(JsonObjectGet(jData, "ritual_type"));
+    string sItemTag = RitTypeItemTag(nType);
+    if(sItemTag == "") return TRUE;
+    return GetIsObjectValid(GetItemPossessedBy(oLeader, sItemTag));
+}

--- a/Ritual Circles/scripts/lib_rit_ev.nss
+++ b/Ritual Circles/scripts/lib_rit_ev.nss
@@ -1,0 +1,60 @@
+// lib_rit_ev.nss - Ritual Circles: NUI event handler
+// Assigned to the window via RIT_EV_SCRIPT constant.
+
+#include "lib_rit"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    if(nToken != NuiFindWindow(oPC, RIT_WINDOW)) return;
+
+    string sTag = GetLocalString(oPC, RIT_LVAR_CIRCLE);
+
+    // Window closed via native X button — clean up if not in an active ritual
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        if(sTag != "" && !RitIsParticipant(oPC, sTag))
+            DeleteLocalString(oPC, RIT_LVAR_CIRCLE);
+        return;
+    }
+
+    if(sTag == "") return; // guard: window open but no circle tracked
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == RIT_BTN_JOIN)
+        {
+            RitJoin(oPC, sTag);
+            return;
+        }
+        if(sElem == RIT_BTN_LEAVE)
+        {
+            RitLeave(oPC, sTag);
+            return;
+        }
+        if(sElem == RIT_BTN_BEGIN)
+        {
+            RitBegin(oPC, sTag);
+            return;
+        }
+        if(sElem == RIT_BTN_CANCEL)
+        {
+            RitCancel(oPC, sTag);
+            return;
+        }
+    }
+
+    // Ritual type row selection (mousedown fires before click, gives better UX feel)
+    if(sEvent == EVENT_TYPE_MOUSEDOWN && sElem == RIT_BTN_TYPE_ROW)
+    {
+        // nIdx is 0-based; ritual types are 1-indexed
+        int nType = nIdx + 1;
+        RitSetType(oPC, sTag, nType);
+        return;
+    }
+}

--- a/Ritual Circles/scripts/sql_rit.nss
+++ b/Ritual Circles/scripts/sql_rit.nss
@@ -1,0 +1,120 @@
+// sql_rit.nss - Ritual Circles: SQLite DB layer
+// Campaign DB: "ritual"
+// Table: rit_circles — one row per circle placeable (identified by its tag)
+
+const string RIT_DB = "ritual";
+
+void RitCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign(RIT_DB,
+        "CREATE TABLE IF NOT EXISTS rit_circles ("
+        " tag TEXT PRIMARY KEY,"
+        " ritual_type INTEGER DEFAULT 0,"
+        " state INTEGER DEFAULT 0,"
+        " leader_uuid TEXT DEFAULT '',"
+        " participants_json TEXT DEFAULT '[]',"
+        " cast_start INTEGER DEFAULT 0,"
+        " cooldown_end INTEGER DEFAULT 0"
+        ")");
+    SqlStep(q);
+}
+
+// Ensures a row exists for the given tag (idempotent).
+void RitEnsureCircle(string sTag)
+{
+    sqlquery q = SqlPrepareQueryCampaign(RIT_DB,
+        "INSERT OR IGNORE INTO rit_circles (tag) VALUES (@tag)");
+    SqlBindString(q, "@tag", sTag);
+    SqlStep(q);
+}
+
+// Returns a JsonObject with all circle fields, or JsonNull if not found.
+json RitGetCircle(string sTag)
+{
+    RitEnsureCircle(sTag);
+    sqlquery q = SqlPrepareQueryCampaign(RIT_DB,
+        "SELECT ritual_type, state, leader_uuid, participants_json, cast_start, cooldown_end"
+        " FROM rit_circles WHERE tag = @tag");
+    SqlBindString(q, "@tag", sTag);
+    if(!SqlStep(q)) return JsonNull();
+
+    json j = JsonObject();
+    j = JsonObjectSet(j, "ritual_type",       JsonInt   (SqlGetInt   (q, 0)));
+    j = JsonObjectSet(j, "state",             JsonInt   (SqlGetInt   (q, 1)));
+    j = JsonObjectSet(j, "leader_uuid",       JsonString(SqlGetString(q, 2)));
+    j = JsonObjectSet(j, "participants_json", JsonString(SqlGetString(q, 3)));
+    j = JsonObjectSet(j, "cast_start",        JsonInt   (SqlGetInt   (q, 4)));
+    j = JsonObjectSet(j, "cooldown_end",      JsonInt   (SqlGetInt   (q, 5)));
+    return j;
+}
+
+// Writes all circle fields back to DB (REPLACE semantics).
+void RitSetCircle(string sTag, json jData)
+{
+    sqlquery q = SqlPrepareQueryCampaign(RIT_DB,
+        "INSERT OR REPLACE INTO rit_circles"
+        " (tag, ritual_type, state, leader_uuid, participants_json, cast_start, cooldown_end)"
+        " VALUES (@tag, @type, @state, @leader, @parts, @start, @cd)");
+    SqlBindString(q, "@tag",    sTag);
+    SqlBindInt   (q, "@type",   JsonGetInt   (JsonObjectGet(jData, "ritual_type")));
+    SqlBindInt   (q, "@state",  JsonGetInt   (JsonObjectGet(jData, "state")));
+    SqlBindString(q, "@leader", JsonGetString(JsonObjectGet(jData, "leader_uuid")));
+    SqlBindString(q, "@parts",  JsonGetString(JsonObjectGet(jData, "participants_json")));
+    SqlBindInt   (q, "@start",  JsonGetInt   (JsonObjectGet(jData, "cast_start")));
+    SqlBindInt   (q, "@cd",     JsonGetInt   (JsonObjectGet(jData, "cooldown_end")));
+    SqlStep(q);
+}
+
+// Resets a circle to idle/empty state.
+void RitResetCircle(string sTag)
+{
+    sqlquery q = SqlPrepareQueryCampaign(RIT_DB,
+        "UPDATE rit_circles"
+        " SET ritual_type=0, state=0, leader_uuid='', participants_json='[]',"
+        "     cast_start=0, cooldown_end=0"
+        " WHERE tag = @tag");
+    SqlBindString(q, "@tag", sTag);
+    SqlStep(q);
+}
+
+// Returns JsonArray of {tag, ritual_type, cast_start} for circles in CASTING state.
+json RitGetActiveCastingCircles()
+{
+    json jList = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign(RIT_DB,
+        "SELECT tag, ritual_type, participants_json, cast_start FROM rit_circles WHERE state = 2");
+    while(SqlStep(q))
+    {
+        json j = JsonObject();
+        j = JsonObjectSet(j, "tag",               JsonString(SqlGetString(q, 0)));
+        j = JsonObjectSet(j, "ritual_type",        JsonInt   (SqlGetInt   (q, 1)));
+        j = JsonObjectSet(j, "participants_json",  JsonString(SqlGetString(q, 2)));
+        j = JsonObjectSet(j, "cast_start",         JsonInt   (SqlGetInt   (q, 3)));
+        jList = JsonArrayInsert(jList, j);
+    }
+    return jList;
+}
+
+// Returns JsonArray of {tag, cooldown_end} for circles in COOLDOWN state.
+json RitGetCooldownCircles()
+{
+    json jList = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign(RIT_DB,
+        "SELECT tag, cooldown_end FROM rit_circles WHERE state = 3");
+    while(SqlStep(q))
+    {
+        json j = JsonObject();
+        j = JsonObjectSet(j, "tag",          JsonString(SqlGetString(q, 0)));
+        j = JsonObjectSet(j, "cooldown_end", JsonInt   (SqlGetInt   (q, 1)));
+        jList = JsonArrayInsert(jList, j);
+    }
+    return jList;
+}
+
+// Current unix timestamp via SQLite (matches server clock for interval math).
+int RitGetUnixTime()
+{
+    sqlquery q = SqlPrepareQueryCampaign(RIT_DB, "SELECT strftime('%s','now')");
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}

--- a/Ritual Circles/scripts/sys_module_hb.nss
+++ b/Ritual Circles/scripts/sys_module_hb.nss
@@ -1,0 +1,12 @@
+// sys_module_hb.nss - module OnHeartbeat (fires every ~6 seconds)
+// Hook: Module Properties -> Events -> OnHeartbeat
+//
+// Advances channeling timers and clears expired cooldowns.
+// Runs one SQL read per call (two queries); cost is negligible.
+
+#include "lib_rit"
+
+void main()
+{
+    RitProcessHeartbeat();
+}

--- a/Ritual Circles/scripts/sys_on_enter.nss
+++ b/Ritual Circles/scripts/sys_on_enter.nss
@@ -1,0 +1,33 @@
+// sys_on_enter.nss - module OnClientEnter
+// Hook: Module Properties -> Events -> OnClientEnter
+//
+// If the player was listed as a participant in an active ritual circle
+// (e.g., they crashed mid-channeling), notify them so they know to rejoin.
+
+#include "lib_rit"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC) || GetIsDM(oPC)) return;
+
+    string sUUID = GetObjectUUID(oPC);
+
+    // Scan active (GATHERING or CASTING) circles for this player's UUID.
+    // LIKE match is approximate; RitIsParticipant confirms the exact match.
+    sqlquery q = SqlPrepareQueryCampaign(RIT_DB,
+        "SELECT tag FROM rit_circles WHERE participants_json LIKE @pat AND state IN (1, 2)");
+    SqlBindString(q, "@pat", "%" + sUUID + "%");
+    while(SqlStep(q))
+    {
+        string sTag = SqlGetString(q, 0);
+        if(RitIsParticipant(oPC, sTag))
+        {
+            SetLocalString(oPC, RIT_LVAR_CIRCLE, sTag);
+            SendMessageToPC(oPC,
+                "[Rytuał] Uczestniczyłeś w rytuale, który trwa lub zbiera uczestników. "
+                "Wróć do kręgu, by otworzyć panel.");
+            break;
+        }
+    }
+}

--- a/Ritual Circles/scripts/sys_on_load.nss
+++ b/Ritual Circles/scripts/sys_on_load.nss
@@ -1,0 +1,9 @@
+// sys_on_load.nss - module OnModuleLoad
+// Hook: Module Properties -> Events -> OnModuleLoad
+
+#include "sql_rit"
+
+void main()
+{
+    RitCreateTables();
+}

--- a/Ritual Circles/scripts/test_rit.nss
+++ b/Ritual Circles/scripts/test_rit.nss
@@ -1,0 +1,25 @@
+// test_rit.nss - OnUsed script for a Ritual Circle placeable
+//
+// Attach to a placeable's OnUsed event in the toolset.
+// The placeable's Tag identifies the circle in the DB, so each
+// circle in the world needs a unique tag (e.g. "rit_circle_01").
+//
+// Demo:
+//   1. Place a placeable (e.g. Brazier) in the toolset.
+//   2. Set its Tag to "rit_circle_01".
+//   3. Assign this script to its OnUsed event.
+//   4. Two or more players use the object to open the panel.
+//   5. First player clicks a ritual type row to become leader.
+//   6. Others click "Dołącz".
+//   7. Leader clicks "Zainicjuj Rytuał" (with the required item in inventory).
+//   8. After 60 seconds the ritual completes and effects are applied.
+
+#include "lib_rit"
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC) || GetIsDM(oPC)) return;
+
+    RitOpenWindow(oPC, OBJECT_SELF);
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Co to robi

System grupowych kręgów rytualnych. Gracze (2–4) zbierają się przy specjalnym placeable w świecie gry, wybierają typ rytuału, lider dostarcza wymagany artefakt i inicjuje 60-sekundowe channelowanie. Po sukcesie wszyscy uczestnicy otrzymują potężne efekty grupowe; przerwanie rytuału przez kogokolwiek powoduje backlash (2d6 obrażeń magicznych + 6s ogłuszenie). Krąg przechodzi następnie w 10-minutowy cooldown.

## Mechanika

**4 rytuały:**
| Rytuał | Min. uczestników | Artefakt | Efekt sukcesu |
|--------|-----------------|----------|---------------|
| Błogosławieństwo Mroku | 2 | Czarna świeca (`rit_candle_black`) | +2 do ataków i +2 magicznych obrażeń przez 1h (wszyscy) |
| Pakt Krwi | 3 | Fiolka krwi (`rit_vial_blood`) | Kosztuje 20% HP każdego → leczy wszystkich do 75% max HP |
| Przywołanie Ducha | 4 | Klejnot duszy (`rit_soul_gem`) | Lider przywołuje wrait (nw_shwraith) na 30 min |
| Splot Klątwy | 2 | Kukła ofiarna (`rit_effigy`) | –2 do wszystkich rzutów obronnych przez 1h (uczestnicy niosą klątwę) |

**Stany kręgu:** Idle → Gathering → Casting (60s, progress bar) → Cooldown (10 min) → Idle

**UX flow:** Gracz używa placeable → okno NUI → klik w wiersz rytuału (auto-dołącza jako lider) → inni klikają "Dołącz" → lider klika "Zainicjuj Rytuał" (wymaga artefaktu).

## Pliki

```
Ritual Circles/
├── INTEGRATION.md
└── scripts/
    ├── lib_nui.nss          — minimalne helpery NUI (kopia z Plague)
    ├── sql_rit.nss          — schema SQLite + zapytania (kampania "ritual")
    ├── lib_rit_def.nss      — stałe, dane rytuałów, helpery uczestników
    ├── lib_rit.nss          — layout NUI, RitOpenWindow/FeedWindow, akcje Join/Leave/Begin/Cancel/Complete
    ├── lib_rit_ev.nss       — handler NUI eventów (click / mousedown)
    ├── sys_on_load.nss      — CREATE TABLE IF NOT EXISTS
    ├── sys_on_enter.nss     — wykrywa gracza z aktywnym rytuałem po reconnect
    ├── sys_module_hb.nss    — wywołuje RitProcessHeartbeat() co 6s
    └── test_rit.nss         — OnUsed na placeable kręgu
```

**Łącznie:** ~1350 LOC NWScript

## Zależności (NWNX? SQL?)

- **NWNX:** brak — wyłącznie standardowy NWScript + NUI (NWN:EE 8193+)
- **SQLite:** kampania `"ritual"`, tabela `rit_circles` (jeden wiersz per tag placeable, tworzony automatycznie)

## Jak włączyć w istniejącym module

1. Dodaj skrypty do HAK/override projektu.
2. Podepnij hooki w Module Properties:
   - `sys_on_load` → **OnModuleLoad**
   - `sys_on_enter` → **OnClientEnter**
   - `sys_module_hb` → **OnHeartbeat**
3. W toolsecie: umieść placeable (np. Brazier), nadaj mu unikalny Tag (np. `rit_circle_01`), przypisz `test_rit` do zdarzenia **OnUsed**.
4. Stwórz przedmioty z tagami z tabeli powyżej i rozsiaj je w świecie.

## Co celowo pominięto

- Brak panelu DM — zrób osobny script oparty o `RitGetCircle`/`RitSetCircle` jeśli potrzebny.
- Brak rejestracji offline graczy — Pakt Krwi i inne rytuały wymagają obecności online.
- Soul Calling używa standardowego blueprinta `nw_shwraith`; podmień na własny resref dla lepszej prezentacji.
- Curse Weaving daje debuff samym uczestnikom (nosiciele klątwy) zamiast działać obszarowo — upraszcza implementację bez NWNX; można rozbudować przez OnSpellHook.
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZCLtcdbQxXrrahsYSQnAm)_