### PR TITLE
feat: Kości Losu

### DIFF
--- a/Kości Losu/INTEGRATION.md
+++ b/Kości Losu/INTEGRATION.md
@@ -1,0 +1,56 @@
+# Kości Losu — Instrukcja integracji
+
+## Co to robi
+
+Stół do gry w kości (poker-dice) dla klimatu dark fantasy. Dwóch graczy (postać i karczmarz NPC)
+rzuca po 5 kości d6. Wygrywają układy: para, dwie pary, trójka, full, kareta, pięć jednakowych.
+Wyjątkowe wyniki wywołują efekty fabularne (błogosławieństwo lub klątwa).
+Wyniki są trwale zapisywane w SQLite per-postać (wygrane, straty, złoto, seria).
+Wspólna pula jackpotu rośnie z każdym zakładem.
+
+## Hooki modułu
+
+| Zdarzenie     | Skrypt do podpięcia |
+|---------------|---------------------|
+| OnModuleLoad  | `sys_on_load`       |
+| OnNuiEvent    | `lib_dice_ev`       |
+
+W Toolsecie:
+1. Otwórz Module Properties → Scripts.
+2. Ustaw `OnModuleLoad` na `sys_on_load` (lub dołącz wywołanie `DiceCreateTables()` do istniejącego skryptu load).
+3. Ustaw `OnNuiEvent` na `lib_dice_ev` (lub dodaj `#include "lib_dice_ev"` i wywołaj main() z istniejącego handlera).
+
+## Placeable "stół do gry"
+
+1. Umieść dowolny placeable (np. `plc_tableround` — okrągły stół karczmowy).
+2. W zakładce Scripts ustaw `OnUsed` na `test_dice`.
+3. Ustaw `Useable = TRUE`.
+
+## Baza danych (SQLite)
+
+Skrypt `sys_on_load` tworzy kampanię `dice` z tabelami:
+- `dice_records` — statystyki per-postać (UUID, imię, wygrane, straty, złoto, seria).
+- `dice_jackpot` — globalna pula jackpotu (domyślnie seed 200 gp).
+
+Tabele są idempotentne (`CREATE TABLE IF NOT EXISTS`), więc można bezpiecznie uruchamiać wielokrotnie.
+
+## Zależności NWNX
+
+Brak. Moduł używa wyłącznie NWScript + NUI + SQLite (wbudowane w NWN:EE 8193.36+).
+
+## Mechanika zakładu
+
+- Minimalna stawka: 10 gp, maksymalna: 5000 gp.
+- Remis zwraca stawkę.
+- Wygrana: +stawka gp (1:1).
+- Przegrana: −stawka gp.
+- 5% każdej stawki (min 1 gp) zasila pulę jackpotu.
+- Pięć jednakowych (gracz): zgarnia całą pulę jackpotu + błogosławieństwo (+1 atak/rzuty na 1h).
+- Pięć jedynek (gracz): przegrywa zakład + klątwa (−1 rzuty obronne na 30 min).
+
+## Co celowo pominięto
+
+- Gra wieloosobowa (gracz vs gracz) — wymagałaby kolejkowania NUI i synchronizacji.
+- Dźwięki kości — wymagałyby zasobów w haku.
+- Obrazki ścianek kości — wymagałyby TGA/DDS w haku; zastąpiono liczbami tekstowymi.
+- Limit dzienny zakładów — nie zakłada się trybu PW; można dodać kolumnę `last_roll_date` w DB.

--- a/Kości Losu/Scripts/lib_dice.nss
+++ b/Kości Losu/Scripts/lib_dice.nss
@@ -1,0 +1,557 @@
+// lib_dice.nss — UI construction, feed functions, and roll logic for Kości Losu
+
+#include "lib_dice_def"
+
+// Forward declarations for mutual use
+void DiceFeedRecord(object oPC, int nToken);
+void DiceRevealResults(object oPC, int nToken, int nBet, json jPlayerDice, json jDealerDice);
+
+// ---------------------------------------------------------------
+// Layout helpers
+// ---------------------------------------------------------------
+
+// Builds one die widget: bordered group containing a single colored label.
+// sValBind — scalar string bind for the displayed value ("1".."6" or "?" or "-")
+// sColBind — scalar NuiColor bind shared across all dice in a row
+json DiceBuildDie(object oPC, string sValBind, string sColBind)
+{
+    float fSz = GetNuiScaleDimension(oPC, 56.0);
+
+    json jLbl = NuiLabel(NuiBind(sValBind), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jLbl = NuiStyleForegroundColor(jLbl, NuiBind(sColBind));
+
+    json jGrp = NuiGroup(NuiRow(JsonArrayInsert(JsonArray(), jLbl)), TRUE, NUI_SCROLLBARS_NONE);
+    jGrp = NuiWidth(jGrp, fSz);
+    jGrp = NuiHeight(jGrp, fSz);
+    return jGrp;
+}
+
+// Builds the row of 5 dice for one side.
+// sD1..sD5 — value bind names; sColBind — shared color bind.
+json DiceBuildDiceRow(object oPC,
+    string sD1, string sD2, string sD3, string sD4, string sD5,
+    string sColBind)
+{
+    float fSpc = GetNuiScaleDimension(oPC, 6.0);
+
+    json jRow = JsonArray();
+    jRow = JsonArrayInsert(jRow, NuiSpacer());
+
+    jRow = JsonArrayInsert(jRow, DiceBuildDie(oPC, sD1, sColBind));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fSpc));
+    jRow = JsonArrayInsert(jRow, DiceBuildDie(oPC, sD2, sColBind));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fSpc));
+    jRow = JsonArrayInsert(jRow, DiceBuildDie(oPC, sD3, sColBind));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fSpc));
+    jRow = JsonArrayInsert(jRow, DiceBuildDie(oPC, sD4, sColBind));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fSpc));
+    jRow = JsonArrayInsert(jRow, DiceBuildDie(oPC, sD5, sColBind));
+
+    jRow = JsonArrayInsert(jRow, NuiSpacer());
+    return NuiRow(jRow);
+}
+
+// ---------------------------------------------------------------
+// Main window layout
+// ---------------------------------------------------------------
+
+json DiceBuildMainLayout(object oPC)
+{
+    float fBtnH = GetNuiScaleDimension(oPC, 32.0);
+    float fLblH = GetNuiScaleDimension(oPC, 26.0);
+
+    // --- Info bar: gold + jackpot ---
+    json jGoldLbl = NuiLabel(NuiBind(DICE_BIND_GOLD_LBL), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jGoldLbl = NuiHeight(jGoldLbl, fLblH);
+
+    json jJackpotLbl = NuiLabel(NuiBind(DICE_BIND_JACKPOT), JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jJackpotLbl = NuiHeight(jJackpotLbl, fLblH);
+
+    json jInfoRow = JsonArray();
+    jInfoRow = JsonArrayInsert(jInfoRow, jGoldLbl);
+    jInfoRow = JsonArrayInsert(jInfoRow, NuiSpacer());
+    jInfoRow = JsonArrayInsert(jInfoRow, jJackpotLbl);
+
+    // --- Player dice section ---
+    json jPLeftLbl = NuiLabel(JsonString("TWOJE KOŚCI:"),
+                              JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jPLeftLbl = NuiHeight(jPLeftLbl, fLblH);
+
+    json jPHandLbl = NuiLabel(NuiBind(DICE_BIND_P_HAND),
+                              JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jPHandLbl = NuiHeight(jPHandLbl, fLblH);
+    jPHandLbl = NuiStyleForegroundColor(jPHandLbl, NuiColor(230, 200, 60));
+
+    json jPHdrRow = JsonArray();
+    jPHdrRow = JsonArrayInsert(jPHdrRow, jPLeftLbl);
+    jPHdrRow = JsonArrayInsert(jPHdrRow, NuiSpacer());
+    jPHdrRow = JsonArrayInsert(jPHdrRow, jPHandLbl);
+
+    json jPDiceRow = DiceBuildDiceRow(oPC,
+        DICE_BIND_P_D1, DICE_BIND_P_D2, DICE_BIND_P_D3,
+        DICE_BIND_P_D4, DICE_BIND_P_D5, DICE_BIND_P_COL);
+
+    // --- Dealer dice section ---
+    json jDLeftLbl = NuiLabel(JsonString("KOŚCI KARCZMIARZA:"),
+                              JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jDLeftLbl = NuiHeight(jDLeftLbl, fLblH);
+
+    json jDHandLbl = NuiLabel(NuiBind(DICE_BIND_D_HAND),
+                              JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jDHandLbl = NuiHeight(jDHandLbl, fLblH);
+    jDHandLbl = NuiStyleForegroundColor(jDHandLbl, NuiColor(200, 80, 80));
+
+    json jDHdrRow = JsonArray();
+    jDHdrRow = JsonArrayInsert(jDHdrRow, jDLeftLbl);
+    jDHdrRow = JsonArrayInsert(jDHdrRow, NuiSpacer());
+    jDHdrRow = JsonArrayInsert(jDHdrRow, jDHandLbl);
+
+    json jDDiceRow = DiceBuildDiceRow(oPC,
+        DICE_BIND_D_D1, DICE_BIND_D_D2, DICE_BIND_D_D3,
+        DICE_BIND_D_D4, DICE_BIND_D_D5, DICE_BIND_D_COL);
+
+    // --- Result flavor text ---
+    json jResultLbl = NuiLabel(NuiBind(DICE_BIND_RESULT),
+                               JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jResultLbl = NuiHeight(jResultLbl, GetNuiScaleDimension(oPC, 50.0));
+    jResultLbl = NuiStyleForegroundColor(jResultLbl, NuiColor(255, 220, 120));
+
+    // --- Bet + roll ---
+    json jBetLbl = NuiLabel(JsonString("Stawka (gp):"),
+                            JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jBetLbl = NuiWidth(jBetLbl, GetNuiScaleDimension(oPC, 110.0));
+    jBetLbl = NuiHeight(jBetLbl, fBtnH);
+
+    json jBetEdit = NuiTextEdit(JsonString("100"), NuiBind(DICE_BIND_BET_TXT), 6, FALSE);
+    jBetEdit = NuiWidth(jBetEdit, GetNuiScaleDimension(oPC, 90.0));
+    jBetEdit = NuiHeight(jBetEdit, fBtnH);
+
+    json jRollBtn = NuiButton(JsonString("RZUĆ KOŚCI"));
+    jRollBtn = NuiId(jRollBtn, DICE_BTN_ROLL);
+    jRollBtn = NuiEnabled(jRollBtn, NuiBind(DICE_BIND_ROLL_ENA));
+    jRollBtn = NuiWidth(jRollBtn, GetNuiScaleDimension(oPC, 140.0));
+    jRollBtn = NuiHeight(jRollBtn, fBtnH);
+
+    json jBetRow = JsonArray();
+    jBetRow = JsonArrayInsert(jBetRow, jBetLbl);
+    jBetRow = JsonArrayInsert(jBetRow, jBetEdit);
+    jBetRow = JsonArrayInsert(jBetRow, NuiSpacer());
+    jBetRow = JsonArrayInsert(jBetRow, jRollBtn);
+
+    // --- Personal record ---
+    json jRecLbl = NuiLabel(NuiBind(DICE_BIND_REC_LBL),
+                            JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRecLbl = NuiHeight(jRecLbl, fLblH);
+    jRecLbl = NuiStyleForegroundColor(jRecLbl, NuiColor(150, 150, 150));
+
+    // --- Leaderboard button ---
+    json jLbBtn = NuiButton(JsonString("Najlepsi gracze"));
+    jLbBtn = NuiId(jLbBtn, DICE_BTN_LB);
+    jLbBtn = NuiWidth(jLbBtn, GetNuiScaleDimension(oPC, 170.0));
+    jLbBtn = NuiHeight(jLbBtn, fBtnH);
+
+    json jBotRow = JsonArray();
+    jBotRow = JsonArrayInsert(jBotRow, NuiSpacer());
+    jBotRow = JsonArrayInsert(jBotRow, jLbBtn);
+
+    // --- Assemble column ---
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(jInfoRow));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jPHdrRow));
+    jCol = JsonArrayInsert(jCol, jPDiceRow);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jDHdrRow));
+    jCol = JsonArrayInsert(jCol, jDDiceRow);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, jResultLbl);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBetRow));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jRecLbl);
+    jCol = JsonArrayInsert(jCol, NuiRow(jBotRow));
+
+    float fContentW = GetNuiScaleDimension(oPC, 480.0);
+    json jSide      = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    json jMainRow   = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiCol(jCol), fContentW));
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    return NuiRow(jMainRow);
+}
+
+// ---------------------------------------------------------------
+// Feed helpers
+// ---------------------------------------------------------------
+
+// Sets all 10 dice binds to a placeholder string and resets color to neutral.
+void DiceFeedBlankDice(object oPC, int nToken, string sPlaceholder)
+{
+    json cNorm = NuiColor(220, 220, 220);
+    NuiSetBind(oPC, nToken, DICE_BIND_P_D1, JsonString(sPlaceholder));
+    NuiSetBind(oPC, nToken, DICE_BIND_P_D2, JsonString(sPlaceholder));
+    NuiSetBind(oPC, nToken, DICE_BIND_P_D3, JsonString(sPlaceholder));
+    NuiSetBind(oPC, nToken, DICE_BIND_P_D4, JsonString(sPlaceholder));
+    NuiSetBind(oPC, nToken, DICE_BIND_P_D5, JsonString(sPlaceholder));
+    NuiSetBind(oPC, nToken, DICE_BIND_D_D1, JsonString(sPlaceholder));
+    NuiSetBind(oPC, nToken, DICE_BIND_D_D2, JsonString(sPlaceholder));
+    NuiSetBind(oPC, nToken, DICE_BIND_D_D3, JsonString(sPlaceholder));
+    NuiSetBind(oPC, nToken, DICE_BIND_D_D4, JsonString(sPlaceholder));
+    NuiSetBind(oPC, nToken, DICE_BIND_D_D5, JsonString(sPlaceholder));
+    NuiSetBind(oPC, nToken, DICE_BIND_P_COL, cNorm);
+    NuiSetBind(oPC, nToken, DICE_BIND_D_COL, cNorm);
+}
+
+void DiceFeedInitialState(object oPC, int nToken)
+{
+    DiceFeedBlankDice(oPC, nToken, "-");
+    NuiSetBind(oPC, nToken, DICE_BIND_P_HAND, JsonString(""));
+    NuiSetBind(oPC, nToken, DICE_BIND_D_HAND, JsonString(""));
+    NuiSetBind(oPC, nToken, DICE_BIND_RESULT, JsonString("Wrzuć stawkę i rzuć kości..."));
+    NuiSetBind(oPC, nToken, DICE_BIND_GOLD_LBL,
+        JsonString("Złoto: " + IntToString(GetGold(oPC)) + " gp"));
+    NuiSetBind(oPC, nToken, DICE_BIND_BET_TXT,  JsonString("100"));
+    NuiSetBind(oPC, nToken, DICE_BIND_ROLL_ENA, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, DICE_BIND_JACKPOT,
+        JsonString("Pula jackpotu: " + IntToString(DiceGetJackpot()) + " gp"));
+    DiceFeedRecord(oPC, nToken);
+}
+
+void DiceFeedRecord(object oPC, int nToken)
+{
+    DiceRegisterPlayer(oPC);
+    json jRec = DiceGetRecord(oPC);
+    if(JsonGetType(jRec) == JSON_TYPE_NULL)
+    {
+        NuiSetBind(oPC, nToken, DICE_BIND_REC_LBL, JsonString("Brak rekordów."));
+        return;
+    }
+
+    int nW  = JsonGetInt(JsonObjectGet(jRec, "wins"));
+    int nL  = JsonGetInt(JsonObjectGet(jRec, "losses"));
+    int nGW = JsonGetInt(JsonObjectGet(jRec, "gold_won"));
+    int nGL = JsonGetInt(JsonObjectGet(jRec, "gold_lost"));
+    int nBH = JsonGetInt(JsonObjectGet(jRec, "best_hand"));
+    int nSB = JsonGetInt(JsonObjectGet(jRec, "streak_best"));
+    int nNet = nGW - nGL;
+
+    string sNet = (nNet >= 0 ? "+" : "") + IntToString(nNet);
+    string sRec = "Bilans: " + IntToString(nW) + "W/" + IntToString(nL) + "P"
+                + "  Złoto: " + sNet + " gp"
+                + "  Najlepszy układ: " + DiceHandName(nBH)
+                + "  Seria: " + IntToString(nSB) + "W";
+    NuiSetBind(oPC, nToken, DICE_BIND_REC_LBL, JsonString(sRec));
+}
+
+// ---------------------------------------------------------------
+// Leaderboard popup
+// ---------------------------------------------------------------
+
+void DiceOpenLeaderboard(object oPC)
+{
+    if(NuiFindWindow(oPC, DICE_WIN_LB) != 0)
+    {
+        NuiDestroy(oPC, NuiFindWindow(oPC, DICE_WIN_LB));
+        return;
+    }
+
+    float fW    = GetNuiScaleDimension(oPC, 500.0);
+    float fH    = GetNuiScaleDimension(oPC, 380.0);
+    float fRowH = GetNuiScaleDimension(oPC, 26.0);
+    float fX    = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - fW) / 2.0;
+    float fY    = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - fH) / 2.0;
+
+    float fNameW = GetNuiScaleDimension(oPC, 180.0);
+    float fWLW   = GetNuiScaleDimension(oPC, 90.0);
+
+    json jNameLbl = NuiLabel(NuiBind(DICE_BIND_LB_NAME), JsonInt(NUI_HALIGN_LEFT),   JsonInt(NUI_VALIGN_MIDDLE));
+    json jWLLbl   = NuiLabel(NuiBind(DICE_BIND_LB_WL),   JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jWLLbl = NuiWidth(jWLLbl, fWLW);
+    json jGoldLbl = NuiLabel(NuiBind(DICE_BIND_LB_GOLD), JsonInt(NUI_HALIGN_RIGHT),  JsonInt(NUI_VALIGN_MIDDLE));
+    jGoldLbl = NuiWidth(jGoldLbl, GetNuiScaleDimension(oPC, 120.0));
+
+    json jCellRow = JsonArray();
+    jCellRow = JsonArrayInsert(jCellRow, NuiWidth(NuiCol(JsonArrayInsert(JsonArray(), jNameLbl)), fNameW));
+    jCellRow = JsonArrayInsert(jCellRow, jWLLbl);
+    jCellRow = JsonArrayInsert(jCellRow, NuiSpacer());
+    jCellRow = JsonArrayInsert(jCellRow, jGoldLbl);
+
+    json jCell = NuiGroup(NuiRow(jCellRow), FALSE, NUI_SCROLLBARS_NONE);
+    jCell = NuiEncouraged(jCell, NuiBind(DICE_BIND_LB_ENC));
+
+    json jTmpl   = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jCell, 0.0, TRUE));
+    json jList   = NuiList(jTmpl, NuiBind("dice_lb_count"), fRowH);
+    jList = NuiHeight(jList, GetNuiScaleDimension(oPC, 300.0));
+
+    json jWin = NuiWindow(NuiCol(JsonArrayInsert(JsonArray(), jList)),
+        JsonString("Najlepsi gracze — Kości Losu"),
+        NuiRect(fX, fY, fW, fH),
+        JsonBool(FALSE), JsonBool(FALSE), JsonBool(TRUE),
+        JsonBool(FALSE), JsonBool(TRUE));
+
+    int nLbToken = NuiCreate(oPC, jWin, DICE_WIN_LB, DICE_EV_SCRIPT);
+
+    json jRows = DiceGetLeaderboard(DICE_LB_ROWS);
+    int nCount = JsonGetLength(jRows);
+    json jNames = JsonArray();
+    json jWLs   = JsonArray();
+    json jGolds = JsonArray();
+    json jEncs  = JsonArray();
+
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jRow = JsonArrayGet(jRows, i);
+        int nNet  = JsonGetInt(JsonObjectGet(jRow, "gold_net"));
+        jNames = JsonArrayInsert(jNames, JsonString(JsonGetString(JsonObjectGet(jRow, "char_name"))));
+        jWLs   = JsonArrayInsert(jWLs,   JsonString(
+                     IntToString(JsonGetInt(JsonObjectGet(jRow, "wins"))) + "W / " +
+                     IntToString(JsonGetInt(JsonObjectGet(jRow, "losses"))) + "P"));
+        jGolds = JsonArrayInsert(jGolds, JsonString((nNet >= 0 ? "+" : "") + IntToString(nNet) + " gp"));
+        jEncs  = JsonArrayInsert(jEncs,  JsonBool(FALSE));
+    }
+
+    NuiSetBind(oPC, nLbToken, DICE_BIND_LB_NAME,  jNames);
+    NuiSetBind(oPC, nLbToken, DICE_BIND_LB_WL,    jWLs);
+    NuiSetBind(oPC, nLbToken, DICE_BIND_LB_GOLD,  jGolds);
+    NuiSetBind(oPC, nLbToken, DICE_BIND_LB_ENC,   jEncs);
+    NuiSetBind(oPC, nLbToken, "dice_lb_count",     JsonInt(nCount));
+}
+
+// ---------------------------------------------------------------
+// Roll resolution (called via DelayCommand after suspense)
+// ---------------------------------------------------------------
+
+void DiceRevealResults(object oPC, int nToken, int nBet, json jPlayerDice, json jDealerDice)
+{
+    // Guard: window may have closed during delay
+    if(NuiFindWindow(oPC, DICE_WINDOW) != nToken)
+    {
+        DeleteLocalInt(oPC, DICE_LVAR_BUSY);
+        return;
+    }
+
+    int nPScore = DiceEvaluateHand(jPlayerDice);
+    int nDScore = DiceEvaluateHand(jDealerDice);
+    int nPRank  = DiceHandRank(nPScore);
+    int nDRank  = DiceHandRank(nDScore);
+
+    // Reveal dice values
+    NuiSetBind(oPC, nToken, DICE_BIND_P_D1, JsonString(IntToString(JsonGetInt(JsonArrayGet(jPlayerDice, 0)))));
+    NuiSetBind(oPC, nToken, DICE_BIND_P_D2, JsonString(IntToString(JsonGetInt(JsonArrayGet(jPlayerDice, 1)))));
+    NuiSetBind(oPC, nToken, DICE_BIND_P_D3, JsonString(IntToString(JsonGetInt(JsonArrayGet(jPlayerDice, 2)))));
+    NuiSetBind(oPC, nToken, DICE_BIND_P_D4, JsonString(IntToString(JsonGetInt(JsonArrayGet(jPlayerDice, 3)))));
+    NuiSetBind(oPC, nToken, DICE_BIND_P_D5, JsonString(IntToString(JsonGetInt(JsonArrayGet(jPlayerDice, 4)))));
+    NuiSetBind(oPC, nToken, DICE_BIND_D_D1, JsonString(IntToString(JsonGetInt(JsonArrayGet(jDealerDice, 0)))));
+    NuiSetBind(oPC, nToken, DICE_BIND_D_D2, JsonString(IntToString(JsonGetInt(JsonArrayGet(jDealerDice, 1)))));
+    NuiSetBind(oPC, nToken, DICE_BIND_D_D3, JsonString(IntToString(JsonGetInt(JsonArrayGet(jDealerDice, 2)))));
+    NuiSetBind(oPC, nToken, DICE_BIND_D_D4, JsonString(IntToString(JsonGetInt(JsonArrayGet(jDealerDice, 3)))));
+    NuiSetBind(oPC, nToken, DICE_BIND_D_D5, JsonString(IntToString(JsonGetInt(JsonArrayGet(jDealerDice, 4)))));
+
+    // Jackpot contribution (rounds down, minimum 1 gp)
+    int nContrib = nBet / DICE_JACKPOT_FRAC;
+    if(nContrib < 1) nContrib = 1;
+
+    // Special case: five 1s beats regular five-of-a-kind (curse, no jackpot payout)
+    int bFiveOfAKind = (nPRank == DICE_HAND_FIVE);
+    int bAllOnes     = (bFiveOfAKind && DiceHandValue(nPScore) == 1);
+
+    int bPlayerWins = (nPScore > nDScore);
+    int bTie        = (nPScore == nDScore);
+
+    string sPHand = DiceHandName(nPRank);
+    string sDHand = DiceHandName(nDRank);
+    string sResult;
+    int nGoldDelta = 0;
+    int nStreak    = GetLocalInt(oPC, DICE_LVAR_STREAK);
+
+    if(bAllOnes)
+    {
+        // Worst outcome: lose bet regardless of dealer's hand
+        AssignCommand(oPC, TakeGoldFromCreature(nBet, oPC, TRUE));
+        DiceAddToJackpot(nContrib);
+        nGoldDelta  = -nBet;
+        bPlayerWins = FALSE;
+        nStreak     = (nStreak < 0 ? nStreak - 1 : -1);
+        sResult = "Pięć jedynek... Fortuna odwraca od ciebie wzrok. Tracisz "
+                + IntToString(nBet) + " gp.";
+        DiceApplyLuckCurse(oPC);
+    }
+    else if(bFiveOfAKind)
+    {
+        // Jackpot: win the entire pool regardless of dealer's hand
+        int nJackpot = DiceGetJackpot();
+        GiveGoldToCreature(oPC, nJackpot);
+        DiceResetJackpot();
+        nGoldDelta  = nJackpot;
+        bPlayerWins = TRUE;
+        nStreak     = (nStreak > 0 ? nStreak + 1 : 1);
+        sResult = "PIĘĆ JEDNAKOWYCH! Jackpot " + IntToString(nJackpot)
+                + " gp trafia w twoje ręce!";
+        DiceApplyLuckBoon(oPC);
+    }
+    else if(bTie)
+    {
+        sResult    = "Remis — kości milczą. Stawka wraca do twojej sakwy.";
+        nGoldDelta = 0;
+        nStreak    = 0;
+    }
+    else if(bPlayerWins)
+    {
+        GiveGoldToCreature(oPC, nBet);
+        DiceAddToJackpot(nContrib);
+        nGoldDelta = nBet;
+        nStreak    = (nStreak > 0 ? nStreak + 1 : 1);
+
+        if(nStreak >= 5)
+            sResult = "SERIA " + IntToString(nStreak) + "! Kostki śpiewają twoje imię! +"
+                    + IntToString(nBet) + " gp.";
+        else
+            sResult = "Wygrywasz! " + sPHand + " bije " + sDHand + ". +"
+                    + IntToString(nBet) + " gp.";
+    }
+    else
+    {
+        AssignCommand(oPC, TakeGoldFromCreature(nBet, oPC, TRUE));
+        DiceAddToJackpot(nContrib);
+        nGoldDelta = -nBet;
+        nStreak    = (nStreak < 0 ? nStreak - 1 : -1);
+
+        if(nStreak <= -5)
+            sResult = "Seria " + IntToString(-nStreak) + " porażek. Może jutro szczęście się uśmiechnie. -"
+                    + IntToString(nBet) + " gp.";
+        else
+            sResult = "Przegrywasz. " + sDHand + " bije " + sPHand + ". -"
+                    + IntToString(nBet) + " gp.";
+    }
+
+    SetLocalInt(oPC, DICE_LVAR_STREAK, nStreak);
+
+    // Update color per side
+    json cWin  = NuiColor(230, 200,  60);
+    json cLose = NuiColor(200,  70,  70);
+    json cTie  = NuiColor(160, 160, 160);
+    NuiSetBind(oPC, nToken, DICE_BIND_P_COL, bTie ? cTie : (bPlayerWins ? cWin : cLose));
+    NuiSetBind(oPC, nToken, DICE_BIND_D_COL, bTie ? cTie : (bPlayerWins ? cLose : cWin));
+
+    NuiSetBind(oPC, nToken, DICE_BIND_P_HAND, JsonString(sPHand));
+    NuiSetBind(oPC, nToken, DICE_BIND_D_HAND, JsonString(sDHand));
+    NuiSetBind(oPC, nToken, DICE_BIND_RESULT, JsonString(sResult));
+
+    // Persist record (ties are not recorded)
+    if(!bTie)
+        DiceUpdateRecord(oPC, bPlayerWins, nGoldDelta, nPRank, nStreak > 0 ? nStreak : 0);
+
+    // Refresh gold and jackpot labels
+    NuiSetBind(oPC, nToken, DICE_BIND_GOLD_LBL,
+        JsonString("Złoto: " + IntToString(GetGold(oPC)) + " gp"));
+    NuiSetBind(oPC, nToken, DICE_BIND_JACKPOT,
+        JsonString("Pula jackpotu: " + IntToString(DiceGetJackpot()) + " gp"));
+
+    DiceFeedRecord(oPC, nToken);
+
+    DeleteLocalInt(oPC, DICE_LVAR_BUSY);
+    NuiSetBind(oPC, nToken, DICE_BIND_ROLL_ENA, JsonBool(TRUE));
+}
+
+// ---------------------------------------------------------------
+// Roll entry point — validates bet, shows suspense, schedules reveal
+// ---------------------------------------------------------------
+
+void DiceRollStart(object oPC, int nToken)
+{
+    if(GetLocalInt(oPC, DICE_LVAR_BUSY)) return;
+
+    string sBetStr = JsonGetString(NuiGetBind(oPC, nToken, DICE_BIND_BET_TXT));
+    int nBet       = StringToInt(sBetStr);
+
+    if(nBet < DICE_MIN_BET)
+    {
+        SendMessageToPC(oPC, "[Kości Losu] Minimalna stawka to " + IntToString(DICE_MIN_BET) + " gp.");
+        return;
+    }
+    if(nBet > DICE_MAX_BET)
+    {
+        SendMessageToPC(oPC, "[Kości Losu] Maksymalna stawka to " + IntToString(DICE_MAX_BET) + " gp.");
+        return;
+    }
+    if(GetGold(oPC) < nBet)
+    {
+        SendMessageToPC(oPC, "[Kości Losu] Nie masz wystarczająco złota.");
+        return;
+    }
+
+    SetLocalInt(oPC, DICE_LVAR_BUSY, 1);
+    NuiSetBind(oPC, nToken, DICE_BIND_ROLL_ENA, JsonBool(FALSE));
+
+    // Suspense: all dice show "?"
+    DiceFeedBlankDice(oPC, nToken, "?");
+    NuiSetBind(oPC, nToken, DICE_BIND_P_HAND, JsonString("..."));
+    NuiSetBind(oPC, nToken, DICE_BIND_D_HAND, JsonString("..."));
+    NuiSetBind(oPC, nToken, DICE_BIND_RESULT, JsonString("Kości toczą się po stole..."));
+
+    // Roll now; reveal after delay
+    json jPlayerDice = DiceRollFive();
+    json jDealerDice = DiceRollFive();
+
+    DelayCommand(1.5, DiceRevealResults(oPC, nToken, nBet, jPlayerDice, jDealerDice));
+}
+
+// ---------------------------------------------------------------
+// Window open / re-open
+// ---------------------------------------------------------------
+
+void DiceOpenWindow(object oPC)
+{
+    DiceRegisterPlayer(oPC);
+
+    int nToken = NuiFindWindow(oPC, DICE_WINDOW);
+    if(nToken != 0)
+    {
+        DiceFeedInitialState(oPC, nToken);
+        return;
+    }
+
+    float fX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))
+                - GetNuiScaleDimension(oPC, DICE_W)) / 2.0;
+    float fY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT))
+                - GetNuiScaleDimension(oPC, DICE_H)) / 2.0;
+    json jGeom = NuiRect(fX, fY,
+                         GetNuiScaleDimension(oPC, DICE_W),
+                         GetNuiScaleDimension(oPC, DICE_H));
+
+    float fBtnH    = GetNuiScaleDimension(oPC, 32.0);
+    json jCloseBtn = NuiButton(JsonString("X"));
+    jCloseBtn = NuiId(jCloseBtn, DICE_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, GetNuiScaleDimension(oPC, 32.0));
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jTitleLbl = NuiLabel(JsonString("Kości Losu"),
+                              JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitleLbl = NuiHeight(jTitleLbl, fBtnH);
+    jTitleLbl = NuiStyleForegroundColor(jTitleLbl, NuiColor(230, 200, 60));
+
+    json jTitleRow = JsonArray();
+    jTitleRow = JsonArrayInsert(jTitleRow, jTitleLbl);
+    jTitleRow = JsonArrayInsert(jTitleRow, NuiSpacer());
+    jTitleRow = JsonArrayInsert(jTitleRow, jCloseBtn);
+
+    json jRootCol = JsonArray();
+    jRootCol = JsonArrayInsert(jRootCol, NuiRow(jTitleRow));
+    jRootCol = JsonArrayInsert(jRootCol, DiceBuildMainLayout(oPC));
+
+    json jWin = NuiWindow(NuiCol(jRootCol),
+        JsonBool(FALSE),
+        NuiBind(DICE_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    nToken = NuiCreate(oPC, jWin, DICE_WINDOW, DICE_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, DICE_WIN_GEOM, jGeom);
+    NuiSetBindWatch(oPC, nToken, DICE_BIND_BET_TXT, TRUE);
+
+    DiceFeedInitialState(oPC, nToken);
+}

--- a/Kości Losu/Scripts/lib_dice_def.nss
+++ b/Kości Losu/Scripts/lib_dice_def.nss
@@ -1,0 +1,205 @@
+// lib_dice_def.nss — constants, hand evaluation, and helpers for Kości Losu
+
+#include "lib_nui"
+#include "sql_dice"
+
+// Forward declarations (resolved in lib_dice.nss)
+void DiceOpenWindow(object oPC);
+void DiceFeedRecord(object oPC, int nToken);
+void DiceRevealResults(object oPC, int nToken, int nBet, json jPlayerDice, json jDealerDice);
+
+// ---------------------------------------------------------------
+// Window / event script identifiers
+// ---------------------------------------------------------------
+
+const string DICE_WINDOW        = "DICE_WINDOW";
+const string DICE_EV_SCRIPT     = "lib_dice_ev";
+const string DICE_WIN_GEOM      = "dice_win_geom";
+const string DICE_WIN_LB        = "DICE_WIN_LB";
+
+// ---------------------------------------------------------------
+// Bind names — player's dice display
+// ---------------------------------------------------------------
+
+const string DICE_BIND_P_D1     = "dice_p_d1";
+const string DICE_BIND_P_D2     = "dice_p_d2";
+const string DICE_BIND_P_D3     = "dice_p_d3";
+const string DICE_BIND_P_D4     = "dice_p_d4";
+const string DICE_BIND_P_D5     = "dice_p_d5";
+const string DICE_BIND_P_HAND   = "dice_p_hand";
+const string DICE_BIND_P_COL    = "dice_p_col";   // single NuiColor for all 5 dice
+
+// Bind names — dealer's dice display
+const string DICE_BIND_D_D1     = "dice_d_d1";
+const string DICE_BIND_D_D2     = "dice_d_d2";
+const string DICE_BIND_D_D3     = "dice_d_d3";
+const string DICE_BIND_D_D4     = "dice_d_d4";
+const string DICE_BIND_D_D5     = "dice_d_d5";
+const string DICE_BIND_D_HAND   = "dice_d_hand";
+const string DICE_BIND_D_COL    = "dice_d_col";
+
+// Bind names — controls & status
+const string DICE_BIND_RESULT   = "dice_result";
+const string DICE_BIND_GOLD_LBL = "dice_gold_lbl";
+const string DICE_BIND_BET_TXT  = "dice_bet_txt";
+const string DICE_BIND_ROLL_ENA = "dice_roll_ena";
+const string DICE_BIND_REC_LBL  = "dice_rec_lbl";
+const string DICE_BIND_JACKPOT  = "dice_jackpot";
+
+// Bind names — leaderboard list
+const string DICE_BIND_LB_NAME  = "dice_lb_name";
+const string DICE_BIND_LB_WL    = "dice_lb_wl";
+const string DICE_BIND_LB_GOLD  = "dice_lb_gold";
+const string DICE_BIND_LB_ENC   = "dice_lb_enc";
+
+// ---------------------------------------------------------------
+// Button IDs
+// ---------------------------------------------------------------
+
+const string DICE_BTN_CLOSE     = "dice_btn_close";
+const string DICE_BTN_ROLL      = "dice_btn_roll";
+const string DICE_BTN_LB        = "dice_btn_lb";
+const string DICE_BTN_LB_CLOSE  = "dice_btn_lb_close";
+
+// ---------------------------------------------------------------
+// Local variables stored on PC
+// ---------------------------------------------------------------
+
+const string DICE_LVAR_BUSY     = "DICE_BUSY";
+const string DICE_LVAR_STREAK   = "DICE_STREAK";  // >0 = win streak, <0 = loss streak
+
+// ---------------------------------------------------------------
+// Layout dimensions
+// ---------------------------------------------------------------
+
+const float  DICE_W             = 540.0;
+const float  DICE_H             = 520.0;
+
+// ---------------------------------------------------------------
+// Hand rank constants (higher = better hand)
+// ---------------------------------------------------------------
+
+const int    DICE_HAND_HIGH_DIE = 1;
+const int    DICE_HAND_PAIR     = 2;
+const int    DICE_HAND_TWO_PAIR = 3;
+const int    DICE_HAND_THREE    = 4;
+const int    DICE_HAND_FULL     = 5;
+const int    DICE_HAND_FOUR     = 6;
+const int    DICE_HAND_FIVE     = 7;
+
+// ---------------------------------------------------------------
+// Bet limits
+// ---------------------------------------------------------------
+
+const int    DICE_MIN_BET       = 10;
+const int    DICE_MAX_BET       = 5000;
+const int    DICE_LB_ROWS       = 10;
+
+// 1/N of each bet contributes to the shared jackpot pool
+const int    DICE_JACKPOT_FRAC  = 20;
+
+// ---------------------------------------------------------------
+// Hand evaluation
+// ---------------------------------------------------------------
+
+// Returns encoded score: rank*100 + tiebreak_value (higher = better).
+// Avoids native arrays — uses individual int variables per die value.
+int DiceEvaluateHand(json jDice)
+{
+    int nC1=0, nC2=0, nC3=0, nC4=0, nC5=0, nC6=0;
+    int i;
+    for(i = 0; i < 5; i++)
+    {
+        int v = JsonGetInt(JsonArrayGet(jDice, i));
+        if     (v == 1) nC1++;
+        else if(v == 2) nC2++;
+        else if(v == 3) nC3++;
+        else if(v == 4) nC4++;
+        else if(v == 5) nC5++;
+        else             nC6++;
+    }
+
+    // Max count and its die value (search ascending → highest value wins ties)
+    int nMax=0, nMaxVal=0;
+    if(nC1 >= nMax) { nMax=nC1; nMaxVal=1; }
+    if(nC2 >= nMax) { nMax=nC2; nMaxVal=2; }
+    if(nC3 >= nMax) { nMax=nC3; nMaxVal=3; }
+    if(nC4 >= nMax) { nMax=nC4; nMaxVal=4; }
+    if(nC5 >= nMax) { nMax=nC5; nMaxVal=5; }
+    if(nC6 >= nMax) { nMax=nC6; nMaxVal=6; }
+
+    // Second-highest count (ignoring nMaxVal's slot)
+    int nSecond=0;
+    if(nMaxVal != 1 && nC1 > nSecond) nSecond=nC1;
+    if(nMaxVal != 2 && nC2 > nSecond) nSecond=nC2;
+    if(nMaxVal != 3 && nC3 > nSecond) nSecond=nC3;
+    if(nMaxVal != 4 && nC4 > nSecond) nSecond=nC4;
+    if(nMaxVal != 5 && nC5 > nSecond) nSecond=nC5;
+    if(nMaxVal != 6 && nC6 > nSecond) nSecond=nC6;
+
+    // Highest die value present (for high-die tiebreak)
+    int nHighDie=1;
+    if(nC2 > 0) nHighDie=2;
+    if(nC3 > 0) nHighDie=3;
+    if(nC4 > 0) nHighDie=4;
+    if(nC5 > 0) nHighDie=5;
+    if(nC6 > 0) nHighDie=6;
+
+    if(nMax == 5) return DICE_HAND_FIVE     * 100 + nMaxVal;
+    if(nMax == 4) return DICE_HAND_FOUR     * 100 + nMaxVal;
+    if(nMax == 3 && nSecond == 2)
+                  return DICE_HAND_FULL     * 100 + nMaxVal;
+    if(nMax == 3) return DICE_HAND_THREE    * 100 + nMaxVal;
+    if(nMax == 2 && nSecond == 2)
+                  return DICE_HAND_TWO_PAIR * 100 + nMaxVal;
+    if(nMax == 2) return DICE_HAND_PAIR     * 100 + nMaxVal;
+    return         DICE_HAND_HIGH_DIE * 100 + nHighDie;
+}
+
+int  DiceHandRank(int nScore)  { return nScore / 100;  }
+int  DiceHandValue(int nScore) { return nScore % 100;  }
+
+string DiceHandName(int nRank)
+{
+    switch(nRank)
+    {
+        case DICE_HAND_PAIR:     return "Para";
+        case DICE_HAND_TWO_PAIR: return "Dwie pary";
+        case DICE_HAND_THREE:    return "Trójka";
+        case DICE_HAND_FULL:     return "Full";
+        case DICE_HAND_FOUR:     return "Kareta";
+        case DICE_HAND_FIVE:     return "Pięć jednakowych";
+        default:                 return "Wysokie oczko";
+    }
+}
+
+// Returns a JsonArray of 5 random d6 rolls
+json DiceRollFive()
+{
+    json jDice = JsonArray();
+    int i;
+    for(i = 0; i < 5; i++)
+        jDice = JsonArrayInsert(jDice, JsonInt(d6()));
+    return jDice;
+}
+
+// Temporary combat boon for a jackpot-winning five-of-a-kind
+void DiceApplyLuckBoon(object oPC)
+{
+    effect eBoon = EffectAttackIncrease(1, ATTACK_BONUS_MISC);
+    eBoon = EffectLinkEffects(eBoon, EffectSavingThrowIncrease(SAVING_THROW_ALL, 1, SAVING_THROW_TYPE_ALL));
+    eBoon = SupernaturalEffect(eBoon);
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eBoon, oPC, 3600.0);
+    FloatingTextStringOnCreature("Błogosławieństwo Fortuny!", oPC, FALSE);
+    SendMessageToPC(oPC, "[Kości Losu] Magia losu płonie w twojej piersi. +1 do ataku i rzutów obronnych przez godzinę.");
+}
+
+// Temporary penalty for rolling five ones (worst possible outcome)
+void DiceApplyLuckCurse(object oPC)
+{
+    effect eCurse = EffectSavingThrowDecrease(SAVING_THROW_ALL, 1, SAVING_THROW_TYPE_ALL);
+    eCurse = SupernaturalEffect(eCurse);
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eCurse, oPC, 1800.0);
+    FloatingTextStringOnCreature("Klątwa Przegranego!", oPC, FALSE);
+    SendMessageToPC(oPC, "[Kości Losu] Przeznaczenie cię opuszcza... -1 do rzutów obronnych przez 30 minut.");
+}

--- a/Kości Losu/Scripts/lib_dice_ev.nss
+++ b/Kości Losu/Scripts/lib_dice_ev.nss
@@ -1,0 +1,58 @@
+// lib_dice_ev.nss — NUI event handler for Kości Losu
+
+#include "lib_dice"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+
+    // ---- Leaderboard popup ----
+    if(nToken == NuiFindWindow(oPC, DICE_WIN_LB))
+    {
+        if(sEvent == EVENT_TYPE_CLICK && sElem == DICE_BTN_LB_CLOSE)
+            NuiDestroy(oPC, nToken);
+        return;
+    }
+
+    if(nToken != NuiFindWindow(oPC, DICE_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalInt(oPC, DICE_LVAR_BUSY);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_WATCH && sElem == DICE_BIND_BET_TXT)
+    {
+        string sVal = JsonGetString(NuiGetBind(oPC, nToken, DICE_BIND_BET_TXT));
+        int nVal    = StringToInt(sVal);
+        int bBusy   = GetLocalInt(oPC, DICE_LVAR_BUSY);
+        int bValid  = (!bBusy && nVal >= DICE_MIN_BET && nVal <= DICE_MAX_BET && GetGold(oPC) >= nVal);
+        NuiSetBind(oPC, nToken, DICE_BIND_ROLL_ENA, JsonBool(bValid));
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == DICE_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        if(sElem == DICE_BTN_ROLL)
+        {
+            DiceRollStart(oPC, nToken);
+            return;
+        }
+
+        if(sElem == DICE_BTN_LB)
+        {
+            DiceOpenLeaderboard(oPC);
+            return;
+        }
+    }
+}

--- a/Kości Losu/Scripts/lib_nui.nss
+++ b/Kości Losu/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Kości Losu/Scripts/lib_nui_utility.nss
+++ b/Kości Losu/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Kości Losu/Scripts/sql_dice.nss
+++ b/Kości Losu/Scripts/sql_dice.nss
@@ -1,0 +1,128 @@
+// sql_dice.nss — SQLite schema and queries for Kości Losu
+
+void DiceCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("dice",
+        "CREATE TABLE IF NOT EXISTS dice_records ("
+        "  uuid        TEXT PRIMARY KEY,"
+        "  char_name   TEXT    DEFAULT '',"
+        "  wins        INTEGER DEFAULT 0,"
+        "  losses      INTEGER DEFAULT 0,"
+        "  gold_won    INTEGER DEFAULT 0,"
+        "  gold_lost   INTEGER DEFAULT 0,"
+        "  best_hand   INTEGER DEFAULT 0,"
+        "  streak_best INTEGER DEFAULT 0"
+        ")");
+    SqlStep(q);
+
+    // Single-row jackpot pool seeded at 200 gp
+    q = SqlPrepareQueryCampaign("dice",
+        "CREATE TABLE IF NOT EXISTS dice_jackpot (id INTEGER PRIMARY KEY, amount INTEGER DEFAULT 200)");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("dice",
+        "INSERT OR IGNORE INTO dice_jackpot (id, amount) VALUES (1, 200)");
+    SqlStep(q);
+}
+
+void DiceRegisterPlayer(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("dice",
+        "INSERT OR IGNORE INTO dice_records (uuid, char_name) VALUES (@uuid, @name)");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindString(q, "@name", GetName(oPC));
+    SqlStep(q);
+
+    // Always refresh char_name in case of rename
+    q = SqlPrepareQueryCampaign("dice",
+        "UPDATE dice_records SET char_name = @name WHERE uuid = @uuid");
+    SqlBindString(q, "@name", GetName(oPC));
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+// nGoldDelta: positive = won, negative = lost
+void DiceUpdateRecord(object oPC, int bWon, int nGoldDelta, int nHandRank, int nStreak)
+{
+    sqlquery q = SqlPrepareQueryCampaign("dice",
+        "UPDATE dice_records SET"
+        "  wins       = wins       + @w,"
+        "  losses     = losses     + @l,"
+        "  gold_won   = gold_won   + @gw,"
+        "  gold_lost  = gold_lost  + @gl,"
+        "  best_hand  = MAX(best_hand, @bh),"
+        "  streak_best= MAX(streak_best, @sb)"
+        " WHERE uuid = @uuid");
+    SqlBindInt   (q, "@w",    bWon ? 1 : 0);
+    SqlBindInt   (q, "@l",    bWon ? 0 : 1);
+    SqlBindInt   (q, "@gw",   nGoldDelta > 0 ? nGoldDelta : 0);
+    SqlBindInt   (q, "@gl",   nGoldDelta < 0 ? -nGoldDelta : 0);
+    SqlBindInt   (q, "@bh",   nHandRank);
+    SqlBindInt   (q, "@sb",   nStreak > 0 ? nStreak : 0);
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+// Returns json object: {wins, losses, gold_won, gold_lost, best_hand, streak_best}
+json DiceGetRecord(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("dice",
+        "SELECT wins, losses, gold_won, gold_lost, best_hand, streak_best"
+        " FROM dice_records WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(!SqlStep(q)) return JsonNull();
+
+    json j = JsonObject();
+    j = JsonObjectSet(j, "wins",        JsonInt(SqlGetInt(q, 0)));
+    j = JsonObjectSet(j, "losses",      JsonInt(SqlGetInt(q, 1)));
+    j = JsonObjectSet(j, "gold_won",    JsonInt(SqlGetInt(q, 2)));
+    j = JsonObjectSet(j, "gold_lost",   JsonInt(SqlGetInt(q, 3)));
+    j = JsonObjectSet(j, "best_hand",   JsonInt(SqlGetInt(q, 4)));
+    j = JsonObjectSet(j, "streak_best", JsonInt(SqlGetInt(q, 5)));
+    return j;
+}
+
+// Returns JsonArray of top players: [{char_name, wins, losses, gold_net}, ...]
+json DiceGetLeaderboard(int nLimit)
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("dice",
+        "SELECT char_name, wins, losses, (gold_won - gold_lost) AS gold_net"
+        " FROM dice_records"
+        " ORDER BY gold_net DESC, wins DESC"
+        " LIMIT @lim");
+    SqlBindInt(q, "@lim", nLimit);
+    while(SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "char_name", JsonString(SqlGetString(q, 0)));
+        jRow = JsonObjectSet(jRow, "wins",      JsonInt   (SqlGetInt   (q, 1)));
+        jRow = JsonObjectSet(jRow, "losses",    JsonInt   (SqlGetInt   (q, 2)));
+        jRow = JsonObjectSet(jRow, "gold_net",  JsonInt   (SqlGetInt   (q, 3)));
+        jRows = JsonArrayInsert(jRows, jRow);
+    }
+    return jRows;
+}
+
+int DiceGetJackpot()
+{
+    sqlquery q = SqlPrepareQueryCampaign("dice",
+        "SELECT amount FROM dice_jackpot WHERE id = 1");
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 200;
+}
+
+void DiceAddToJackpot(int nAmount)
+{
+    sqlquery q = SqlPrepareQueryCampaign("dice",
+        "UPDATE dice_jackpot SET amount = amount + @a WHERE id = 1");
+    SqlBindInt(q, "@a", nAmount);
+    SqlStep(q);
+}
+
+void DiceResetJackpot()
+{
+    sqlquery q = SqlPrepareQueryCampaign("dice",
+        "UPDATE dice_jackpot SET amount = 200 WHERE id = 1");
+    SqlStep(q);
+}

--- a/Kości Losu/Scripts/sys_on_load.nss
+++ b/Kości Losu/Scripts/sys_on_load.nss
@@ -1,0 +1,8 @@
+// sys_on_load.nss — OnModuleLoad hook for Kości Losu
+
+#include "lib_dice_def"
+
+void main()
+{
+    DiceCreateTables();
+}

--- a/Kości Losu/Scripts/test_dice.nss
+++ b/Kości Losu/Scripts/test_dice.nss
@@ -1,0 +1,10 @@
+// test_dice.nss — OnUsed placeable script; place on a dice table prop in the module
+
+#include "lib_dice"
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+    DiceOpenWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

Kości Losu to moduł karczmianej gry hazardowej dla dark fantasy CRPG. Gracz siada przy stole i rzuca 5 kości d6 przeciwko karciarzowi (NPC karczmarz). Wygrywa ten, kto ma lepszy układ w stylu poker-dice. Wyniki są trwale zapisywane w SQLite per-postać; istnieje wspólna pula jackpotu zasilana każdym zakładem.

## Mechanika

- **Układy** (rosnąco): wysokie oczko, para, dwie pary, trójka, full, kareta, pięć jednakowych.
- **Zakład**: 10–5000 gp; gracz wpisuje stawkę w polu tekstowym i klika „RZUĆ KOŚCI".
- **Suspens**: kości pokazują „?" przez 1.5 sek. (DelayCommand), potem odsłaniają wynik.
- **Remis** zwraca stawkę.  
- **Wygrana / Przegrana**: 1:1.  
- **5% każdego zakładu** (min 1 gp) trafia do puli jackpotu.
- **Pięć jednakowych** (wartość ≥ 2): gracz zgarnia całą pulę jackpotu + tymczasowe błogosławieństwo (+1 atak i rzuty obronne przez 1h).
- **Pięć jedynek**: najgorszy wynik — gracz traci zakład, dostaje klątwę (−1 rzuty obronne przez 30 min).
- **Serie zwycięstw/porażek** generują specjalny flavor text po 5+ rozgrywkach pod rząd.
- **Tabela najlepszych** (top 10 według złota netto) dostępna z poziomu okna gry.

## Pliki

| Plik | Opis |
|------|------|
| `Scripts/sql_dice.nss` | Schemat SQLite (`dice_records`, `dice_jackpot`), wszystkie zapytania |
| `Scripts/lib_dice_def.nss` | Stałe, bindy NUI, ID przycisków, `DiceEvaluateHand`, efekty klątywy/błogosławieństwa |
| `Scripts/lib_dice.nss` | Builder okna NUI, `DiceRollStart`, `DiceRevealResults`, leaderboard |
| `Scripts/lib_dice_ev.nss` | Handler zdarzeń NUI (switch po `NuiGetEventType`) |
| `Scripts/sys_on_load.nss` | `OnModuleLoad` — tworzy tabele SQLite |
| `Scripts/test_dice.nss` | `OnUsed` placeable — otwiera okno dla gracza |
| `Scripts/lib_nui.nss` | Kopia shared NUI utilities (skala GUI, CreateEmptyRow, itp.) |
| `INTEGRATION.md` | Instrukcja podpinania hooków i ustawienia placseable |

## Zależności (NWNX? SQL?)

- **Brak NWNX** — wyłącznie NWScript + NUI + wbudowany SQLite (NWN:EE 8193.36+).
- Kampania SQLite: `dice` (tworzona automatycznie przez `DiceCreateTables()`).

## Jak włączyć w istniejącym module

1. Skopiuj pliki z `Scripts/` do folderu skryptów modułu.
2. W `OnModuleLoad` wywołaj `DiceCreateTables()` (lub użyj `sys_on_load` jako skryptu).
3. W `OnNuiEvent` wywołaj skrypt `lib_dice_ev` (lub dołącz `#include "lib_dice_ev"` do istniejącego handlera NUI).
4. Umieść placeable (np. okrągły stół) i ustaw `OnUsed = test_dice`, `Useable = TRUE`.

## Co celowo pominięto

- **Gra wieloosobowa (gracz vs gracz)** — wymagałaby kolejkowania i synchronizacji między dwoma oknami NUI.
- **Obrazki ścianek kości** — wymagałyby TGA/DDS w haku; zastąpione tekstowymi etykietami `1`–`6`.
- **Dźwięki rzutu** — wymagałyby zasobów audio w haku.
- **Dzienny limit zakładów** — nie zakłada się trybu PW z limitami; łatwo dodać kolumnę `last_roll_date`.
- **Historia rozgrywek** — tylko sumaryczne statystyki; szczegółowy log rozszerzyłby schemat BD.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gj2YemAg6ojckUpB397654)_