### PR TITLE
feat: Wampiryzm (Vampirism)

### DIFF
--- a/Vampirism/INTEGRATION.md
+++ b/Vampirism/INTEGRATION.md
@@ -1,0 +1,87 @@
+# Vampirism — Integration Guide
+
+## What it does
+
+A persistent vampire-curse system for NWN:EE. Characters infected via a
+test placeable (or an attacker with a custom script) accumulate a **blood
+level** (0–100) that drains 1 point every 6 seconds. A compact NUI panel
+shows the blood bar, current tier, active modifiers, and daylight hazard.
+
+The player feeds by clicking **Karmi się**, selecting a living creature
+within 3.5 m, and draining 15 HP → gaining 25 blood. The cure requires
+a `vamp_holy_blood` item in inventory.
+
+### Blood tiers
+
+| Range | Name | Effects |
+|-------|------|---------|
+| 75–100 | Sytość | +2 STR/DEX, Regen 2 HP/s |
+| 50–74 | Zaspokojenie | +1 STR/DEX, Regen 1 HP/s |
+| 25–49 | Głód | No modifiers |
+| 10–24 | Wygłodzenie | −1 STR/DEX/CON |
+| 1–9 | Szał Krwi | −3 STR/DEX/CON, −50% move speed |
+| 0 | Konanie z Głodu | −6 STR/DEX, −4 CON, −75% move speed |
+
+Sun damage: **1d6 divine damage per tick** when outdoors (exterior area)
+during daytime.
+
+---
+
+## Files
+
+```
+Vampirism/scripts/
+  sql_vamp.nss       Campaign DB layer (vampirism.sqlite)
+  lib_vamp_def.nss   Constants, NUI bind names, forward declarations
+  lib_vamp.nss       Core logic: effects, NUI layout, feeding, cure
+  lib_vamp_ev.nss    NUI event handler (assigned to VAMP_WINDOW)
+  sys_on_load.nss    OnModuleLoad: CREATE TABLE + start 6 s HB loop
+  sys_on_enter.nss   OnClientEnter: restore effects + open window
+  sys_on_target.nss  OnPlayerTarget: route feed result
+  test_vamp.nss      OnUsed placeable: infect / give cure item
+  lib_nui.nss        Shared NUI helpers (copy from any other module)
+  lib_nui_utility.nss Shared NUI utility helpers
+```
+
+---
+
+## Hooks to wire up
+
+In the Aurora Toolset (or via `.mod` properties):
+
+| Event | Script |
+|-------|--------|
+| **OnModuleLoad** | `sys_on_load` (or call `ExecuteScript("sys_on_load", GetModule())` from your existing load script) |
+| **OnClientEnter** | `sys_on_enter` (merge if you already have one) |
+| **OnPlayerTarget** | `sys_on_target` (merge if you already have one) |
+
+Place a **Placeable** with its **OnUsed** event set to `test_vamp`.
+
+---
+
+## No NWNX required
+
+The module is pure NWN:EE NWScript + built-in SQLite
+(`SqlPrepareQueryCampaign`). No NWNX plugins needed.
+
+---
+
+## Cure item
+
+Create a **Unique Power (Self Only)** item with tag **`vamp_holy_blood`**
+(resref can match). The test script will spawn it from inventory for
+testing; in production it should be a craftable or loot-table item.
+
+---
+
+## What was intentionally omitted
+
+- **Vampire appearance change** — integration with the Appearance module
+  is non-trivial; left for a follow-up.
+- **NPC vampire attackers** — infection-on-hit from existing creatures
+  would require editing their OnHit scripts; documented as an extension
+  point rather than implemented here.
+- **Thirst for PC blood** — feeding on other PCs is enabled but there is
+  no forced-PvP gating; server rules govern whether this is allowed.
+- **Vampire spawn abilities** (e.g. bat form, charm gaze) — future
+  expansion; current scope focuses on the blood-management loop.

--- a/Vampirism/scripts/lib_nui.nss
+++ b/Vampirism/scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Vampirism/scripts/lib_nui_utility.nss
+++ b/Vampirism/scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Vampirism/scripts/lib_vamp.nss
+++ b/Vampirism/scripts/lib_vamp.nss
@@ -1,0 +1,493 @@
+#include "lib_vamp_def"
+
+// ================================================================
+// Tier helpers
+// ================================================================
+
+// Returns 0 (worst) to 5 (best).
+int VampGetTier(int nBlood)
+{
+    if(nBlood <= 0)                    return 0;
+    if(nBlood < VAMP_TIER_STARVING)    return 1; // frenzy
+    if(nBlood < VAMP_TIER_NEUTRAL)     return 2; // starving
+    if(nBlood < VAMP_TIER_FED)         return 3; // hungry / neutral
+    if(nBlood < VAMP_TIER_SATED)       return 4; // fed
+    return 5;                                     // sated
+}
+
+string VampTierLabel(int nTier)
+{
+    switch(nTier)
+    {
+        case 0: return "Konanie z Głodu";
+        case 1: return "Szał Krwi";
+        case 2: return "Wygłodzenie";
+        case 3: return "Głód";
+        case 4: return "Zaspokojenie";
+        case 5: return "Sytość";
+    }
+    return "";
+}
+
+json VampTierColor(int nTier)
+{
+    switch(nTier)
+    {
+        case 0: return NuiColor( 80,   0,   0);
+        case 1: return NuiColor(220,  30,  30);
+        case 2: return NuiColor(200,  80,   0);
+        case 3: return NuiColor(180, 140,   0);
+        case 4: return NuiColor(130, 200,  70);
+        case 5: return NuiColor(180, 255, 130);
+    }
+    return NuiColor(255, 255, 255);
+}
+
+string VampTierEffectsLabel(int nTier)
+{
+    switch(nTier)
+    {
+        case 0: return "OBЕЗДВИЖONY  •  ciężkie kary do cech";
+        case 1: return "-3 SIŁ / ZRE / KON  •  Powolność -50%";
+        case 2: return "-1 SIŁ / ZRE / KON";
+        case 3: return "Brak modyfikatorów";
+        case 4: return "+1 SIŁ / ZRE  •  Regeneracja 1 HP/s";
+        case 5: return "+2 SIŁ / ZRE  •  Regeneracja 2 HP/s";
+    }
+    return "";
+}
+
+// ================================================================
+// Effect management
+// ================================================================
+
+void VampRemoveEffects(object oPC)
+{
+    effect e = GetFirstEffect(oPC);
+    while(GetIsEffectValid(e))
+    {
+        string sTag = GetEffectTag(e);
+        if(sTag == VAMP_TAG_BUFF || sTag == VAMP_TAG_DEBUFF || sTag == VAMP_TAG_HEAVY)
+            RemoveEffect(oPC, e);
+        e = GetNextEffect(oPC);
+    }
+}
+
+void VampApplyEffects(object oPC, int nBlood)
+{
+    VampRemoveEffects(oPC);
+    int nTier = VampGetTier(nBlood);
+    SetLocalInt(oPC, VAMP_LVAR_TIER, nTier);
+
+    if(nTier == 0)
+    {
+        // Incapacitating blood-zero state — severe but not instant death
+        effect eStr  = TagEffect(EffectAbilityDecrease(ABILITY_STRENGTH,     6), VAMP_TAG_HEAVY);
+        effect eDex  = TagEffect(EffectAbilityDecrease(ABILITY_DEXTERITY,    6), VAMP_TAG_HEAVY);
+        effect eCon  = TagEffect(EffectAbilityDecrease(ABILITY_CONSTITUTION, 4), VAMP_TAG_HEAVY);
+        effect eSlow = TagEffect(EffectMovementSpeedDecrease(75),                VAMP_TAG_HEAVY);
+        effect eLink = EffectLinkEffects(
+                           EffectLinkEffects(EffectLinkEffects(eStr, eDex), eCon), eSlow);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eLink, oPC);
+        ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectVisualEffect(VFX_IMP_HARM), oPC);
+        SendMessageToPC(oPC, "[Wampiryzm] Umierasz z pragnienia krwi... Każdy krok to agonia.");
+    }
+    else if(nTier == 1)
+    {
+        effect eStr  = TagEffect(EffectAbilityDecrease(ABILITY_STRENGTH,     3), VAMP_TAG_DEBUFF);
+        effect eDex  = TagEffect(EffectAbilityDecrease(ABILITY_DEXTERITY,    3), VAMP_TAG_DEBUFF);
+        effect eCon  = TagEffect(EffectAbilityDecrease(ABILITY_CONSTITUTION, 3), VAMP_TAG_DEBUFF);
+        effect eSlow = TagEffect(EffectMovementSpeedDecrease(50),                VAMP_TAG_DEBUFF);
+        effect eLink = EffectLinkEffects(
+                           EffectLinkEffects(EffectLinkEffects(eStr, eDex), eCon), eSlow);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eLink, oPC);
+        ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectVisualEffect(VFX_IMP_HARM), oPC);
+    }
+    else if(nTier == 2)
+    {
+        effect eStr = TagEffect(EffectAbilityDecrease(ABILITY_STRENGTH,     1), VAMP_TAG_DEBUFF);
+        effect eDex = TagEffect(EffectAbilityDecrease(ABILITY_DEXTERITY,    1), VAMP_TAG_DEBUFF);
+        effect eCon = TagEffect(EffectAbilityDecrease(ABILITY_CONSTITUTION, 1), VAMP_TAG_DEBUFF);
+        effect eLink= EffectLinkEffects(EffectLinkEffects(eStr, eDex), eCon);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eLink, oPC);
+    }
+    else if(nTier == 3)
+    {
+        // neutral — no effects applied
+    }
+    else if(nTier == 4)
+    {
+        effect eStr  = TagEffect(EffectAbilityIncrease(ABILITY_STRENGTH,  1), VAMP_TAG_BUFF);
+        effect eDex  = TagEffect(EffectAbilityIncrease(ABILITY_DEXTERITY, 1), VAMP_TAG_BUFF);
+        effect eReg  = TagEffect(EffectRegenerate(1, 6.0),                    VAMP_TAG_BUFF);
+        effect eLink = EffectLinkEffects(EffectLinkEffects(eStr, eDex), eReg);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eLink, oPC);
+    }
+    else if(nTier == 5)
+    {
+        effect eStr  = TagEffect(EffectAbilityIncrease(ABILITY_STRENGTH,  2), VAMP_TAG_BUFF);
+        effect eDex  = TagEffect(EffectAbilityIncrease(ABILITY_DEXTERITY, 2), VAMP_TAG_BUFF);
+        effect eReg  = TagEffect(EffectRegenerate(2, 6.0),                    VAMP_TAG_BUFF);
+        effect eLink = EffectLinkEffects(EffectLinkEffects(eStr, eDex), eReg);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eLink, oPC);
+        ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectVisualEffect(VFX_IMP_HEALING_M), oPC);
+    }
+}
+
+// ================================================================
+// NUI layout
+// ================================================================
+
+json VampBuildLayout(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 30.0);
+    float fLblH  = GetNuiScaleDimension(oPC, 26.0);
+    float fProgH = GetNuiScaleDimension(oPC, 22.0);
+    float fCW    = GetNuiScaleDimension(oPC, VAMP_W - 44.0);
+
+    // Title
+    json jTitle = NuiLabel(JsonString("— Klątwa Wampira —"),
+                           JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitle = NuiHeight(jTitle, fBtnH);
+
+    // Blood progress bar
+    json jProg = NuiProgress(NuiBind(VAMP_BIND_BLOOD_VAL));
+    jProg = NuiWidth(jProg, fCW);
+    jProg = NuiHeight(jProg, fProgH);
+    jProg = NuiTooltip(jProg, NuiBind(VAMP_BIND_BLOOD_LBL));
+
+    // Blood label under bar
+    json jBloodLbl = NuiLabel(NuiBind(VAMP_BIND_BLOOD_LBL),
+                              JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jBloodLbl = NuiHeight(jBloodLbl, fLblH);
+
+    // Status (tier name, coloured)
+    json jStatusLbl = NuiLabel(NuiBind(VAMP_BIND_STATUS_LBL),
+                               JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jStatusLbl = NuiHeight(jStatusLbl, fLblH);
+    jStatusLbl = NuiStyleForegroundColor(jStatusLbl, NuiBind(VAMP_BIND_STATUS_COL));
+
+    // Effects line
+    json jEffLbl = NuiLabel(NuiBind(VAMP_BIND_EFFECTS_LBL),
+                            JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jEffLbl = NuiHeight(jEffLbl, fLblH);
+
+    // Sun hazard line
+    json jSunLbl = NuiLabel(NuiBind(VAMP_BIND_SUN_LBL),
+                            JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jSunLbl = NuiHeight(jSunLbl, fLblH);
+    jSunLbl = NuiStyleForegroundColor(jSunLbl, NuiBind(VAMP_BIND_SUN_COL));
+
+    // Feed button
+    json jFeedBtn = NuiButton(JsonString("Karmi się"));
+    jFeedBtn = NuiId(jFeedBtn, VAMP_BTN_FEED);
+    jFeedBtn = NuiEnabled(jFeedBtn, NuiBind(VAMP_BIND_FEED_ENA));
+    jFeedBtn = NuiWidth(jFeedBtn,  GetNuiScaleDimension(oPC, 140.0));
+    jFeedBtn = NuiHeight(jFeedBtn, fBtnH);
+    jFeedBtn = NuiTooltip(jFeedBtn, JsonString("Wysysa krew z pobliskiej żywej istoty."));
+
+    // Cure button
+    json jCureBtn = NuiButton(NuiBind(VAMP_BIND_CURE_LBL));
+    jCureBtn = NuiId(jCureBtn, VAMP_BTN_CURE);
+    jCureBtn = NuiEnabled(jCureBtn, NuiBind(VAMP_BIND_CURE_ENA));
+    jCureBtn = NuiWidth(jCureBtn,  GetNuiScaleDimension(oPC, 150.0));
+    jCureBtn = NuiHeight(jCureBtn, fBtnH);
+    jCureBtn = NuiTooltip(jCureBtn, JsonString("Zużyj Krew Świętą, by zdjąć klątwę."));
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, jFeedBtn);
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jCureBtn);
+
+    // Assemble inner column
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jTitle);
+    jCol = JsonArrayInsert(jCol, jProg);
+    jCol = JsonArrayInsert(jCol, jBloodLbl);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jStatusLbl);
+    jCol = JsonArrayInsert(jCol, jEffLbl);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jSunLbl);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+
+    // Side spacers for centering
+    json jSide = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    json jMain = JsonArray();
+    jMain = JsonArrayInsert(jMain, jSide);
+    jMain = JsonArrayInsert(jMain, NuiWidth(NuiCol(jCol), fCW));
+    jMain = JsonArrayInsert(jMain, jSide);
+    return NuiRow(jMain);
+}
+
+void CreateVampWindow(object oPC)
+{
+    int nExisting = NuiFindWindow(oPC, VAMP_WINDOW);
+    if(nExisting != 0)
+    {
+        VampUpdateUI(oPC, nExisting);
+        return;
+    }
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))
+                 - GetNuiScaleDimension(oPC, VAMP_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT))
+                 - GetNuiScaleDimension(oPC, VAMP_H)) / 2.0;
+    json jGeom = NuiRect(fCX, fCY,
+                         GetNuiScaleDimension(oPC, VAMP_W),
+                         GetNuiScaleDimension(oPC, VAMP_H));
+
+    // Top-bar close button (manual, since we hide the title bar)
+    float fBtnH = GetNuiScaleDimension(oPC, 30.0);
+    json jClose = NuiButton(JsonString("X"));
+    jClose = NuiId(jClose, VAMP_BTN_CLOSE);
+    jClose = NuiWidth(jClose,  GetNuiScaleDimension(oPC, 30.0));
+    jClose = NuiHeight(jClose, fBtnH);
+    json jTopBar = JsonArray();
+    jTopBar = JsonArrayInsert(jTopBar, NuiSpacer());
+    jTopBar = JsonArrayInsert(jTopBar, jClose);
+
+    json jRootChildren = JsonArray();
+    jRootChildren = JsonArrayInsert(jRootChildren, NuiRow(jTopBar));
+    jRootChildren = JsonArrayInsert(jRootChildren, VampBuildLayout(oPC));
+    json jRoot = NuiCol(jRootChildren);
+
+    json jWin = NuiWindow(
+        jRoot,
+        JsonBool(FALSE),          // no title-bar title
+        NuiBind(VAMP_WIN_GEOM),
+        JsonBool(FALSE),          // not resizable
+        JsonBool(FALSE),          // not collapsed
+        JsonBool(FALSE),          // not closable via X
+        JsonBool(TRUE),           // border
+        JsonBool(FALSE));         // not transparent
+
+    int nToken = NuiCreate(oPC, jWin, VAMP_WINDOW, VAMP_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, VAMP_WIN_GEOM, jGeom);
+    VampUpdateUI(oPC, nToken);
+}
+
+// ================================================================
+// UI data feed
+// ================================================================
+
+void VampUpdateUI(object oPC, int nToken)
+{
+    int nBlood = VampGetBlood(oPC);
+    if(nBlood < 0) nBlood = 0;
+    int nTier = VampGetTier(nBlood);
+
+    NuiSetBind(oPC, nToken, VAMP_BIND_BLOOD_VAL,
+               JsonFloat(IntToFloat(nBlood) / 100.0));
+    NuiSetBind(oPC, nToken, VAMP_BIND_BLOOD_LBL,
+               JsonString("Krew: " + IntToString(nBlood) + " / 100"));
+    NuiSetBind(oPC, nToken, VAMP_BIND_STATUS_LBL,
+               JsonString("Stan: " + VampTierLabel(nTier)));
+    NuiSetBind(oPC, nToken, VAMP_BIND_STATUS_COL, VampTierColor(nTier));
+    NuiSetBind(oPC, nToken, VAMP_BIND_EFFECTS_LBL,
+               JsonString(VampTierEffectsLabel(nTier)));
+
+    // Daylight / area hazard
+    int bDay     = !GetIsNight();
+    int bOutdoor = GetIsAreaExterior(GetArea(oPC));
+    string sSun;
+    json   jSunCol;
+    if(bDay && bOutdoor)
+    {
+        sSun    = "Słońce: NIEBEZPIECZEŃSTWO — jesteś na zewnątrz!";
+        jSunCol = NuiColor(255, 80, 30);
+    }
+    else if(bDay)
+    {
+        sSun    = "Słońce: Bezpieczny (wewnątrz)";
+        jSunCol = NuiColor(180, 160, 80);
+    }
+    else
+    {
+        sSun    = "Słońce: Bezpieczny (noc)";
+        jSunCol = NuiColor(100, 150, 220);
+    }
+    NuiSetBind(oPC, nToken, VAMP_BIND_SUN_LBL, JsonString(sSun));
+    NuiSetBind(oPC, nToken, VAMP_BIND_SUN_COL, jSunCol);
+
+    // Feed enabled: not currently targeting, not full, not incapacitated (tier>0)
+    int bFeedEna = !GetLocalInt(oPC, VAMP_LVAR_IS_FEEDING)
+                   && nTier > 0
+                   && nBlood < 100;
+    NuiSetBind(oPC, nToken, VAMP_BIND_FEED_ENA, JsonBool(bFeedEna));
+
+    // Cure enabled: player carries the holy blood item
+    int bHasCure = GetIsObjectValid(GetItemPossessedBy(oPC, VAMP_CURE_ITEM_TAG));
+    NuiSetBind(oPC, nToken, VAMP_BIND_CURE_ENA, JsonBool(bHasCure));
+    NuiSetBind(oPC, nToken, VAMP_BIND_CURE_LBL,
+               JsonString(bHasCure ? "Oczyść Klątwę" : "Brak Krwi Świętej"));
+}
+
+// ================================================================
+// Feeding mechanic
+// ================================================================
+
+void VampFeedOnTarget(object oPC, object oTarget)
+{
+    SetLocalInt(oPC, VAMP_LVAR_IS_FEEDING, 0);
+
+    int nToken = NuiFindWindow(oPC, VAMP_WINDOW);
+
+    if(!GetIsObjectValid(oTarget) || oTarget == oPC)
+    {
+        SendMessageToPC(oPC, "[Wampiryzm] Nie wybrano odpowiedniego celu.");
+        if(nToken != 0) VampUpdateUI(oPC, nToken);
+        return;
+    }
+
+    // Cannot feed on beings without living blood
+    int nRace = GetRacialType(oTarget);
+    if(nRace == RACIAL_TYPE_UNDEAD     ||
+       nRace == RACIAL_TYPE_CONSTRUCT  ||
+       nRace == RACIAL_TYPE_ELEMENTAL)
+    {
+        SendMessageToPC(oPC, "[Wampiryzm] Ta istota nie ma żywej krwi do wysysania.");
+        if(nToken != 0) VampUpdateUI(oPC, nToken);
+        return;
+    }
+
+    if(GetDistanceBetween(oPC, oTarget) > VAMP_FEED_RANGE)
+    {
+        SendMessageToPC(oPC, "[Wampiryzm] Cel jest zbyt daleko. Zbliż się.");
+        if(nToken != 0) VampUpdateUI(oPC, nToken);
+        return;
+    }
+
+    // Clamp drain to leave the target at 1 HP minimum
+    int nHP    = GetCurrentHitPoints(oTarget);
+    int nDrain = VAMP_FEED_HP_DRAIN;
+    if(nHP <= nDrain) nDrain = nHP - 1;
+    if(nDrain <= 0)
+    {
+        SendMessageToPC(oPC, "[Wampiryzm] Cel jest zbyt osłabiony — nie możesz wyssać więcej krwi.");
+        if(nToken != 0) VampUpdateUI(oPC, nToken);
+        return;
+    }
+
+    // Damage to target
+    effect eDmg = EffectDamage(nDrain, DAMAGE_TYPE_NEGATIVE);
+    effect eVFX = EffectVisualEffect(VFX_IMP_NEGATIVE_ENERGY);
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectLinkEffects(eDmg, eVFX), oTarget);
+
+    // Healing flash on self
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectVisualEffect(VFX_IMP_HEALING_S), oPC);
+
+    // Gain blood
+    int nOld   = VampGetBlood(oPC);
+    int nNew   = nOld + VAMP_FEED_BLOOD_GAIN;
+    VampSetBlood(oPC, nNew);
+    if(nNew > 100) nNew = 100;
+
+    // Re-apply effects if tier changed
+    if(VampGetTier(nNew) != VampGetTier(nOld))
+        VampApplyEffects(oPC, nNew);
+
+    SendMessageToPC(oPC,
+        "[Wampiryzm] Wysysasz krew z " + GetName(oTarget) + "."
+        + " Krew: " + IntToString(nNew) + "/100.");
+
+    if(GetIsPC(oTarget))
+        SendMessageToPC(oTarget,
+            "[Wampiryzm] " + GetName(oPC) + " wysysa twoją krew! ("
+            + IntToString(nDrain) + " HP)");
+
+    // NPC counter-attacks
+    if(!GetIsPC(oTarget) && !GetIsDead(oTarget))
+        AssignCommand(oTarget, ActionAttack(oPC));
+
+    if(nToken != 0) VampUpdateUI(oPC, nToken);
+}
+
+// ================================================================
+// Infection / Cure
+// ================================================================
+
+void VampInfectPC(object oPC)
+{
+    if(VampIsVampire(oPC)) return;
+
+    VampInfect(oPC);
+    VampApplyEffects(oPC, 75);
+
+    SendMessageToPC(oPC,
+        "[Wampiryzm] Zimno przeszywa twoje żyły niczym ostrze lodu."
+        " Klątwa krwi osiadła na tobie.");
+    FloatingTextStringOnCreature("Zarażony Klątwą Wampira!", oPC, FALSE);
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectVisualEffect(VFX_IMP_NEGATIVE_ENERGY), oPC);
+
+    DelayCommand(1.0, CreateVampWindow(oPC));
+}
+
+void VampCurePC(object oPC)
+{
+    if(!VampIsVampire(oPC)) return;
+
+    VampRemoveEffects(oPC);
+    VampCure(oPC);
+
+    int nToken = NuiFindWindow(oPC, VAMP_WINDOW);
+    if(nToken != 0) NuiDestroy(oPC, nToken);
+
+    SendMessageToPC(oPC,
+        "[Wampiryzm] Klątwa krwi zostaje zerwana. Ciepło powraca do twojego ciała.");
+    FloatingTextStringOnCreature("Klątwa Zdjęta!", oPC, FALSE);
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectVisualEffect(VFX_IMP_HOLY_AID), oPC);
+}
+
+// ================================================================
+// Heartbeat processing (called every ~6 s per vampire PC)
+// ================================================================
+
+void VampCheckSunDamage(object oPC, int nBlood)
+{
+    if(nBlood <= 0)                         return; // already incapacitated
+    if(GetIsNight())                        return;
+    if(!GetIsObjectValid(GetArea(oPC)))     return;
+    if(!GetIsAreaExterior(GetArea(oPC)))    return;
+
+    int nDmg = d6(1);
+    effect eDmg = EffectDamage(nDmg, DAMAGE_TYPE_DIVINE);
+    effect eVFX = EffectVisualEffect(VFX_IMP_HARM);
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectLinkEffects(eDmg, eVFX), oPC);
+    SendMessageToPC(oPC,
+        "[Wampiryzm] Słońce pali twoją wampirzą skórę... ("
+        + IntToString(nDmg) + " obrażeń świętych)");
+}
+
+void VampOnHeartbeat(object oPC)
+{
+    if(!GetIsPC(oPC))  return;
+    if(GetIsDead(oPC)) return;
+
+    int nOld = VampGetBlood(oPC);
+    if(nOld < 0) return; // row vanished (e.g. GM purge)
+
+    int nNew = nOld - VAMP_HB_DRAIN;
+    if(nNew < 0) nNew = 0;
+
+    VampSetBlood(oPC, nNew);
+
+    // Tier change → re-apply effect set
+    if(VampGetTier(nNew) != VampGetTier(nOld))
+        VampApplyEffects(oPC, nNew);
+
+    VampCheckSunDamage(oPC, nNew);
+
+    // Update open window
+    int nToken = NuiFindWindow(oPC, VAMP_WINDOW);
+    if(nToken != 0) VampUpdateUI(oPC, nToken);
+
+    // Threshold warnings to guide the player
+    if(nNew == VAMP_TIER_SATED - 1)
+        SendMessageToPC(oPC, "[Wampiryzm] Pieczęć krwi pulsuje słabo... Wkrótce poczujesz głód.");
+    else if(nNew == VAMP_TIER_STARVING - 1)
+        SendMessageToPC(oPC, "[Wampiryzm] Głód staje się nie do zniesienia. Musisz się nakarmić!");
+    else if(nNew == 0)
+        SendMessageToPC(oPC, "[Wampiryzm] Krew wyschła całkowicie. Mdlejesz z pragnienia...");
+}

--- a/Vampirism/scripts/lib_vamp_def.nss
+++ b/Vampirism/scripts/lib_vamp_def.nss
@@ -1,0 +1,90 @@
+#include "lib_nui"
+#include "sql_vamp"
+
+// ----------------------------------------------------------------
+// Forward declarations
+// ----------------------------------------------------------------
+
+void CreateVampWindow(object oPC);
+void VampUpdateUI(object oPC, int nToken);
+void VampApplyEffects(object oPC, int nBlood);
+void VampRemoveEffects(object oPC);
+void VampFeedOnTarget(object oPC, object oTarget);
+void VampInfectPC(object oPC);
+void VampCurePC(object oPC);
+void VampOnHeartbeat(object oPC);
+
+// ----------------------------------------------------------------
+// NUI window / bind names  (prefix: vamp_)
+// ----------------------------------------------------------------
+
+const string VAMP_WINDOW        = "VAMP_WINDOW";
+const string VAMP_EV_SCRIPT     = "lib_vamp_ev";
+const string VAMP_WIN_GEOM      = "vamp_win_geom";
+
+const string VAMP_BIND_BLOOD_VAL  = "vamp_blood_val";    // float 0.0-1.0 for NuiProgress
+const string VAMP_BIND_BLOOD_LBL  = "vamp_blood_lbl";    // "Krew: 67/100"
+const string VAMP_BIND_STATUS_LBL = "vamp_status_lbl";   // hunger tier name
+const string VAMP_BIND_STATUS_COL = "vamp_status_col";   // tier colour (json color)
+const string VAMP_BIND_EFFECTS_LBL= "vamp_effects_lbl";  // active modifiers line
+const string VAMP_BIND_SUN_LBL    = "vamp_sun_lbl";      // daylight hazard line
+const string VAMP_BIND_SUN_COL    = "vamp_sun_col";      // daylight colour
+const string VAMP_BIND_FEED_ENA   = "vamp_feed_ena";
+const string VAMP_BIND_CURE_LBL   = "vamp_cure_lbl";
+const string VAMP_BIND_CURE_ENA   = "vamp_cure_ena";
+
+// ----------------------------------------------------------------
+// Button IDs
+// ----------------------------------------------------------------
+
+const string VAMP_BTN_CLOSE = "vamp_btn_close";
+const string VAMP_BTN_FEED  = "vamp_btn_feed";
+const string VAMP_BTN_CURE  = "vamp_btn_cure";
+
+// ----------------------------------------------------------------
+// Local variable keys on PC object
+// ----------------------------------------------------------------
+
+const string VAMP_LVAR_IS_FEEDING = "VAMP_IS_FEEDING"; // 1 while targeting mode active
+const string VAMP_LVAR_TIER       = "VAMP_TIER";       // last applied tier (0-5)
+
+// ----------------------------------------------------------------
+// Effect tags — allows removing only our effects
+// ----------------------------------------------------------------
+
+const string VAMP_TAG_BUFF   = "VAMP_BUFF";
+const string VAMP_TAG_DEBUFF = "VAMP_DEBUFF";
+const string VAMP_TAG_HEAVY  = "VAMP_HEAVY";   // frenzy + blood-zero debuffs
+
+// ----------------------------------------------------------------
+// Blood level tier boundaries
+// ----------------------------------------------------------------
+
+const int VAMP_TIER_SATED    = 75;  // 75-100 → buffs
+const int VAMP_TIER_FED      = 50;  // 50-74  → minor buffs
+const int VAMP_TIER_NEUTRAL  = 25;  // 25-49  → no modifiers
+const int VAMP_TIER_STARVING = 10;  // 10-24  → minor debuffs
+                                    //  1-9   → heavy debuffs + slow (frenzy)
+                                    //  0     → incapacitating debuffs
+
+// ----------------------------------------------------------------
+// Tuning
+// ----------------------------------------------------------------
+
+const int   VAMP_FEED_BLOOD_GAIN = 25;  // blood gained per successful feed
+const int   VAMP_FEED_HP_DRAIN   = 15;  // HP drained from target per feed
+const int   VAMP_HB_DRAIN        = 1;   // blood lost per 6 s heartbeat tick
+const float VAMP_FEED_RANGE      = 3.5; // max metres to feed
+
+// ----------------------------------------------------------------
+// Cure item
+// ----------------------------------------------------------------
+
+const string VAMP_CURE_ITEM_TAG = "vamp_holy_blood"; // resref / tag of consumable
+
+// ----------------------------------------------------------------
+// Window dimensions
+// ----------------------------------------------------------------
+
+const float VAMP_W = 360.0;
+const float VAMP_H = 310.0;

--- a/Vampirism/scripts/lib_vamp_ev.nss
+++ b/Vampirism/scripts/lib_vamp_ev.nss
@@ -1,0 +1,71 @@
+#include "lib_vamp"
+
+// NUI event handler assigned to VAMP_WINDOW.
+// All vampire UI interactions are routed here.
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+
+    if(nToken != NuiFindWindow(oPC, VAMP_WINDOW)) return;
+
+    // ---- Window closed (e.g. escape key) ----
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        // Clear targeting flag so Feed button is not stuck
+        SetLocalInt(oPC, VAMP_LVAR_IS_FEEDING, 0);
+        return;
+    }
+
+    if(sEvent != EVENT_TYPE_CLICK) return;
+
+    // ---- [X] close button ----
+    if(sElem == VAMP_BTN_CLOSE)
+    {
+        SetLocalInt(oPC, VAMP_LVAR_IS_FEEDING, 0);
+        NuiDestroy(oPC, nToken);
+        return;
+    }
+
+    // ---- Feed button ----
+    if(sElem == VAMP_BTN_FEED)
+    {
+        int nBlood = VampGetBlood(oPC);
+        if(nBlood >= 100)
+        {
+            SendMessageToPC(oPC, "[Wampiryzm] Jesteś już nasycony — krew kapie z ust.");
+            return;
+        }
+        if(VampGetTier(nBlood) == 0)
+        {
+            SendMessageToPC(oPC, "[Wampiryzm] Jesteś zbyt osłabiony, by samemu polować.");
+            return;
+        }
+
+        SetLocalInt(oPC, VAMP_LVAR_IS_FEEDING, 1);
+        // Disable button while targeting mode is active
+        NuiSetBind(oPC, nToken, VAMP_BIND_FEED_ENA, JsonBool(FALSE));
+        EnterTargetingMode(oPC, OBJECT_TYPE_CREATURE);
+        SendMessageToPC(oPC, "[Wampiryzm] Wybierz ofiarę, z której wysysasz krew...");
+        return;
+    }
+
+    // ---- Cure button ----
+    if(sElem == VAMP_BTN_CURE)
+    {
+        object oItem = GetItemPossessedBy(oPC, VAMP_CURE_ITEM_TAG);
+        if(!GetIsObjectValid(oItem))
+        {
+            SendMessageToPC(oPC, "[Wampiryzm] Nie posiadasz Krwi Świętej.");
+            VampUpdateUI(oPC, nToken);
+            return;
+        }
+        VampIncrementCureAttempts(oPC);
+        DestroyObject(oItem);
+        VampCurePC(oPC);
+        return;
+    }
+}

--- a/Vampirism/scripts/sql_vamp.nss
+++ b/Vampirism/scripts/sql_vamp.nss
@@ -1,0 +1,87 @@
+// Persistent storage for the Vampirism system.
+// Campaign DB name: "vampirism"
+// One row per infected character; non-vampires have no row.
+
+void VampCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("vampirism",
+        "CREATE TABLE IF NOT EXISTS vamp_infected ("
+        "  uuid           TEXT PRIMARY KEY,"
+        "  blood_level    INTEGER NOT NULL DEFAULT 75,"
+        "  infected_at    INTEGER NOT NULL DEFAULT 0,"
+        "  cure_attempts  INTEGER NOT NULL DEFAULT 0"
+        ")");
+    SqlStep(q);
+}
+
+int VampIsVampire(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("vampirism",
+        "SELECT 1 FROM vamp_infected WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    return SqlStep(q);
+}
+
+// Returns blood level 0-100, or -1 if not a vampire.
+int VampGetBlood(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("vampirism",
+        "SELECT blood_level FROM vamp_infected WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return -1;
+}
+
+void VampSetBlood(object oPC, int nBlood)
+{
+    if(nBlood < 0)   nBlood = 0;
+    if(nBlood > 100) nBlood = 100;
+    sqlquery q = SqlPrepareQueryCampaign("vampirism",
+        "UPDATE vamp_infected SET blood_level = @blood WHERE uuid = @uuid");
+    SqlBindInt   (q, "@blood", nBlood);
+    SqlBindString(q, "@uuid",  GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+void VampInfect(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("vampirism",
+        "INSERT OR IGNORE INTO vamp_infected (uuid, blood_level, infected_at)"
+        " VALUES (@uuid, 75, strftime('%s','now'))");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+void VampCure(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("vampirism",
+        "DELETE FROM vamp_infected WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+int VampGetCureAttempts(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("vampirism",
+        "SELECT cure_attempts FROM vamp_infected WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+void VampIncrementCureAttempts(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("vampirism",
+        "UPDATE vamp_infected SET cure_attempts = cure_attempts + 1 WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+// Returns the number of currently infected online players (for GM/debug).
+int VampGetInfectedCount()
+{
+    sqlquery q = SqlPrepareQueryCampaign("vampirism",
+        "SELECT COUNT(*) FROM vamp_infected");
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}

--- a/Vampirism/scripts/sys_on_enter.nss
+++ b/Vampirism/scripts/sys_on_enter.nss
@@ -1,0 +1,22 @@
+#include "lib_vamp"
+
+// OnClientEnter: restore vampire effects and open status window for returning vampires.
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC)) return;
+    if(!VampIsVampire(oPC)) return;
+
+    int nBlood = VampGetBlood(oPC);
+
+    // Session restart wiped in-memory effects — reapply from stored blood level
+    VampApplyEffects(oPC, nBlood);
+
+    SendMessageToPC(oPC,
+        "[Wampiryzm] Klątwa krwi wciąż ciąży na tobie."
+        " Poziom krwi: " + IntToString(nBlood) + "/100.");
+
+    // Small delay lets the client finish loading the GUI before we create the window
+    DelayCommand(3.0, CreateVampWindow(oPC));
+}

--- a/Vampirism/scripts/sys_on_load.nss
+++ b/Vampirism/scripts/sys_on_load.nss
@@ -1,0 +1,24 @@
+#include "lib_vamp"
+
+// Heartbeat loop runs on the module object every 6 s.
+// Processes all online vampire PCs without overriding any PC scripts.
+void VampHBLoop();
+
+void VampHBLoop()
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        if(VampIsVampire(oPC))
+            VampOnHeartbeat(oPC);
+        oPC = GetNextPC();
+    }
+    DelayCommand(6.0, VampHBLoop());
+}
+
+void main()
+{
+    VampCreateTables();
+    // Slight delay so the module finishes loading before first tick
+    DelayCommand(2.0, VampHBLoop());
+}

--- a/Vampirism/scripts/sys_on_target.nss
+++ b/Vampirism/scripts/sys_on_target.nss
@@ -1,0 +1,15 @@
+#include "lib_vamp"
+
+// OnPlayerTarget: routes the creature-select result back to the feeding mechanic.
+// This script must be assigned to the module's OnPlayerTarget event.
+
+void main()
+{
+    object oPC = GetLastPlayerToSelectTarget();
+    if(!GetIsPC(oPC)) return;
+    if(!GetLocalInt(oPC, VAMP_LVAR_IS_FEEDING)) return;
+    if(!VampIsVampire(oPC)) return;
+
+    object oTarget = GetTargetingModeSelectedObject();
+    VampFeedOnTarget(oPC, oTarget);
+}

--- a/Vampirism/scripts/test_vamp.nss
+++ b/Vampirism/scripts/test_vamp.nss
@@ -1,0 +1,41 @@
+#include "lib_vamp"
+
+// OnUsed script for a test Placeable.
+//
+// First use:  infects the PC (or shows status if already vampire).
+// Second use (while vampire): creates a holy-blood cure item in inventory.
+// The placeable can be placed anywhere in the test area for demonstration.
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    if(!VampIsVampire(oPC))
+    {
+        SendMessageToPC(oPC,
+            "[Test] Dotykasz starożytnego kamienia pokrytego krwią."
+            " Czujesz, jak coś zimnego przenika twoją duszę...");
+        VampInfectPC(oPC);
+        return;
+    }
+
+    // Already a vampire — give a cure item for testing the remedy flow
+    object oCure = CreateItemOnObject(VAMP_CURE_ITEM_TAG, oPC);
+    if(GetIsObjectValid(oCure))
+    {
+        SendMessageToPC(oPC,
+            "[Test] Znajdziesz w swoim ekwipunku Krew Świętą."
+            " Otwórz okno klątwy i kliknij 'Oczyść Klątwę'.");
+    }
+    else
+    {
+        // Resref not in hak — fall back to a dummy item (potion of healing) for quick demo
+        SendMessageToPC(oPC,
+            "[Test] Nie znaleziono itemu '" + VAMP_CURE_ITEM_TAG + "' w hak."
+            " Dodaj go lub stwórz ręcznie z tagiem 'vamp_holy_blood'.");
+    }
+
+    // Re-open the status window in case it was closed
+    CreateVampWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

System klątwy wampira: postać zostaje zarażona i zyskuje pasek krwi (0–100), który maleje co 6 sekund. Kompaktowe okno NUI pokazuje poziom krwi, aktualny tier z kolorowym wskaźnikiem, aktywne modyfikatory oraz ostrzeżenie o słońcu. Gracza-wampira można wyleczyć, używając itemu `vamp_holy_blood`.

## Mechanika

**Karmienie** — gracz klika _Karmi się_ → wchodzi w tryb targetowania → wybiera żywą istotę w zasięgu 3,5 m → cel traci 15 HP (obrażenia negatywne), wampir zyskuje 25 krwi. NPC-ofiary automatycznie atakują w odpowiedzi; PC-ofiary dostają komunikat z imieniem atakującego.

**Pięć tierów** ze skutkami aplikowanymi przez `TagEffect` (zdejmowanymi po przejściu granicy bez usuwania innych efektów):

| Zakres | Tier | Efekty |
|--------|------|--------|
| 75–100 | Sytość | +2 SIŁ/ZRE, Regen 2 HP/s |
| 50–74 | Zaspokojenie | +1 SIŁ/ZRE, Regen 1 HP/s |
| 25–49 | Głód | Brak |
| 10–24 | Wygłodzenie | −1 SIŁ/ZRE/KON |
| 1–9 | Szał Krwi | −3 SIŁ/ZRE/KON, −50% prędkości |
| 0 | Konanie z Głodu | −6 SIŁ/ZRE, −4 KON, −75% prędkości |

**Słońce** — 1k6 obrażeń świętych co tick, jeśli postać jest na zewnątrz w ciągu dnia. UI podświetla hazard na czerwono.

**Trwałość** — kampanijna baza danych `vampirism.sqlite`, tabela `vamp_infected` (uuid PK, blood_level, infected_at, cure_attempts). Status i poziom krwi przetrwają relogowanie.

## Pliki

```
Vampirism/
  scripts/
    sql_vamp.nss        Warstwa SQLite (CRUD vampirism.sqlite)
    lib_vamp_def.nss    Stałe, nazwy bindów NUI, deklaracje
    lib_vamp.nss        Rdzeń: efekty, układ NUI, karmienie, leczenie
    lib_vamp_ev.nss     Handler eventów NUI (klik Feed / Cure / Close)
    sys_on_load.nss     OnModuleLoad: CREATE TABLE + pętla HB 6 s
    sys_on_enter.nss    OnClientEnter: przywrócenie efektów + okno
    sys_on_target.nss   OnPlayerTarget: przekierowanie wyboru ofiary
    test_vamp.nss       OnUsed placeable: zarażenie + item leczący
    lib_nui.nss         Współdzielona biblioteka NUI (kopia)
    lib_nui_utility.nss Pomocnicze funkcje NUI (kopia)
  INTEGRATION.md        Instrukcja podpięcia hooków
```

## Zależności

- **NWNX**: brak — czyste NWScript + wbudowane SQLite NWN:EE.
- **NWN:EE 8193+**: wymaga `TagEffect` / `GetEffectTag` i `NuiProgress`.

## Jak włączyć w istniejącym module

| Event modułu | Skrypt |
|---|---|
| OnModuleLoad | `sys_on_load` (lub `ExecuteScript("sys_on_load", GetModule())`) |
| OnClientEnter | `sys_on_enter` (scalić z istniejącym) |
| OnPlayerTarget | `sys_on_target` (scalić z istniejącym) |

Placeable z OnUsed → `test_vamp`. Item z tagiem `vamp_holy_blood` w hak lub jako loot.

## Co celowo pominięto

- Zmiana wyglądu postaci po zarażeniu (wymaga integracji z modułem Appearance).
- Zarażanie przez atak NPC (wymagałoby edycji OnHit w blueprintach).
- Dodatkowe moce wampira (forma nietoperza, uroczy wzrok) — poza zakresem pierwszej iteracji.
- Przymusowy PvP gating — polityka serwera decyduje, czy karmienie na PC jest dozwolone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BsMMWGeSPkuuaD8jqzrtvF)_