### PR TITLE
feat: Bonfire System (Ognisko)

### DIFF
--- a/Bonfire/INTEGRATION.md
+++ b/Bonfire/INTEGRATION.md
@@ -1,0 +1,65 @@
+# Bonfire System — Integracja
+
+## Co to robi
+
+System ognisk (wzorowany na Dark Souls). Gracz może zapalić ognisko przy
+użyciu Łuczywa (`bfire_tinder`), odpocząć przy nim (pełne leczenie, usunięcie
+debuffów, uzupełnienie Flaszek Ocalenia), szybko podróżować do innych zapalonych
+ognisk, oraz czytać i zostawiać wiadomości dla innych graczy.
+
+## Wymagania
+
+- NWN:EE z obsługą NUI (`nw_inc_nui` w hakpaku)
+- `lib_nui.nss` i `lib_nui_utility.nss` w hakpaku (ze Appearance/Mailbox)
+- Brak wymagań NWNX dla rdzenia systemu
+
+## Podpięcie hooków
+
+| Zdarzenie modułu       | Skrypt                  |
+|------------------------|-------------------------|
+| OnModuleLoad           | `sys_on_load`           |
+| OnClientEnter          | `sys_on_enter`          |
+| NUI Event Script       | `lib_bfire_ev` (auto)   |
+
+Jeśli masz już własne skrypty OnModuleLoad / OnClientEnter, wywołaj z nich:
+```nss
+// OnModuleLoad:
+#include "lib_bfire_def"
+BfireCreateTables();
+
+// OnClientEnter:
+#include "lib_bfire_def"
+object oPC = GetEnteringObject();
+if(GetIsPC(oPC)) BfireEnsurePC(GetObjectUUID(oPC));
+```
+
+## Konfiguracja ognisk w module
+
+1. Umieść placeable'a w obszarze.
+2. Nadaj mu tag w formacie `bonfire_XXXX` (np. `bonfire_oboz`, `bonfire_ruiny`).
+3. Ustaw skrypt OnUsed: `test_bfire`.
+4. Opcjonalne zmienne lokalne na placeablu (ustawiane w toolsecie):
+   - `BFIRE_START_LIT` (int, 1) — ognisko startuje zapalone
+   - `BFIRE_DISPLAY_NAME` (string) — nazwa wyświetlana w UI zamiast pola Name
+
+## Item: Łuczywo (bfire_tinder)
+
+Stwórz item (np. Miscellaneous Small) z tag `bfire_tinder` i dodaj do haka.
+Można go stackować; jedno użycie zużywa 1 sztukę ze stosu.
+Gracze mogą go kupować u handlarzy lub znajdować jako loot.
+
+## Testy
+
+1. Umieść 2+ placeable'y z tagami `bonfire_test1`, `bonfire_test2`.
+2. Na `bonfire_test1` ustaw `BFIRE_START_LIT = 1`.
+3. Wejdź do modułu jako gracz — bonfire_test1 powinno być od razu dostępne.
+4. Przy `bonfire_test2`: użyj ogniska → w UI powinna być opcja "Zapal Ognisko"
+   (wymaga `bfire_tinder` w ekwipunku).
+5. Po zapaleniu: opcja "Podróżuj" powinna pokazać oba ogniska na liście.
+
+## Pominięto celowo
+
+- Respawn wrogów przy odpoczynku — wymaga NWNX lub własnej logiki per-obszar
+- Przywrócenie slotów czarów przy odpoczynku — wymaga NWNX_Creature
+- Animacja "siadania przy ognisku" — wymaga custom animacji w haku
+- Limit wiadomości per gracz — można dodać SQL-owo jeśli gracze spamują

--- a/Bonfire/scripts/lib_bfire.nss
+++ b/Bonfire/scripts/lib_bfire.nss
@@ -1,0 +1,587 @@
+#include "lib_bfire_def"
+
+// ----------------------------------------------------------------
+// Internal helper — centered button row
+// ----------------------------------------------------------------
+
+json BfireCenteredBtn(json jBtn)
+{
+    json jRow = JsonArray();
+    jRow = JsonArrayInsert(jRow, NuiSpacer());
+    jRow = JsonArrayInsert(jRow, jBtn);
+    jRow = JsonArrayInsert(jRow, NuiSpacer());
+    return NuiRow(jRow);
+}
+
+// ----------------------------------------------------------------
+// Main view layout
+// ----------------------------------------------------------------
+
+json BuildBfireMainView(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 32.0);
+    float fBtnW  = GetNuiScaleDimension(oPC, 220.0);
+    float fLblH  = GetNuiScaleDimension(oPC, 26.0);
+
+    // Bonfire name (large, amber)
+    json jName = NuiLabel(NuiBind(BFIRE_BIND_NAME),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jName = NuiHeight(jName, GetNuiScaleDimension(oPC, 36.0));
+    jName = NuiStyleForegroundColor(jName, NuiColor(220, 140, 60));
+
+    // Lit status line
+    json jStatus = NuiLabel(NuiBind(BFIRE_BIND_STATUS),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jStatus = NuiHeight(jStatus, fLblH);
+    jStatus = NuiStyleForegroundColor(jStatus, NuiBind(BFIRE_BIND_STATUS_CLR));
+
+    // Flask count line (blue-white)
+    json jFlaskLbl = NuiLabel(NuiBind(BFIRE_BIND_FLASK_LBL),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jFlaskLbl = NuiHeight(jFlaskLbl, fLblH);
+    jFlaskLbl = NuiStyleForegroundColor(jFlaskLbl, NuiColor(160, 200, 255));
+
+    // Rest button
+    json jRestBtn = NuiButton(NuiBind(BFIRE_BIND_REST_LBL));
+    jRestBtn = NuiId(jRestBtn, BFIRE_BTN_REST);
+    jRestBtn = NuiEnabled(jRestBtn, NuiBind(BFIRE_BIND_REST_ENA));
+    jRestBtn = NuiWidth(jRestBtn, fBtnW);
+    jRestBtn = NuiHeight(jRestBtn, fBtnH);
+
+    // Use flask button
+    json jFlaskBtn = NuiButton(JsonString("Wypij Flaszkę"));
+    jFlaskBtn = NuiId(jFlaskBtn, BFIRE_BTN_FLASK);
+    jFlaskBtn = NuiEnabled(jFlaskBtn, NuiBind(BFIRE_BIND_FLASK_ENA));
+    jFlaskBtn = NuiWidth(jFlaskBtn, fBtnW);
+    jFlaskBtn = NuiHeight(jFlaskBtn, fBtnH);
+
+    // Travel button (requires lit)
+    json jTravBtn = NuiButton(JsonString("Podróżuj"));
+    jTravBtn = NuiId(jTravBtn, BFIRE_BTN_TRAVEL);
+    jTravBtn = NuiEnabled(jTravBtn, NuiBind(BFIRE_BIND_REST_ENA));
+    jTravBtn = NuiWidth(jTravBtn, fBtnW);
+    jTravBtn = NuiHeight(jTravBtn, fBtnH);
+
+    // Messages button (requires lit)
+    json jMsgBtn = NuiButton(JsonString("Echa Poległych"));
+    jMsgBtn = NuiId(jMsgBtn, BFIRE_BTN_MESSAGES);
+    jMsgBtn = NuiEnabled(jMsgBtn, NuiBind(BFIRE_BIND_REST_ENA));
+    jMsgBtn = NuiWidth(jMsgBtn, fBtnW);
+    jMsgBtn = NuiHeight(jMsgBtn, fBtnH);
+
+    // Kindle button (requires unlit + tinder in inventory)
+    json jKindleBtn = NuiButton(JsonString("Zapal Ognisko"));
+    jKindleBtn = NuiId(jKindleBtn, BFIRE_BTN_KINDLE);
+    jKindleBtn = NuiEnabled(jKindleBtn, NuiBind(BFIRE_BIND_KINDLE_ENA));
+    jKindleBtn = NuiWidth(jKindleBtn, fBtnW);
+    jKindleBtn = NuiHeight(jKindleBtn, fBtnH);
+
+    // Close button
+    json jCloseBtn = NuiButton(JsonString("Odejdź"));
+    jCloseBtn = NuiId(jCloseBtn, BFIRE_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, GetNuiScaleDimension(oPC, 100.0));
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    float fContentW = GetNuiScaleDimension(oPC, 460.0);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jName);
+    jCol = JsonArrayInsert(jCol, jStatus);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 10.0));
+    jCol = JsonArrayInsert(jCol, BfireCenteredBtn(jRestBtn));
+    jCol = JsonArrayInsert(jCol, BfireCenteredBtn(jFlaskBtn));
+    jCol = JsonArrayInsert(jCol, BfireCenteredBtn(jTravBtn));
+    jCol = JsonArrayInsert(jCol, BfireCenteredBtn(jMsgBtn));
+    jCol = JsonArrayInsert(jCol, BfireCenteredBtn(jKindleBtn));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jFlaskLbl);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 10.0));
+    jCol = JsonArrayInsert(jCol, BfireCenteredBtn(jCloseBtn));
+
+    json jSide = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    json jMainRow = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiCol(jCol), fContentW));
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    return NuiRow(jMainRow);
+}
+
+// ----------------------------------------------------------------
+// Travel view layout
+// ----------------------------------------------------------------
+
+json BuildBfireTravelView(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 30.0);
+    float fRowH  = GetNuiScaleDimension(oPC, 28.0);
+    float fListH = GetNuiScaleDimension(oPC, 270.0);
+
+    json jHeader = NuiLabel(JsonString("Wybierz cel podróży"),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jHeader = NuiHeight(jHeader, GetNuiScaleDimension(oPC, 30.0));
+    jHeader = NuiStyleForegroundColor(jHeader, NuiColor(220, 140, 60));
+
+    // List: name (left, elastic) | area (right, fixed)
+    json jNameLbl = NuiLabel(NuiBind(BFIRE_BIND_TRAV_NAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    json jAreaLbl = NuiLabel(NuiBind(BFIRE_BIND_TRAV_AREA),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jAreaLbl = NuiWidth(jAreaLbl, GetNuiScaleDimension(oPC, 180.0));
+    jAreaLbl = NuiStyleForegroundColor(jAreaLbl, NuiColor(160, 160, 160));
+
+    json jCellRow = JsonArray();
+    jCellRow = JsonArrayInsert(jCellRow, jNameLbl);
+    jCellRow = JsonArrayInsert(jCellRow, jAreaLbl);
+
+    json jCell = NuiGroup(NuiRow(jCellRow), TRUE, NUI_SCROLLBARS_NONE);
+    jCell = NuiId(jCell, BFIRE_BTN_TRAV_ROW);
+    jCell = NuiEncouraged(jCell, NuiBind(BFIRE_BIND_TRAV_ENC));
+
+    json jTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jCell, 0.0, TRUE));
+    json jList = NuiList(jTmpl, NuiBind(BFIRE_BIND_TRAV_CNT), fRowH);
+    jList = NuiHeight(jList, fListH);
+
+    json jBackBtn = NuiButton(JsonString("Powrót"));
+    jBackBtn = NuiId(jBackBtn, BFIRE_BTN_BACK);
+    jBackBtn = NuiWidth(jBackBtn, GetNuiScaleDimension(oPC, 100.0));
+    jBackBtn = NuiHeight(jBackBtn, fBtnH);
+
+    float fContentW = GetNuiScaleDimension(oPC, 460.0);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jHeader);
+    jCol = JsonArrayInsert(jCol, jList);
+    jCol = JsonArrayInsert(jCol, BfireCenteredBtn(jBackBtn));
+
+    json jSide = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    json jMainRow = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiCol(jCol), fContentW));
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    return NuiRow(jMainRow);
+}
+
+// ----------------------------------------------------------------
+// Messages view layout
+// ----------------------------------------------------------------
+
+json BuildBfireMessagesView(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 30.0);
+    float fRowH  = GetNuiScaleDimension(oPC, 44.0);
+    float fListH = GetNuiScaleDimension(oPC, 200.0);
+
+    json jHeader = NuiLabel(JsonString("Echa Poległych"),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jHeader = NuiHeight(jHeader, GetNuiScaleDimension(oPC, 30.0));
+    jHeader = NuiStyleForegroundColor(jHeader, NuiColor(220, 140, 60));
+
+    json jSubHdr = NuiLabel(
+        JsonString("Duchy poległych wciąż szepcą przy ognisku..."),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jSubHdr = NuiHeight(jSubHdr, GetNuiScaleDimension(oPC, 22.0));
+    jSubHdr = NuiStyleForegroundColor(jSubHdr, NuiColor(140, 140, 140));
+
+    // List cell: [author (amber, top-left) + message (white, bottom)] + [date (gray, right)]
+    json jAuthorLbl = NuiLabel(NuiBind(BFIRE_BIND_MSG_AUTHOR),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_TOP));
+    jAuthorLbl = NuiStyleForegroundColor(jAuthorLbl, NuiColor(200, 160, 90));
+    jAuthorLbl = NuiHeight(jAuthorLbl, GetNuiScaleDimension(oPC, 18.0));
+
+    json jMsgLbl = NuiLabel(NuiBind(BFIRE_BIND_MSG_TEXT),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_BOTTOM));
+    jMsgLbl = NuiStyleForegroundColor(jMsgLbl, NuiColor(220, 220, 210));
+    jMsgLbl = NuiHeight(jMsgLbl, GetNuiScaleDimension(oPC, 22.0));
+
+    json jDateLbl = NuiLabel(NuiBind(BFIRE_BIND_MSG_DATE),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_TOP));
+    jDateLbl = NuiStyleForegroundColor(jDateLbl, NuiColor(110, 110, 110));
+    jDateLbl = NuiWidth(jDateLbl, GetNuiScaleDimension(oPC, 80.0));
+    jDateLbl = NuiHeight(jDateLbl, GetNuiScaleDimension(oPC, 18.0));
+
+    json jLeftCol = JsonArray();
+    jLeftCol = JsonArrayInsert(jLeftCol, jAuthorLbl);
+    jLeftCol = JsonArrayInsert(jLeftCol, jMsgLbl);
+
+    json jCellRow = JsonArray();
+    jCellRow = JsonArrayInsert(jCellRow, NuiCol(jLeftCol));
+    jCellRow = JsonArrayInsert(jCellRow,
+        NuiWidth(NuiCol(JsonArrayInsert(JsonArray(), jDateLbl)),
+        GetNuiScaleDimension(oPC, 80.0)));
+
+    json jCell = NuiGroup(NuiRow(jCellRow), FALSE, NUI_SCROLLBARS_NONE);
+
+    json jTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jCell, 0.0, TRUE));
+    json jList = NuiList(jTmpl, NuiBind(BFIRE_BIND_MSG_CNT), fRowH);
+    jList = NuiHeight(jList, fListH);
+
+    // New message input + Post
+    json jInputField = NuiTextEdit(
+        JsonString("Zostaw wiadomość dla poległych..."),
+        NuiBind(BFIRE_BIND_NEW_MSG), BFIRE_MSG_MAX_LEN, FALSE);
+    jInputField = NuiHeight(jInputField, fBtnH);
+
+    json jPostBtn = NuiButton(JsonString("Zapisz"));
+    jPostBtn = NuiId(jPostBtn, BFIRE_BTN_POST);
+    jPostBtn = NuiEnabled(jPostBtn, NuiBind(BFIRE_BIND_POST_ENA));
+    jPostBtn = NuiWidth(jPostBtn, GetNuiScaleDimension(oPC, 80.0));
+    jPostBtn = NuiHeight(jPostBtn, fBtnH);
+
+    json jInputRow = JsonArray();
+    jInputRow = JsonArrayInsert(jInputRow, jInputField);
+    jInputRow = JsonArrayInsert(jInputRow, jPostBtn);
+
+    json jBackBtn = NuiButton(JsonString("Powrót"));
+    jBackBtn = NuiId(jBackBtn, BFIRE_BTN_BACK);
+    jBackBtn = NuiWidth(jBackBtn, GetNuiScaleDimension(oPC, 100.0));
+    jBackBtn = NuiHeight(jBackBtn, fBtnH);
+
+    float fContentW = GetNuiScaleDimension(oPC, 460.0);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jHeader);
+    jCol = JsonArrayInsert(jCol, jSubHdr);
+    jCol = JsonArrayInsert(jCol, jList);
+    jCol = JsonArrayInsert(jCol, NuiRow(jInputRow));
+    jCol = JsonArrayInsert(jCol, BfireCenteredBtn(jBackBtn));
+
+    json jSide = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    json jMainRow = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiCol(jCol), fContentW));
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    return NuiRow(jMainRow);
+}
+
+// ----------------------------------------------------------------
+// Window create / swap
+// ----------------------------------------------------------------
+
+void BfireOpenWindow(object oPC, object oBonfire)
+{
+    SetLocalString(oPC, BFIRE_LVAR_TAG, GetTag(oBonfire));
+
+    if(NuiFindWindow(oPC, BFIRE_WINDOW) != 0)
+    {
+        BfireSwapToMain(oPC, NuiFindWindow(oPC, BFIRE_WINDOW));
+        return;
+    }
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))
+                 - GetNuiScaleDimension(oPC, BFIRE_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT))
+                 - GetNuiScaleDimension(oPC, BFIRE_H)) / 2.0;
+
+    json jGeom = NuiRect(fCX, fCY,
+        GetNuiScaleDimension(oPC, BFIRE_W),
+        GetNuiScaleDimension(oPC, BFIRE_H));
+
+    json jSwapGrp = NuiGroup(BuildBfireMainView(oPC), FALSE, NUI_SCROLLBARS_NONE);
+    jSwapGrp = NuiId(jSwapGrp, BFIRE_GRP_SWAP);
+
+    json jRoot = NuiCol(JsonArrayInsert(JsonArray(), jSwapGrp));
+
+    json jWin = NuiWindow(jRoot,
+        JsonBool(FALSE),
+        NuiBind(BFIRE_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    int nToken = NuiCreate(oPC, jWin, BFIRE_WINDOW, BFIRE_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, BFIRE_WIN_GEOM, jGeom);
+
+    BfireFeedMain(oPC, nToken);
+}
+
+void BfireSwapToMain(object oPC, int nToken)
+{
+    NuiSetGroupLayout(oPC, nToken, BFIRE_GRP_SWAP, BuildBfireMainView(oPC));
+    BfireFeedMain(oPC, nToken);
+}
+
+void BfireSwapToTravel(object oPC, int nToken)
+{
+    NuiSetGroupLayout(oPC, nToken, BFIRE_GRP_SWAP, BuildBfireTravelView(oPC));
+    BfireFeedTravel(oPC, nToken);
+}
+
+void BfireSwapToMessages(object oPC, int nToken)
+{
+    NuiSetGroupLayout(oPC, nToken, BFIRE_GRP_SWAP, BuildBfireMessagesView(oPC));
+    BfireFeedMessages(oPC, nToken);
+    NuiSetBindWatch(oPC, nToken, BFIRE_BIND_NEW_MSG, TRUE);
+}
+
+// ----------------------------------------------------------------
+// Feed — main view
+// ----------------------------------------------------------------
+
+void BfireFeedMain(object oPC, int nToken)
+{
+    string sTag  = BfireGetTag(oPC);
+    int    bLit  = BfireIsLit(sTag);
+    string sUUID = GetObjectUUID(oPC);
+
+    object oBonfire   = GetObjectByTag(sTag);
+    string sDisplay   = GetIsObjectValid(oBonfire)
+        ? BfireGetDisplayName(oBonfire)
+        : sTag;
+
+    NuiSetBind(oPC, nToken, BFIRE_BIND_NAME, JsonString(sDisplay));
+
+    if(bLit)
+    {
+        NuiSetBind(oPC, nToken, BFIRE_BIND_STATUS,     JsonString("~ Ognisko płonie ~"));
+        NuiSetBind(oPC, nToken, BFIRE_BIND_STATUS_CLR, NuiColor(220, 120, 40));
+    }
+    else
+    {
+        NuiSetBind(oPC, nToken, BFIRE_BIND_STATUS,     JsonString("Ognisko wygasłe"));
+        NuiSetBind(oPC, nToken, BFIRE_BIND_STATUS_CLR, NuiColor(100, 100, 100));
+    }
+
+    // Rest: enabled if lit and cooldown passed
+    int bCanRest  = FALSE;
+    string sRestLbl = "Odpoczni przy ognisku";
+    if(bLit)
+    {
+        int nLastRest = BfireGetLastRest(sUUID);
+        int nNow      = BfireNow();
+        int nElapsed  = nNow - nLastRest;
+        if(nElapsed >= BFIRE_REST_COOLDOWN)
+        {
+            bCanRest = TRUE;
+        }
+        else
+        {
+            int nWait = BFIRE_REST_COOLDOWN - nElapsed;
+            sRestLbl = "Odpoczni (za " + IntToString(nWait / 60) + "m "
+                      + IntToString(nWait % 60) + "s)";
+        }
+    }
+    NuiSetBind(oPC, nToken, BFIRE_BIND_REST_ENA, JsonBool(bCanRest));
+    NuiSetBind(oPC, nToken, BFIRE_BIND_REST_LBL, JsonString(sRestLbl));
+
+    // Kindle: enabled when unlit and player carries tinder
+    int bHasTinder = GetIsObjectValid(GetItemPossessedBy(oPC, BFIRE_TINDER_TAG));
+    NuiSetBind(oPC, nToken, BFIRE_BIND_KINDLE_ENA, JsonBool(!bLit && bHasTinder));
+
+    // Flasks
+    int    nFlasks   = BfireGetFlasks(sUUID);
+    string sFlaskLbl = "Flaszki Ocalenia: " + IntToString(nFlasks)
+                      + " / " + IntToString(BFIRE_MAX_FLASKS);
+    NuiSetBind(oPC, nToken, BFIRE_BIND_FLASK_LBL, JsonString(sFlaskLbl));
+    NuiSetBind(oPC, nToken, BFIRE_BIND_FLASK_ENA, JsonBool(nFlasks > 0));
+}
+
+// ----------------------------------------------------------------
+// Feed — travel view
+// ----------------------------------------------------------------
+
+void BfireFeedTravel(object oPC, int nToken)
+{
+    json jLit = BfireGetLitList();
+    SetLocalJson(oPC, BFIRE_LVAR_TRAV_LIST, jLit);
+
+    int nCount = JsonGetLength(jLit);
+
+    json jNames = JsonArray();
+    json jAreas = JsonArray();
+    json jEncs  = JsonArray();
+
+    string sCurTag = BfireGetTag(oPC);
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jEntry  = JsonArrayGet(jLit, i);
+        string sTag  = JsonGetString(JsonObjectGet(jEntry, "tag"));
+        string sArea = JsonGetString(JsonObjectGet(jEntry, "area_name"));
+
+        object oBonfire = GetObjectByTag(sTag);
+        string sName = GetIsObjectValid(oBonfire)
+            ? BfireGetDisplayName(oBonfire)
+            : sTag;
+
+        jNames = JsonArrayInsert(jNames, JsonString(sName));
+        jAreas = JsonArrayInsert(jAreas, JsonString(sArea));
+        jEncs  = JsonArrayInsert(jEncs,  JsonBool(sTag == sCurTag));
+    }
+
+    NuiSetBind(oPC, nToken, BFIRE_BIND_TRAV_NAME, jNames);
+    NuiSetBind(oPC, nToken, BFIRE_BIND_TRAV_AREA, jAreas);
+    NuiSetBind(oPC, nToken, BFIRE_BIND_TRAV_ENC,  jEncs);
+    NuiSetBind(oPC, nToken, BFIRE_BIND_TRAV_CNT,  JsonInt(nCount));
+}
+
+// ----------------------------------------------------------------
+// Feed — messages view
+// ----------------------------------------------------------------
+
+void BfireFeedMessages(object oPC, int nToken)
+{
+    string sTag = BfireGetTag(oPC);
+    json jMsgs  = BfireGetMessages(sTag, BFIRE_MAX_MSGS_SHOWN);
+    int  nCount = JsonGetLength(jMsgs);
+
+    json jAuthors = JsonArray();
+    json jTexts   = JsonArray();
+    json jDates   = JsonArray();
+
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jEntry = JsonArrayGet(jMsgs, i);
+        jAuthors = JsonArrayInsert(jAuthors,
+            JsonString(JsonGetString(JsonObjectGet(jEntry, "author_name"))));
+        jTexts = JsonArrayInsert(jTexts,
+            JsonString(JsonGetString(JsonObjectGet(jEntry, "message"))));
+        jDates = JsonArrayInsert(jDates,
+            JsonString(BfireFormatDate(JsonGetInt(JsonObjectGet(jEntry, "posted_at")))));
+    }
+
+    NuiSetBind(oPC, nToken, BFIRE_BIND_MSG_AUTHOR, jAuthors);
+    NuiSetBind(oPC, nToken, BFIRE_BIND_MSG_TEXT,   jTexts);
+    NuiSetBind(oPC, nToken, BFIRE_BIND_MSG_DATE,   jDates);
+    NuiSetBind(oPC, nToken, BFIRE_BIND_MSG_CNT,    JsonInt(nCount));
+    NuiSetBind(oPC, nToken, BFIRE_BIND_NEW_MSG,    JsonString(""));
+    NuiSetBind(oPC, nToken, BFIRE_BIND_POST_ENA,   JsonBool(FALSE));
+}
+
+// ----------------------------------------------------------------
+// Actions
+// ----------------------------------------------------------------
+
+void BfireDoRest(object oPC, int nToken)
+{
+    string sUUID = GetObjectUUID(oPC);
+
+    // Full HP restore
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectHeal(GetMaxHitPoints(oPC)), oPC);
+
+    // Remove negative persistent effects
+    effect eCheck = GetFirstEffect(oPC);
+    while(GetIsEffectValid(eCheck))
+    {
+        int nType = GetEffectType(eCheck);
+        if(nType == EFFECT_TYPE_ABILITY_DECREASE
+        || nType == EFFECT_TYPE_AC_DECREASE
+        || nType == EFFECT_TYPE_ATTACK_DECREASE
+        || nType == EFFECT_TYPE_DAMAGE_DECREASE
+        || nType == EFFECT_TYPE_SKILL_DECREASE
+        || nType == EFFECT_TYPE_NEGATIVELEVEL
+        || nType == EFFECT_TYPE_POISON
+        || nType == EFFECT_TYPE_DISEASE)
+        {
+            RemoveEffect(oPC, eCheck);
+        }
+        eCheck = GetNextEffect(oPC);
+    }
+
+    // Refill flasks and record rest time
+    BfireSetFlasks(sUUID, BFIRE_MAX_FLASKS);
+    BfireSetLastRest(sUUID);
+
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectVisualEffect(VFX_IMP_RESTORATION), oPC);
+
+    SendMessageToPC(oPC,
+        "[Ognisko] Odpoczywasz przy ognisku. Ciemność zdaje się cofać. "
+        "Flaszki uzupełnione do " + IntToString(BFIRE_MAX_FLASKS) + ".");
+    FloatingTextStringOnCreature("Odpoczynek przy ognisku...", oPC, FALSE);
+
+    BfireFeedMain(oPC, nToken);
+}
+
+void BfireDoKindle(object oPC, int nToken)
+{
+    string sTag = BfireGetTag(oPC);
+
+    object oTinder = GetItemPossessedBy(oPC, BFIRE_TINDER_TAG);
+    if(!GetIsObjectValid(oTinder))
+    {
+        SendMessageToPC(oPC, "[Ognisko] Potrzebujesz Łuczywa, by zapalić ognisko.");
+        return;
+    }
+
+    // Consume one unit of tinder
+    int nStack = GetItemStackSize(oTinder);
+    if(nStack <= 1)
+        DestroyObject(oTinder);
+    else
+        SetItemStackSize(oTinder, nStack - 1);
+
+    string sAreaName = GetName(GetArea(oPC));
+    BfireLightBonfire(sTag, sAreaName, GetName(oPC));
+
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectVisualEffect(VFX_IMP_FLAME_M), oPC);
+
+    SendMessageToPC(oPC,
+        "[Ognisko] Łuczywo płonie... ognisko zajmuje ogień! "
+        "Ciepło rozchodzi się wokół.");
+    FloatingTextStringOnCreature("Ognisko zapalone!", oPC, FALSE);
+
+    BfireSwapToMain(oPC, nToken);
+}
+
+void BfireDoUseFlask(object oPC, int nToken)
+{
+    string sUUID = GetObjectUUID(oPC);
+    int nFlasks  = BfireGetFlasks(sUUID);
+
+    if(nFlasks <= 0)
+    {
+        SendMessageToPC(oPC, "[Ognisko] Wszystkie flaszki są puste. "
+            "Odpocznij przy ognisku, by uzupełnić zapasy.");
+        return;
+    }
+
+    int nHeal = GetMaxHitPoints(oPC) / 2;
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectHeal(nHeal), oPC);
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectVisualEffect(VFX_IMP_HEALING_M), oPC);
+
+    BfireSetFlasks(sUUID, nFlasks - 1);
+
+    SendMessageToPC(oPC,
+        "[Ognisko] Flaszka opróżniona. Ciepło rozchodzi się po ciele. ("
+        + IntToString(nFlasks - 1) + " pozostało)");
+
+    BfireFeedMain(oPC, nToken);
+}
+
+void BfireDoTravel(object oPC, int nToken, int nIdx)
+{
+    json jLit = GetLocalJson(oPC, BFIRE_LVAR_TRAV_LIST);
+    if(nIdx < 0 || nIdx >= JsonGetLength(jLit)) return;
+
+    json jEntry  = JsonArrayGet(jLit, nIdx);
+    string sTag  = JsonGetString(JsonObjectGet(jEntry, "tag"));
+
+    object oDest = GetObjectByTag(sTag);
+    if(!GetIsObjectValid(oDest))
+    {
+        SendMessageToPC(oPC,
+            "[Ognisko] Nie można zlokalizować celu podróży — "
+            "ognisko mogło zostać zniszczone.");
+        BfireSwapToTravel(oPC, nToken);
+        return;
+    }
+
+    NuiDestroy(oPC, nToken);
+    SetLocalString(oPC, BFIRE_LVAR_TAG, sTag);
+
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectVisualEffect(VFX_IMP_MAGICAL_NORMAL), oPC);
+
+    DelayCommand(0.5f, JumpToObject(oPC, oDest));
+    DelayCommand(0.8f, ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectVisualEffect(VFX_IMP_RESTORATION), oPC));
+
+    SendMessageToPC(oPC,
+        "[Ognisko] Podróżujesz do: " + BfireGetDisplayName(oDest) + ".");
+}

--- a/Bonfire/scripts/lib_bfire_def.nss
+++ b/Bonfire/scripts/lib_bfire_def.nss
@@ -1,0 +1,119 @@
+#include "lib_nui"
+#include "sql_bfire"
+
+// Forward declarations
+void BfireOpenWindow(object oPC, object oBonfire);
+void BfireSwapToMain(object oPC, int nToken);
+void BfireSwapToTravel(object oPC, int nToken);
+void BfireSwapToMessages(object oPC, int nToken);
+void BfireFeedMain(object oPC, int nToken);
+void BfireFeedTravel(object oPC, int nToken);
+void BfireFeedMessages(object oPC, int nToken);
+void BfireDoRest(object oPC, int nToken);
+void BfireDoKindle(object oPC, int nToken);
+void BfireDoUseFlask(object oPC, int nToken);
+
+// ----------------------------------------------------------------
+// Window / view identifiers
+// ----------------------------------------------------------------
+
+const string BFIRE_WINDOW     = "BFIRE_WINDOW";
+const string BFIRE_EV_SCRIPT  = "lib_bfire_ev";
+const string BFIRE_GRP_SWAP   = "BFIRE_GRP_SWAP";
+const string BFIRE_WIN_GEOM   = "bfire_win_geom";
+
+// ----------------------------------------------------------------
+// Binds — main view
+// ----------------------------------------------------------------
+
+const string BFIRE_BIND_NAME        = "bfire_name";
+const string BFIRE_BIND_STATUS      = "bfire_status";
+const string BFIRE_BIND_STATUS_CLR  = "bfire_status_clr";
+const string BFIRE_BIND_REST_ENA    = "bfire_rest_ena";
+const string BFIRE_BIND_REST_LBL    = "bfire_rest_lbl";
+const string BFIRE_BIND_KINDLE_ENA  = "bfire_kindle_ena";
+const string BFIRE_BIND_FLASK_LBL   = "bfire_flask_lbl";
+const string BFIRE_BIND_FLASK_ENA   = "bfire_flask_ena";
+
+// ----------------------------------------------------------------
+// Binds — travel view
+// ----------------------------------------------------------------
+
+const string BFIRE_BIND_TRAV_NAME   = "bfire_trav_name";
+const string BFIRE_BIND_TRAV_AREA   = "bfire_trav_area";
+const string BFIRE_BIND_TRAV_ENC    = "bfire_trav_enc";
+const string BFIRE_BIND_TRAV_CNT    = "bfire_trav_cnt";
+
+// ----------------------------------------------------------------
+// Binds — messages view
+// ----------------------------------------------------------------
+
+const string BFIRE_BIND_MSG_AUTHOR  = "bfire_msg_author";
+const string BFIRE_BIND_MSG_TEXT    = "bfire_msg_text";
+const string BFIRE_BIND_MSG_DATE    = "bfire_msg_date";
+const string BFIRE_BIND_MSG_CNT     = "bfire_msg_cnt";
+const string BFIRE_BIND_NEW_MSG     = "bfire_new_msg";
+const string BFIRE_BIND_POST_ENA    = "bfire_post_ena";
+
+// ----------------------------------------------------------------
+// Button IDs
+// ----------------------------------------------------------------
+
+const string BFIRE_BTN_CLOSE        = "bfire_btn_close";
+const string BFIRE_BTN_REST         = "bfire_btn_rest";
+const string BFIRE_BTN_TRAVEL       = "bfire_btn_travel";
+const string BFIRE_BTN_MESSAGES     = "bfire_btn_msgs";
+const string BFIRE_BTN_KINDLE       = "bfire_btn_kindle";
+const string BFIRE_BTN_FLASK        = "bfire_btn_flask";
+const string BFIRE_BTN_BACK         = "bfire_btn_back";
+const string BFIRE_BTN_TRAV_ROW     = "bfire_btn_trav_row";
+const string BFIRE_BTN_POST         = "bfire_btn_post";
+
+// ----------------------------------------------------------------
+// Local vars on PC
+// ----------------------------------------------------------------
+
+const string BFIRE_LVAR_TAG         = "BFIRE_CUR_TAG";   // tag of bonfire PC is standing at
+const string BFIRE_LVAR_TRAV_LIST   = "BFIRE_TRAV_LIST"; // cached JsonArray of lit bonfires
+
+// Local var on bonfire placeable (set in toolset)
+const string BFIRE_OVAR_START_LIT   = "BFIRE_START_LIT";   // int 1 = starts lit
+const string BFIRE_OVAR_DISPLAY     = "BFIRE_DISPLAY_NAME"; // string display name override
+
+// ----------------------------------------------------------------
+// Tuning constants
+// ----------------------------------------------------------------
+
+const int    BFIRE_MAX_FLASKS       = 5;
+const int    BFIRE_REST_COOLDOWN    = 600;  // 10 min between rests
+const int    BFIRE_MAX_MSGS_SHOWN   = 10;
+const int    BFIRE_MSG_MAX_LEN      = 120;
+const string BFIRE_TINDER_TAG       = "bfire_tinder";
+
+// ----------------------------------------------------------------
+// Layout
+// ----------------------------------------------------------------
+
+const float  BFIRE_W                = 500.0;
+const float  BFIRE_H                = 400.0;
+
+// ----------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------
+
+// Extracts a readable name from a bonfire object.
+// Prefers BFIRE_OVAR_DISPLAY local var, then the object's Name property.
+string BfireGetDisplayName(object oBonfire)
+{
+    string sOverride = GetLocalString(oBonfire, BFIRE_OVAR_DISPLAY);
+    if(sOverride != "") return sOverride;
+    string sName = GetName(oBonfire);
+    if(sName != "") return sName;
+    return GetTag(oBonfire);
+}
+
+// Returns the tag stored on the PC for the currently open bonfire.
+string BfireGetTag(object oPC)
+{
+    return GetLocalString(oPC, BFIRE_LVAR_TAG);
+}

--- a/Bonfire/scripts/lib_bfire_ev.nss
+++ b/Bonfire/scripts/lib_bfire_ev.nss
@@ -1,0 +1,101 @@
+#include "lib_bfire"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    if(nToken != NuiFindWindow(oPC, BFIRE_WINDOW)) return;
+
+    // ---- Window close ----
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalString(oPC, BFIRE_LVAR_TAG);
+        DeleteLocalJson(oPC, BFIRE_LVAR_TRAV_LIST);
+        return;
+    }
+
+    // ---- Watch: new message input → update Post button state ----
+    if(sEvent == EVENT_TYPE_WATCH && sElem == BFIRE_BIND_NEW_MSG)
+    {
+        string sText = JsonGetString(NuiGetBind(oPC, nToken, BFIRE_BIND_NEW_MSG));
+        NuiSetBind(oPC, nToken, BFIRE_BIND_POST_ENA, JsonBool(sText != ""));
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        // ---- Main view buttons ----
+        if(sElem == BFIRE_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        if(sElem == BFIRE_BTN_REST)
+        {
+            BfireDoRest(oPC, nToken);
+            return;
+        }
+
+        if(sElem == BFIRE_BTN_FLASK)
+        {
+            BfireDoUseFlask(oPC, nToken);
+            return;
+        }
+
+        if(sElem == BFIRE_BTN_TRAVEL)
+        {
+            BfireSwapToTravel(oPC, nToken);
+            return;
+        }
+
+        if(sElem == BFIRE_BTN_MESSAGES)
+        {
+            BfireSwapToMessages(oPC, nToken);
+            return;
+        }
+
+        if(sElem == BFIRE_BTN_KINDLE)
+        {
+            BfireDoKindle(oPC, nToken);
+            return;
+        }
+
+        // ---- Shared back button ----
+        if(sElem == BFIRE_BTN_BACK)
+        {
+            BfireSwapToMain(oPC, nToken);
+            return;
+        }
+
+        // ---- Messages view: post ----
+        if(sElem == BFIRE_BTN_POST)
+        {
+            string sText = JsonGetString(NuiGetBind(oPC, nToken, BFIRE_BIND_NEW_MSG));
+            if(sText == "") return;
+
+            string sTag = BfireGetTag(oPC);
+            BfireAddMessage(sTag, GetName(oPC), sText);
+
+            NuiSetBind(oPC, nToken, BFIRE_BIND_NEW_MSG, JsonString(""));
+            NuiSetBind(oPC, nToken, BFIRE_BIND_POST_ENA, JsonBool(FALSE));
+
+            BfireFeedMessages(oPC, nToken);
+
+            SendMessageToPC(oPC,
+                "[Ognisko] Twoje słowa zostają przy ognisku, jak echa poległych...");
+            return;
+        }
+    }
+
+    // ---- Travel row click ----
+    if(sEvent == EVENT_TYPE_MOUSEDOWN && sElem == BFIRE_BTN_TRAV_ROW)
+    {
+        BfireDoTravel(oPC, nToken, nIdx);
+        return;
+    }
+}

--- a/Bonfire/scripts/sql_bfire.nss
+++ b/Bonfire/scripts/sql_bfire.nss
@@ -1,0 +1,180 @@
+// SQL schema and queries for the Bonfire system.
+// Campaign DB name: "bonfire"
+
+void BfireCreateTables()
+{
+    sqlquery q;
+
+    q = SqlPrepareQueryCampaign("bonfire",
+        "CREATE TABLE IF NOT EXISTS bfire_lit ("
+        "  tag       TEXT PRIMARY KEY,"
+        "  area_name TEXT DEFAULT '',"
+        "  lit_by    TEXT DEFAULT '',"
+        "  lit_at    INTEGER DEFAULT 0"
+        ")");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("bonfire",
+        "CREATE TABLE IF NOT EXISTS bfire_messages ("
+        "  id           INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "  bonfire_tag  TEXT NOT NULL,"
+        "  author_name  TEXT DEFAULT '',"
+        "  message      TEXT DEFAULT '',"
+        "  posted_at    INTEGER DEFAULT 0"
+        ")");
+    SqlStep(q);
+
+    // per-PC data: flask count and last rest timestamp
+    q = SqlPrepareQueryCampaign("bonfire",
+        "CREATE TABLE IF NOT EXISTS bfire_pc ("
+        "  pc_uuid      TEXT PRIMARY KEY,"
+        "  flasks       INTEGER DEFAULT 5,"
+        "  last_rest_at INTEGER DEFAULT 0"
+        ")");
+    SqlStep(q);
+}
+
+// ----------------------------------------------------------------
+// Bonfire lit state
+// ----------------------------------------------------------------
+
+int BfireIsLit(string sTag)
+{
+    sqlquery q = SqlPrepareQueryCampaign("bonfire",
+        "SELECT 1 FROM bfire_lit WHERE tag = @tag");
+    SqlBindString(q, "@tag", sTag);
+    return SqlStep(q);
+}
+
+void BfireLightBonfire(string sTag, string sAreaName, string sLighterName)
+{
+    sqlquery q = SqlPrepareQueryCampaign("bonfire",
+        "INSERT OR REPLACE INTO bfire_lit (tag, area_name, lit_by, lit_at) "
+        "VALUES (@tag, @area, @name, strftime('%s','now'))");
+    SqlBindString(q, "@tag",  sTag);
+    SqlBindString(q, "@area", sAreaName);
+    SqlBindString(q, "@name", sLighterName);
+    SqlStep(q);
+}
+
+// Returns JsonArray of {tag, area_name} for all lit bonfires, ordered newest first.
+json BfireGetLitList()
+{
+    json jList = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("bonfire",
+        "SELECT tag, area_name FROM bfire_lit ORDER BY lit_at DESC");
+    while(SqlStep(q))
+    {
+        json jEntry = JsonObject();
+        jEntry = JsonObjectSet(jEntry, "tag",       JsonString(SqlGetString(q, 0)));
+        jEntry = JsonObjectSet(jEntry, "area_name", JsonString(SqlGetString(q, 1)));
+        jList  = JsonArrayInsert(jList, jEntry);
+    }
+    return jList;
+}
+
+// ----------------------------------------------------------------
+// Messages / Echoes
+// ----------------------------------------------------------------
+
+void BfireAddMessage(string sBonfireTag, string sAuthorName, string sMessage)
+{
+    sqlquery q = SqlPrepareQueryCampaign("bonfire",
+        "INSERT INTO bfire_messages (bonfire_tag, author_name, message, posted_at) "
+        "VALUES (@tag, @author, @msg, strftime('%s','now'))");
+    SqlBindString(q, "@tag",    sBonfireTag);
+    SqlBindString(q, "@author", sAuthorName);
+    SqlBindString(q, "@msg",    sMessage);
+    SqlStep(q);
+}
+
+// Returns JsonArray of last BFIRE_MAX_MSGS messages: {author_name, message, posted_at}.
+json BfireGetMessages(string sBonfireTag, int nLimit)
+{
+    json jList = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("bonfire",
+        "SELECT author_name, message, posted_at "
+        "FROM bfire_messages WHERE bonfire_tag = @tag "
+        "ORDER BY posted_at DESC LIMIT @lim");
+    SqlBindString(q, "@tag", sBonfireTag);
+    SqlBindInt   (q, "@lim", nLimit);
+    while(SqlStep(q))
+    {
+        json jEntry = JsonObject();
+        jEntry = JsonObjectSet(jEntry, "author_name", JsonString(SqlGetString(q, 0)));
+        jEntry = JsonObjectSet(jEntry, "message",     JsonString(SqlGetString(q, 1)));
+        jEntry = JsonObjectSet(jEntry, "posted_at",   JsonInt   (SqlGetInt   (q, 2)));
+        jList  = JsonArrayInsert(jList, jEntry);
+    }
+    return jList;
+}
+
+// ----------------------------------------------------------------
+// Per-PC data
+// ----------------------------------------------------------------
+
+void BfireEnsurePC(string sUUID)
+{
+    sqlquery q = SqlPrepareQueryCampaign("bonfire",
+        "INSERT OR IGNORE INTO bfire_pc (pc_uuid) VALUES (@uuid)");
+    SqlBindString(q, "@uuid", sUUID);
+    SqlStep(q);
+}
+
+int BfireGetFlasks(string sUUID)
+{
+    BfireEnsurePC(sUUID);
+    sqlquery q = SqlPrepareQueryCampaign("bonfire",
+        "SELECT flasks FROM bfire_pc WHERE pc_uuid = @uuid");
+    SqlBindString(q, "@uuid", sUUID);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 5;
+}
+
+void BfireSetFlasks(string sUUID, int nFlasks)
+{
+    BfireEnsurePC(sUUID);
+    sqlquery q = SqlPrepareQueryCampaign("bonfire",
+        "UPDATE bfire_pc SET flasks = @n WHERE pc_uuid = @uuid");
+    SqlBindInt   (q, "@n",    nFlasks);
+    SqlBindString(q, "@uuid", sUUID);
+    SqlStep(q);
+}
+
+int BfireGetLastRest(string sUUID)
+{
+    BfireEnsurePC(sUUID);
+    sqlquery q = SqlPrepareQueryCampaign("bonfire",
+        "SELECT last_rest_at FROM bfire_pc WHERE pc_uuid = @uuid");
+    SqlBindString(q, "@uuid", sUUID);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+void BfireSetLastRest(string sUUID)
+{
+    BfireEnsurePC(sUUID);
+    sqlquery q = SqlPrepareQueryCampaign("bonfire",
+        "UPDATE bfire_pc SET last_rest_at = strftime('%s','now') WHERE pc_uuid = @uuid");
+    SqlBindString(q, "@uuid", sUUID);
+    SqlStep(q);
+}
+
+// Returns "HH:MM DD.MM" for a unix timestamp via SQLite.
+string BfireFormatDate(int nUnix)
+{
+    sqlquery q = SqlPrepareQueryCampaign("bonfire",
+        "SELECT strftime('%H:%M %d.%m', @ts, 'unixepoch')");
+    SqlBindInt(q, "@ts", nUnix);
+    if(SqlStep(q)) return SqlGetString(q, 0);
+    return "";
+}
+
+// Returns seconds since epoch via SQLite.
+int BfireNow()
+{
+    sqlquery q = SqlPrepareQueryCampaign("bonfire",
+        "SELECT strftime('%s','now')");
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}

--- a/Bonfire/scripts/sys_on_enter.nss
+++ b/Bonfire/scripts/sys_on_enter.nss
@@ -1,0 +1,20 @@
+#include "lib_bfire_def"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC)) return;
+
+    string sUUID = GetObjectUUID(oPC);
+    BfireEnsurePC(sUUID);
+
+    // If the PC has never rested (flasks at default 5), this is effectively
+    // their first session — nothing extra needed.
+    // Flasks are already seeded via INSERT OR IGNORE in BfireEnsurePC.
+
+    int nFlasks = BfireGetFlasks(sUUID);
+    if(nFlasks < BFIRE_MAX_FLASKS)
+        SendMessageToPC(oPC,
+            "[Ognisko] Masz " + IntToString(nFlasks) + " Flaszek Ocalenia. "
+            "Odpocznij przy ognisku, by uzupełnić zapasy.");
+}

--- a/Bonfire/scripts/sys_on_load.nss
+++ b/Bonfire/scripts/sys_on_load.nss
@@ -1,0 +1,6 @@
+#include "lib_bfire_def"
+
+void main()
+{
+    BfireCreateTables();
+}

--- a/Bonfire/scripts/test_bfire.nss
+++ b/Bonfire/scripts/test_bfire.nss
@@ -1,0 +1,25 @@
+#include "lib_bfire"
+
+// Place this script in the OnUsed slot of any placeable tagged "bonfire_XXXX".
+// Optional local vars on the placeable (set in toolset):
+//   BFIRE_START_LIT   (int)    1 = bonfire starts already lit
+//   BFIRE_DISPLAY_NAME (string) overrides the Name field shown in UI
+
+void main()
+{
+    object oPC      = GetLastUsedBy();
+    object oBonfire = OBJECT_SELF;
+
+    if(!GetIsPC(oPC)) return;
+
+    // Auto-light bonfires that were configured to start lit but haven't been
+    // registered yet (e.g. first server start after the tables were created).
+    string sTag = GetTag(oBonfire);
+    if(!BfireIsLit(sTag) && GetLocalInt(oBonfire, BFIRE_OVAR_START_LIT))
+    {
+        string sArea = GetName(GetArea(oBonfire));
+        BfireLightBonfire(sTag, sArea, "Pradawna Siła");
+    }
+
+    BfireOpenWindow(oPC, oBonfire);
+}


### PR DESCRIPTION
## Co to robi

System ognisk w stylu Dark Souls — gracz może zapalić ognisko przy użyciu Łuczywa (`bfire_tinder`), odpocząć przy nim, szybko podróżować do innych zapalonych ognisk oraz czytać i zostawiać wiadomości dla innych graczy („Echa Poległych"). Wszystkie dane persisted w SQLite.

## Mechanika

- **Zapalanie** — gracz musi mieć w ekwipunku item z tagiem `bfire_tinder` (stackowalny). Jedno użycie zużywa 1 sztukę. Ognisko rejestruje się w DB z nazwą obszaru i imieniem zapalającego.
- **Odpoczynek** — pełne leczenie HP, usunięcie negatywnych efektów (ability drain, trucizny, choroby, poziomy ujemne), uzupełnienie Flaszek Ocalenia do max (5). Cooldown 10 minut per postać w SQL.
- **Flaszki Ocalenia** — przy ognisku dostępna opcja „Wypij Flaszkę" (+50% max HP). Stan flaszek persisted między sesjami. Uzupełniają się tylko przy odpoczynku.
- **Szybka podróż** — lista wszystkich zapalonych ognisk (tag + obszar) z NuiList; kliknięcie teleportuje gracza do wybranego obiektu przez `JumpToObject(GetObjectByTag(sTag))`.
- **Wiadomości** — każdy gracz może zostawić krótką wiadomość (max 120 znaków) widoczną dla wszystkich przy danym ognisku; wyświetlane ostatnie 10, posortowane od najnowszych.

## Pliki

| Plik | Opis |
|------|------|
| `scripts/sql_bfire.nss` | Schema SQL + wszystkie zapytania (bfire_lit, bfire_messages, bfire_pc) |
| `scripts/lib_bfire_def.nss` | Stałe NUI, ID bindów/przycisków, LVARy, helpery display/tag |
| `scripts/lib_bfire.nss` | Budowanie layoutu 3 widoków, window create/swap, feed functions, handlery akcji |
| `scripts/lib_bfire_ev.nss` | Dispatcher eventów NUI (click, watch, close, mousedown) |
| `scripts/sys_on_load.nss` | Inicjalizacja tabel SQL |
| `scripts/sys_on_enter.nss` | Powiadomienie gracza o stanie flaszek przy logowaniu |
| `scripts/test_bfire.nss` | OnUsed na placeablu ogniska — auto-zapalanie START_LIT + otwieranie UI |
| `INTEGRATION.md` | Instrukcja podpięcia hooków, konfiguracja placeabli, opis itemu Łuczywo |

## Zależności (NWNX? SQL?)

- **Brak NWNX** dla rdzenia systemu
- **SQLite** via `SqlPrepareQueryCampaign("bonfire", ...)` — kampania o nazwie `bonfire`
- Opcjonalne (NWNX_Creature): przywrócenie slotów czarów przy odpoczynku — celowo pominięte, wymaga dodatkowej zależności

## Jak włączyć w istniejącym module

1. Dodaj `sql_bfire`, `lib_bfire_def`, `lib_bfire`, `lib_bfire_ev` do haka
2. Dodaj `lib_nui` i `lib_nui_utility` do haka (ze wspólnej biblioteki Appearance/Mailbox)
3. W `OnModuleLoad` wywołaj `BfireCreateTables()`
4. W `OnClientEnter` wywołaj `BfireEnsurePC(GetObjectUUID(GetEnteringObject()))`
5. Umieść placeabla z tagiem `bonfire_XXXX`, ustaw OnUsed = `test_bfire`
6. Utwórz item tag `bfire_tinder` i dodaj go do handlarzy/looту

## Co celowo pominięto

- Respawn wrogów przy odpoczynku — wymaga per-obszarowej logiki lub NWNX
- Przywrócenie slotów czarów — wymaga `NWNX_Creature`
- Animacja siadania przy ognisku — wymaga custom animacji w haku
- Limit wiadomości per gracz — można dodać SQL-owo w razie potrzeby
- Dedykowany item „Łuczywo" w folderze modułu — item musi być stworzony w toolsecie przez dewelopera modułu

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMEXFgiBvFecfHj2wdHxsD)_