### PR TITLE
feat: Hazard — Trzy Smocze Kości

### DIFF
--- a/Hazard/INTEGRATION.md
+++ b/Hazard/INTEGRATION.md
@@ -1,0 +1,117 @@
+# Hazard — Trzy Smocze Kości: Integration Guide
+
+## Wymagania
+
+- NWN:EE 8193.36+ (NUI + SQLite campaign DB)
+- NWNX: **nie wymagany**
+- Kampania SQLite o nazwie `haz` tworzona automatycznie przez `HazCreateTables()`
+
+## Hooki modułu
+
+| Zdarzenie modułu | Skrypt               |
+|------------------|----------------------|
+| OnModuleLoad     | `sys_on_load.nss`    |
+| OnClientEnter    | `sys_on_enter.nss`   |
+
+Jeśli moduł ma już własne OnModuleLoad / OnClientEnter, dodaj wywołanie:
+
+```nss
+// OnModuleLoad
+HazCreateTables();
+
+// OnClientEnter
+object oPC = GetEnteringObject();
+if(GetIsPC(oPC) && !GetIsDMPossessed(oPC)) HazRegisterPlayer(oPC);
+```
+
+## Placeable — stół hazardowy
+
+1. W toolsecie utwórz placeable (np. `plc_table`).
+2. Ustaw zdarzenie **OnUsed** na `test_haz`.
+3. Dodaj skrypt do HAK modułu razem ze wszystkimi plikami `lib_haz*.nss`,
+   `sql_haz.nss`.
+
+Alternatywnie wywołuj `HazOpenWindow(oPC)` z dowolnego zdarzenia
+(rozmowy NPC, skrzyni, klawisza skrótu przez Ribbon System).
+
+## Pliki
+
+```
+Hazard/Scripts/
+  sql_haz.nss        — schemat SQLite + zapytania
+  lib_haz_def.nss    — stałe, ID bindów, ID przycisków, LVARy
+  lib_haz.nss        — mechanika gry, scoring, budowa UI, funkcje feed
+  lib_haz_ev.nss     — główny handler eventów NUI
+  sys_on_load.nss    — OnModuleLoad: tworzy tabele SQL
+  sys_on_enter.nss   — OnClientEnter: rejestruje gracza
+  test_haz.nss       — OnUsed dla placeable-demo
+```
+
+## Mechanika gry — Trzy Smocze Kości
+
+Gracz stawia zakład (10–5000 szt. złota) i rzuca trzema sześciościennymi
+kośćmi przeciwko krupierowi (dom).
+
+### Kolejność rundy
+
+1. Gracz ustawia zakład i opcjonalnie włącza **Cenę Krwi**.
+2. Kliknięcie **Rzuć kości** → rzut 3k6.
+3. Gracz może kliknąć każdą kość, by ją **trzymać** (podświetlona).
+4. Kliknięcie **Przerzuć wolne** → wolne kości przerzucone (raz na rundę).
+5. Kliknięcie **Stój** → krupier ujawnia swoje kości i wynik porównany.
+
+### Układy (rosnąco)
+
+| Układ             | Punktacja        | Opis                    |
+|-------------------|------------------|-------------------------|
+| Wysoka Kość       | 3–18             | suma trzech kości       |
+| Para Bazyliszka   | 3000–3605        | para + kicker           |
+| Wąż Schodowy      | 4100–4400        | sekwencja (n, n+1, n+2) |
+| Smok Trojaki      | 5100–5600        | trójka                  |
+
+### Wypłaty (w przypadku wygranej)
+
+| Układ gracza    | Podstawowy zysk  |
+|-----------------|-----------------|
+| Wysoka Kość/Para| 1× zakład       |
+| Wąż Schodowy    | 1,5× zakład     |
+| Smok Trojaki    | 2× zakład       |
+
+Remis (równy wynik): zakład zwrócony bez zysku ani straty.
+
+### Cena Krwi
+
+Przed rzutem gracz może zaznaczyć **Cena Krwi**:
+
+- **Wygrana** → wszystkie wypłaty pomnożone przez ×3.
+- **Porażka** → standardowa strata złota PLUS 10% maksymalnych punktów HP
+  jako obrażenia od negatywnej energii.
+
+### AI krupiera
+
+Krupier rzuca 3k6. Jeśli wynik < Para Bazyliszka z dwójek (3201 pkt),
+przerzuca najgorszą jedną kość. Strategia jest prosta i łatwa do pokonania
+przez sprawne trzymanie kości.
+
+## Baza danych
+
+Tabela `haz_players` w kampanii `haz`:
+
+```sql
+CREATE TABLE IF NOT EXISTS haz_players (
+  uuid       TEXT PRIMARY KEY,
+  char_name  TEXT NOT NULL DEFAULT '',
+  wins       INTEGER NOT NULL DEFAULT 0,
+  losses     INTEGER NOT NULL DEFAULT 0,
+  pushes     INTEGER NOT NULL DEFAULT 0,
+  gold_won   INTEGER NOT NULL DEFAULT 0,
+  gold_lost  INTEGER NOT NULL DEFAULT 0
+);
+```
+
+## Co celowo pominięto
+
+- Gra wieloosobowa (gracz vs gracz) — wymagałaby synchronizacji sesji.
+- Animacje rzutu kośćmi — NWN NUI nie obsługuje animacji sprite.
+- Dług (możliwość gry na kredyt) — celowo, by unikać exploitów złota.
+- Limity dzienne / ograniczniki anty-farm — do rozważenia przez serwer.

--- a/Hazard/Scripts/lib_haz.nss
+++ b/Hazard/Scripts/lib_haz.nss
@@ -1,0 +1,667 @@
+// lib_haz.nss — core logic, scoring, UI construction and feed functions
+#include "lib_haz_def"
+
+void HazFeedBetPhase(object oPC, int nToken);
+void HazFeedRolledPhase(object oPC, int nToken);
+void HazFeedResult(object oPC, int nToken, int nPlayerScore, int nDealerScore, int nPayout);
+void HazUpdateGoldLabel(object oPC, int nToken);
+void HazOpenStatsWindow(object oPC);
+
+// ----------------------------------------------------------------
+// Scoring
+// Three-of-a-kind:  5000 + face*100          → 5100–5600
+// Straight (low):   4000 + low_die*100        → 4100–4400
+// Pair:             3000 + pair_face*100 + kicker → 3101–3605
+// High card:        sum of dice               → 3–18
+// ----------------------------------------------------------------
+
+int HazScore(int d1, int d2, int d3)
+{
+    // Sort ascending
+    int tmp;
+    if(d1 > d2) { tmp = d1; d1 = d2; d2 = tmp; }
+    if(d2 > d3) { tmp = d2; d2 = d3; d3 = tmp; }
+    if(d1 > d2) { tmp = d1; d1 = d2; d2 = tmp; }
+
+    if(d1 == d3)
+        return 5000 + d1 * 100;                         // Dragon
+
+    if(d2 == d1 + 1 && d3 == d1 + 2)
+        return 4000 + d1 * 100;                         // Serpent (straight)
+
+    if(d1 == d2)
+        return 3000 + d1 * 100 + d3;                   // Wyvern (pair d1, kicker d3)
+
+    if(d2 == d3)
+        return 3000 + d2 * 100 + d1;                   // Wyvern (pair d2, kicker d1)
+
+    return d1 + d2 + d3;                               // Demon's Hand (high card)
+}
+
+string HazHandName(int nScore)
+{
+    if(nScore >= 5000) return "Smok Trojaki";
+    if(nScore >= 4000) return "Wąż Schodowy";
+    if(nScore >= 3000) return "Para Bazyliszka";
+    return "Wysoka Kość";
+}
+
+json HazHandColor(int nScore)
+{
+    if(nScore >= 5000) return NuiColor(255, 140,   0);  // fiery orange — Dragon
+    if(nScore >= 4000) return NuiColor(140, 200, 255);  // ice blue   — Serpent
+    if(nScore >= 3000) return NuiColor(180, 255, 180);  // pale green — Wyvern
+    return NuiColor(180, 180, 180);                     // grey       — high card
+}
+
+// ----------------------------------------------------------------
+// Dealer AI — rolls 3d6; rerolls single worst die once if score < pair-of-2s
+// Stores final dice into PC LVARs HAZ_DD1/DD2/DD3 and returns final score
+// ----------------------------------------------------------------
+
+int HazDealerPlayFull(object oPC, int d1, int d2, int d3)
+{
+    int nScore = HazScore(d1, d2, d3);
+
+    // Stand threshold: pair of 2s = 3000+200+highest_kicker ≥ 3201
+    if(nScore < 3201)
+    {
+        // Reroll the single die not part of the best partial combination
+        // Simple: if pair exists keep it; otherwise reroll the lowest die
+        int bPair = (d1 == d2 || d1 == d3 || d2 == d3);
+        if(bPair)
+        {
+            // Reroll the odd die out
+            if(d1 != d2 && d1 != d3)      d1 = Random(6) + 1;
+            else if(d2 != d1 && d2 != d3) d2 = Random(6) + 1;
+            else                           d3 = Random(6) + 1;
+        }
+        else
+        {
+            // No pair — reroll lowest (d1 after sorting above)
+            int lo = d1;
+            if(d2 < lo) lo = d2;
+            if(d3 < lo) lo = d3;
+            if(d1 == lo)      d1 = Random(6) + 1;
+            else if(d2 == lo) d2 = Random(6) + 1;
+            else              d3 = Random(6) + 1;
+        }
+        nScore = HazScore(d1, d2, d3);
+    }
+
+    SetLocalInt(oPC, HAZ_LVAR_DD1, d1);
+    SetLocalInt(oPC, HAZ_LVAR_DD2, d2);
+    SetLocalInt(oPC, HAZ_LVAR_DD3, d3);
+    return nScore;
+}
+
+// ----------------------------------------------------------------
+// Payout calculation — returns signed gold delta for the player
+// Positive = profit received; negative = gold taken
+// Dragon win: 2× bet as profit; Serpent win: 1× bet + 50%; normal win: 1× bet
+// Blood multiplier applies on top after the base calculation
+// ----------------------------------------------------------------
+
+int HazCalcPayout(int nPlayerScore, int nDealerScore, int nBet, int bBlood)
+{
+    int nMult = bBlood ? 3 : 1;
+
+    if(nPlayerScore > nDealerScore)
+    {
+        int nBase = nBet;
+        if(nPlayerScore >= 5000)      nBase = nBet * 2;      // Dragon
+        else if(nPlayerScore >= 4000) nBase = nBet + nBet / 2; // Serpent (1.5×, floor)
+        return nBase * nMult;
+    }
+    if(nPlayerScore < nDealerScore)
+        return -(nBet * nMult);
+
+    return 0; // push
+}
+
+// ----------------------------------------------------------------
+// UI helpers
+// ----------------------------------------------------------------
+
+void HazUpdateGoldLabel(object oPC, int nToken)
+{
+    json jStats = HazGetStats(oPC);
+    int nWins   = JsonGetInt(JsonObjectGet(jStats, "wins"));
+    int nLosses = JsonGetInt(JsonObjectGet(jStats, "losses"));
+    int nGold   = GetGold(oPC);
+    string sLbl = "Złoto: " + IntToString(nGold) + " szt."
+                + "   |   W: " + IntToString(nWins)
+                + "  P: " + IntToString(nLosses);
+    NuiSetBind(oPC, nToken, HAZ_BIND_GOLD_LBL, JsonString(sLbl));
+}
+
+json HazBuildDieButton(object oPC, string sBtnId, string sBindFace, string sBindEnc, float fSz)
+{
+    json jBtn = NuiButton(NuiBind(sBindFace));
+    jBtn = NuiId(jBtn, sBtnId);
+    jBtn = NuiWidth(jBtn, fSz);
+    jBtn = NuiHeight(jBtn, fSz);
+    jBtn = NuiEncouraged(jBtn, NuiBind(sBindEnc));
+    return jBtn;
+}
+
+json HazBuildDealerDieBox(object oPC, string sBindFace, float fSz)
+{
+    json jLbl = NuiLabel(NuiBind(sBindFace),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    json jGrp = NuiGroup(jLbl, FALSE, NUI_SCROLLBARS_NONE);
+    jGrp = NuiWidth(jGrp, fSz);
+    jGrp = NuiHeight(jGrp, fSz);
+    return jGrp;
+}
+
+// ----------------------------------------------------------------
+// Window layout — built once, state driven entirely through binds
+// ----------------------------------------------------------------
+
+json HazBuildRoot(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 32.0);
+    float fDieSz = GetNuiScaleDimension(oPC, 76.0);
+    float fLblH  = GetNuiScaleDimension(oPC, 24.0);
+    float fGap   = GetNuiScaleDimension(oPC, 6.0);
+
+    // -- Title --
+    json jTitle = NuiLabel(JsonString("Trzy Smocze Kości"),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitle = NuiHeight(jTitle, GetNuiScaleDimension(oPC, 30.0));
+    jTitle = NuiStyleForegroundColor(jTitle, NuiColor(200, 160, 60));
+
+    // -- Bet row --
+    json jBetLbl = NuiLabel(JsonString("Zakład:"),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jBetLbl = NuiWidth(jBetLbl, GetNuiScaleDimension(oPC, 65.0));
+
+    json jBetField = NuiTextEdit(JsonString("100"), NuiBind(HAZ_BIND_BET), 6, FALSE);
+    jBetField = NuiWidth(jBetField, GetNuiScaleDimension(oPC, 90.0));
+    jBetField = NuiHeight(jBetField, fBtnH);
+    jBetField = NuiEnabled(jBetField, NuiBind(HAZ_BIND_BET_ENA));
+
+    json jBetUnit = NuiLabel(JsonString("szt."),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jBetUnit = NuiWidth(jBetUnit, GetNuiScaleDimension(oPC, 32.0));
+
+    json jBloodChk = NuiCheckbox(JsonString("Cena Krwi"), NuiBind(HAZ_BIND_BLOOD));
+    jBloodChk = NuiEnabled(jBloodChk, NuiBind(HAZ_BIND_BET_ENA));
+    jBloodChk = NuiTooltip(jBloodChk,
+        JsonString("Wygrana ×3, lecz porażka kosztuje 10% maksymalnego zdrowia."));
+
+    json jBetRow = JsonArray();
+    jBetRow = JsonArrayInsert(jBetRow, jBetLbl);
+    jBetRow = JsonArrayInsert(jBetRow, jBetField);
+    jBetRow = JsonArrayInsert(jBetRow, jBetUnit);
+    jBetRow = JsonArrayInsert(jBetRow, NuiSpacer());
+    jBetRow = JsonArrayInsert(jBetRow, jBloodChk);
+
+    // -- Player dice header --
+    json jPHdr = NuiLabel(JsonString("~~~ Twoje Kości ~~~"),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jPHdr = NuiHeight(jPHdr, fLblH);
+    jPHdr = NuiStyleForegroundColor(jPHdr, NuiColor(210, 210, 210));
+
+    // -- Player dice row --
+    json jD1 = HazBuildDieButton(oPC, HAZ_BTN_D1, HAZ_BIND_D1_FACE, HAZ_BIND_D1_ENC, fDieSz);
+    json jD2 = HazBuildDieButton(oPC, HAZ_BTN_D2, HAZ_BIND_D2_FACE, HAZ_BIND_D2_ENC, fDieSz);
+    json jD3 = HazBuildDieButton(oPC, HAZ_BTN_D3, HAZ_BIND_D3_FACE, HAZ_BIND_D3_ENC, fDieSz);
+
+    json jDiceRow = JsonArray();
+    jDiceRow = JsonArrayInsert(jDiceRow, NuiSpacer());
+    jDiceRow = JsonArrayInsert(jDiceRow, jD1);
+    jDiceRow = JsonArrayInsert(jDiceRow, NuiSpacer());
+    jDiceRow = JsonArrayInsert(jDiceRow, jD2);
+    jDiceRow = JsonArrayInsert(jDiceRow, NuiSpacer());
+    jDiceRow = JsonArrayInsert(jDiceRow, jD3);
+    jDiceRow = JsonArrayInsert(jDiceRow, NuiSpacer());
+
+    // -- Player hand label --
+    json jHandLbl = NuiLabel(NuiBind(HAZ_BIND_HAND_LBL),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jHandLbl = NuiHeight(jHandLbl, fLblH);
+    jHandLbl = NuiStyleForegroundColor(jHandLbl, NuiBind(HAZ_BIND_HAND_COL));
+
+    // -- Dealer dice header --
+    json jDHdr = NuiLabel(JsonString("~~~ Kości Krupiera ~~~"),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jDHdr = NuiHeight(jDHdr, fLblH);
+    jDHdr = NuiStyleForegroundColor(jDHdr, NuiColor(210, 210, 210));
+
+    // -- Dealer dice row (non-interactive boxes) --
+    json jDD1 = HazBuildDealerDieBox(oPC, HAZ_BIND_DD1_FACE, fDieSz);
+    json jDD2 = HazBuildDealerDieBox(oPC, HAZ_BIND_DD2_FACE, fDieSz);
+    json jDD3 = HazBuildDealerDieBox(oPC, HAZ_BIND_DD3_FACE, fDieSz);
+
+    json jDDiceRow = JsonArray();
+    jDDiceRow = JsonArrayInsert(jDDiceRow, NuiSpacer());
+    jDDiceRow = JsonArrayInsert(jDDiceRow, jDD1);
+    jDDiceRow = JsonArrayInsert(jDDiceRow, NuiSpacer());
+    jDDiceRow = JsonArrayInsert(jDDiceRow, jDD2);
+    jDDiceRow = JsonArrayInsert(jDDiceRow, NuiSpacer());
+    jDDiceRow = JsonArrayInsert(jDDiceRow, jDD3);
+    jDDiceRow = JsonArrayInsert(jDDiceRow, NuiSpacer());
+
+    // -- Dealer hand label --
+    json jDHandLbl = NuiLabel(NuiBind(HAZ_BIND_DHAND_LBL),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jDHandLbl = NuiHeight(jDHandLbl, fLblH);
+    jDHandLbl = NuiStyleForegroundColor(jDHandLbl, NuiBind(HAZ_BIND_DHAND_COL));
+
+    // -- Hint / result label --
+    json jHint = NuiLabel(NuiBind(HAZ_BIND_HINT_LBL),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jHint = NuiHeight(jHint, fLblH);
+    jHint = NuiStyleForegroundColor(jHint, NuiBind(HAZ_BIND_HINT_COL));
+
+    json jResult = NuiLabel(NuiBind(HAZ_BIND_RESULT),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jResult = NuiHeight(jResult, GetNuiScaleDimension(oPC, 28.0));
+    jResult = NuiStyleForegroundColor(jResult, NuiBind(HAZ_BIND_RESULT_COL));
+
+    // -- Action buttons: Roll | Reroll | Stand --
+    float fActW = GetNuiScaleDimension(oPC, 130.0);
+
+    json jRollBtn = NuiButton(JsonString("Rzuć kości"));
+    jRollBtn = NuiId(jRollBtn, HAZ_BTN_ROLL);
+    jRollBtn = NuiEnabled(jRollBtn, NuiBind(HAZ_BIND_ROLL_ENA));
+    jRollBtn = NuiWidth(jRollBtn, fActW);
+    jRollBtn = NuiHeight(jRollBtn, fBtnH);
+
+    json jRerollBtn = NuiButton(JsonString("Przerzuć wolne"));
+    jRerollBtn = NuiId(jRerollBtn, HAZ_BTN_REROLL);
+    jRerollBtn = NuiEnabled(jRerollBtn, NuiBind(HAZ_BIND_REROLL_ENA));
+    jRerollBtn = NuiWidth(jRerollBtn, GetNuiScaleDimension(oPC, 145.0));
+    jRerollBtn = NuiHeight(jRerollBtn, fBtnH);
+    jRerollBtn = NuiTooltip(jRerollBtn,
+        JsonString("Przerzuca kości, których nie trzymasz. Można użyć raz na rundę."));
+
+    json jStandBtn = NuiButton(JsonString("Stój"));
+    jStandBtn = NuiId(jStandBtn, HAZ_BTN_STAND);
+    jStandBtn = NuiEnabled(jStandBtn, NuiBind(HAZ_BIND_STAND_ENA));
+    jStandBtn = NuiWidth(jStandBtn, fActW);
+    jStandBtn = NuiHeight(jStandBtn, fBtnH);
+
+    json jActRow = JsonArray();
+    jActRow = JsonArrayInsert(jActRow, NuiSpacer());
+    jActRow = JsonArrayInsert(jActRow, jRollBtn);
+    jActRow = JsonArrayInsert(jActRow, jRerollBtn);
+    jActRow = JsonArrayInsert(jActRow, jStandBtn);
+    jActRow = JsonArrayInsert(jActRow, NuiSpacer());
+
+    // -- New Round button --
+    json jNewBtn = NuiButton(JsonString("Nowa Runda"));
+    jNewBtn = NuiId(jNewBtn, HAZ_BTN_NEW);
+    jNewBtn = NuiEnabled(jNewBtn, NuiBind(HAZ_BIND_NEW_ENA));
+    jNewBtn = NuiWidth(jNewBtn, GetNuiScaleDimension(oPC, 180.0));
+    jNewBtn = NuiHeight(jNewBtn, fBtnH);
+
+    json jNewRow = JsonArray();
+    jNewRow = JsonArrayInsert(jNewRow, NuiSpacer());
+    jNewRow = JsonArrayInsert(jNewRow, jNewBtn);
+    jNewRow = JsonArrayInsert(jNewRow, NuiSpacer());
+
+    // -- Status bar: gold + stats button --
+    json jGoldLbl = NuiLabel(NuiBind(HAZ_BIND_GOLD_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+
+    json jStatBtn = NuiButton(JsonString("Statystyki"));
+    jStatBtn = NuiId(jStatBtn, HAZ_BTN_STATS);
+    jStatBtn = NuiWidth(jStatBtn, GetNuiScaleDimension(oPC, 100.0));
+    jStatBtn = NuiHeight(jStatBtn, GetNuiScaleDimension(oPC, 26.0));
+
+    json jStatusRow = JsonArray();
+    jStatusRow = JsonArrayInsert(jStatusRow, jGoldLbl);
+    jStatusRow = JsonArrayInsert(jStatusRow, NuiSpacer());
+    jStatusRow = JsonArrayInsert(jStatusRow, jStatBtn);
+
+    // -- Top bar: title + close --
+    json jCloseBtn = NuiButton(JsonString("X"));
+    jCloseBtn = NuiId(jCloseBtn, HAZ_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, GetNuiScaleDimension(oPC, 30.0));
+    jCloseBtn = NuiHeight(jCloseBtn, GetNuiScaleDimension(oPC, 26.0));
+
+    json jTopRow = JsonArray();
+    jTopRow = JsonArrayInsert(jTopRow, jTitle);
+    jTopRow = JsonArrayInsert(jTopRow, NuiSpacer());
+    jTopRow = JsonArrayInsert(jTopRow, jCloseBtn);
+
+    // -- Assemble root column --
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(jTopRow));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBetRow));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jPHdr);
+    jCol = JsonArrayInsert(jCol, NuiRow(jDiceRow));
+    jCol = JsonArrayInsert(jCol, jHandLbl);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jDHdr);
+    jCol = JsonArrayInsert(jCol, NuiRow(jDDiceRow));
+    jCol = JsonArrayInsert(jCol, jDHandLbl);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jHint);
+    jCol = JsonArrayInsert(jCol, jResult);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jActRow));
+    jCol = JsonArrayInsert(jCol, NuiRow(jNewRow));
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+    jCol = JsonArrayInsert(jCol, NuiRow(jStatusRow));
+
+    // -- Centre content with side spacers --
+    float fContentW = GetNuiScaleDimension(oPC, 500.0);
+    json jSide = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    json jMainRow = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiCol(jCol), fContentW));
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    return NuiRow(jMainRow);
+}
+
+// ----------------------------------------------------------------
+// Window creation
+// ----------------------------------------------------------------
+
+void HazOpenWindow(object oPC)
+{
+    if(NuiFindWindow(oPC, HAZ_WINDOW) != 0)
+    {
+        NuiDestroy(oPC, NuiFindWindow(oPC, HAZ_WINDOW));
+        return;
+    }
+
+    HazRegisterPlayer(oPC);
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))
+                 - GetNuiScaleDimension(oPC, HAZ_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT))
+                 - GetNuiScaleDimension(oPC, HAZ_H)) / 2.0;
+    json jGeom = NuiRect(fCX, fCY,
+                         GetNuiScaleDimension(oPC, HAZ_W),
+                         GetNuiScaleDimension(oPC, HAZ_H));
+
+    json jWin = NuiWindow(
+        HazBuildRoot(oPC),
+        JsonBool(FALSE),
+        NuiBind(HAZ_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    int nToken = NuiCreate(oPC, jWin, HAZ_WINDOW, HAZ_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, HAZ_WIN_GEOM, jGeom);
+    NuiSetBindWatch(oPC, nToken, HAZ_BIND_BET, TRUE);
+
+    SetLocalInt(oPC, HAZ_LVAR_PHASE, HAZ_PHASE_BET);
+    HazFeedBetPhase(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Feed — Bet phase (initial state, new round)
+// ----------------------------------------------------------------
+
+void HazFeedBetPhase(object oPC, int nToken)
+{
+    NuiSetBind(oPC, nToken, HAZ_BIND_D1_FACE, JsonString("—"));
+    NuiSetBind(oPC, nToken, HAZ_BIND_D2_FACE, JsonString("—"));
+    NuiSetBind(oPC, nToken, HAZ_BIND_D3_FACE, JsonString("—"));
+    NuiSetBind(oPC, nToken, HAZ_BIND_D1_ENC,  JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, HAZ_BIND_D2_ENC,  JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, HAZ_BIND_D3_ENC,  JsonBool(FALSE));
+
+    NuiSetBind(oPC, nToken, HAZ_BIND_DD1_FACE, JsonString("?"));
+    NuiSetBind(oPC, nToken, HAZ_BIND_DD2_FACE, JsonString("?"));
+    NuiSetBind(oPC, nToken, HAZ_BIND_DD3_FACE, JsonString("?"));
+
+    NuiSetBind(oPC, nToken, HAZ_BIND_HAND_LBL,  JsonString(""));
+    NuiSetBind(oPC, nToken, HAZ_BIND_HAND_COL,  NuiColor(200, 200, 200));
+    NuiSetBind(oPC, nToken, HAZ_BIND_DHAND_LBL, JsonString(""));
+    NuiSetBind(oPC, nToken, HAZ_BIND_DHAND_COL, NuiColor(200, 200, 200));
+
+    NuiSetBind(oPC, nToken, HAZ_BIND_HINT_LBL,   JsonString("Postaw zakład i rzuć kośćmi..."));
+    NuiSetBind(oPC, nToken, HAZ_BIND_HINT_COL,   NuiColor(180, 180, 180));
+    NuiSetBind(oPC, nToken, HAZ_BIND_RESULT,      JsonString(""));
+    NuiSetBind(oPC, nToken, HAZ_BIND_RESULT_COL,  NuiColor(200, 200, 200));
+    NuiSetBind(oPC, nToken, HAZ_BIND_BLOOD,       JsonBool(FALSE));
+
+    NuiSetBind(oPC, nToken, HAZ_BIND_BET_ENA,    JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, HAZ_BIND_ROLL_ENA,   JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, HAZ_BIND_REROLL_ENA, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, HAZ_BIND_STAND_ENA,  JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, HAZ_BIND_NEW_ENA,    JsonBool(FALSE));
+
+    HazUpdateGoldLabel(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Feed — Rolled phase (can hold dice, reroll, or stand)
+// ----------------------------------------------------------------
+
+void HazFeedRolledPhase(object oPC, int nToken)
+{
+    int d1 = GetLocalInt(oPC, HAZ_LVAR_D1);
+    int d2 = GetLocalInt(oPC, HAZ_LVAR_D2);
+    int d3 = GetLocalInt(oPC, HAZ_LVAR_D3);
+    int h1 = GetLocalInt(oPC, HAZ_LVAR_H1);
+    int h2 = GetLocalInt(oPC, HAZ_LVAR_H2);
+    int h3 = GetLocalInt(oPC, HAZ_LVAR_H3);
+
+    NuiSetBind(oPC, nToken, HAZ_BIND_D1_FACE, JsonString(IntToString(d1)));
+    NuiSetBind(oPC, nToken, HAZ_BIND_D2_FACE, JsonString(IntToString(d2)));
+    NuiSetBind(oPC, nToken, HAZ_BIND_D3_FACE, JsonString(IntToString(d3)));
+    NuiSetBind(oPC, nToken, HAZ_BIND_D1_ENC,  JsonBool(h1));
+    NuiSetBind(oPC, nToken, HAZ_BIND_D2_ENC,  JsonBool(h2));
+    NuiSetBind(oPC, nToken, HAZ_BIND_D3_ENC,  JsonBool(h3));
+
+    int nScore = HazScore(d1, d2, d3);
+    NuiSetBind(oPC, nToken, HAZ_BIND_HAND_LBL,
+        JsonString(HazHandName(nScore) + "  (" + IntToString(nScore) + " pkt)"));
+    NuiSetBind(oPC, nToken, HAZ_BIND_HAND_COL, HazHandColor(nScore));
+
+    NuiSetBind(oPC, nToken, HAZ_BIND_DD1_FACE, JsonString("?"));
+    NuiSetBind(oPC, nToken, HAZ_BIND_DD2_FACE, JsonString("?"));
+    NuiSetBind(oPC, nToken, HAZ_BIND_DD3_FACE, JsonString("?"));
+    NuiSetBind(oPC, nToken, HAZ_BIND_DHAND_LBL, JsonString("Krupier czeka..."));
+    NuiSetBind(oPC, nToken, HAZ_BIND_DHAND_COL, NuiColor(180, 180, 180));
+
+    int bRerolled = GetLocalInt(oPC, HAZ_LVAR_REROLLED);
+    NuiSetBind(oPC, nToken, HAZ_BIND_HINT_LBL,
+        JsonString(bRerolled
+            ? "Przerzut już użyty. Stój lub zmień trzymane kości."
+            : "Kliknij kości, by trzymać. Przerzuć wolne lub Stój."));
+    NuiSetBind(oPC, nToken, HAZ_BIND_HINT_COL,  NuiColor(180, 180, 180));
+    NuiSetBind(oPC, nToken, HAZ_BIND_RESULT,     JsonString(""));
+
+    NuiSetBind(oPC, nToken, HAZ_BIND_BET_ENA,    JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, HAZ_BIND_ROLL_ENA,   JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, HAZ_BIND_REROLL_ENA, JsonBool(!bRerolled));
+    NuiSetBind(oPC, nToken, HAZ_BIND_STAND_ENA,  JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, HAZ_BIND_NEW_ENA,    JsonBool(FALSE));
+}
+
+// ----------------------------------------------------------------
+// Feed — Result phase (round finished)
+// ----------------------------------------------------------------
+
+void HazFeedResult(object oPC, int nToken, int nPlayerScore, int nDealerScore, int nPayout)
+{
+    NuiSetBind(oPC, nToken, HAZ_BIND_D1_FACE,
+        JsonString(IntToString(GetLocalInt(oPC, HAZ_LVAR_D1))));
+    NuiSetBind(oPC, nToken, HAZ_BIND_D2_FACE,
+        JsonString(IntToString(GetLocalInt(oPC, HAZ_LVAR_D2))));
+    NuiSetBind(oPC, nToken, HAZ_BIND_D3_FACE,
+        JsonString(IntToString(GetLocalInt(oPC, HAZ_LVAR_D3))));
+    NuiSetBind(oPC, nToken, HAZ_BIND_D1_ENC, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, HAZ_BIND_D2_ENC, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, HAZ_BIND_D3_ENC, JsonBool(FALSE));
+
+    NuiSetBind(oPC, nToken, HAZ_BIND_DD1_FACE,
+        JsonString(IntToString(GetLocalInt(oPC, HAZ_LVAR_DD1))));
+    NuiSetBind(oPC, nToken, HAZ_BIND_DD2_FACE,
+        JsonString(IntToString(GetLocalInt(oPC, HAZ_LVAR_DD2))));
+    NuiSetBind(oPC, nToken, HAZ_BIND_DD3_FACE,
+        JsonString(IntToString(GetLocalInt(oPC, HAZ_LVAR_DD3))));
+
+    NuiSetBind(oPC, nToken, HAZ_BIND_HAND_LBL,
+        JsonString(HazHandName(nPlayerScore) + "  (" + IntToString(nPlayerScore) + " pkt)"));
+    NuiSetBind(oPC, nToken, HAZ_BIND_HAND_COL, HazHandColor(nPlayerScore));
+
+    NuiSetBind(oPC, nToken, HAZ_BIND_DHAND_LBL,
+        JsonString(HazHandName(nDealerScore) + "  (" + IntToString(nDealerScore) + " pkt)"));
+    NuiSetBind(oPC, nToken, HAZ_BIND_DHAND_COL, HazHandColor(nDealerScore));
+
+    string sResult;
+    json jResCol;
+    if(nPayout > 0)
+    {
+        sResult  = "WYGRYWASZ!  Zdobywasz " + IntToString(nPayout) + " szt.";
+        jResCol  = NuiColor(80, 220, 80);
+    }
+    else if(nPayout < 0)
+    {
+        sResult  = "PRZEGRYWASZ.  Tracisz " + IntToString(-nPayout) + " szt.";
+        jResCol  = NuiColor(220, 80, 80);
+    }
+    else
+    {
+        sResult  = "REMIS.  Zakład zwrócony.";
+        jResCol  = NuiColor(200, 200, 200);
+    }
+
+    NuiSetBind(oPC, nToken, HAZ_BIND_HINT_LBL,    JsonString(""));
+    NuiSetBind(oPC, nToken, HAZ_BIND_RESULT,       JsonString(sResult));
+    NuiSetBind(oPC, nToken, HAZ_BIND_RESULT_COL,   jResCol);
+
+    NuiSetBind(oPC, nToken, HAZ_BIND_BET_ENA,    JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, HAZ_BIND_ROLL_ENA,   JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, HAZ_BIND_REROLL_ENA, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, HAZ_BIND_STAND_ENA,  JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, HAZ_BIND_NEW_ENA,    JsonBool(TRUE));
+
+    HazUpdateGoldLabel(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Stats popup
+// ----------------------------------------------------------------
+
+void HazOpenStatsWindow(object oPC)
+{
+    if(NuiFindWindow(oPC, HAZ_WIN_STATS) != 0)
+    {
+        NuiDestroy(oPC, NuiFindWindow(oPC, HAZ_WIN_STATS));
+        return;
+    }
+
+    float fW = GetNuiScaleDimension(oPC, 440.0);
+    float fH = GetNuiScaleDimension(oPC, 360.0);
+    float fX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - fW) / 2.0;
+    float fY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - fH) / 2.0;
+    float fRowH = GetNuiScaleDimension(oPC, 24.0);
+
+    // Player stats
+    json jStats  = HazGetStats(oPC);
+    int nWins    = JsonGetInt(JsonObjectGet(jStats, "wins"));
+    int nLosses  = JsonGetInt(JsonObjectGet(jStats, "losses"));
+    int nPushes  = JsonGetInt(JsonObjectGet(jStats, "pushes"));
+    int nWon     = JsonGetInt(JsonObjectGet(jStats, "gold_won"));
+    int nLost    = JsonGetInt(JsonObjectGet(jStats, "gold_lost"));
+
+    string sMyStats = "Twoje wyniki:  W: " + IntToString(nWins)
+        + "  P: " + IntToString(nLosses)
+        + "  R: " + IntToString(nPushes)
+        + "\nSaldo:  " + (nWon >= nLost
+            ? "+" + IntToString(nWon - nLost)
+            : IntToString(nWon - nLost)) + " szt.";
+
+    json jMyLbl = NuiLabel(JsonString(sMyStats),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jMyLbl = NuiHeight(jMyLbl, GetNuiScaleDimension(oPC, 52.0));
+
+    // Leaderboard header
+    json jLBHdr = NuiLabel(JsonString("Tablica sławy (wygrane):"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jLBHdr = NuiHeight(jLBHdr, fRowH);
+
+    // Leaderboard rows (static list, built at open time)
+    json jBoard = HazGetLeaderboard();
+    int nBCount = JsonGetLength(jBoard);
+    json jBoardCol = JsonArray();
+    int i;
+    for(i = 0; i < nBCount; i++)
+    {
+        json jEntry  = JsonArrayGet(jBoard, i);
+        string sName = JsonGetString(JsonObjectGet(jEntry, "name"));
+        int nW       = JsonGetInt   (JsonObjectGet(jEntry, "wins"));
+        int nL       = JsonGetInt   (JsonObjectGet(jEntry, "losses"));
+        int nBal     = JsonGetInt   (JsonObjectGet(jEntry, "balance"));
+        string sRow  = IntToString(i + 1) + ". " + sName
+            + "   W:" + IntToString(nW)
+            + " P:" + IntToString(nL)
+            + "   saldo: " + IntToString(nBal) + " szt.";
+
+        json jRowLbl = NuiLabel(JsonString(sRow),
+            JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+        jRowLbl = NuiHeight(jRowLbl, fRowH);
+        jBoardCol = JsonArrayInsert(jBoardCol, jRowLbl);
+    }
+    if(nBCount == 0)
+    {
+        json jEmpty = NuiLabel(JsonString("Brak danych."),
+            JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+        jEmpty = NuiHeight(jEmpty, fRowH);
+        jBoardCol = JsonArrayInsert(jBoardCol, jEmpty);
+    }
+
+    json jCloseBtn = NuiButton(JsonString("Zamknij"));
+    jCloseBtn = NuiId(jCloseBtn, HAZ_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, GetNuiScaleDimension(oPC, 100.0));
+    jCloseBtn = NuiHeight(jCloseBtn, GetNuiScaleDimension(oPC, 28.0));
+
+    json jCloseRow = JsonArray();
+    jCloseRow = JsonArrayInsert(jCloseRow, NuiSpacer());
+    jCloseRow = JsonArrayInsert(jCloseRow, jCloseBtn);
+    jCloseRow = JsonArrayInsert(jCloseRow, NuiSpacer());
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jMyLbl);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, jLBHdr);
+    jCol = JsonArrayInsert(jCol, NuiCol(jBoardCol));
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+    jCol = JsonArrayInsert(jCol, NuiRow(jCloseRow));
+
+    json jWin = NuiWindow(
+        NuiCol(jCol),
+        JsonString("Statystyki — Trzy Smocze Kości"),
+        NuiRect(fX, fY, fW, fH),
+        JsonBool(FALSE), JsonBool(FALSE), JsonBool(TRUE),
+        JsonBool(FALSE), JsonBool(TRUE));
+
+    NuiCreate(oPC, jWin, HAZ_WIN_STATS, HAZ_EV_SCRIPT);
+}
+
+// ----------------------------------------------------------------
+// Cleanup LVARs on window close
+// ----------------------------------------------------------------
+
+void HazCleanupLvars(object oPC)
+{
+    DeleteLocalInt(oPC, HAZ_LVAR_PHASE);
+    DeleteLocalInt(oPC, HAZ_LVAR_BET);
+    DeleteLocalInt(oPC, HAZ_LVAR_D1);
+    DeleteLocalInt(oPC, HAZ_LVAR_D2);
+    DeleteLocalInt(oPC, HAZ_LVAR_D3);
+    DeleteLocalInt(oPC, HAZ_LVAR_H1);
+    DeleteLocalInt(oPC, HAZ_LVAR_H2);
+    DeleteLocalInt(oPC, HAZ_LVAR_H3);
+    DeleteLocalInt(oPC, HAZ_LVAR_REROLLED);
+    DeleteLocalInt(oPC, HAZ_LVAR_BLOOD);
+    DeleteLocalInt(oPC, HAZ_LVAR_DD1);
+    DeleteLocalInt(oPC, HAZ_LVAR_DD2);
+    DeleteLocalInt(oPC, HAZ_LVAR_DD3);
+}

--- a/Hazard/Scripts/lib_haz_def.nss
+++ b/Hazard/Scripts/lib_haz_def.nss
@@ -1,0 +1,88 @@
+// lib_haz_def.nss — constants, bind IDs, button IDs for Hazard module
+#include "lib_nui"
+#include "sql_haz"
+
+void HazOpenWindow(object oPC);
+
+// Window IDs
+const string HAZ_WINDOW    = "HAZ_WINDOW";
+const string HAZ_WIN_STATS = "HAZ_WIN_STATS";
+const string HAZ_EV_SCRIPT = "lib_haz_ev";
+const string HAZ_WIN_GEOM  = "haz_win_geom";
+
+// Game phases stored in HAZ_LVAR_PHASE
+const int HAZ_PHASE_BET    = 0;  // waiting for bet + first roll
+const int HAZ_PHASE_ROLLED = 1;  // first roll done; can hold/reroll/stand
+const int HAZ_PHASE_RESULT = 2;  // round over; new round button active
+
+// Bind IDs — player dice face text + hold indicator
+const string HAZ_BIND_D1_FACE = "haz_d1_face";
+const string HAZ_BIND_D2_FACE = "haz_d2_face";
+const string HAZ_BIND_D3_FACE = "haz_d3_face";
+const string HAZ_BIND_D1_ENC  = "haz_d1_enc";
+const string HAZ_BIND_D2_ENC  = "haz_d2_enc";
+const string HAZ_BIND_D3_ENC  = "haz_d3_enc";
+
+// Bind IDs — dealer dice
+const string HAZ_BIND_DD1_FACE  = "haz_dd1";
+const string HAZ_BIND_DD2_FACE  = "haz_dd2";
+const string HAZ_BIND_DD3_FACE  = "haz_dd3";
+
+// Bind IDs — hand labels + result
+const string HAZ_BIND_HAND_LBL  = "haz_hand_lbl";
+const string HAZ_BIND_HAND_COL  = "haz_hand_col";
+const string HAZ_BIND_DHAND_LBL = "haz_dhand_lbl";
+const string HAZ_BIND_DHAND_COL = "haz_dhand_col";
+const string HAZ_BIND_RESULT    = "haz_result";
+const string HAZ_BIND_RESULT_COL= "haz_res_col";
+
+// Bind IDs — bet controls
+const string HAZ_BIND_BET      = "haz_bet";
+const string HAZ_BIND_BET_ENA  = "haz_bet_ena";
+const string HAZ_BIND_BLOOD    = "haz_blood_chk";  // NuiCheckbox bind (bool)
+
+// Bind IDs — button enabled states
+const string HAZ_BIND_ROLL_ENA   = "haz_roll_ena";
+const string HAZ_BIND_REROLL_ENA = "haz_reroll_ena";
+const string HAZ_BIND_STAND_ENA  = "haz_stand_ena";
+const string HAZ_BIND_NEW_ENA    = "haz_new_ena";
+
+// Bind IDs — info labels
+const string HAZ_BIND_GOLD_LBL  = "haz_gold_lbl";
+const string HAZ_BIND_HINT_LBL  = "haz_hint_lbl";
+const string HAZ_BIND_HINT_COL  = "haz_hint_col";
+
+// Button IDs
+const string HAZ_BTN_CLOSE  = "haz_btn_close";
+const string HAZ_BTN_ROLL   = "haz_btn_roll";
+const string HAZ_BTN_REROLL = "haz_btn_reroll";
+const string HAZ_BTN_STAND  = "haz_btn_stand";
+const string HAZ_BTN_NEW    = "haz_btn_new";
+const string HAZ_BTN_STATS  = "haz_btn_stats";
+const string HAZ_BTN_D1     = "haz_btn_d1";
+const string HAZ_BTN_D2     = "haz_btn_d2";
+const string HAZ_BTN_D3     = "haz_btn_d3";
+
+// LVARs on PC (cleared on window close)
+const string HAZ_LVAR_PHASE    = "HAZ_PHASE";
+const string HAZ_LVAR_BET      = "HAZ_BET";
+const string HAZ_LVAR_D1       = "HAZ_D1";
+const string HAZ_LVAR_D2       = "HAZ_D2";
+const string HAZ_LVAR_D3       = "HAZ_D3";
+const string HAZ_LVAR_H1       = "HAZ_H1";
+const string HAZ_LVAR_H2       = "HAZ_H2";
+const string HAZ_LVAR_H3       = "HAZ_H3";
+const string HAZ_LVAR_REROLLED = "HAZ_REROLLED";
+const string HAZ_LVAR_BLOOD    = "HAZ_BLOOD";
+// Dealer's rolled dice stored here after HazDealerPlayFull
+const string HAZ_LVAR_DD1      = "HAZ_DD1";
+const string HAZ_LVAR_DD2      = "HAZ_DD2";
+const string HAZ_LVAR_DD3      = "HAZ_DD3";
+
+// Game limits
+const int   HAZ_BET_MIN = 10;
+const int   HAZ_BET_MAX = 5000;
+
+// Window dimensions
+const float HAZ_W = 540.0;
+const float HAZ_H = 510.0;

--- a/Hazard/Scripts/lib_haz_ev.nss
+++ b/Hazard/Scripts/lib_haz_ev.nss
@@ -1,0 +1,241 @@
+// lib_haz_ev.nss — NUI event handler for Hazard module
+#include "lib_haz"
+
+// ----------------------------------------------------------------
+// Roll handler — validates bet, rolls 3d6, transitions to ROLLED phase
+// ----------------------------------------------------------------
+
+void HazHandleRoll(object oPC, int nToken)
+{
+    string sBet = JsonGetString(NuiGetBind(oPC, nToken, HAZ_BIND_BET));
+    int nBet    = StringToInt(sBet);
+
+    if(nBet < HAZ_BET_MIN)
+    {
+        SendMessageToPC(oPC, "[Hazard] Minimalny zakład to " + IntToString(HAZ_BET_MIN) + " szt.");
+        return;
+    }
+    if(nBet > HAZ_BET_MAX)
+    {
+        SendMessageToPC(oPC, "[Hazard] Maksymalny zakład to " + IntToString(HAZ_BET_MAX) + " szt.");
+        return;
+    }
+    if(GetGold(oPC) < nBet)
+    {
+        SendMessageToPC(oPC, "[Hazard] Nie masz wystarczająco złota.");
+        return;
+    }
+
+    int bBlood = JsonGetInt(NuiGetBind(oPC, nToken, HAZ_BIND_BLOOD));
+
+    SetLocalInt(oPC, HAZ_LVAR_BET,      nBet);
+    SetLocalInt(oPC, HAZ_LVAR_BLOOD,    bBlood);
+    SetLocalInt(oPC, HAZ_LVAR_REROLLED, 0);
+    SetLocalInt(oPC, HAZ_LVAR_H1, 0);
+    SetLocalInt(oPC, HAZ_LVAR_H2, 0);
+    SetLocalInt(oPC, HAZ_LVAR_H3, 0);
+    SetLocalInt(oPC, HAZ_LVAR_D1, Random(6) + 1);
+    SetLocalInt(oPC, HAZ_LVAR_D2, Random(6) + 1);
+    SetLocalInt(oPC, HAZ_LVAR_D3, Random(6) + 1);
+    SetLocalInt(oPC, HAZ_LVAR_PHASE, HAZ_PHASE_ROLLED);
+
+    HazFeedRolledPhase(oPC, nToken);
+
+    if(bBlood)
+        SendMessageToPC(oPC, "[Hazard] Pieczęć krwi pulsuje słabo... Rzucasz kości.");
+    else
+        SendMessageToPC(oPC, "[Hazard] Kości toczą się po stole...");
+}
+
+// ----------------------------------------------------------------
+// Reroll handler — rolls only the un-held dice (once per round)
+// ----------------------------------------------------------------
+
+void HazHandleReroll(object oPC, int nToken)
+{
+    if(GetLocalInt(oPC, HAZ_LVAR_REROLLED)) return;
+
+    int h1 = GetLocalInt(oPC, HAZ_LVAR_H1);
+    int h2 = GetLocalInt(oPC, HAZ_LVAR_H2);
+    int h3 = GetLocalInt(oPC, HAZ_LVAR_H3);
+
+    if(!h1) SetLocalInt(oPC, HAZ_LVAR_D1, Random(6) + 1);
+    if(!h2) SetLocalInt(oPC, HAZ_LVAR_D2, Random(6) + 1);
+    if(!h3) SetLocalInt(oPC, HAZ_LVAR_D3, Random(6) + 1);
+
+    SetLocalInt(oPC, HAZ_LVAR_REROLLED, 1);
+    HazFeedRolledPhase(oPC, nToken);
+    SendMessageToPC(oPC, "[Hazard] Wolne kości przerzucone.");
+}
+
+// ----------------------------------------------------------------
+// Stand handler — dealer plays, scores compared, gold settled
+// ----------------------------------------------------------------
+
+void HazHandleStand(object oPC, int nToken)
+{
+    int d1 = GetLocalInt(oPC, HAZ_LVAR_D1);
+    int d2 = GetLocalInt(oPC, HAZ_LVAR_D2);
+    int d3 = GetLocalInt(oPC, HAZ_LVAR_D3);
+    int nPlayerScore = HazScore(d1, d2, d3);
+
+    // Dealer initial roll
+    int dd1 = Random(6) + 1;
+    int dd2 = Random(6) + 1;
+    int dd3 = Random(6) + 1;
+    int nDealerScore = HazDealerPlayFull(oPC, dd1, dd2, dd3);
+
+    int nBet   = GetLocalInt(oPC, HAZ_LVAR_BET);
+    int bBlood = GetLocalInt(oPC, HAZ_LVAR_BLOOD);
+    int nPayout = HazCalcPayout(nPlayerScore, nDealerScore, nBet, bBlood);
+
+    if(nPayout > 0)
+    {
+        GiveGoldToCreature(oPC, nPayout);
+        HazRecordWin(oPC, nPayout);
+    }
+    else if(nPayout < 0)
+    {
+        int nLoss = -nPayout;
+        AssignCommand(oPC, TakeGoldFromCreature(nLoss, oPC, TRUE));
+
+        if(bBlood)
+        {
+            int nDmg = GetMaxHitPoints(oPC) / 10;
+            if(nDmg < 1) nDmg = 1;
+            ApplyEffectToObject(DURATION_TYPE_INSTANT,
+                EffectDamage(nDmg, DAMAGE_TYPE_NEGATIVE), oPC);
+            SendMessageToPC(oPC,
+                "[Hazard] Cena Krwi — pieczęć pęka: " + IntToString(nDmg) + " obrażeń.");
+        }
+
+        HazRecordLoss(oPC, nLoss);
+    }
+    else
+    {
+        HazRecordPush(oPC);
+    }
+
+    SetLocalInt(oPC, HAZ_LVAR_PHASE, HAZ_PHASE_RESULT);
+    HazFeedResult(oPC, nToken, nPlayerScore, nDealerScore, nPayout);
+}
+
+// ----------------------------------------------------------------
+// Toggle hold on a player die (only in ROLLED phase)
+// ----------------------------------------------------------------
+
+void HazToggleHold(object oPC, int nToken, string sLvar)
+{
+    if(GetLocalInt(oPC, HAZ_LVAR_PHASE) != HAZ_PHASE_ROLLED) return;
+    SetLocalInt(oPC, sLvar, !GetLocalInt(oPC, sLvar));
+    HazFeedRolledPhase(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Reset to bet phase for a new round
+// ----------------------------------------------------------------
+
+void HazHandleNewRound(object oPC, int nToken)
+{
+    DeleteLocalInt(oPC, HAZ_LVAR_D1);
+    DeleteLocalInt(oPC, HAZ_LVAR_D2);
+    DeleteLocalInt(oPC, HAZ_LVAR_D3);
+    DeleteLocalInt(oPC, HAZ_LVAR_H1);
+    DeleteLocalInt(oPC, HAZ_LVAR_H2);
+    DeleteLocalInt(oPC, HAZ_LVAR_H3);
+    DeleteLocalInt(oPC, HAZ_LVAR_REROLLED);
+    DeleteLocalInt(oPC, HAZ_LVAR_BLOOD);
+    DeleteLocalInt(oPC, HAZ_LVAR_DD1);
+    DeleteLocalInt(oPC, HAZ_LVAR_DD2);
+    DeleteLocalInt(oPC, HAZ_LVAR_DD3);
+    SetLocalInt(oPC, HAZ_LVAR_PHASE, HAZ_PHASE_BET);
+    HazFeedBetPhase(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Main event dispatcher
+// ----------------------------------------------------------------
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+
+    // Stats window events
+    if(nToken == NuiFindWindow(oPC, HAZ_WIN_STATS))
+    {
+        if(sEvent == EVENT_TYPE_CLICK && sElem == HAZ_BTN_CLOSE)
+            NuiDestroy(oPC, nToken);
+        return;
+    }
+
+    if(nToken != NuiFindWindow(oPC, HAZ_WINDOW)) return;
+
+    // Window closed via OS chrome
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        HazCleanupLvars(oPC);
+        int nStats = NuiFindWindow(oPC, HAZ_WIN_STATS);
+        if(nStats != 0) NuiDestroy(oPC, nStats);
+        return;
+    }
+
+    if(sEvent != EVENT_TYPE_CLICK) return;
+
+    if(sElem == HAZ_BTN_CLOSE)
+    {
+        HazCleanupLvars(oPC);
+        int nStats = NuiFindWindow(oPC, HAZ_WIN_STATS);
+        if(nStats != 0) NuiDestroy(oPC, nStats);
+        NuiDestroy(oPC, nToken);
+        return;
+    }
+
+    if(sElem == HAZ_BTN_ROLL)
+    {
+        HazHandleRoll(oPC, nToken);
+        return;
+    }
+
+    if(sElem == HAZ_BTN_REROLL)
+    {
+        HazHandleReroll(oPC, nToken);
+        return;
+    }
+
+    if(sElem == HAZ_BTN_STAND)
+    {
+        HazHandleStand(oPC, nToken);
+        return;
+    }
+
+    if(sElem == HAZ_BTN_NEW)
+    {
+        HazHandleNewRound(oPC, nToken);
+        return;
+    }
+
+    if(sElem == HAZ_BTN_STATS)
+    {
+        HazOpenStatsWindow(oPC);
+        return;
+    }
+
+    if(sElem == HAZ_BTN_D1)
+    {
+        HazToggleHold(oPC, nToken, HAZ_LVAR_H1);
+        return;
+    }
+    if(sElem == HAZ_BTN_D2)
+    {
+        HazToggleHold(oPC, nToken, HAZ_LVAR_H2);
+        return;
+    }
+    if(sElem == HAZ_BTN_D3)
+    {
+        HazToggleHold(oPC, nToken, HAZ_LVAR_H3);
+        return;
+    }
+}

--- a/Hazard/Scripts/lib_nui.nss
+++ b/Hazard/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Hazard/Scripts/lib_nui_utility.nss
+++ b/Hazard/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Hazard/Scripts/sql_haz.nss
+++ b/Hazard/Scripts/sql_haz.nss
@@ -1,0 +1,97 @@
+// sql_haz.nss — SQLite schema + queries for Hazard module
+
+void HazCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("haz",
+        "CREATE TABLE IF NOT EXISTS haz_players ("
+        " uuid       TEXT PRIMARY KEY,"
+        " char_name  TEXT NOT NULL DEFAULT '',"
+        " wins       INTEGER NOT NULL DEFAULT 0,"
+        " losses     INTEGER NOT NULL DEFAULT 0,"
+        " pushes     INTEGER NOT NULL DEFAULT 0,"
+        " gold_won   INTEGER NOT NULL DEFAULT 0,"
+        " gold_lost  INTEGER NOT NULL DEFAULT 0"
+        ")");
+    SqlStep(q);
+}
+
+void HazRegisterPlayer(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("haz",
+        "INSERT OR IGNORE INTO haz_players (uuid, char_name) VALUES (@uuid, @name)");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindString(q, "@name", GetName(oPC));
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("haz",
+        "UPDATE haz_players SET char_name = @name WHERE uuid = @uuid");
+    SqlBindString(q, "@name", GetName(oPC));
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+void HazRecordWin(object oPC, int nGold)
+{
+    sqlquery q = SqlPrepareQueryCampaign("haz",
+        "UPDATE haz_players SET wins = wins + 1, gold_won = gold_won + @g WHERE uuid = @uuid");
+    SqlBindInt   (q, "@g",    nGold);
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+void HazRecordLoss(object oPC, int nGold)
+{
+    sqlquery q = SqlPrepareQueryCampaign("haz",
+        "UPDATE haz_players SET losses = losses + 1, gold_lost = gold_lost + @g WHERE uuid = @uuid");
+    SqlBindInt   (q, "@g",    nGold);
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+void HazRecordPush(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("haz",
+        "UPDATE haz_players SET pushes = pushes + 1 WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+// Returns {wins, losses, pushes, gold_won, gold_lost} or empty object if unknown player
+json HazGetStats(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("haz",
+        "SELECT wins, losses, pushes, gold_won, gold_lost"
+        " FROM haz_players WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    json jStats = JsonObject();
+    if(SqlStep(q))
+    {
+        jStats = JsonObjectSet(jStats, "wins",      JsonInt(SqlGetInt(q, 0)));
+        jStats = JsonObjectSet(jStats, "losses",    JsonInt(SqlGetInt(q, 1)));
+        jStats = JsonObjectSet(jStats, "pushes",    JsonInt(SqlGetInt(q, 2)));
+        jStats = JsonObjectSet(jStats, "gold_won",  JsonInt(SqlGetInt(q, 3)));
+        jStats = JsonObjectSet(jStats, "gold_lost", JsonInt(SqlGetInt(q, 4)));
+    }
+    return jStats;
+}
+
+// Returns JsonArray [{name, wins, losses, balance}, ...] — top 5 by wins
+json HazGetLeaderboard()
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("haz",
+        "SELECT char_name, wins, losses, gold_won - gold_lost AS balance"
+        " FROM haz_players"
+        " ORDER BY wins DESC, balance DESC"
+        " LIMIT 5");
+    while(SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "name",    JsonString(SqlGetString(q, 0)));
+        jRow = JsonObjectSet(jRow, "wins",    JsonInt   (SqlGetInt   (q, 1)));
+        jRow = JsonObjectSet(jRow, "losses",  JsonInt   (SqlGetInt   (q, 2)));
+        jRow = JsonObjectSet(jRow, "balance", JsonInt   (SqlGetInt   (q, 3)));
+        jRows = JsonArrayInsert(jRows, jRow);
+    }
+    return jRows;
+}

--- a/Hazard/Scripts/sys_on_enter.nss
+++ b/Hazard/Scripts/sys_on_enter.nss
@@ -1,0 +1,9 @@
+// sys_on_enter.nss — module OnClientEnter hook for Hazard
+#include "lib_haz_def"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC) || GetIsDMPossessed(oPC)) return;
+    HazRegisterPlayer(oPC);
+}

--- a/Hazard/Scripts/sys_on_load.nss
+++ b/Hazard/Scripts/sys_on_load.nss
@@ -1,0 +1,7 @@
+// sys_on_load.nss — module OnModuleLoad hook for Hazard
+#include "lib_haz_def"
+
+void main()
+{
+    HazCreateTables();
+}

--- a/Hazard/Scripts/test_haz.nss
+++ b/Hazard/Scripts/test_haz.nss
@@ -1,0 +1,10 @@
+// test_haz.nss — OnUsed script for the gambling-table placeable demo
+// Place a placeable in the toolset, set its OnUsed event to this script.
+#include "lib_haz"
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+    HazOpenWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

Nowy moduł **Hazard** implementuje ciemno-fantasy grę w kości „Trzy Smocze Kości" — gracze mogą siadać przy stole hazardowym, stawiać zakłady złotem i rywalizować z krupierem (domem) przez taktyczne trzymanie i przerzucanie kości. Moduł zawiera pełne UI w NUI, trwałe statystyki graczy w SQLite i mroczną mechanikę „Ceny Krwi".

## Mechanika

### Przebieg rundy
1. Gracz ustawia zakład (10–5000 szt.) i opcjonalnie włącza **Cenę Krwi**.
2. Kliknięcie **Rzuć kości** → rzut 3k6.
3. Gracz **klika kości**, żeby je trzymać (podświetlane przez `NuiEncouraged`).
4. **Przerzuć wolne** — raz na rundę przerzuca niezablokowane kości.
5. **Stój** — krupier ujawnia swoje kości i rozstrzyga rundu.

### Układy (rosnąco)
| Układ           | Zakres pkt | Wypłata zysku |
|-----------------|-----------|---------------|
| Wysoka Kość     | 3–18      | 1× zakład     |
| Para Bazyliszka | 3101–3605 | 1× zakład     |
| Wąż Schodowy   | 4100–4400 | 1,5× zakład   |
| Smok Trojaki   | 5100–5600 | 2× zakład     |

### Cena Krwi (dark fantasy twist)
- Wygrana → wszystkie wypłaty ×3.
- Porażka → standardowa strata złota + 10% max HP (obrażenia negatywne).

### AI krupiera
Krupier rzuca 3k6; jeśli wynik < Para Bazyliszka z 2s (3201 pkt), przerzuca najgorszą jedną kość. Prosta strategia daje graczowi realną szansę przez taktyczne trzymanie.

## Pliki

```
Hazard/
  INTEGRATION.md                 — instrukcja integracji (hooki, placeable, SQL)
  Scripts/
    sql_haz.nss                  — schemat SQLite + zapytania (7 funkcji)
    lib_haz_def.nss              — stałe, bind ID, button ID, LVAR, limity, wymiary
    lib_haz.nss                  — scoring, AI krupiera, budowa NUI, feed-functions
    lib_haz_ev.nss               — główny handler zdarzeń NUI (dispatcher)
    sys_on_load.nss              — OnModuleLoad: CREATE TABLE IF NOT EXISTS
    sys_on_enter.nss             — OnClientEnter: rejestracja gracza w SQL
    test_haz.nss                 — OnUsed placeable: otwiera okno gry
    lib_nui.nss / lib_nui_utility.nss  — współdzielone helpery NUI (kopia)
```

## Zależności (NWNX? SQL?)

- **NWNX**: nie wymagany.
- **SQLite**: kampania `haz` — tworzona automatycznie przez `SqlPrepareQueryCampaign("haz", ...)`.
- NWN:EE 8193.36+ (NUI + campaign SQLite).

## Jak włączyć w istniejącym module

1. Dodaj wszystkie pliki `Hazard/Scripts/*.nss` do HAK modułu.
2. W **OnModuleLoad**: dołącz `HazCreateTables()`.
3. W **OnClientEnter**: dołącz `HazRegisterPlayer(oPC)` (tylko dla PC).
4. W toolsecie utwórz placeable-stół, ustaw jego **OnUsed** → `test_haz`.
5. Alternatywnie wywołuj `HazOpenWindow(oPC)` z rozmowy NPC lub Ribbon System.

## Co celowo pominięto

- **Gra wieloosobowa (PvP)** — wymagałaby synchronizacji sesji między graczami.
- **Animacje rzutu** — NWN NUI nie obsługuje animacji sprite/gif w przyciskach.
- **Kredyt / dług** — celowo usunięty, żeby uniknąć exploitów goldfarming.
- **Limity dzienne** — do konfiguracji przez DM/serwer wedle uznania.
- **Plik .mod** — środowisko nie posiada narzędzi do pakowania .mod; zamiast tego `INTEGRATION.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_0149cq4UHF1H6PNKyuG7Naqh)_