### PR TITLE
feat: Lycanthropy (Wilkołactwo)

### DIFF
--- a/Lycanthropy/INTEGRATION.md
+++ b/Lycanthropy/INTEGRATION.md
@@ -1,0 +1,86 @@
+# Lycanthropy — Instrukcja Integracji
+
+## Hooki modułu (Module Events)
+
+| Zdarzenie modułu | Skrypt | Opis |
+|---|---|---|
+| OnModuleLoad | `sys_on_load` | Tworzy tabele SQLite; wywoływany raz przy starcie serwera. |
+| OnClientEnter | `sys_on_enter` | Przywraca efekty klątwy po zalogowaniu; uruchamia per-PC heartbeat. |
+| OnClientLeave | `sys_on_leave` | Przywraca formę ludzką przy rozłączeniu (czystość stanu). |
+
+Jeśli moduł ma już własne skrypty dla tych zdarzeń, dodaj wywołania:
+```nss
+// Na końcu istniejącego OnClientEnter:
+ExecuteScript("sys_on_enter", GetEnteringObject());
+```
+lub skopiuj zawartość do istniejących skryptów.
+
+## Silver Weapon Damage (opcjonalne)
+
+Skrypt `sys_on_attacked.nss` obsługuje zadawanie dodatkowych obrażeń przez srebrne bronie.
+Należy go podpiąć jako `EVENT_SCRIPT_CREATURE_ON_DAMAGED` lub `OnPhysicalAttacked`
+dla postaci graczy — najwygodniej w `sys_on_enter.nss`:
+
+```nss
+SetEventScript(oPC, EVENT_SCRIPT_CREATURE_ON_PHYSICAL_ATTACKED, "sys_on_attacked");
+```
+
+**Uwaga:** To nadpisze istniejący skrypt `OnPhysicalAttacked` PC. Jeśli masz inne
+systemy korzystające z tego zdarzenia, połącz je w jeden skrypt.
+
+## Bronie srebrne
+
+Broń zadaje dodatkowe `2d6` obrażeń magicznych transformowanemu wilkołakowi,
+jeśli jej **tag** lub **nazwa** zawiera podciąg `silver` (małe litery).
+
+Przykładowe tagi: `silver_sword`, `blade_of_silver`, `silverlight`.
+
+## Placeable testowy
+
+1. Utwórz dowolny Placeable z tagiem np. `lycan_test`.
+2. Ustaw `OnUsed = test_lycan`.
+3. Opcjonalnie ustaw lokalną zmienną `LYCAN_TEST_MODE` (INT):
+   - `1` — zaraź gracza (etap utajony)
+   - `2` — awansuj do pełnego wilkołactwa
+   - `3` — wylecz klątwę bez kitu
+   - `0` (domyślnie) — otwórz tylko okno statusu
+
+## Przedmiot: Zestaw Odpędnika Wilkołaka
+
+Utwórz przedmiot (np. zwój lub mikstura) z **tagiem `lycan_cure_kit`**.
+Sprzedawaj go u kapłanów lub alchemików za wysoką cenę.
+
+Gracz musi posiadać ten przedmiot w ekwipunku i **nie być w formie wilka**,
+by przeprowadzić rytuał oczyszczenia z poziomu okna statusu.
+
+## Tuning cyklu księżyca
+
+W `lib_lycan_def.nss` zmień:
+
+```nss
+const int LYCAN_MOON_CYCLE_S = 7560; // sekundy realnego czasu na 28 "dni NWN"
+```
+
+Domyślnie: `7560 s ≈ 2.1 h` (zakłada 1 dzień NWN = ok. 4.5 min realnego czasu).
+
+Pełnia trwa od dnia 12 do 16 cyklu (zakres konfigurowalny przez `LYCAN_FULL_MOON_START`/`END`).
+
+## Zależności
+
+| Zależność | Wymagana? | Uwagi |
+|---|---|---|
+| NWNX | NIE | Moduł w całości opiera się na standardowym NWScript + NWN:EE NUI |
+| SQLite Campaign DB | TAK | `SqlPrepareQueryCampaign` — dostępne w NWN:EE od wersji 8193.14.3 |
+| appearance.2da | TAK | Rząd 285 = Dire Wolf; możliwa podmiana na własny werewolf |
+
+## Co celowo pominięto
+
+- **Zarażanie przez walkę NPC→PC**: silnik NWN nie udostępnia modułowego zdarzenia
+  „PC dostał cios od NPC X". Spread dotyczy tylko PC→PC w pobliżu (heartbeat).
+- **Moonphase tilesetowe**: brak modyfikacji skyboxa; wizualna zmiana księżyca
+  wymagałaby niestandardowego haka lub NWNX:Weather.
+- **Kurator specjalny**: rytuał oczyszczenia realizowany przez item, nie przez
+  rozmowę z NPC — upraszcza moduł i pozostawia integrację z systemem NPC
+  konwersacji po stronie serwera.
+- **Ulepszone wilcze zdolności**: transformacja daje jedynie zmianę wyglądu + efekty
+  statystyk; specjalne ataki (gryzienie, wyjeczenie AoE) są opcjonalne do dobudowania.

--- a/Lycanthropy/Scripts/lib_lycan.nss
+++ b/Lycanthropy/Scripts/lib_lycan.nss
@@ -1,0 +1,467 @@
+#include "lib_lycan_def"
+
+// Forward declarations
+void LycanOpenWindow(object oPC);
+void LycanFeedWindow(object oPC, int nToken);
+void LycanTransform(object oPC);
+void LycanRevert(object oPC);
+void LycanApplyStageEffects(object oPC, int nStage);
+void LycanRemoveEffects(object oPC);
+void LycanCure(object oPC);
+void LycanCheckAdvanceStage(object oPC);
+void LycanHeartbeat(object oPC);
+
+// -----------------------------------------------------------------------
+// Effect helpers
+// -----------------------------------------------------------------------
+
+void LycanRemoveTaggedEffects(object oTarget, string sTag)
+{
+    effect e = GetFirstEffect(oTarget);
+    while(GetIsEffectValid(e))
+    {
+        if(GetEffectTag(e) == sTag)
+            RemoveEffect(oTarget, e);
+        e = GetNextEffect(oTarget);
+    }
+}
+
+void LycanRemoveEffects(object oPC)
+{
+    LycanRemoveTaggedEffects(oPC, LYCAN_EFF_ACTIVE);
+    LycanRemoveTaggedEffects(oPC, LYCAN_EFF_FULL);
+}
+
+// Applies persistent stat effects appropriate for nStage.
+void LycanApplyStageEffects(object oPC, int nStage)
+{
+    LycanRemoveEffects(oPC);
+    if(nStage == LYCAN_STAGE_NONE) return;
+
+    if(nStage == LYCAN_STAGE_ACTIVE)
+    {
+        // Minor bestial surge: +2 STR, -1 WIS
+        effect eStr = TagEffect(EffectAbilityIncrease(ABILITY_STRENGTH, 2),    LYCAN_EFF_ACTIVE);
+        effect eWis = TagEffect(EffectAbilityDecrease(ABILITY_WISDOM,   1),    LYCAN_EFF_ACTIVE);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, EffectLinkEffects(eStr, eWis), oPC);
+    }
+    else if(nStage == LYCAN_STAGE_FULL)
+    {
+        // Full curse: +4 STR, +2 CON, -3 WIS, -2 CHA
+        effect eStr = TagEffect(EffectAbilityIncrease(ABILITY_STRENGTH,     4), LYCAN_EFF_FULL);
+        effect eCon = TagEffect(EffectAbilityIncrease(ABILITY_CONSTITUTION, 2), LYCAN_EFF_FULL);
+        effect eWis = TagEffect(EffectAbilityDecrease(ABILITY_WISDOM,       3), LYCAN_EFF_FULL);
+        effect eCha = TagEffect(EffectAbilityDecrease(ABILITY_CHARISMA,     2), LYCAN_EFF_FULL);
+        effect eAll = EffectLinkEffects(eStr,
+                        EffectLinkEffects(eCon,
+                          EffectLinkEffects(eWis, eCha)));
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eAll, oPC);
+    }
+}
+
+// -----------------------------------------------------------------------
+// Stage advancement
+// -----------------------------------------------------------------------
+
+void LycanCheckAdvanceStage(object oPC)
+{
+    int nStage = LycanGetInfectionStage(oPC);
+    if(nStage == LYCAN_STAGE_NONE) return;
+
+    int nDays     = LycanGetDaysSinceInfection(oPC);
+    int nNewStage = nStage;
+
+    if(nDays >= 7 && nStage < LYCAN_STAGE_FULL)
+        nNewStage = LYCAN_STAGE_FULL;
+    else if(nDays >= 3 && nStage < LYCAN_STAGE_ACTIVE)
+        nNewStage = LYCAN_STAGE_ACTIVE;
+
+    if(nNewStage == nStage) return;
+
+    LycanSetInfection(oPC, nNewStage);
+    LycanApplyStageEffects(oPC, nNewStage);
+
+    if(nNewStage == LYCAN_STAGE_ACTIVE)
+    {
+        string sMsg = "[Wilkołactwo] Gorączka narasta. Zęby bolą, a oczy błyszczą w ciemności...";
+        SendMessageToPC(oPC, sMsg);
+        FloatingTextStringOnCreature("Klątwa bestii się przebudza!", oPC, FALSE);
+    }
+    else if(nNewStage == LYCAN_STAGE_FULL)
+    {
+        string sMsg = "[Wilkołactwo] Klątwa wypełniona. Pełnia księżyca cię przemieni.";
+        SendMessageToPC(oPC, sMsg);
+        FloatingTextStringOnCreature("Piętno wilka — pełne!", oPC, FALSE);
+    }
+}
+
+// -----------------------------------------------------------------------
+// Transformation
+// -----------------------------------------------------------------------
+
+// Store original appearance so we can restore it on revert.
+void LycanTransform(object oPC)
+{
+    if(GetLocalInt(oPC, LYCAN_LVAR_TRANSFORMED)) return;
+
+    // Save human appearance type for restoration
+    SetLocalInt(oPC, "LYCAN_ORIG_APPEARANCE", GetAppearanceType(oPC));
+    SetCreatureAppearanceType(oPC, LYCAN_WOLF_APPEARANCE);
+    SetLocalInt(oPC, LYCAN_LVAR_TRANSFORMED, TRUE);
+    LycanRecordTransform(oPC);
+
+    // Brief visual burst
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectVisualEffect(VFX_FNF_HOWL_WAR_CRY), oPC);
+
+    SendMessageToPC(oPC, "[Wilkołactwo] Ciało pęka i zmienia się. Bestia pochłania człowieka.");
+    FloatingTextStringOnCreature("*Przemiana w wilkołaka!*", oPC, FALSE);
+
+    object oOther = GetFirstPC();
+    while(GetIsObjectValid(oOther))
+    {
+        if(oOther != oPC && GetDistanceBetween(oPC, oOther) <= 30.0f)
+            SendMessageToPC(oOther,
+                "[Wilkołactwo] " + GetName(oPC) + " przemienia się w wilkołaka!");
+        oOther = GetNextPC();
+    }
+}
+
+void LycanRevert(object oPC)
+{
+    if(!GetLocalInt(oPC, LYCAN_LVAR_TRANSFORMED)) return;
+
+    int nOrig = GetLocalInt(oPC, "LYCAN_ORIG_APPEARANCE");
+    if(nOrig > 0) SetCreatureAppearanceType(oPC, nOrig);
+
+    DeleteLocalInt(oPC, LYCAN_LVAR_TRANSFORMED);
+    DeleteLocalInt(oPC, "LYCAN_ORIG_APPEARANCE");
+
+    SendMessageToPC(oPC, "[Wilkołactwo] Bestia cofa się. Człowiek wraca — lecz pamięta...");
+}
+
+// -----------------------------------------------------------------------
+// Silver weakness
+// -----------------------------------------------------------------------
+
+// Call from the target's OnPhysicalAttacked (see INTEGRATION.md).
+void LycanCheckSilverDamage(object oTarget, object oAttacker)
+{
+    if(!GetLocalInt(oTarget, LYCAN_LVAR_TRANSFORMED)) return;
+
+    object oWeapon = GetLastWeaponUsed(oAttacker);
+    if(!GetIsObjectValid(oWeapon)) return;
+
+    string sTag  = GetStringLowerCase(GetTag(oWeapon));
+    string sName = GetStringLowerCase(GetName(oWeapon));
+
+    if(FindSubString(sTag,  LYCAN_SILVER_SUBSTR) == -1 &&
+       FindSubString(sName, LYCAN_SILVER_SUBSTR) == -1)
+        return;
+
+    // Silver hits the wolf for 2d6 extra magical damage.
+    effect eDmg = EffectDamage(d6(2), DAMAGE_TYPE_MAGICAL);
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, eDmg, oTarget);
+    SendMessageToPC(oTarget, "[Wilkołactwo] Srebro pali ciało wilka jak żar!");
+}
+
+// -----------------------------------------------------------------------
+// Infection spread
+// -----------------------------------------------------------------------
+
+// Called each heartbeat for each transformed PC.
+// Any non-infected PC within 2 m has a 5 % chance of being bitten.
+void LycanCheckSpread(object oWolf)
+{
+    if(!GetLocalInt(oWolf, LYCAN_LVAR_TRANSFORMED)) return;
+
+    object oTarget = GetFirstPC();
+    while(GetIsObjectValid(oTarget))
+    {
+        if(oTarget != oWolf && GetDistanceBetween(oWolf, oTarget) <= 2.0f)
+        {
+            if(LycanGetInfectionStage(oTarget) == LYCAN_STAGE_NONE && d100() <= 5)
+            {
+                LycanSetInfection(oTarget, LYCAN_STAGE_LATENT);
+                SendMessageToPC(oTarget,
+                    "[Wilkołactwo] Czujesz pieczenie — wilk cię dosięgnął. "
+                    + "Coś złego kiełkuje w krwi...");
+                SendMessageToPC(oWolf,
+                    "[Wilkołactwo] Bestia dosięgnęła pobliskiej duszy.");
+            }
+        }
+        oTarget = GetNextPC();
+    }
+}
+
+// -----------------------------------------------------------------------
+// Cure
+// -----------------------------------------------------------------------
+
+void LycanCure(object oPC)
+{
+    LycanSetInfection(oPC, LYCAN_STAGE_NONE);
+    LycanRemoveEffects(oPC);
+    LycanRevert(oPC);
+
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectVisualEffect(VFX_FNF_DISPEL_DISJUNCTION), oPC);
+
+    SendMessageToPC(oPC, "[Wilkołactwo] Klątwa bestii odpędzona. Jesteś wolny.");
+    FloatingTextStringOnCreature("*Klątwa wilkołaka złamana!*", oPC, FALSE);
+}
+
+// Attempts to cure; consumes lycan_cure_kit if found.
+// Returns TRUE on success.
+int LycanTryCure(object oPC)
+{
+    if(GetLocalInt(oPC, LYCAN_LVAR_TRANSFORMED))
+    {
+        SendMessageToPC(oPC,
+            "[Wilkołactwo] Nie możesz wykonać rytuału oczyszczenia w formie bestii. "
+            + "Poczekaj do świtu.");
+        return FALSE;
+    }
+
+    object oKit = GetItemPossessedBy(oPC, LYCAN_CURE_KIT_TAG);
+    if(!GetIsObjectValid(oKit))
+    {
+        SendMessageToPC(oPC,
+            "[Wilkołactwo] Potrzebujesz Zestawu Odpędnika Wilkołaka. "
+            + "Poszukaj go u kapłana lub alchemika.");
+        return FALSE;
+    }
+
+    DestroyObject(oKit);
+    LycanCure(oPC);
+    return TRUE;
+}
+
+// -----------------------------------------------------------------------
+// Per-PC heartbeat (self-perpetuating, started in sys_on_enter.nss)
+// -----------------------------------------------------------------------
+
+void LycanHeartbeat(object oPC)
+{
+    if(!GetIsObjectValid(oPC) || !GetIsPC(oPC)) return;
+
+    int nStage = LycanGetInfectionStage(oPC);
+    if(nStage > 0)
+    {
+        LycanCheckAdvanceStage(oPC);
+        // Re-read: stage may have advanced above.
+        nStage = LycanGetInfectionStage(oPC);
+
+        int bFull  = LycanIsFullMoon();
+        int bTrans = GetLocalInt(oPC, LYCAN_LVAR_TRANSFORMED);
+
+        // Auto-transform at full moon for stage-3 PCs.
+        if(bFull && nStage == LYCAN_STAGE_FULL && !bTrans)
+            LycanTransform(oPC);
+
+        // Revert when full moon ends.
+        if(!bFull && bTrans && nStage == LYCAN_STAGE_FULL)
+            LycanRevert(oPC);
+
+        // Spread infection to nearby PCs.
+        if(bTrans)
+            LycanCheckSpread(oPC);
+    }
+
+    // Refresh open window each tick so moon bar stays live.
+    int nToken = NuiFindWindow(oPC, LYCAN_WIN_STATUS);
+    if(nToken != 0)
+        LycanFeedWindow(oPC, nToken);
+
+    DelayCommand(6.0f, LycanHeartbeat(oPC));
+}
+
+// -----------------------------------------------------------------------
+// NUI — window construction
+// -----------------------------------------------------------------------
+
+json BuildLycanWindow(object oPC)
+{
+    float fBtnH   = GetNuiScaleDimension(oPC, 30.0f);
+    float fLblH   = GetNuiScaleDimension(oPC, 22.0f);
+    float fDescH  = GetNuiScaleDimension(oPC, 100.0f);
+    float fBtnW1  = GetNuiScaleDimension(oPC, 190.0f);
+    float fBtnW2  = GetNuiScaleDimension(oPC, 150.0f);
+    float fBtnW3  = GetNuiScaleDimension(oPC, 80.0f);
+
+    // -- Moon section --
+    json jMoonLabelLbl = NuiLabel(JsonString("Faza Księżyca:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jMoonLabelLbl = NuiHeight(jMoonLabelLbl, fLblH);
+
+    json jMoonName = NuiLabel(NuiBind(LYCAN_BIND_MOON_LABEL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jMoonName = NuiHeight(jMoonName, fLblH);
+    jMoonName = NuiStyleForegroundColor(jMoonName, NuiColor(220, 210, 255));
+
+    json jMoonBarLbl = NuiLabel(NuiBind(LYCAN_BIND_MOON_BAR),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jMoonBarLbl = NuiHeight(jMoonBarLbl, fLblH);
+    jMoonBarLbl = NuiStyleForegroundColor(jMoonBarLbl, NuiColor(180, 180, 200));
+
+    // -- Infection section --
+    json jInfHeaderLbl = NuiLabel(JsonString("Stan Klątwy:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jInfHeaderLbl = NuiHeight(jInfHeaderLbl, fLblH);
+
+    json jStageLbl = NuiLabel(NuiBind(LYCAN_BIND_STAGE_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jStageLbl = NuiHeight(jStageLbl, fLblH);
+    jStageLbl = NuiStyleForegroundColor(jStageLbl, NuiBind(LYCAN_BIND_STAGE_COLOR));
+
+    json jDaysLbl = NuiLabel(NuiBind(LYCAN_BIND_DAYS_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jDaysLbl = NuiHeight(jDaysLbl, fLblH);
+
+    json jFormLbl = NuiLabel(NuiBind(LYCAN_BIND_FORM_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jFormLbl = NuiHeight(jFormLbl, fLblH);
+    jFormLbl = NuiStyleForegroundColor(jFormLbl, NuiBind(LYCAN_BIND_FORM_COLOR));
+
+    // -- Description text --
+    json jDescTxt = NuiGroup(
+        NuiText(NuiBind(LYCAN_BIND_DESC_TXT), FALSE),
+        TRUE, NUI_SCROLLBARS_NONE);
+    jDescTxt = NuiHeight(jDescTxt, fDescH);
+
+    // -- Buttons --
+    json jCureBtn = NuiButton(NuiBind(LYCAN_BIND_CURE_LBL));
+    jCureBtn = NuiId(jCureBtn, LYCAN_BTN_CURE);
+    jCureBtn = NuiEnabled(jCureBtn, NuiBind(LYCAN_BIND_CURE_ENA));
+    jCureBtn = NuiWidth(jCureBtn, fBtnW1);
+    jCureBtn = NuiHeight(jCureBtn, fBtnH);
+
+    json jXformBtn = NuiButton(NuiBind(LYCAN_BIND_XFORM_LBL));
+    jXformBtn = NuiId(jXformBtn, LYCAN_BTN_TRANSFORM);
+    jXformBtn = NuiEnabled(jXformBtn, NuiBind(LYCAN_BIND_XFORM_ENA));
+    jXformBtn = NuiWidth(jXformBtn, fBtnW2);
+    jXformBtn = NuiHeight(jXformBtn, fBtnH);
+
+    json jCloseBtn = NuiButton(JsonString("Zamknij"));
+    jCloseBtn = NuiId(jCloseBtn, LYCAN_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, fBtnW3);
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, jCureBtn);
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jXformBtn);
+    jBtnRow = JsonArrayInsert(jBtnRow, jCloseBtn);
+
+    // -- Assemble column --
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jMoonLabelLbl);
+    jCol = JsonArrayInsert(jCol, jMoonName);
+    jCol = JsonArrayInsert(jCol, jMoonBarLbl);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0f));
+    jCol = JsonArrayInsert(jCol, jInfHeaderLbl);
+    jCol = JsonArrayInsert(jCol, jStageLbl);
+    jCol = JsonArrayInsert(jCol, jDaysLbl);
+    jCol = JsonArrayInsert(jCol, jFormLbl);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0f));
+    jCol = JsonArrayInsert(jCol, jDescTxt);
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+
+    // Centre-pad with side spacers (same LFG/Mail pattern)
+    float fContentW = GetNuiScaleDimension(oPC, LYCAN_WIN_W - 30.0f);
+    json jSide = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    json jMainRow = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiCol(jCol), fContentW));
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+
+    json jWin = NuiWindow(
+        NuiRow(jMainRow),
+        JsonString("Klątwa Wilkołaka"),
+        NuiBind(LYCAN_BIND_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    return jWin;
+}
+
+// -----------------------------------------------------------------------
+// NUI — feed binds from current game state
+// -----------------------------------------------------------------------
+
+void LycanFeedWindow(object oPC, int nToken)
+{
+    int    nStage  = LycanGetInfectionStage(oPC);
+    int    nDays   = LycanGetDaysSinceInfection(oPC);
+    int    bTrans  = GetLocalInt(oPC, LYCAN_LVAR_TRANSFORMED);
+    int    bFull   = LycanIsFullMoon();
+    string sMoon   = LycanGetMoonPhaseName();
+    string sBar    = LycanGetMoonBar();
+
+    NuiSetBind(oPC, nToken, LYCAN_BIND_MOON_LABEL, JsonString(sMoon));
+    NuiSetBind(oPC, nToken, LYCAN_BIND_MOON_BAR,   JsonString(sBar));
+
+    // Stage colour: none=grey, latent=yellow, active=orange, full=red
+    json jStageColor;
+    switch(nStage)
+    {
+        case LYCAN_STAGE_NONE:   jStageColor = NuiColor(160, 160, 160); break;
+        case LYCAN_STAGE_LATENT: jStageColor = NuiColor(230, 220,  80); break;
+        case LYCAN_STAGE_ACTIVE: jStageColor = NuiColor(230, 130,  30); break;
+        default:                 jStageColor = NuiColor(220,  50,  50); break;
+    }
+    NuiSetBind(oPC, nToken, LYCAN_BIND_STAGE_LBL,   JsonString(LycanGetStageLabel(nStage)));
+    NuiSetBind(oPC, nToken, LYCAN_BIND_STAGE_COLOR,  jStageColor);
+
+    string sDays = (nStage > 0)
+        ? "Dni od zarażenia: " + IntToString(nDays)
+        : "";
+    NuiSetBind(oPC, nToken, LYCAN_BIND_DAYS_LBL, JsonString(sDays));
+
+    string sForm = bTrans ? "Forma: Wilk [AKTYWNA]" : "Forma: Człowiek";
+    json   jFormColor = bTrans ? NuiColor(220, 50, 50) : NuiColor(200, 200, 200);
+    NuiSetBind(oPC, nToken, LYCAN_BIND_FORM_LBL,   JsonString(sForm));
+    NuiSetBind(oPC, nToken, LYCAN_BIND_FORM_COLOR,  jFormColor);
+
+    NuiSetBind(oPC, nToken, LYCAN_BIND_DESC_TXT, JsonString(LycanGetStageDesc(nStage)));
+
+    // Cure button: enabled only if infected and not transformed
+    int bCanCure = (nStage > 0 && !bTrans);
+    NuiSetBind(oPC, nToken, LYCAN_BIND_CURE_ENA, JsonBool(bCanCure));
+    NuiSetBind(oPC, nToken, LYCAN_BIND_CURE_LBL,
+        JsonString(bCanCure ? "Odpedz Klatwe (kit)" : "Brak Klątwy / Forma Wilka"));
+
+    // Transform button: stage FULL only; label changes based on current state
+    int bCanXform = (nStage == LYCAN_STAGE_FULL);
+    NuiSetBind(oPC, nToken, LYCAN_BIND_XFORM_ENA, JsonBool(bCanXform));
+    NuiSetBind(oPC, nToken, LYCAN_BIND_XFORM_LBL,
+        JsonString(bTrans ? "Przywroc Postac Ludzka" : "Wywolaj Przemiane"));
+}
+
+// -----------------------------------------------------------------------
+// NUI — open / focus window
+// -----------------------------------------------------------------------
+
+void LycanOpenWindow(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, LYCAN_WIN_STATUS);
+    if(nToken != 0)
+    {
+        LycanFeedWindow(oPC, nToken);
+        return;
+    }
+
+    float fGuiW = IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH));
+    float fGuiH = IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT));
+    float fWinW = GetNuiScaleDimension(oPC, LYCAN_WIN_W);
+    float fWinH = GetNuiScaleDimension(oPC, LYCAN_WIN_H);
+    json  jGeom = NuiRect((fGuiW - fWinW) / 2.0f, (fGuiH - fWinH) / 2.0f, fWinW, fWinH);
+
+    nToken = NuiCreate(oPC, BuildLycanWindow(oPC), LYCAN_WIN_STATUS, LYCAN_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, LYCAN_BIND_WIN_GEOM, jGeom);
+    LycanFeedWindow(oPC, nToken);
+}

--- a/Lycanthropy/Scripts/lib_lycan_def.nss
+++ b/Lycanthropy/Scripts/lib_lycan_def.nss
@@ -1,0 +1,189 @@
+#include "lib_nui"
+#include "sql_lycan"
+
+// -----------------------------------------------------------------------
+// NUI window / event
+// -----------------------------------------------------------------------
+
+const string LYCAN_WIN_STATUS   = "LYCAN_WIN_STATUS";
+const string LYCAN_EV_SCRIPT    = "lib_lycan_ev";
+
+// Bind names
+const string LYCAN_BIND_WIN_GEOM    = "lycan_win_geom";
+const string LYCAN_BIND_MOON_LABEL  = "lycan_moon_label";
+const string LYCAN_BIND_MOON_BAR    = "lycan_moon_bar";
+const string LYCAN_BIND_STAGE_LBL   = "lycan_stage_lbl";
+const string LYCAN_BIND_STAGE_COLOR = "lycan_stage_color";
+const string LYCAN_BIND_DAYS_LBL    = "lycan_days_lbl";
+const string LYCAN_BIND_FORM_LBL    = "lycan_form_lbl";
+const string LYCAN_BIND_FORM_COLOR  = "lycan_form_color";
+const string LYCAN_BIND_DESC_TXT    = "lycan_desc_txt";
+const string LYCAN_BIND_CURE_ENA    = "lycan_cure_ena";
+const string LYCAN_BIND_CURE_LBL    = "lycan_cure_lbl";
+const string LYCAN_BIND_XFORM_ENA   = "lycan_xform_ena";
+const string LYCAN_BIND_XFORM_LBL   = "lycan_xform_lbl";
+
+// Button IDs
+const string LYCAN_BTN_CLOSE        = "lycan_btn_close";
+const string LYCAN_BTN_CURE         = "lycan_btn_cure";
+const string LYCAN_BTN_TRANSFORM    = "lycan_btn_transform";
+
+// -----------------------------------------------------------------------
+// Local variables on PC object
+// -----------------------------------------------------------------------
+
+const string LYCAN_LVAR_TRANSFORMED = "LYCAN_TRANSFORMED";  // 1 = in wolf form
+
+// -----------------------------------------------------------------------
+// Infection stages
+// -----------------------------------------------------------------------
+
+const int LYCAN_STAGE_NONE    = 0;  // not infected
+const int LYCAN_STAGE_LATENT  = 1;  // 0-2 real days since bite
+const int LYCAN_STAGE_ACTIVE  = 2;  // 3-6 real days — minor effects
+const int LYCAN_STAGE_FULL    = 3;  // 7+ real days — full werewolf
+
+// -----------------------------------------------------------------------
+// Moon cycle (real-time seconds)
+//
+// Default tuning: 1 NWN calendar month ≈ 3 real hours → full 28-day
+// moon cycle ≈ 2.1 real hours (7560 s).  Administrators can change
+// LYCAN_MOON_CYCLE_S to suit their server's NWN-day length.
+//
+// Full moon occupies days 12-16 of the 28-day cycle.
+// -----------------------------------------------------------------------
+
+const int LYCAN_MOON_CYCLE_S      = 7560;   // real seconds per 28-day cycle
+const int LYCAN_FULL_MOON_START   = 12;     // first full-moon day (0-indexed)
+const int LYCAN_FULL_MOON_END     = 16;     // last full-moon day (inclusive)
+
+// -----------------------------------------------------------------------
+// Appearance / wolf form
+//
+// Row 285 of appearance.2da is the Dire Wolf. Change to any row that
+// fits your hak (e.g. a custom werewolf appearance).
+// -----------------------------------------------------------------------
+
+const int LYCAN_WOLF_APPEARANCE   = 285;   // Dire Wolf appearance.2da row
+
+// Effect tags — used to identify and remove lycanthropy effects cleanly.
+const string LYCAN_EFF_ACTIVE     = "LYCAN_ACTIVE_EFF";
+const string LYCAN_EFF_FULL       = "LYCAN_FULL_EFF";
+
+// Cure kit — item with this tag is consumed when the PC attempts a cure.
+const string LYCAN_CURE_KIT_TAG   = "lycan_cure_kit";
+
+// Silver — weapon tags / names containing this substring deal bonus damage
+// to a transformed lycanthrope.
+const string LYCAN_SILVER_SUBSTR  = "silver";
+
+// Window dimensions (pre-scale)
+const float LYCAN_WIN_W  = 460.0;
+const float LYCAN_WIN_H  = 390.0;
+
+// -----------------------------------------------------------------------
+// Moon helpers (only SQL dependency, safe to call from def layer)
+// -----------------------------------------------------------------------
+
+// Returns the current day within the 28-day moon cycle (0-27).
+int LycanGetMoonDay()
+{
+    int nStart   = LycanGetMoonCycleStart();
+    int nDayLen  = LYCAN_MOON_CYCLE_S / 28;
+    if(nDayLen < 1) nDayLen = 1;
+
+    sqlquery q = SqlPrepareQueryCampaign("lycanthropy",
+        "SELECT CAST((strftime('%s','now') - @start) AS INTEGER)");
+    SqlBindInt(q, "@start", nStart);
+    if(!SqlStep(q)) return 0;
+
+    int nElapsed = SqlGetInt(q, 0);
+    if(nElapsed < 0) nElapsed = 0;
+    return (nElapsed / nDayLen) % 28;
+}
+
+int LycanIsFullMoon()
+{
+    int nDay = LycanGetMoonDay();
+    return (nDay >= LYCAN_FULL_MOON_START && nDay <= LYCAN_FULL_MOON_END);
+}
+
+// Returns 0-7 mapping from the 28-day cycle to a display phase.
+int LycanGetMoonPhase()
+{
+    int nDay = LycanGetMoonDay();
+    return (nDay * 8) / 28;
+}
+
+string LycanGetMoonPhaseName()
+{
+    switch(LycanGetMoonPhase())
+    {
+        case 0: return "Nów Księżyca";
+        case 1: return "Sierp Wschodzący";
+        case 2: return "Pierwsza Kwadra";
+        case 3: return "Księżyc Wschodzący";
+        case 4: return "Pełnia Księżyca";
+        case 5: return "Księżyc Zachodzący";
+        case 6: return "Ostatnia Kwadra";
+        case 7: return "Sierp Zachodzący";
+    }
+    return "Nów Księżyca";
+}
+
+// Returns a simple ASCII progress bar showing the moon cycle position.
+string LycanGetMoonBar()
+{
+    int nDay  = LycanGetMoonDay();
+    int nFull = (nDay >= LYCAN_FULL_MOON_START && nDay <= LYCAN_FULL_MOON_END);
+
+    // 14-character bar: each char = 2 days
+    string sBar  = "[";
+    int i;
+    for(i = 0; i < 14; i++)
+    {
+        int nDayPos = i * 2;
+        int bInFull = (nDayPos >= LYCAN_FULL_MOON_START && nDayPos <= LYCAN_FULL_MOON_END);
+        if(i == nDay / 2)
+            sBar = sBar + (nFull ? "*" : "o");
+        else
+            sBar = sBar + (bInFull ? "F" : ".");
+    }
+    sBar = sBar + "]";
+    return sBar;
+}
+
+string LycanGetStageLabel(int nStage)
+{
+    switch(nStage)
+    {
+        case LYCAN_STAGE_NONE:   return "Bez Klątwy";
+        case LYCAN_STAGE_LATENT: return "Infekcja Utajona";
+        case LYCAN_STAGE_ACTIVE: return "Klątwa Aktywna";
+        case LYCAN_STAGE_FULL:   return "Pełne Wilkołactwo";
+    }
+    return "Nieznany";
+}
+
+string LycanGetStageDesc(int nStage)
+{
+    switch(nStage)
+    {
+        case LYCAN_STAGE_NONE:
+            return "Krew czysta. Nie nosisz piętna bestii.";
+        case LYCAN_STAGE_LATENT:
+            return "Ziarno klątwy kiełkuje w żyłach.\n"
+                 + "Objawy jeszcze nie widoczne — lecz nadejdą.\n"
+                 + "Działaj, póki czas.";
+        case LYCAN_STAGE_ACTIVE:
+            return "Krew wre. Siła rośnie, lecz umysł się mgli.\n"
+                 + "W pełnię księżyca przemiana nastąpi wbrew woli.\n"
+                 + "Srebro pali jak ogień.";
+        case LYCAN_STAGE_FULL:
+            return "Bestia jest częścią ciebie.\n"
+                 + "W pełnię — zmienisz się, czy chcesz, czy nie.\n"
+                 + "Zarażasz innych samą obecnością w formie wilka.\n"
+                 + "Srebro jest twoją zmorą.";
+    }
+    return "";
+}

--- a/Lycanthropy/Scripts/lib_lycan_ev.nss
+++ b/Lycanthropy/Scripts/lib_lycan_ev.nss
@@ -1,0 +1,54 @@
+#include "lib_lycan"
+
+// NUI event handler — registered as LYCAN_EV_SCRIPT on the status window.
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+
+    if(nToken != NuiFindWindow(oPC, LYCAN_WIN_STATUS)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE) return;
+
+    if(sEvent != EVENT_TYPE_CLICK) return;
+
+    if(sElem == LYCAN_BTN_CLOSE)
+    {
+        NuiDestroy(oPC, nToken);
+        return;
+    }
+
+    if(sElem == LYCAN_BTN_CURE)
+    {
+        if(LycanGetInfectionStage(oPC) == LYCAN_STAGE_NONE)
+        {
+            SendMessageToPC(oPC, "[Wilkołactwo] Nie jesteś zarażony.");
+            return;
+        }
+        LycanTryCure(oPC);
+        LycanFeedWindow(oPC, nToken);
+        return;
+    }
+
+    if(sElem == LYCAN_BTN_TRANSFORM)
+    {
+        int nStage = LycanGetInfectionStage(oPC);
+        if(nStage < LYCAN_STAGE_FULL)
+        {
+            SendMessageToPC(oPC,
+                "[Wilkołactwo] Klątwa jeszcze nie dojrzała do pełnej przemiany.");
+            return;
+        }
+
+        if(GetLocalInt(oPC, LYCAN_LVAR_TRANSFORMED))
+            LycanRevert(oPC);
+        else
+            LycanTransform(oPC);
+
+        LycanFeedWindow(oPC, nToken);
+        return;
+    }
+}

--- a/Lycanthropy/Scripts/lib_nui.nss
+++ b/Lycanthropy/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Lycanthropy/Scripts/lib_nui_utility.nss
+++ b/Lycanthropy/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Lycanthropy/Scripts/sql_lycan.nss
+++ b/Lycanthropy/Scripts/sql_lycan.nss
@@ -1,0 +1,108 @@
+// sql_lycan.nss — SQLite schema + queries for the Lycanthropy module.
+// Campaign DB name: "lycanthropy".
+
+void LycanCreateTables()
+{
+    sqlquery q;
+
+    q = SqlPrepareQueryCampaign("lycanthropy",
+        "CREATE TABLE IF NOT EXISTS lycan_infected ("
+        "  pc_uuid      TEXT PRIMARY KEY,"
+        "  pc_name      TEXT NOT NULL DEFAULT '',"
+        "  stage        INTEGER NOT NULL DEFAULT 1,"
+        "  infected_at  INTEGER NOT NULL DEFAULT 0,"
+        "  last_transform INTEGER NOT NULL DEFAULT 0"
+        ")");
+    SqlStep(q);
+
+    // Tracks the start of the current moon cycle (unix epoch).
+    // Seeded once at module load; persists across restarts.
+    q = SqlPrepareQueryCampaign("lycanthropy",
+        "CREATE TABLE IF NOT EXISTS lycan_moon ("
+        "  id           INTEGER PRIMARY KEY DEFAULT 1,"
+        "  cycle_start  INTEGER NOT NULL DEFAULT 0"
+        ")");
+    SqlStep(q);
+
+    // Seed moon cycle only on first ever run.
+    q = SqlPrepareQueryCampaign("lycanthropy",
+        "INSERT OR IGNORE INTO lycan_moon (id, cycle_start) VALUES (1, strftime('%s','now'))");
+    SqlStep(q);
+}
+
+// -----------------------------------------------------------------------
+// Reads
+// -----------------------------------------------------------------------
+
+int LycanGetInfectionStage(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("lycanthropy",
+        "SELECT stage FROM lycan_infected WHERE pc_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+int LycanGetInfectedAt(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("lycanthropy",
+        "SELECT infected_at FROM lycan_infected WHERE pc_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// Returns elapsed real-time days since infection.
+int LycanGetDaysSinceInfection(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("lycanthropy",
+        "SELECT CAST((strftime('%s','now') - infected_at) / 86400.0 AS INTEGER) "
+        "FROM lycan_infected WHERE pc_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+int LycanGetMoonCycleStart()
+{
+    sqlquery q = SqlPrepareQueryCampaign("lycanthropy",
+        "SELECT cycle_start FROM lycan_moon WHERE id = 1");
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// -----------------------------------------------------------------------
+// Writes
+// -----------------------------------------------------------------------
+
+// nStage == 0 removes the infection record entirely.
+void LycanSetInfection(object oPC, int nStage)
+{
+    sqlquery q;
+    if(nStage <= 0)
+    {
+        q = SqlPrepareQueryCampaign("lycanthropy",
+            "DELETE FROM lycan_infected WHERE pc_uuid = @uuid");
+        SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+        SqlStep(q);
+        return;
+    }
+
+    q = SqlPrepareQueryCampaign("lycanthropy",
+        "INSERT INTO lycan_infected (pc_uuid, pc_name, stage, infected_at) "
+        "VALUES (@uuid, @name, @stage, strftime('%s','now')) "
+        "ON CONFLICT(pc_uuid) DO UPDATE SET stage = @stage, pc_name = @name");
+    SqlBindString(q, "@uuid",  GetObjectUUID(oPC));
+    SqlBindString(q, "@name",  GetName(oPC));
+    SqlBindInt   (q, "@stage", nStage);
+    SqlStep(q);
+}
+
+// Records the unix time of the most recent transformation.
+void LycanRecordTransform(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("lycanthropy",
+        "UPDATE lycan_infected SET last_transform = strftime('%s','now') WHERE pc_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}

--- a/Lycanthropy/Scripts/sys_on_attacked.nss
+++ b/Lycanthropy/Scripts/sys_on_attacked.nss
@@ -1,0 +1,19 @@
+#include "lib_lycan"
+
+// Creature OnPhysicalAttacked event — set on PC creatures via SetEventScript
+// in sys_on_enter.nss or by the server administrator.
+//
+// Handles:
+//   • Silver weapon bonus damage against transformed lycanthropes.
+
+void main()
+{
+    object oTarget   = OBJECT_SELF;
+    object oAttacker = GetLastAttacker(oTarget);
+
+    if(!GetIsPC(oTarget) && !GetIsPC(oAttacker)) return;
+
+    // Silver damage to transformed PCs
+    if(GetIsPC(oTarget))
+        LycanCheckSilverDamage(oTarget, oAttacker);
+}

--- a/Lycanthropy/Scripts/sys_on_enter.nss
+++ b/Lycanthropy/Scripts/sys_on_enter.nss
@@ -1,0 +1,29 @@
+#include "lib_lycan"
+
+// Module OnClientEnter — restore effects and start the per-PC heartbeat.
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC) || GetIsDMPossessed(oPC)) return;
+
+    // Advance stage in case real-world time passed while offline.
+    LycanCheckAdvanceStage(oPC);
+
+    int nStage = LycanGetInfectionStage(oPC);
+    if(nStage > 0)
+    {
+        LycanApplyStageEffects(oPC, nStage);
+
+        string sMsg = "[Wilkołactwo] Klątwa wilka nadal cię trawi. Etap: "
+                    + LycanGetStageLabel(nStage) + ".";
+        DelayCommand(3.0f, SendMessageToPC(oPC, sMsg));
+
+        // If the PC logs in during a full moon and is stage-3, transform them.
+        if(LycanIsFullMoon() && nStage == LYCAN_STAGE_FULL)
+            DelayCommand(5.0f, LycanTransform(oPC));
+    }
+
+    // Start the 6-second heartbeat loop for this PC.
+    DelayCommand(6.0f, LycanHeartbeat(oPC));
+}

--- a/Lycanthropy/Scripts/sys_on_leave.nss
+++ b/Lycanthropy/Scripts/sys_on_leave.nss
@@ -1,0 +1,13 @@
+#include "lib_lycan"
+
+// Module OnClientLeave — revert wolf form cleanly on disconnect.
+
+void main()
+{
+    object oPC = GetExitingObject();
+    if(!GetIsPC(oPC)) return;
+
+    // Restore human appearance so the stored appearance type stays consistent.
+    if(GetLocalInt(oPC, LYCAN_LVAR_TRANSFORMED))
+        LycanRevert(oPC);
+}

--- a/Lycanthropy/Scripts/sys_on_load.nss
+++ b/Lycanthropy/Scripts/sys_on_load.nss
@@ -1,0 +1,8 @@
+#include "lib_lycan_def"
+
+// Module OnModuleLoad — initialise tables once.
+
+void main()
+{
+    LycanCreateTables();
+}

--- a/Lycanthropy/Scripts/test_lycan.nss
+++ b/Lycanthropy/Scripts/test_lycan.nss
@@ -1,0 +1,62 @@
+#include "lib_lycan"
+
+// test_lycan.nss — OnUsed script for a test placeable.
+//
+// Left-click → shows the Lycanthropy Status window.
+// Shift-click (modifier via local int "LYCAN_TEST_MODE" on the placeable):
+//   MODE 1 — infect the user at LATENT stage (for testing).
+//   MODE 2 — fast-forward to FULL stage.
+//   MODE 3 — cure the user.
+
+void main()
+{
+    object oPC       = GetLastUsedBy();
+    object oPlaceable = OBJECT_SELF;
+
+    if(!GetIsPC(oPC)) return;
+
+    int nMode = GetLocalInt(oPlaceable, "LYCAN_TEST_MODE");
+
+    switch(nMode)
+    {
+        case 1:
+        {
+            if(LycanGetInfectionStage(oPC) == LYCAN_STAGE_NONE)
+            {
+                LycanSetInfection(oPC, LYCAN_STAGE_LATENT);
+                SendMessageToPC(oPC,
+                    "[Test] Zarażono klątwą wilkołaka — etap utajony.");
+            }
+            else
+            {
+                SendMessageToPC(oPC,
+                    "[Test] Już jesteś zarażony. Zmień LYCAN_TEST_MODE na 3, by się uleczyć.");
+            }
+            break;
+        }
+        case 2:
+        {
+            LycanSetInfection(oPC, LYCAN_STAGE_FULL);
+            LycanApplyStageEffects(oPC, LYCAN_STAGE_FULL);
+            SendMessageToPC(oPC,
+                "[Test] Klątwa zaawansowana do etapu PELNEGO.");
+            break;
+        }
+        case 3:
+        {
+            LycanCure(oPC);
+            SendMessageToPC(oPC,
+                "[Test] Klątwa usunięta (tryb testowy, bez zuzycia kitu).");
+            break;
+        }
+        default:
+        {
+            // Standard use: open status window.
+            LycanOpenWindow(oPC);
+            break;
+        }
+    }
+
+    // Always (re-)open the window so the player can see current state.
+    LycanOpenWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

Moduł **Wilkołactwo** wprowadza klątwę wilkołaka jako trwały stan postaci z progresją stadiów, automatyczną transformacją w pełnię księżyca, oknem statusu NUI i mechanizmem zarażania pobliskich graczy.

## Mechanika

### Infekcja (3 etapy)
| Etap | Trigger | Efekty |
|---|---|---|
| 1 — Utajona | 0–2 dni od zarażenia | Brak objawów, nie zaraża |
| 2 — Aktywna | 3–6 dni | +2 STR, -1 WIS; możliwa transformacja w pełnię |
| 3 — Pełna | 7+ dni | +4 STR, +2 CON, -3 WIS, -2 CHA; obowiązkowa transformacja w pełnię |

Etapy awansują automatycznie w per-PC heartbeacie (co 6 s) mierzącym realne sekundy od zarażenia.

### Cykl księżyca
- Domyślny cykl: **7560 s realnego czasu** na 28 „dni NWN" (~2.1 h; konfigurowalny stałą `LYCAN_MOON_CYCLE_S`).
- Pełnia: dni 12–16 cyklu → stage-3 PC automatycznie zmienia formę, wraca po zakończeniu pełni.
- W oknie NUI widoczny ASCII progress bar: `[....oFF*FF....]`.

### Transformacja
- Zmiana wyglądu przez `SetCreatureAppearanceType()` (rząd 285 = Dire Wolf; wymienialny).
- Oryginalny wygląd zapisywany w lokal varze i przywracany przy rewercie / rozłączeniu.
- Powiadomienie dla graczy w promieniu 30 m.

### Zarażanie
- Transformowany stage-3 gracz w promieniu 2 m od niezarażonego PC: **5% szansy/tick** na infekcję latentną.

### Srebro
- Broń z `silver` w tagu lub nazwie (case-insensitive) zadaje **2d6 dodatkowych obrażeń magicznych** trafionemu wilkołakowi.
- Obsługiwane przez `sys_on_attacked.nss` (podpinane jako `OnPhysicalAttacked` na creature).

### Leczenie
- Wymaga przedmiotu z tagiem `lycan_cure_kit` w ekwipunku.
- Gracz musi być w formie ludzkiej.
- Przedmiot zostaje zniszczony; klątwa, efekty i forma wilka zostają usunięte.

## Pliki

```
Lycanthropy/
  Scripts/
    sql_lycan.nss          — SQLite schema + queries (campaign DB "lycanthropy")
    lib_lycan_def.nss      — stałe, ID bindów/przycisków, helpery fazy księżyca
    lib_lycan.nss          — rdzeń logiki: efekty, transformacja, zarażanie, NUI
    lib_lycan_ev.nss       — handler eventów NUI (LYCAN_WIN_STATUS)
    sys_on_load.nss        — OnModuleLoad: init tabel
    sys_on_enter.nss       — OnClientEnter: restore efektów + start heartbeata
    sys_on_leave.nss       — OnClientLeave: revert formy wilka przy DC
    sys_on_attacked.nss    — OnPhysicalAttacked: srebrne obrażenia
    test_lycan.nss         — OnUsed placeable (tryb 0–3: UI / infect / full / cure)
    lib_nui.nss            — współdzielona biblioteka NUI (kopia z Mailbox)
    lib_nui_utility.nss    — współdzielone utils NUI
  INTEGRATION.md           — instrukcja podpięcia hooków, tuning, zależności
```

**LOC własnego kodu:** ~950 (bez skopiowanych lib_nui*).

## Zależności (NWNX? SQL?)

- **NWNX:** NIE wymagany.
- **SQLite Campaign DB:** TAK — `SqlPrepareQueryCampaign` (NWN:EE ≥ 8193.14).
- **appearance.2da:** rząd 285 (Dire Wolf) musi istnieć w haku lub bazie.

## Jak włączyć w istniejącym module

1. Skopiuj folder `Lycanthropy/Scripts/` do haka lub Override.
2. W `OnModuleLoad` → wywołaj `ExecuteScript("sys_on_load", GetModule())`.
3. W `OnClientEnter` → wywołaj `ExecuteScript("sys_on_enter", GetEnteringObject())`.
4. W `OnClientLeave` → wywołaj `ExecuteScript("sys_on_leave", GetExitingObject())`.
5. (Opcjonalnie) W `OnClientEnter`, po `GetIsPC()`: `SetEventScript(oPC, EVENT_SCRIPT_CREATURE_ON_PHYSICAL_ATTACKED, "sys_on_attacked")` — dla obsługi srebra.
6. Utwórz placeable z `OnUsed = test_lycan` do testowania.
7. Utwórz przedmiot z tagiem `lycan_cure_kit` dostępny u kapłanów.

## Co celowo pominięto

- **Zarażanie przez NPC:** silnik nie udostępnia modułowego zdarzenia „PC trafiony przez NPC X" — spread dotyczy tylko PC→PC w heartbeacie.
- **Wizualna zmiana skyboxa / fazy księżyca:** wymagałoby NWNX:Weather lub niestandardowego haka.
- **Specjalne zdolności wilka (gryzienie AoE, wyjeczenie):** poza zakresem; stworzone jako rozszerzalny fundament.
- **Konfiguracja przez NPC-konwersację:** leczenie przez item jest wystarczające i pozostawia integrację NPC po stronie serwera.


---
_Generated by [Claude Code](https://claude.ai/code/session_014fQf1b4sBq4tcQYtSuNpnq)_