### PR TITLE
feat: Sins & Absolution

### DIFF
--- a/Sins & Absolution/INTEGRATION.md
+++ b/Sins & Absolution/INTEGRATION.md
@@ -1,0 +1,105 @@
+# Sins & Absolution — Integracja
+
+## Co to jest
+
+System śledzenia grzechów postaci (SQLite per UUID). Każdy grzech dodaje punkty;
+narastający wynik nakłada trwałe kary statystyk. Absolucja kosztuje złoto;
+alternatywą jest „Mroczne Objęcie" — nieodwracalna zgoda na mrok w zamian za bonusy bojowe.
+
+## Hooki modułu
+
+| Zdarzenie          | Skrypt             |
+|--------------------|--------------------|
+| `OnModuleLoad`     | `sys_on_load`      |
+| `OnClientEnter`    | `sys_on_enter`     |
+| `OnUsed` (placeable) | `test_sin`       |
+
+Plik `lib_sin_ev` podpinamy jako skrypt NUI (`NUI_EVENT_SCRIPT`) — robi to automatycznie
+`SinOpenWindow` przez wywołanie `NuiCreate(oPC, jNui, SIN_WINDOW, "lib_sin_ev")`.
+
+## Publiczne API
+
+```nwscript
+#include "lib_sin"
+
+// Dodaj grzech (z dowolnego skryptu gry, np. OnDeath, OnTheft, OnSpellCast).
+SinAddSin(oPC, SIN_TYPE_MURDER, 8, "Zabójstwo kupca w Athkatli");
+
+// Sprawdź aktualny poziom.
+int nScore = SinGetScore(oPC);
+
+// Otwórz okno spowiedzi dla gracza (np. OnConversation NPC).
+SinOpenWindow(oPC);
+```
+
+## Typy grzechów i zalecane ciężary
+
+| Stała                | Przykłady zastosowania                               | Typowy ciężar |
+|----------------------|------------------------------------------------------|---------------|
+| `SIN_TYPE_MURDER`    | Zabójstwo sojusznika, niewinnego, strażnika          | 5–15          |
+| `SIN_TYPE_THEFT`     | Kradzież ze sklepu/kościoła, kieszonkowanie          | 2–6           |
+| `SIN_TYPE_BLASPHEMY` | Zbezczeszczenie ołtarza, obrażenie bóstwa            | 3–8           |
+| `SIN_TYPE_DARK_RITUAL` | Rytuał kultystyczny, taniec z demonami             | 8–15          |
+| `SIN_TYPE_BETRAYAL`  | Zdrada gildii, kompana, sojusznika                   | 4–10          |
+| `SIN_TYPE_UNDEAD`    | Ożywianie zwłok, kontrola nieumarłych                | 5–10          |
+| `SIN_TYPE_DEMON_PACT`| Pakt z istotą demoniczną                             | 10–20         |
+| `SIN_TYPE_CORRUPTION`| Przekupstwo urzędnika, sabotaż                       | 3–7           |
+| `SIN_TYPE_DESECRATION`| Profanacja grobów/kościoła, zbezczeszczenie relikwii| 3–8           |
+
+## Progi i kary
+
+| Próg (score) | Nazwa           | Kary                                   |
+|--------------|-----------------|----------------------------------------|
+| 0–9          | Czysty          | brak                                   |
+| 10–24        | Skażony         | −1 Cha                                 |
+| 25–49        | Nieczysty       | −2 Cha, −1 Mąd                         |
+| 50–74        | Niegodziwiec    | −3 Cha, −2 Mąd, −1 Int                 |
+| 75–99        | Przeklęty       | −3 Cha, −2 Mąd, −2 Int, −2 Wola       |
+| 100+         | POTĘPIONY       | −4 Cha, −3 Mąd, −3 Int, −3 Wola + ikona|
+
+Kary są supernaturalne (nie znika po odpoczynku, nie da się rozwiać Dispel Magic).
+
+## Mroczne Objęcie
+
+Dostępne przy ≥ 75 pkt grzechu. Nieodwracalne. Dodaje +15 pkt grzechu i:
+- +2 Siły
+- +2 Budowy
+- +1 obrażenia nekrotyczne (każde trafienie)
+- Odporność na Strach
+
+Blokuje absolucję na zawsze. Efekty tagowane `SIN_EMBRACE_TAG`; przywracane przy
+każdym `OnClientEnter`.
+
+## Absolucja
+
+Koszt: `score × 80` sz. Dostępna tylko dla niezapieczętowanych. Zeruje score i log.
+
+## Przykład integracji z systemem walk
+
+```nwscript
+// W skrypcie OnDeath NPC:
+object oKiller = GetLastKiller();
+if (GetIsPC(oKiller))
+{
+    // Jeśli ofiara jest sojuszniczym NPC lub strażnikiem:
+    if (GetFactionEqual(oKiller, GetFactionLeader(OBJECT_SELF)) == FALSE)
+        SinAddSin(oKiller, SIN_TYPE_MURDER, 10, "Zabójstwo " + GetName(OBJECT_SELF));
+}
+```
+
+## Zależności
+
+- **NWNX:** brak
+- **SQLite:** kampania `"sins"` (baza tworzona automatycznie w `sys_on_load`)
+- **NWN:EE:** min. build 8193.14 (NUI + `TagEffect` + `EffectIcon`)
+
+## Co celowo pominięto
+
+- Automatyczne wyzwalanie grzechów z systemu walki — wymaga modyfikacji
+  skryptów `OnDeath`/`OnSpellCast`; integracja przez API jest zamierzona.
+- Kara dla klas kleryk/paladyn (utrata slotów zaklęć) — wymaga ingerencji
+  w system zaklęć lub NWNX; można dołożyć w `SinApplyPenalties`.
+- UI konfesjonału NPC-driven — wystarczy podpiąć `SinOpenWindow(oPC)` do
+  `OnConversation` odpowiedniego NPC.
+- Rozgrzeszenie połowiczne (np. zmniejszenie o 50%) — celowo nie ma, by
+  absolucja miała wagę decyzji.

--- a/Sins & Absolution/Scripts/lib_nui.nss
+++ b/Sins & Absolution/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Sins & Absolution/Scripts/lib_nui_utility.nss
+++ b/Sins & Absolution/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Sins & Absolution/Scripts/lib_sin.nss
+++ b/Sins & Absolution/Scripts/lib_sin.nss
@@ -1,0 +1,506 @@
+#include "lib_sin_def"
+
+// ================================================================
+// String / color helpers
+// ================================================================
+
+string SinTypeName(int nType)
+{
+    switch (nType)
+    {
+        case SIN_TYPE_MURDER:      return "Morderstwo";
+        case SIN_TYPE_THEFT:       return "Kradzież";
+        case SIN_TYPE_BLASPHEMY:   return "Bluźnierstwo";
+        case SIN_TYPE_DARK_RITUAL: return "Mroczny Rytuał";
+        case SIN_TYPE_BETRAYAL:    return "Zdrada";
+        case SIN_TYPE_UNDEAD:      return "Nekromancja";
+        case SIN_TYPE_DEMON_PACT:  return "Pakt z Demonem";
+        case SIN_TYPE_CORRUPTION:  return "Korupcja";
+        case SIN_TYPE_DESECRATION: return "Profanacja";
+    }
+    return "Grzech";
+}
+
+json SinTypeColor(int nType)
+{
+    switch (nType)
+    {
+        case SIN_TYPE_MURDER:      return NuiColor(220,  40,  40);
+        case SIN_TYPE_THEFT:       return NuiColor(190, 140,  50);
+        case SIN_TYPE_BLASPHEMY:   return NuiColor(140,  60, 200);
+        case SIN_TYPE_DARK_RITUAL: return NuiColor(110,  40, 180);
+        case SIN_TYPE_BETRAYAL:    return NuiColor(210, 180,  30);
+        case SIN_TYPE_UNDEAD:      return NuiColor(170, 200, 170);
+        case SIN_TYPE_DEMON_PACT:  return NuiColor(230,  20,  70);
+        case SIN_TYPE_CORRUPTION:  return NuiColor( 60, 170,  70);
+        case SIN_TYPE_DESECRATION: return NuiColor(160, 150, 140);
+    }
+    return NuiColor(200, 200, 200);
+}
+
+string SinLevelName(int nScore)
+{
+    if (nScore >= SIN_LEVEL_DAMNED)  return "POTĘPIONY";
+    if (nScore >= SIN_LEVEL_CORRUPT) return "Przeklęty";
+    if (nScore >= SIN_LEVEL_WICKED)  return "Niegodziwiec";
+    if (nScore >= SIN_LEVEL_IMPURE)  return "Nieczysty";
+    if (nScore >= SIN_LEVEL_TAINTED) return "Skażony";
+    return "Czysty";
+}
+
+json SinLevelColor(int nScore)
+{
+    if (nScore >= SIN_LEVEL_DAMNED)  return NuiColor(255,  20,  20);
+    if (nScore >= SIN_LEVEL_CORRUPT) return NuiColor(230,  70,  50);
+    if (nScore >= SIN_LEVEL_WICKED)  return NuiColor(210, 120,  50);
+    if (nScore >= SIN_LEVEL_IMPURE)  return NuiColor(190, 170,  60);
+    if (nScore >= SIN_LEVEL_TAINTED) return NuiColor(160, 190, 100);
+    return NuiColor(130, 200, 130);
+}
+
+string SinGetPenaltyDesc(int nScore)
+{
+    if (nScore >= SIN_LEVEL_DAMNED)
+        return "−4 Cha, −3 Mąd, −3 Int, −3 Wola";
+    if (nScore >= SIN_LEVEL_CORRUPT)
+        return "−3 Cha, −2 Mąd, −2 Int, −2 Wola";
+    if (nScore >= SIN_LEVEL_WICKED)
+        return "−3 Cha, −2 Mąd, −1 Int";
+    if (nScore >= SIN_LEVEL_IMPURE)
+        return "−2 Cha, −1 Mąd";
+    if (nScore >= SIN_LEVEL_TAINTED)
+        return "−1 Cha";
+    return "Brak";
+}
+
+int SinCalcAbsolveCost(int nScore)
+{
+    return nScore * SIN_ABS_GOLD_PER_PT;
+}
+
+// ================================================================
+// Effect management
+// ================================================================
+
+void SinRemoveTaggedEffects(object oPC, string sTag)
+{
+    effect e = GetFirstEffect(oPC);
+    while (GetIsEffectValid(e))
+    {
+        if (GetEffectTag(e) == sTag)
+            RemoveEffect(oPC, e);
+        e = GetNextEffect(oPC);
+    }
+}
+
+void SinApplyPenalties(object oPC)
+{
+    SinRemoveTaggedEffects(oPC, SIN_EFFECT_TAG);
+
+    int nScore = SinGetScore(oPC);
+    if (nScore < SIN_LEVEL_TAINTED) return;
+
+    // Cumulative stat decreases per threshold
+    int nCha = 0;
+    int nWis = 0;
+    int nInt = 0;
+    int nWil = 0;
+
+    if (nScore >= SIN_LEVEL_TAINTED) { nCha += 1; }
+    if (nScore >= SIN_LEVEL_IMPURE)  { nCha += 1; nWis += 1; }
+    if (nScore >= SIN_LEVEL_WICKED)  { nCha += 1; nWis += 1; nInt += 1; }
+    if (nScore >= SIN_LEVEL_CORRUPT) { nInt += 1; nWil += 2; }
+    if (nScore >= SIN_LEVEL_DAMNED)  { nCha += 1; nWis += 1; nInt += 1; nWil += 1; }
+
+    // Build single linked effect so removal by tag is O(1) in the effects list
+    effect ePen = EffectAbilityDecrease(ABILITY_CHARISMA, nCha);
+    if (nWis > 0)
+        ePen = EffectLinkEffects(ePen, EffectAbilityDecrease(ABILITY_WISDOM, nWis));
+    if (nInt > 0)
+        ePen = EffectLinkEffects(ePen, EffectAbilityDecrease(ABILITY_INTELLIGENCE, nInt));
+    if (nWil > 0)
+        ePen = EffectLinkEffects(ePen, EffectSavingThrowDecrease(SAVING_THROW_WILL, nWil));
+    if (nScore >= SIN_LEVEL_DAMNED)
+        ePen = EffectLinkEffects(ePen, EffectIcon(EFFECT_ICON_DISEASE));
+
+    ePen = SupernaturalEffect(ePen);
+    ePen = TagEffect(ePen, SIN_EFFECT_TAG);
+    ApplyEffectToObject(DURATION_TYPE_PERMANENT, ePen, oPC);
+}
+
+void SinApplyEmbraceEffects(object oPC)
+{
+    SinRemoveTaggedEffects(oPC, SIN_EMBRACE_TAG);
+
+    effect eEmb = EffectAbilityIncrease(ABILITY_STRENGTH, 2);
+    eEmb = EffectLinkEffects(eEmb, EffectAbilityIncrease(ABILITY_CONSTITUTION, 2));
+    eEmb = EffectLinkEffects(eEmb, EffectDamageBonus(DAMAGE_BONUS_1, DAMAGE_TYPE_NEGATIVE));
+    eEmb = EffectLinkEffects(eEmb, EffectImmunity(IMMUNITY_TYPE_FEAR));
+    eEmb = SupernaturalEffect(eEmb);
+    eEmb = TagEffect(eEmb, SIN_EMBRACE_TAG);
+    ApplyEffectToObject(DURATION_TYPE_PERMANENT, eEmb, oPC);
+}
+
+// ================================================================
+// Public API — call from other modules to record sin
+// ================================================================
+
+void SinAddSin(object oPC, int nSinType, int nAmount, string sDesc)
+{
+    if (!GetIsPC(oPC) || nAmount <= 0) return;
+
+    SinRegisterChar(oPC);
+
+    int nCurrent = SinGetScore(oPC);
+    int nNew     = nCurrent + nAmount;
+    if (nNew > SIN_MAX) nNew = SIN_MAX;
+
+    SinSetScore(oPC, nNew);
+    SinLogEntry(oPC, nSinType, nAmount, sDesc);
+    SinApplyPenalties(oPC);
+
+    SendMessageToPC(oPC,
+        "[Piętno] " + SinTypeName(nSinType) + ": +" + IntToString(nAmount) +
+        " pkt. (" + IntToString(nNew) + "/" + IntToString(SIN_MAX) + ")");
+
+    if (nNew >= SIN_LEVEL_DAMNED && nCurrent < SIN_LEVEL_DAMNED)
+        FloatingTextStringOnCreature(
+            "Piętno pożera twoją duszę bez reszty. Jesteś POTĘPIONY.", oPC, FALSE);
+    else if (nNew >= SIN_LEVEL_CORRUPT && nCurrent < SIN_LEVEL_CORRUPT)
+        FloatingTextStringOnCreature(
+            "Ciemność znaczy cię na zawsze. Jesteś przeklęty.", oPC, FALSE);
+    else if (nNew >= SIN_LEVEL_WICKED && nCurrent < SIN_LEVEL_WICKED)
+        FloatingTextStringOnCreature(
+            "Grzech wyżera ci twarz. Ludzie odwracają wzrok.", oPC, FALSE);
+
+    int nToken = NuiFindWindow(oPC, SIN_WINDOW);
+    if (nToken != 0) SinFeedWindow(oPC, nToken);
+}
+
+void SinAbsolve(object oPC)
+{
+    if (SinIsEmbraced(oPC))
+    {
+        SendMessageToPC(oPC,
+            "[Piętno] Mroczne Objęcie zamknęło twą duszę na łaskę. Absolucja jest niedostępna.");
+        return;
+    }
+
+    int nScore = SinGetScore(oPC);
+    if (nScore <= 0)
+    {
+        SendMessageToPC(oPC, "[Piętno] Twoja dusza jest czysta — nie ma czego przebaczać.");
+        return;
+    }
+
+    int nCost = SinCalcAbsolveCost(nScore);
+    if (GetGold(oPC) < nCost)
+    {
+        SendMessageToPC(oPC,
+            "[Piętno] Absolucja kosztuje " + IntToString(nCost) +
+            " sz. Brakuje ci złota na oczyszczenie duszy.");
+        return;
+    }
+
+    AssignCommand(oPC, TakeGoldFromCreature(nCost, oPC, TRUE));
+    SinSetScore(oPC, 0);
+    SinClearLog(oPC);
+    SinApplyPenalties(oPC);
+
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectVisualEffect(VFX_IMP_HOLY_AID), oPC);
+    FloatingTextStringOnCreature(
+        "Absolucja udzielona. Dusza oczyszczona jak nowo wykuta stal.", oPC, FALSE);
+    SendMessageToPC(oPC,
+        "[Piętno] Absolucja przyjęta. −" + IntToString(nCost) + " sz. Grzechy wymazane z rejestru.");
+
+    int nToken = NuiFindWindow(oPC, SIN_WINDOW);
+    if (nToken != 0) SinFeedWindow(oPC, nToken);
+}
+
+void SinEmbrace(object oPC)
+{
+    if (SinIsEmbraced(oPC))
+    {
+        SendMessageToPC(oPC, "[Piętno] Już przyjąłeś Mroczne Objęcie. Droga wstecz jest zamknięta.");
+        return;
+    }
+
+    int nScore = SinGetScore(oPC);
+    if (nScore < SIN_EMBRACE_MIN)
+    {
+        SendMessageToPC(oPC,
+            "[Piętno] Piętno jest zbyt słabe. Potrzebujesz " +
+            IntToString(SIN_EMBRACE_MIN) + " pkt grzechu by Objęcie cię przyjęło.");
+        return;
+    }
+
+    SinSetEmbraced(oPC, 1);
+
+    int nNew = nScore + SIN_EMBRACE_COST;
+    if (nNew > SIN_MAX) nNew = SIN_MAX;
+    SinSetScore(oPC, nNew);
+    SinLogEntry(oPC, SIN_TYPE_DARK_RITUAL, SIN_EMBRACE_COST, "Przyjęcie Mrocznego Objęcia");
+
+    SinApplyPenalties(oPC);
+    SinApplyEmbraceEffects(oPC);
+
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectVisualEffect(VFX_IMP_EVIL_HELP), oPC);
+    FloatingTextStringOnCreature(
+        "Mroczne Objęcie wypala znamię na duszy. Moc bez granic — odkupienie niemożliwe.", oPC, FALSE);
+    SendMessageToPC(oPC,
+        "[Piętno] Mroczne Objęcie przyjęte: +2 Siły, +2 Budowy, odporność na Strach, +1 obrażenia nekrotyczne. "
+        "Absolucja zamknięta na zawsze.");
+
+    int nToken = NuiFindWindow(oPC, SIN_WINDOW);
+    if (nToken != 0) SinFeedWindow(oPC, nToken);
+}
+
+// ================================================================
+// NUI — list row template cell
+// ================================================================
+
+json SinBuildRowCell(object oPC)
+{
+    float fTypeW = GetNuiScaleDimension(oPC, 140.0);
+    float fAmtW  = GetNuiScaleDimension(oPC, 44.0);
+    float fH     = GetNuiScaleDimension(oPC, 24.0);
+
+    json jType = NuiLabel(
+        NuiBind(SIN_BIND_ROW_TYPE),
+        JsonInt(NUI_HALIGN_LEFT),
+        JsonInt(NUI_VALIGN_MIDDLE));
+    jType = NuiWidth(jType, fTypeW);
+    jType = NuiStyleForegroundColor(jType, NuiBind(SIN_BIND_ROW_COLOR));
+
+    json jDesc = NuiLabel(
+        NuiBind(SIN_BIND_ROW_DESC),
+        JsonInt(NUI_HALIGN_LEFT),
+        JsonInt(NUI_VALIGN_MIDDLE));
+    jDesc = NuiStyleForegroundColor(jDesc, NuiBind(SIN_BIND_ROW_COLOR));
+
+    // Amount column always in blood red — color is not row-specific
+    json jAmt = NuiLabel(
+        NuiBind(SIN_BIND_ROW_AMT),
+        JsonInt(NUI_HALIGN_RIGHT),
+        JsonInt(NUI_VALIGN_MIDDLE));
+    jAmt = NuiWidth(jAmt, fAmtW);
+    jAmt = NuiStyleForegroundColor(jAmt, NuiColor(220, 50, 50));
+
+    json jCols = JsonArray();
+    jCols = JsonArrayInsert(jCols, jType);
+    jCols = JsonArrayInsert(jCols, jDesc);
+    jCols = JsonArrayInsert(jCols, jAmt);
+
+    json jCell = NuiGroup(NuiRow(jCols), FALSE, NUI_SCROLLBARS_NONE);
+    jCell = NuiHeight(jCell, fH);
+    return jCell;
+}
+
+// ================================================================
+// NUI — window builder
+// ================================================================
+
+void SinOpenWindow(object oPC)
+{
+    int nExisting = NuiFindWindow(oPC, SIN_WINDOW);
+    if (nExisting != 0)
+    {
+        SinFeedWindow(oPC, nExisting);
+        return;
+    }
+
+    float fW    = GetNuiScaleDimension(oPC, SIN_W);
+    float fH    = GetNuiScaleDimension(oPC, SIN_H);
+    float fBtnH = GetNuiScaleDimension(oPC, 30.0);
+    float fBarH = GetNuiScaleDimension(oPC, 20.0);
+    float fLblH = GetNuiScaleDimension(oPC, 22.0);
+
+    // Title row: label left, X right
+    json jTitleLbl = NuiLabel(
+        JsonString("PIĘTNO GRZECHU"),
+        JsonInt(NUI_HALIGN_LEFT),
+        JsonInt(NUI_VALIGN_MIDDLE));
+    jTitleLbl = NuiHeight(jTitleLbl, fBtnH);
+    jTitleLbl = NuiStyleForegroundColor(jTitleLbl, NuiColor(220, 55, 55));
+
+    json jClose = NuiButton(JsonString("X"));
+    jClose = NuiId(jClose, SIN_BTN_CLOSE);
+    jClose = NuiWidth(jClose, GetNuiScaleDimension(oPC, 30.0));
+    jClose = NuiHeight(jClose, fBtnH);
+
+    json jTitleRow = JsonArray();
+    jTitleRow = JsonArrayInsert(jTitleRow, jTitleLbl);
+    jTitleRow = JsonArrayInsert(jTitleRow, NuiSpacer());
+    jTitleRow = JsonArrayInsert(jTitleRow, jClose);
+
+    // Sin gauge (0.0 - 1.0)
+    json jGauge = NuiProgress(NuiBind(SIN_BIND_GAUGE));
+    jGauge = NuiHeight(jGauge, fBarH);
+    jGauge = NuiTooltip(jGauge, JsonString("Poziom piętna grzechu"));
+
+    json jGaugeRow = JsonArray();
+    jGaugeRow = JsonArrayInsert(jGaugeRow, jGauge);
+
+    // Status label: level name + score
+    json jStatus = NuiLabel(
+        NuiBind(SIN_BIND_STATUS_LBL),
+        JsonInt(NUI_HALIGN_CENTER),
+        JsonInt(NUI_VALIGN_MIDDLE));
+    jStatus = NuiHeight(jStatus, fLblH);
+    jStatus = NuiStyleForegroundColor(jStatus, NuiBind(SIN_BIND_STATUS_COL));
+
+    json jStatusRow = JsonArray();
+    jStatusRow = JsonArrayInsert(jStatusRow, jStatus);
+
+    // Sin log list header label
+    json jLogHdr = NuiLabel(
+        JsonString("Rejestr grzechów:"),
+        JsonInt(NUI_HALIGN_LEFT),
+        JsonInt(NUI_VALIGN_MIDDLE));
+    jLogHdr = NuiHeight(jLogHdr, fLblH);
+    jLogHdr = NuiStyleForegroundColor(jLogHdr, NuiColor(180, 170, 140));
+
+    json jLogHdrRow = JsonArray();
+    jLogHdrRow = JsonArrayInsert(jLogHdrRow, jLogHdr);
+
+    // Sin log list
+    json jListCells = JsonArray();
+    jListCells = JsonArrayInsert(jListCells,
+        NuiListTemplateCell(SinBuildRowCell(oPC), 0.0, TRUE));
+
+    float fListH = fH - GetNuiScaleDimension(oPC, 260.0);
+    json jList = NuiList(jListCells, NuiBind(SIN_BIND_ROW_COUNT),
+        GetNuiScaleDimension(oPC, 24.0));
+    jList = NuiHeight(jList, fListH);
+
+    json jListRow = JsonArray();
+    jListRow = JsonArrayInsert(jListRow, jList);
+
+    // Penalty description label
+    json jPenLbl = NuiLabel(
+        NuiBind(SIN_BIND_PENALTY_LBL),
+        JsonInt(NUI_HALIGN_LEFT),
+        JsonInt(NUI_VALIGN_MIDDLE));
+    jPenLbl = NuiHeight(jPenLbl, fLblH);
+    jPenLbl = NuiStyleForegroundColor(jPenLbl, NuiColor(200, 170, 70));
+
+    json jPenRow = JsonArray();
+    jPenRow = JsonArrayInsert(jPenRow, jPenLbl);
+
+    // Action buttons: Absolucja | Mroczne Objęcie
+    json jAbsBtn = NuiButton(NuiBind(SIN_BIND_ABS_LBL));
+    jAbsBtn = NuiId(jAbsBtn, SIN_BTN_ABS);
+    jAbsBtn = NuiEnabled(jAbsBtn, NuiBind(SIN_BIND_ABS_ENA));
+    jAbsBtn = NuiHeight(jAbsBtn, fBtnH);
+    jAbsBtn = NuiTooltip(jAbsBtn,
+        JsonString("Oddaj złoto kapłanowi i usuń wszystkie grzechy z rejestru"));
+
+    json jEmbBtn = NuiButton(NuiBind(SIN_BIND_EMB_LBL));
+    jEmbBtn = NuiId(jEmbBtn, SIN_BTN_EMBRACE);
+    jEmbBtn = NuiEnabled(jEmbBtn, NuiBind(SIN_BIND_EMB_ENA));
+    jEmbBtn = NuiHeight(jEmbBtn, fBtnH);
+    jEmbBtn = NuiTooltip(jEmbBtn,
+        JsonString("Przyjmij mrok jako część siebie. Nieodwracalne. Blokuje absolucję."));
+
+    json jActRow = JsonArray();
+    jActRow = JsonArrayInsert(jActRow, jAbsBtn);
+    jActRow = JsonArrayInsert(jActRow,
+        NuiWidth(NuiSpacer(), GetNuiScaleDimension(oPC, 8.0)));
+    jActRow = JsonArrayInsert(jActRow, jEmbBtn);
+
+    // Assemble column layout
+    json jCols = JsonArray();
+    jCols = JsonArrayInsert(jCols, NuiRow(jTitleRow));
+    jCols = JsonArrayInsert(jCols, CreateEmptyRow(oPC, 6.0));
+    jCols = JsonArrayInsert(jCols, NuiRow(jGaugeRow));
+    jCols = JsonArrayInsert(jCols, NuiRow(jStatusRow));
+    jCols = JsonArrayInsert(jCols, CreateEmptyRow(oPC, 4.0));
+    jCols = JsonArrayInsert(jCols, NuiRow(jLogHdrRow));
+    jCols = JsonArrayInsert(jCols, NuiRow(jListRow));
+    jCols = JsonArrayInsert(jCols, CreateEmptyRow(oPC, 4.0));
+    jCols = JsonArrayInsert(jCols, NuiRow(jPenRow));
+    jCols = JsonArrayInsert(jCols, CreateEmptyRow(oPC, 6.0));
+    jCols = JsonArrayInsert(jCols, NuiRow(jActRow));
+
+    json jRoot = NuiCol(jCols);
+
+    json jNui = NuiWindow(jRoot,
+        JsonString(""),            // no native title bar text (custom title in layout)
+        NuiRect(-1.0, -1.0, fW, fH),
+        JsonBool(FALSE),           // resizable
+        JsonBool(FALSE),           // collapsed
+        JsonBool(FALSE),           // closable (hide engine X button)
+        JsonBool(FALSE),           // transparent
+        JsonBool(TRUE));           // border (draggable title area)
+
+    int nToken = NuiCreate(oPC, jNui, SIN_WINDOW, SIN_EV_SCRIPT);
+    SinFeedWindow(oPC, nToken);
+}
+
+// ================================================================
+// NUI — feed binds from current DB state
+// ================================================================
+
+void SinFeedWindow(object oPC, int nToken)
+{
+    int nScore    = SinGetScore(oPC);
+    int bEmbraced = SinIsEmbraced(oPC);
+
+    // Progress gauge (0.0 - 1.0)
+    float fGauge = IntToFloat(nScore) / IntToFloat(SIN_MAX);
+    if (fGauge > 1.0) fGauge = 1.0;
+    NuiSetBind(oPC, nToken, SIN_BIND_GAUGE, JsonFloat(fGauge));
+
+    // Status line
+    string sLevel = SinLevelName(nScore);
+    if (bEmbraced) sLevel = sLevel + "  [Mroczne Objęcie]";
+    NuiSetBind(oPC, nToken, SIN_BIND_STATUS_LBL,
+        JsonString(sLevel + "  —  " + IntToString(nScore) + " / " + IntToString(SIN_MAX)));
+    NuiSetBind(oPC, nToken, SIN_BIND_STATUS_COL, SinLevelColor(nScore));
+
+    // Penalty label
+    NuiSetBind(oPC, nToken, SIN_BIND_PENALTY_LBL,
+        JsonString("Kary: " + SinGetPenaltyDesc(nScore)));
+
+    // Absolucja button
+    int nCost = SinCalcAbsolveCost(nScore);
+    NuiSetBind(oPC, nToken, SIN_BIND_ABS_LBL,
+        JsonString("Absolucja (" + IntToString(nCost) + " sz)"));
+    NuiSetBind(oPC, nToken, SIN_BIND_ABS_ENA,
+        JsonBool(nScore > 0 && !bEmbraced));
+
+    // Mroczne Objęcie button
+    NuiSetBind(oPC, nToken, SIN_BIND_EMB_LBL,
+        JsonString(bEmbraced ? "Mroczne Objęcie (aktywne)" : "Mroczne Objęcie"));
+    NuiSetBind(oPC, nToken, SIN_BIND_EMB_ENA,
+        JsonBool(!bEmbraced && nScore >= SIN_EMBRACE_MIN));
+
+    // Sin log list data
+    json jLog    = SinGetLog(oPC, SIN_LOG_LIMIT);
+    int  nCount  = JsonGetLength(jLog);
+
+    json jTypes  = JsonArray();
+    json jDescs  = JsonArray();
+    json jAmts   = JsonArray();
+    json jColors = JsonArray();
+
+    int i;
+    for (i = 0; i < nCount; i++)
+    {
+        json   jRow  = JsonArrayGet(jLog, i);
+        int    nType = JsonGetInt(JsonObjectGet(jRow, "sin_type"));
+        int    nAmt  = JsonGetInt(JsonObjectGet(jRow, "amount"));
+        string sDesc = JsonGetString(JsonObjectGet(jRow, "description"));
+
+        jTypes  = JsonArrayInsert(jTypes,  JsonString(SinTypeName(nType)));
+        jDescs  = JsonArrayInsert(jDescs,  JsonString(sDesc));
+        jAmts   = JsonArrayInsert(jAmts,   JsonString("+" + IntToString(nAmt)));
+        jColors = JsonArrayInsert(jColors, SinTypeColor(nType));
+    }
+
+    NuiSetBind(oPC, nToken, SIN_BIND_ROW_COUNT, JsonInt(nCount));
+    NuiSetBind(oPC, nToken, SIN_BIND_ROW_TYPE,  jTypes);
+    NuiSetBind(oPC, nToken, SIN_BIND_ROW_DESC,  jDescs);
+    NuiSetBind(oPC, nToken, SIN_BIND_ROW_AMT,   jAmts);
+    NuiSetBind(oPC, nToken, SIN_BIND_ROW_COLOR, jColors);
+}

--- a/Sins & Absolution/Scripts/lib_sin_def.nss
+++ b/Sins & Absolution/Scripts/lib_sin_def.nss
@@ -1,0 +1,96 @@
+#include "lib_nui"
+#include "sql_sin"
+
+// ----------------------------------------------------------------
+// Forward declarations
+// ----------------------------------------------------------------
+
+void SinRemoveTaggedEffects(object oPC, string sTag);
+void SinApplyPenalties(object oPC);
+void SinApplyEmbraceEffects(object oPC);
+void SinAddSin(object oPC, int nSinType, int nAmount, string sDesc);
+void SinAbsolve(object oPC);
+void SinEmbrace(object oPC);
+void SinOpenWindow(object oPC);
+void SinFeedWindow(object oPC, int nToken);
+
+// ----------------------------------------------------------------
+// Window identifiers
+// ----------------------------------------------------------------
+
+const string SIN_WINDOW    = "SIN_WINDOW";
+const string SIN_EV_SCRIPT = "lib_sin_ev";
+
+// ----------------------------------------------------------------
+// Bind names — prefix "sin_"
+// ----------------------------------------------------------------
+
+const string SIN_BIND_GAUGE       = "sin_gauge";
+const string SIN_BIND_STATUS_LBL  = "sin_status_lbl";
+const string SIN_BIND_STATUS_COL  = "sin_status_col";
+const string SIN_BIND_PENALTY_LBL = "sin_penalty_lbl";
+const string SIN_BIND_ABS_LBL     = "sin_abs_lbl";
+const string SIN_BIND_ABS_ENA     = "sin_abs_ena";
+const string SIN_BIND_EMB_LBL     = "sin_emb_lbl";
+const string SIN_BIND_EMB_ENA     = "sin_emb_ena";
+const string SIN_BIND_ROW_TYPE    = "sin_row_type";
+const string SIN_BIND_ROW_DESC    = "sin_row_desc";
+const string SIN_BIND_ROW_AMT     = "sin_row_amt";
+const string SIN_BIND_ROW_COLOR   = "sin_row_col";
+const string SIN_BIND_ROW_COUNT   = "sin_row_cnt";
+
+// ----------------------------------------------------------------
+// Button identifiers
+// ----------------------------------------------------------------
+
+const string SIN_BTN_CLOSE   = "sin_btn_close";
+const string SIN_BTN_ABS     = "sin_btn_abs";
+const string SIN_BTN_EMBRACE = "sin_btn_emb";
+
+// ----------------------------------------------------------------
+// Sin type constants
+// ----------------------------------------------------------------
+
+const int SIN_TYPE_MURDER      = 1;
+const int SIN_TYPE_THEFT       = 2;
+const int SIN_TYPE_BLASPHEMY   = 3;
+const int SIN_TYPE_DARK_RITUAL = 4;
+const int SIN_TYPE_BETRAYAL    = 5;
+const int SIN_TYPE_UNDEAD      = 6;
+const int SIN_TYPE_DEMON_PACT  = 7;
+const int SIN_TYPE_CORRUPTION  = 8;
+const int SIN_TYPE_DESECRATION = 9;
+
+// ----------------------------------------------------------------
+// Score thresholds (inclusive lower bound)
+// ----------------------------------------------------------------
+
+const int SIN_LEVEL_TAINTED = 10;
+const int SIN_LEVEL_IMPURE  = 25;
+const int SIN_LEVEL_WICKED  = 50;
+const int SIN_LEVEL_CORRUPT = 75;
+const int SIN_LEVEL_DAMNED  = 100;
+
+// ----------------------------------------------------------------
+// Limits and costs
+// ----------------------------------------------------------------
+
+const int SIN_MAX             = 150;
+const int SIN_LOG_LIMIT       = 15;
+const int SIN_ABS_GOLD_PER_PT = 80;
+const int SIN_EMBRACE_MIN     = 75;
+const int SIN_EMBRACE_COST    = 15;
+
+// ----------------------------------------------------------------
+// Tagged effect identifiers
+// ----------------------------------------------------------------
+
+const string SIN_EFFECT_TAG  = "SIN_PENALTY";
+const string SIN_EMBRACE_TAG = "SIN_EMBRACE";
+
+// ----------------------------------------------------------------
+// Window geometry
+// ----------------------------------------------------------------
+
+const float SIN_W = 480.0;
+const float SIN_H = 530.0;

--- a/Sins & Absolution/Scripts/lib_sin_ev.nss
+++ b/Sins & Absolution/Scripts/lib_sin_ev.nss
@@ -1,0 +1,33 @@
+#include "lib_sin"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+
+    if (nToken != NuiFindWindow(oPC, SIN_WINDOW)) return;
+
+    if (sEvent == EVENT_TYPE_CLOSE) return;
+
+    if (sEvent != EVENT_TYPE_CLICK) return;
+
+    if (sElem == SIN_BTN_CLOSE)
+    {
+        NuiDestroy(oPC, nToken);
+        return;
+    }
+
+    if (sElem == SIN_BTN_ABS)
+    {
+        SinAbsolve(oPC);
+        return;
+    }
+
+    if (sElem == SIN_BTN_EMBRACE)
+    {
+        SinEmbrace(oPC);
+        return;
+    }
+}

--- a/Sins & Absolution/Scripts/sql_sin.nss
+++ b/Sins & Absolution/Scripts/sql_sin.nss
@@ -1,0 +1,118 @@
+void SinCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("sins",
+        "CREATE TABLE IF NOT EXISTS sin_chars ("
+        "  uuid         TEXT    PRIMARY KEY,"
+        "  char_name    TEXT    DEFAULT '',"
+        "  sin_score    INTEGER DEFAULT 0,"
+        "  is_embraced  INTEGER DEFAULT 0,"
+        "  last_updated INTEGER DEFAULT 0"
+        ")");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("sins",
+        "CREATE TABLE IF NOT EXISTS sin_log ("
+        "  id          INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "  uuid        TEXT    NOT NULL,"
+        "  sin_type    INTEGER DEFAULT 0,"
+        "  amount      INTEGER DEFAULT 0,"
+        "  description TEXT    DEFAULT '',"
+        "  logged_at   INTEGER DEFAULT 0"
+        ")");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("sins",
+        "CREATE INDEX IF NOT EXISTS idx_sinlog_uuid ON sin_log (uuid, logged_at DESC)");
+    SqlStep(q);
+}
+
+void SinRegisterChar(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("sins",
+        "INSERT OR IGNORE INTO sin_chars (uuid, char_name, last_updated) "
+        "VALUES (@uuid, @name, strftime('%s','now'))");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindString(q, "@name", GetName(oPC));
+    SqlStep(q);
+}
+
+int SinGetScore(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("sins",
+        "SELECT sin_score FROM sin_chars WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if (SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+int SinIsEmbraced(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("sins",
+        "SELECT is_embraced FROM sin_chars WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if (SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+void SinSetScore(object oPC, int nScore)
+{
+    if (nScore < 0) nScore = 0;
+    sqlquery q = SqlPrepareQueryCampaign("sins",
+        "UPDATE sin_chars SET sin_score = @score, last_updated = strftime('%s','now') "
+        "WHERE uuid = @uuid");
+    SqlBindInt(q,    "@score", nScore);
+    SqlBindString(q, "@uuid",  GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+void SinSetEmbraced(object oPC, int bEmbraced)
+{
+    sqlquery q = SqlPrepareQueryCampaign("sins",
+        "UPDATE sin_chars SET is_embraced = @val, last_updated = strftime('%s','now') "
+        "WHERE uuid = @uuid");
+    SqlBindInt(q,    "@val",  bEmbraced);
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+void SinLogEntry(object oPC, int nSinType, int nAmount, string sDesc)
+{
+    sqlquery q = SqlPrepareQueryCampaign("sins",
+        "INSERT INTO sin_log (uuid, sin_type, amount, description, logged_at) "
+        "VALUES (@uuid, @type, @amt, @desc, strftime('%s','now'))");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt(q,    "@type", nSinType);
+    SqlBindInt(q,    "@amt",  nAmount);
+    SqlBindString(q, "@desc", sDesc);
+    SqlStep(q);
+}
+
+void SinClearLog(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("sins",
+        "DELETE FROM sin_log WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+// Returns JsonArray of {sin_type, amount, description, date} ordered newest first.
+json SinGetLog(object oPC, int nLimit)
+{
+    json jLog = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("sins",
+        "SELECT sin_type, amount, description, "
+        "  strftime('%d.%m', logged_at, 'unixepoch') AS dt "
+        "FROM sin_log WHERE uuid = @uuid ORDER BY logged_at DESC LIMIT @lim");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt(q,    "@lim",  nLimit);
+    while (SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "sin_type",    JsonInt(SqlGetInt(q, 0)));
+        jRow = JsonObjectSet(jRow, "amount",      JsonInt(SqlGetInt(q, 1)));
+        jRow = JsonObjectSet(jRow, "description", JsonString(SqlGetString(q, 2)));
+        jRow = JsonObjectSet(jRow, "date",        JsonString(SqlGetString(q, 3)));
+        jLog = JsonArrayInsert(jLog, jRow);
+    }
+    return jLog;
+}

--- a/Sins & Absolution/Scripts/sys_on_enter.nss
+++ b/Sins & Absolution/Scripts/sys_on_enter.nss
@@ -1,0 +1,22 @@
+#include "lib_sin"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if (!GetIsPC(oPC)) return;
+
+    SinRegisterChar(oPC);
+    SinApplyPenalties(oPC);
+
+    if (SinIsEmbraced(oPC))
+        SinApplyEmbraceEffects(oPC);
+
+    int nScore = SinGetScore(oPC);
+    if (nScore < SIN_LEVEL_TAINTED) return;
+
+    string sMsg = "[Piętno] " + SinLevelName(nScore) +
+        " — " + IntToString(nScore) + " pkt grzechu. " +
+        "Kary: " + SinGetPenaltyDesc(nScore) + ". " +
+        "Użyj ołtarza spowiedzi, by sprawdzić stan duszy.";
+    DelayCommand(3.0, SendMessageToPC(oPC, sMsg));
+}

--- a/Sins & Absolution/Scripts/sys_on_load.nss
+++ b/Sins & Absolution/Scripts/sys_on_load.nss
@@ -1,0 +1,6 @@
+#include "lib_sin_def"
+
+void main()
+{
+    SinCreateTables();
+}

--- a/Sins & Absolution/Scripts/test_sin.nss
+++ b/Sins & Absolution/Scripts/test_sin.nss
@@ -1,0 +1,24 @@
+#include "lib_sin"
+
+// OnUsed script for a placeable "Ołtarz Spowiedzi" (Confession Altar).
+// Demonstrates the full API: adds sample sins then opens the UI.
+// Remove the sample SinAddSin calls in production — replace with
+// just SinOpenWindow(oPC) so the altar only shows the current state.
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if (!GetIsPC(oPC)) return;
+
+    SinRegisterChar(oPC);
+
+    // Demo only: inject a variety of sins to show different types + colors
+    SinAddSin(oPC, SIN_TYPE_MURDER,      8,  "Zabójstwo niewinnego pielgrzyma");
+    SinAddSin(oPC, SIN_TYPE_THEFT,       3,  "Kradzież z kościelnej ofiarni");
+    SinAddSin(oPC, SIN_TYPE_BLASPHEMY,   5,  "Bluźnierstwo przed obliczem Helma");
+    SinAddSin(oPC, SIN_TYPE_DARK_RITUAL, 10, "Udział w mrocznym rytuale o północy");
+    SinAddSin(oPC, SIN_TYPE_BETRAYAL,    6,  "Zdrada towarzysza w obliczu śmierci");
+    SinAddSin(oPC, SIN_TYPE_UNDEAD,      7,  "Ożywienie zwłok zabitego strażnika");
+    SinAddSin(oPC, SIN_TYPE_DESECRATION, 4,  "Profanacja grobów na cmentarzu w Baldur's Gate");
+
+    SinOpenWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

System śledzenia grzechów postaci — każda zbrodnia, bluźnierstwo, pakt z demonem czy zdrada trafia do rejestru i nakłada trwałe kary statystyk. Gracz może zapłacić za absolucję u ołtarza kościelnego lub przyjąć „Mroczne Objęcie" — nieodwracalną wymianę odkupienia za siłę.

## Mechanika

- **Rejestr grzechów:** 9 typów (Morderstwo, Kradzież, Bluźnierstwo, Mroczny Rytuał, Zdrada, Nekromancja, Pakt z Demonem, Korupcja, Profanacja). Każdy wpis logowany z datą i opisem.
- **Progi karności:** 5 poziomów (Skażony 10 pkt → Potępiony 100+ pkt). Kary narastają kumulatywnie: od −1 Cha do −4 Cha / −3 Mąd / −3 Int / −3 Wola. Efekty są `SupernaturalEffect` (nie znikają po odpoczynku, nie da się ich rozwiać).
- **Absolucja:** Koszt = `score × 80` sz. Zeruje score i log. Niedostępna po Mrocznym Objęciu.
- **Mroczne Objęcie:** Dostępne przy ≥ 75 pkt. Trwale blokuje absolucję; daje +2 Sił, +2 Bud, odporność na Strach, +1 obrażenia nekrotyczne.
- **NUI:** Okno konfesjonału z paskiem grzechu (NuiProgress), listą ostatnich 15 wpisów (NuiList z kolorowaniem per typ grzechu), etykietą aktywnych kar i przyciskami Absolucja / Mroczne Objęcie.
- **API:** `SinAddSin(oPC, SIN_TYPE_*, nAmount, sDesc)` — publiczne API do wywołania z dowolnego skryptu (OnDeath, OnSpellCast, OnConversation).

## Pliki

```
Sins & Absolution/
├── Scripts/
│   ├── sql_sin.nss          — schema SQLite (sin_chars + sin_log) + CRUD
│   ├── lib_sin_def.nss      — stałe, ID bindów, forward declarations
│   ├── lib_sin.nss          — rdzeń: efekty, API, builder NUI (506 LOC)
│   ├── lib_sin_ev.nss       — router zdarzeń NUI
│   ├── sys_on_load.nss      — CREATE TABLE IF NOT EXISTS
│   ├── sys_on_enter.nss     — przywrócenie efektów + powiadomienie
│   ├── test_sin.nss         — demo na placeable (OnUsed)
│   ├── lib_nui.nss          — (kopia z Mailbox)
│   └── lib_nui_utility.nss  — (kopia z Mailbox)
└── INTEGRATION.md
```

## Zależności (NWNX? SQL?)

- **NWNX:** brak
- **SQLite:** kampania `"sins"` (auto-tworzona w `sys_on_load`)
- **NWN:EE:** min. build 8193.14 — wymaga `TagEffect`, `EffectIcon`, NUI

## Jak włączyć w istniejącym module

1. Podepnij `sys_on_load` jako **OnModuleLoad**.
2. Podepnij `sys_on_enter` jako **OnClientEnter** (lub dołącz do istniejącego).
3. Umieść placeable z `test_sin` jako OnUsed — pełni rolę ołtarza spowiedzi.
4. W skryptach OnDeath / OnConversation / OnSpellCast wywołuj API:
   ```nwscript
   #include "lib_sin"
   SinAddSin(oKiller, SIN_TYPE_MURDER, 10, "Zabójstwo " + GetName(OBJECT_SELF));
   ```

## Co celowo pominięto

- **Automatyczne triggerowanie grzechów** z systemu walki — wymaga modyfikacji OnDeath/OnSpellCast istniejącego modułu; integracja przez API jest zamierzona i daje kontrolę nad tym, co jest grzechem w danym świecie.
- **Kara klas kleryk/paladyn** (utrata slotów) — wymaga NWNX lub ingerencji w system zaklęć; można dokompletować w `SinApplyPenalties`.
- **Półabsolucja** (redukcja o X%) — celowo nie ma; absolucja ma być decyzją kosztowną i kompletną.
- **Plik .mod** — środowisko nie pozwala pakować modułów; INTEGRATION.md zawiera pełną instrukcję.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UpjNekEEqcMj2FTWFEuX2Q)_