### PR TITLE
feat: Soul Crystals (Kryształy Dusz)

### DIFF
--- a/Soul Crystals/INTEGRATION.md
+++ b/Soul Crystals/INTEGRATION.md
@@ -1,0 +1,59 @@
+# Soul Crystals — Integracja z istniejącym modułem
+
+## Hooki do podpięcia
+
+| Zdarzenie modułu    | Skrypt do ustawienia | Uwaga |
+|---------------------|----------------------|-------|
+| `OnModuleLoad`      | `sys_on_load.nss`    | Tworzy tabele SQLite w kampanii `soc` |
+| `OnClientEnter`     | `sys_on_enter.nss`   | Rejestruje gracza, powiadamia o posiadanych duszach |
+| `OnPlayerTarget`    | `sys_on_target.nss`  | Obsługuje schwytanie duszy po wejściu w tryb celowania |
+
+Jeśli moduł ma już skrypty dla tych zdarzeń, należy dołączyć wywołania z powyższych skryptów do istniejącego handlera (np. przez `#include "sys_on_enter"` i wywołanie `main()` lub refaktoryzację do wspólnej funkcji).
+
+## Placeable — Kuźnia Dusz
+
+1. Stwórz placeable (np. `plc_altar1` lub dowolny stosowny wizualnie).
+2. Ustaw `OnUsed` → `test_soc.nss`.
+3. Nadaj mu nazwę np. **„Kuźnia Dusz"** lub **„Kryształowy Ołtarz"**.
+4. Umieść w świecie. Gracze aktywują go, by otworzyć UI zarządzania kryształami.
+
+## Wymagania
+
+- **NWN:EE** z obsługą NUI (`nw_inc_nui.nss`) — patch 8193.32 lub nowszy.
+- **Brak NWNX** — moduł używa wyłącznie wbudowanego API NWScript i SQLite.
+- Kampania SQLite: `soc.db` tworzna automatycznie przy pierwszym załadowaniu modułu.
+
+## Jak działa schwytanie duszy
+
+1. Gracz klika „Zwiąż Duszę" w oknie Kuźni Dusz.
+2. Kursor przechodzi w tryb celowania (strzałka wyboru).
+3. Gracz klika na stworzenie z HP ≤ 25% (nie-PC).
+4. `sys_on_target.nss` uruchamia `SocOnPlayerTarget`: waliduje cel, zabija go efektem śmierci i zapisuje duszę do SQL.
+5. Kryształ pojawia się natychmiast w liście po lewej stronie okna.
+
+## Typy kryształów
+
+| Tier        | Dotyczy                         | Esencja maks |
+|-------------|---------------------------------|--------------|
+| Popękany    | Humanoidy HD < 4                | ~20          |
+| Zwykły      | Bestie HD 4–7                   | ~40          |
+| Wyższy      | Nieumarli lub HD 8–14           | ~80          |
+| Nieskazitelny | Przybysze lub HD ≥ 15         | ~250         |
+
+## Efekty wzmocnień (consume)
+
+| Przycisk           | Efekt                                       | Koszt        |
+|--------------------|---------------------------------------------|--------------|
+| Moc Siły           | Siła +2…+8, 1–10 min                       | 50% esencji  |
+| Bystrość Ducha     | Mądrość + Inteligencja +2…+8, 1–10 min     | 50% esencji  |
+| Pancerz Duszy      | Pancerz unikowy +1…+6, 1–10 min            | 50% esencji  |
+| Regeneracja        | Leczenie 1–5 HP/rundę, 1–10 min            | 50% esencji  |
+| Wchłonij Całość    | Wszystkie powyższe (silniejsze) + Haste     | 100% (usuwa kryształ), CD 5 min |
+| Uwolnij Duszę      | Brak efektu; zwrot złota = tier×5 + ess/10 | Usuwa kryształ |
+
+## Co celowo pominięto
+
+- **Fizyczne itemy kryształów** w ekwipunku — całość trzymana w SQL; brak potrzeby haka.
+- **Handel kryształami** między graczami.
+- **Efekty cząsteczkowe** na krysztale (wymagałoby niestandardowego assetu w haku).
+- **Integracja z Runic Forge** — esencja mogłaby zasilać enkhanty, ale to rozszerzenie dla przyszłych modułów.

--- a/Soul Crystals/Scripts/lib_nui.nss
+++ b/Soul Crystals/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Soul Crystals/Scripts/lib_nui_utility.nss
+++ b/Soul Crystals/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Soul Crystals/Scripts/lib_soc.nss
+++ b/Soul Crystals/Scripts/lib_soc.nss
@@ -1,0 +1,655 @@
+// lib_soc.nss — Soul Crystals: NUI builder, game logic, soul binding.
+
+#include "lib_soc_def"
+
+// ---------------------------------------------------------------
+// Utility
+// ---------------------------------------------------------------
+
+float SocClampF(float fVal, float fMin, float fMax)
+{
+    if (fVal < fMin) return fMin;
+    if (fVal > fMax) return fMax;
+    return fVal;
+}
+
+// Buff duration in seconds, scaled to crystal essence
+float SocCalcDuration(int nEssence)
+{
+    return SocClampF((nEssence / 100.0) * SOC_DUR_PER_100, SOC_DUR_MIN, SOC_DUR_MAX);
+}
+
+string SocGetTierName(int nTier)
+{
+    if (nTier == SOC_TIER_FLAWLESS) return "Nieskazitelny";
+    if (nTier == SOC_TIER_GREATER)  return "Wyższy";
+    if (nTier == SOC_TIER_COMMON)   return "Zwykły";
+    return "Popękany";
+}
+
+string SocGetRaceCatName(int nRaceCat)
+{
+    if (nRaceCat == SOC_RACE_OUTSIDER) return "Przybysz";
+    if (nRaceCat == SOC_RACE_UNDEAD)   return "Nieumarły";
+    if (nRaceCat == SOC_RACE_BEAST)    return "Bestia";
+    return "Humanoid";
+}
+
+// Maps NWN racial type to our four-category system
+int SocGetRaceCat(object oCreature)
+{
+    int nRace = GetRacialType(oCreature);
+
+    if (nRace == RACIAL_TYPE_UNDEAD)
+        return SOC_RACE_UNDEAD;
+
+    if (nRace == RACIAL_TYPE_OUTSIDER || nRace == RACIAL_TYPE_ELEMENTAL)
+        return SOC_RACE_OUTSIDER;
+
+    if (nRace == RACIAL_TYPE_ANIMAL      || nRace == RACIAL_TYPE_BEAST
+     || nRace == RACIAL_TYPE_MAGICAL_BEAST || nRace == RACIAL_TYPE_VERMIN
+     || nRace == RACIAL_TYPE_DRAGON)
+        return SOC_RACE_BEAST;
+
+    return SOC_RACE_HUMANOID;
+}
+
+// Tier based on race category and creature HD
+int SocGetSoulTier(object oCreature)
+{
+    int nRaceCat = SocGetRaceCat(oCreature);
+    int nHD      = GetHitDice(oCreature);
+
+    if (nRaceCat == SOC_RACE_OUTSIDER || nHD >= 15) return SOC_TIER_FLAWLESS;
+    if (nRaceCat == SOC_RACE_UNDEAD   || nHD >= 8)  return SOC_TIER_GREATER;
+    if (nRaceCat == SOC_RACE_BEAST    || nHD >= 4)  return SOC_TIER_COMMON;
+    return SOC_TIER_CRACKED;
+}
+
+// Essence = 5 × HD, capped at 250
+int SocGetSoulEssence(object oCreature)
+{
+    int nEss = GetHitDice(oCreature) * 5;
+    if (nEss < 5)   nEss = 5;
+    if (nEss > 250) nEss = 250;
+    return nEss;
+}
+
+// ---------------------------------------------------------------
+// Detail pane layouts
+// ---------------------------------------------------------------
+
+json SocBuildDetailEmpty(object oPC)
+{
+    float fBtnH = GetNuiScaleDimension(oPC, 28.0);
+
+    json jHint = NuiLabel(
+        JsonString("Wybierz kryształ z listy..."),
+        JsonInt(NUI_HALIGN_CENTER),
+        JsonInt(NUI_VALIGN_MIDDLE));
+
+    json jHintRow = JsonArray();
+    jHintRow = JsonArrayInsert(jHintRow, jHint);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+    jCol = JsonArrayInsert(jCol, NuiHeight(NuiRow(jHintRow), fBtnH));
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+    return NuiCol(jCol);
+}
+
+json SocBuildDetailFilled(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 28.0);
+    float fHdrH  = GetNuiScaleDimension(oPC, 34.0);
+    float fLblW  = GetNuiScaleDimension(oPC, 88.0);
+    float fGapH  = GetNuiScaleDimension(oPC, 6.0);
+
+    // Soul name header (gold tint)
+    json jNameLbl = NuiLabel(
+        NuiBind(SOC_BIND_DET_NAME),
+        JsonInt(NUI_HALIGN_CENTER),
+        JsonInt(NUI_VALIGN_MIDDLE));
+    jNameLbl = NuiStyleForegroundColor(jNameLbl, NuiColor(220, 160, 80));
+
+    // Info row helper macros (inlined since NWScript has no nested functions)
+    // --- Race row ---
+    json jRaceLbl = NuiLabel(JsonString("Gatunek:"),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRaceLbl = NuiWidth(jRaceLbl, fLblW);
+    json jRaceVal = NuiLabel(NuiBind(SOC_BIND_DET_RACE),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    json jRaceRow = JsonArray();
+    jRaceRow = JsonArrayInsert(jRaceRow, jRaceLbl);
+    jRaceRow = JsonArrayInsert(jRaceRow, jRaceVal);
+
+    // --- Essence row ---
+    json jEssLbl = NuiLabel(JsonString("Esencja:"),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jEssLbl = NuiWidth(jEssLbl, fLblW);
+    json jEssVal = NuiLabel(NuiBind(SOC_BIND_DET_ESS),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    json jEssRow = JsonArray();
+    jEssRow = JsonArrayInsert(jEssRow, jEssLbl);
+    jEssRow = JsonArrayInsert(jEssRow, jEssVal);
+
+    // --- Tier row ---
+    json jTierLbl = NuiLabel(JsonString("Kryształ:"),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTierLbl = NuiWidth(jTierLbl, fLblW);
+    json jTierVal = NuiLabel(NuiBind(SOC_BIND_DET_TIER),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    json jTierRow = JsonArray();
+    jTierRow = JsonArrayInsert(jTierRow, jTierLbl);
+    jTierRow = JsonArrayInsert(jTierRow, jTierVal);
+
+    // Section label
+    json jDivLbl = NuiLabel(JsonString("─── Wydaj Esencję ───"),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+
+    // Buff button row 1: Strength | Wisdom+Int
+    json jStrBtn = NuiButton(JsonString("Moc Siły"));
+    jStrBtn = NuiId(jStrBtn, SOC_BTN_STR);
+    jStrBtn = NuiEnabled(jStrBtn, NuiBind(SOC_BIND_BTN_STR_ENA));
+    jStrBtn = NuiTooltip(jStrBtn, JsonString("Wzmocnienie Siły na kilka minut. Zużywa połowę esencji."));
+
+    json jWisBtn = NuiButton(JsonString("Bystrość Ducha"));
+    jWisBtn = NuiId(jWisBtn, SOC_BTN_WIS);
+    jWisBtn = NuiEnabled(jWisBtn, NuiBind(SOC_BIND_BTN_WIS_ENA));
+    jWisBtn = NuiTooltip(jWisBtn, JsonString("Wzmocnienie Mądrości i Inteligencji. Zużywa połowę esencji."));
+
+    json jBuff1Row = JsonArray();
+    jBuff1Row = JsonArrayInsert(jBuff1Row, jStrBtn);
+    jBuff1Row = JsonArrayInsert(jBuff1Row, jWisBtn);
+
+    // Buff button row 2: AC | Regen
+    json jAcBtn = NuiButton(JsonString("Pancerz Duszy"));
+    jAcBtn = NuiId(jAcBtn, SOC_BTN_AC);
+    jAcBtn = NuiEnabled(jAcBtn, NuiBind(SOC_BIND_BTN_AC_ENA));
+    jAcBtn = NuiTooltip(jAcBtn, JsonString("Eteryczna powłoka zwiększa Pancerz. Zużywa połowę esencji."));
+
+    json jRegBtn = NuiButton(JsonString("Regeneracja"));
+    jRegBtn = NuiId(jRegBtn, SOC_BTN_REGEN);
+    jRegBtn = NuiEnabled(jRegBtn, NuiBind(SOC_BIND_BTN_REG_ENA));
+    jRegBtn = NuiTooltip(jRegBtn, JsonString("Powolne odnawianie ran przez czas trwania efektu. Zużywa połowę esencji."));
+
+    json jBuff2Row = JsonArray();
+    jBuff2Row = JsonArrayInsert(jBuff2Row, jAcBtn);
+    jBuff2Row = JsonArrayInsert(jBuff2Row, jRegBtn);
+
+    // Full consume (uses whole crystal, 5min CD)
+    json jFullBtn = NuiButton(JsonString("⚡ Wchłonij Całość"));
+    jFullBtn = NuiId(jFullBtn, SOC_BTN_FULL);
+    jFullBtn = NuiEnabled(jFullBtn, NuiBind(SOC_BIND_BTN_FULL_ENA));
+    jFullBtn = NuiHeight(jFullBtn, fBtnH);
+    jFullBtn = NuiTooltip(jFullBtn, JsonString(
+        "Pochłania całą esencję — silne, krótkie wzmocnienie wszystkich statystyk. Odnowienie: 5 minut."));
+    json jFullRow = JsonArray();
+    jFullRow = JsonArrayInsert(jFullRow, jFullBtn);
+
+    // Release for gold
+    json jRelBtn = NuiButton(JsonString("Uwolnij Duszę"));
+    jRelBtn = NuiId(jRelBtn, SOC_BTN_RELEASE);
+    jRelBtn = NuiEnabled(jRelBtn, NuiBind(SOC_BIND_BTN_REL_ENA));
+    jRelBtn = NuiHeight(jRelBtn, fBtnH);
+    jRelBtn = NuiTooltip(jRelBtn, JsonString("Uwalnia duszę w zamian za odrobinę złota."));
+    json jRelRow = JsonArray();
+    jRelRow = JsonArrayInsert(jRelRow, jRelBtn);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiHeight(NuiRow(JsonArrayInsert(JsonArray(), jNameLbl)), fHdrH));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, fGapH));
+    jCol = JsonArrayInsert(jCol, NuiRow(jRaceRow));
+    jCol = JsonArrayInsert(jCol, NuiRow(jEssRow));
+    jCol = JsonArrayInsert(jCol, NuiRow(jTierRow));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, fGapH * 2.0));
+    jCol = JsonArrayInsert(jCol, NuiHeight(NuiRow(JsonArrayInsert(JsonArray(), jDivLbl)), fBtnH));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, fGapH));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBuff1Row));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, fGapH));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBuff2Row));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, fGapH));
+    jCol = JsonArrayInsert(jCol, NuiRow(jFullRow));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, fGapH));
+    jCol = JsonArrayInsert(jCol, NuiRow(jRelRow));
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+    return NuiCol(jCol);
+}
+
+// ---------------------------------------------------------------
+// Feed functions
+// ---------------------------------------------------------------
+
+void SocFeedDetail(object oPC, int nToken)
+{
+    int nId = GetLocalInt(oPC, SOC_LVAR_SEL_ID);
+    if (nId <= 0)
+    {
+        NuiSetGroupLayout(oPC, nToken, SOC_GRP_DETAIL, SocBuildDetailEmpty(oPC));
+        return;
+    }
+
+    json jCrystal = SocGetCrystalById(nId);
+    if (JsonGetType(jCrystal) == JSON_TYPE_NULL)
+    {
+        // Crystal was deleted (consumed/released)
+        SetLocalInt(oPC, SOC_LVAR_SEL_ID, 0);
+        NuiSetGroupLayout(oPC, nToken, SOC_GRP_DETAIL, SocBuildDetailEmpty(oPC));
+        return;
+    }
+
+    NuiSetGroupLayout(oPC, nToken, SOC_GRP_DETAIL, SocBuildDetailFilled(oPC));
+
+    string sSoulName = JsonGetString(JsonObjectGet(jCrystal, "soul_name"));
+    int nRaceCat     = JsonGetInt   (JsonObjectGet(jCrystal, "race_cat"));
+    int nEssence     = JsonGetInt   (JsonObjectGet(jCrystal, "essence"));
+    int nTier        = JsonGetInt   (JsonObjectGet(jCrystal, "tier"));
+
+    NuiSetBind(oPC, nToken, SOC_BIND_DET_NAME,  JsonString(sSoulName));
+    NuiSetBind(oPC, nToken, SOC_BIND_DET_RACE,  JsonString(SocGetRaceCatName(nRaceCat)));
+    NuiSetBind(oPC, nToken, SOC_BIND_DET_ESS,   JsonString(IntToString(nEssence)));
+    NuiSetBind(oPC, nToken, SOC_BIND_DET_TIER,  JsonString(SocGetTierName(nTier)));
+
+    // Full-consume button respects 5-minute cooldown
+    int bFullOk = TRUE;
+    int nLast   = SocGetLastFullConsume(oPC);
+    if (nLast > 0)
+        bFullOk = ((SocGetNowUnix() - nLast) >= SOC_FULL_CD_SECS);
+
+    NuiSetBind(oPC, nToken, SOC_BIND_BTN_STR_ENA,  JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, SOC_BIND_BTN_WIS_ENA,  JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, SOC_BIND_BTN_AC_ENA,   JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, SOC_BIND_BTN_REG_ENA,  JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, SOC_BIND_BTN_FULL_ENA, JsonBool(bFullOk));
+    NuiSetBind(oPC, nToken, SOC_BIND_BTN_REL_ENA,  JsonBool(TRUE));
+}
+
+void SocFeedList(object oPC, int nToken)
+{
+    json jCrystals = SocGetCrystals(oPC);
+    int nCount     = JsonGetLength(jCrystals);
+
+    json jNames  = JsonArray();
+    json jTiers  = JsonArray();
+    json jEsss   = JsonArray();
+    json jEncs   = JsonArray();
+    json jColors = JsonArray();
+
+    int nSelId = GetLocalInt(oPC, SOC_LVAR_SEL_ID);
+
+    int i;
+    for (i = 0; i < nCount; i++)
+    {
+        json jRow    = JsonArrayGet(jCrystals, i);
+        int  nId     = JsonGetInt   (JsonObjectGet(jRow, "id"));
+        string sName = JsonGetString(JsonObjectGet(jRow, "soul_name"));
+        int  nTier   = JsonGetInt   (JsonObjectGet(jRow, "tier"));
+        int  nEss    = JsonGetInt   (JsonObjectGet(jRow, "essence"));
+
+        jNames = JsonArrayInsert(jNames, JsonString(sName));
+        jTiers = JsonArrayInsert(jTiers, JsonString(SocGetTierName(nTier)));
+        jEsss  = JsonArrayInsert(jEsss,  JsonString(IntToString(nEss)));
+        jEncs  = JsonArrayInsert(jEncs,  JsonBool(nId == nSelId));
+
+        json jColor = NuiColor(140, 130, 120);  // cracked: dim gray
+        if      (nTier == SOC_TIER_FLAWLESS) jColor = NuiColor(220, 160,  80);  // gold
+        else if (nTier == SOC_TIER_GREATER)  jColor = NuiColor(140, 190, 255);  // steel blue
+        else if (nTier == SOC_TIER_COMMON)   jColor = NuiColor(200, 200, 200);  // light gray
+        jColors = JsonArrayInsert(jColors, jColor);
+    }
+
+    NuiSetBind(oPC, nToken, SOC_BIND_ROW_NAME,  jNames);
+    NuiSetBind(oPC, nToken, SOC_BIND_ROW_TIER,  jTiers);
+    NuiSetBind(oPC, nToken, SOC_BIND_ROW_ESS,   jEsss);
+    NuiSetBind(oPC, nToken, SOC_BIND_ROW_ENC,   jEncs);
+    NuiSetBind(oPC, nToken, SOC_BIND_ROW_COLOR, jColors);
+
+    NuiSetBind(oPC, nToken, SOC_BIND_CAP_LBL,
+        JsonString("Pojemność: " + IntToString(nCount) + "/" + IntToString(SOC_MAX_CRYSTALS)));
+
+    NuiSetBind(oPC, nToken, SOC_BIND_BTN_BIND_ENA, JsonBool(nCount < SOC_MAX_CRYSTALS));
+
+    // row count LAST — triggers list re-render once all data is ready
+    NuiSetBind(oPC, nToken, SOC_BIND_ROW_COUNT, JsonInt(nCount));
+}
+
+void SocFeedStats(object oPC, int nToken)
+{
+    json jStats = SocGetPlayerStats(oPC);
+    if (JsonGetType(jStats) == JSON_TYPE_NULL) return;
+
+    int nCap   = JsonGetInt(JsonObjectGet(jStats, "total_captured"));
+    int nSpent = JsonGetInt(JsonObjectGet(jStats, "total_essence_spent"));
+
+    NuiSetBind(oPC, nToken, SOC_BIND_STATS_LBL,
+        JsonString("Schwytano: " + IntToString(nCap) + "  |  Wydano esencji: " + IntToString(nSpent)));
+}
+
+// ---------------------------------------------------------------
+// Window construction
+// ---------------------------------------------------------------
+
+void SocOpenWindow(object oPC)
+{
+    // Reopen: destroy existing instance first
+    int nExisting = NuiFindWindow(oPC, SOC_WINDOW);
+    if (nExisting != 0)
+        NuiDestroy(oPC, nExisting);
+
+    float fW     = GetNuiScaleDimension(oPC, SOC_WIN_W);
+    float fH     = GetNuiScaleDimension(oPC, SOC_WIN_H);
+    float fBtnH  = GetNuiScaleDimension(oPC, 28.0);
+    float fRowH  = GetNuiScaleDimension(oPC, 26.0);
+    float fListH = GetNuiScaleDimension(oPC, 320.0);
+    float fLeftW = GetNuiScaleDimension(oPC, 240.0);
+
+    // ---- Title bar ----
+    json jTitleLbl = NuiLabel(
+        JsonString("⚗  Kryształy Dusz"),
+        JsonInt(NUI_HALIGN_LEFT),
+        JsonInt(NUI_VALIGN_MIDDLE));
+    jTitleLbl = NuiStyleForegroundColor(jTitleLbl, NuiColor(220, 160, 80));
+
+    json jCloseBtn = NuiButton(JsonString("X"));
+    jCloseBtn = NuiId(jCloseBtn, SOC_BTN_CLOSE);
+    jCloseBtn = NuiWidth (jCloseBtn, GetNuiScaleDimension(oPC, 28.0));
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jTopRow = JsonArray();
+    jTopRow = JsonArrayInsert(jTopRow, jTitleLbl);
+    jTopRow = JsonArrayInsert(jTopRow, jCloseBtn);
+
+    // ---- Crystal list template ----
+    float fTierW = GetNuiScaleDimension(oPC, 72.0);
+    float fEssW  = GetNuiScaleDimension(oPC, 44.0);
+
+    json jRowName = NuiLabel(NuiBind(SOC_BIND_ROW_NAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRowName = NuiStyleForegroundColor(jRowName, NuiBind(SOC_BIND_ROW_COLOR));
+
+    json jRowTier = NuiLabel(NuiBind(SOC_BIND_ROW_TIER),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jRowTier = NuiWidth(jRowTier, fTierW);
+    jRowTier = NuiStyleForegroundColor(jRowTier, NuiBind(SOC_BIND_ROW_COLOR));
+
+    json jRowEss = NuiLabel(NuiBind(SOC_BIND_ROW_ESS),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRowEss = NuiWidth(jRowEss, fEssW);
+    jRowEss = NuiStyleForegroundColor(jRowEss, NuiBind(SOC_BIND_ROW_COLOR));
+
+    json jCellRow = JsonArray();
+    jCellRow = JsonArrayInsert(jCellRow, jRowName);
+    jCellRow = JsonArrayInsert(jCellRow, jRowTier);
+    jCellRow = JsonArrayInsert(jCellRow, jRowEss);
+
+    json jCell = NuiGroup(NuiRow(jCellRow), TRUE, NUI_SCROLLBARS_NONE);
+    jCell = NuiId(jCell, SOC_BTN_ROW);
+    jCell = NuiEncouraged(jCell, NuiBind(SOC_BIND_ROW_ENC));
+
+    json jTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jCell, 0.0, TRUE));
+    json jList = NuiList(jTmpl, NuiBind(SOC_BIND_ROW_COUNT), fRowH);
+    jList = NuiHeight(jList, fListH);
+
+    // ---- Bind + capacity row ----
+    json jBindBtn = NuiButton(JsonString("Zwiąż Duszę"));
+    jBindBtn = NuiId(jBindBtn, SOC_BTN_BIND);
+    jBindBtn = NuiEnabled(jBindBtn, NuiBind(SOC_BIND_BTN_BIND_ENA));
+    jBindBtn = NuiTooltip(jBindBtn,
+        JsonString("Celuj w osłabione stworzenie (HP ≤ 25%), by schwytać jego duszę."));
+
+    json jCapLbl = NuiLabel(NuiBind(SOC_BIND_CAP_LBL),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jCapLbl = NuiWidth(jCapLbl, GetNuiScaleDimension(oPC, 88.0));
+
+    json jBindRow = JsonArray();
+    jBindRow = JsonArrayInsert(jBindRow, jBindBtn);
+    jBindRow = JsonArrayInsert(jBindRow, jCapLbl);
+
+    // Left column
+    json jLeftCol = JsonArray();
+    jLeftCol = JsonArrayInsert(jLeftCol, jList);
+    jLeftCol = JsonArrayInsert(jLeftCol, NuiRow(jBindRow));
+    json jLeftGrp = NuiWidth(NuiCol(jLeftCol), fLeftW);
+
+    // Right column: detail group (content filled on demand by SocFeedDetail)
+    json jDetailGrp = NuiGroup(JsonNull(), TRUE, NUI_SCROLLBARS_NONE);
+    jDetailGrp = NuiId(jDetailGrp, SOC_GRP_DETAIL);
+
+    json jMainRow = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jLeftGrp);
+    jMainRow = JsonArrayInsert(jMainRow, jDetailGrp);
+
+    // Stats footer
+    json jStatsLbl = NuiLabel(NuiBind(SOC_BIND_STATS_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jStatsLbl = NuiHeight(jStatsLbl, GetNuiScaleDimension(oPC, 22.0));
+
+    // Root
+    json jRootCol = JsonArray();
+    jRootCol = JsonArrayInsert(jRootCol, NuiHeight(NuiRow(jTopRow), fBtnH));
+    jRootCol = JsonArrayInsert(jRootCol, NuiRow(jMainRow));
+    jRootCol = JsonArrayInsert(jRootCol, NuiRow(JsonArrayInsert(JsonArray(), jStatsLbl)));
+
+    json jRoot = NuiCol(jRootCol);
+
+    float fGuiW = IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH));
+    float fGuiH = IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT));
+    json jGeom  = NuiRect((fGuiW - SOC_WIN_W) / 2.0, (fGuiH - SOC_WIN_H) / 2.0, fW, fH);
+
+    json jWin = NuiWindow(jRoot,
+        JsonBool(FALSE),
+        NuiBind(SOC_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    int nToken = NuiCreate(oPC, jWin, SOC_WINDOW, SOC_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, SOC_WIN_GEOM, jGeom);
+
+    SocFeedList  (oPC, nToken);
+    SocFeedDetail(oPC, nToken);
+    SocFeedStats (oPC, nToken);
+}
+
+// ---------------------------------------------------------------
+// Consume logic
+// ---------------------------------------------------------------
+
+// nConsumeType: 1=STR, 2=WIS+INT, 3=AC, 4=REGEN, 5=FULL
+void SocConsumeFor(object oPC, int nToken, int nCrystalId, int nConsumeType)
+{
+    json jCrystal = SocGetCrystalById(nCrystalId);
+    if (JsonGetType(jCrystal) == JSON_TYPE_NULL) return;
+
+    int nEssence = JsonGetInt(JsonObjectGet(jCrystal, "essence"));
+    float fDur   = SocCalcDuration(nEssence);
+
+    effect eEffect;
+    string sMsg;
+    int nCostEss;
+    int bRemoveCrystal = FALSE;
+
+    if (nConsumeType == 1)
+    {
+        int nBonus = 2 + (nEssence / 50);
+        if (nBonus > 8) nBonus = 8;
+        eEffect  = EffectAbilityIncrease(ABILITY_STRENGTH, nBonus);
+        nCostEss = nEssence / 2;
+        sMsg     = "Esencja duszy wzmacnia twe mięśnie. Siła wzrosła o " + IntToString(nBonus) + ".";
+    }
+    else if (nConsumeType == 2)
+    {
+        int nBonus = 2 + (nEssence / 50);
+        if (nBonus > 8) nBonus = 8;
+        eEffect  = EffectLinkEffects(
+            EffectAbilityIncrease(ABILITY_WISDOM,       nBonus),
+            EffectAbilityIncrease(ABILITY_INTELLIGENCE, nBonus));
+        nCostEss = nEssence / 2;
+        sMsg     = "Duch rozjaśnia umysł i percepcję. Mądrość i Inteligencja wzrosły o " + IntToString(nBonus) + ".";
+    }
+    else if (nConsumeType == 3)
+    {
+        int nAc  = 1 + (nEssence / 60);
+        if (nAc > 6) nAc = 6;
+        eEffect  = EffectACIncrease(nAc);
+        nCostEss = nEssence / 2;
+        sMsg     = "Eteryczna powłoka otacza twe ciało. Pancerz wzrósł o " + IntToString(nAc) + ".";
+    }
+    else if (nConsumeType == 4)
+    {
+        int nRegen = 1 + (nEssence / 80);
+        if (nRegen > 5) nRegen = 5;
+        eEffect  = EffectRegenerate(nRegen, 6.0);
+        nCostEss = nEssence / 2;
+        sMsg     = "Esencja duszy zszywa twe rany. Regenerujesz " + IntToString(nRegen) + " HP co rundę.";
+    }
+    else if (nConsumeType == 5)
+    {
+        int nLast = SocGetLastFullConsume(oPC);
+        if (nLast > 0 && (SocGetNowUnix() - nLast) < SOC_FULL_CD_SECS)
+        {
+            SendMessageToPC(oPC, "[Kryształy Dusz] Moc wchłonięcia jeszcze się nie odnowiła.");
+            return;
+        }
+
+        fDur = SocClampF(fDur * 0.5, 30.0, 300.0);
+        int nStr  = 4 + (nEssence / 50);  if (nStr  > 10) nStr  = 10;
+        int nAc   = 2 + (nEssence / 60);  if (nAc   > 8)  nAc   = 8;
+        int nReg  = 2 + (nEssence / 80);  if (nReg  > 6)  nReg  = 6;
+        int nWis  = nStr / 2 + 1;
+
+        eEffect = EffectLinkEffects(EffectAbilityIncrease(ABILITY_STRENGTH,     nStr),
+                  EffectLinkEffects(EffectAbilityIncrease(ABILITY_WISDOM,        nWis),
+                  EffectLinkEffects(EffectACIncrease(nAc),
+                  EffectLinkEffects(EffectRegenerate(nReg, 6.0),
+                                    EffectHaste()))));
+
+        nCostEss       = nEssence;
+        bRemoveCrystal = TRUE;
+        SocSetLastFullConsume(oPC);
+        sMsg = "Cała esencja wylewa się w falach mrocznej mocy. Duch przenika twe ciało...";
+    }
+
+    if (nCostEss < 5) nCostEss = 5;
+
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eEffect, oPC, fDur);
+    FloatingTextStringOnCreature(sMsg, oPC, FALSE);
+    SocRecordEssenceSpent(oPC, nCostEss);
+
+    if (bRemoveCrystal)
+    {
+        SocRemoveCrystal(nCrystalId);
+        SetLocalInt(oPC, SOC_LVAR_SEL_ID, 0);
+    }
+    else
+    {
+        int nNewEss = nEssence - nCostEss;
+        if (nNewEss <= 0)
+        {
+            SocRemoveCrystal(nCrystalId);
+            SetLocalInt(oPC, SOC_LVAR_SEL_ID, 0);
+            FloatingTextStringOnCreature("Kryształ rozsypuje się w pył — esencja wyczerpana.", oPC, FALSE);
+        }
+        else
+        {
+            SocSetCrystalEssence(nCrystalId, nNewEss);
+        }
+    }
+
+    SocFeedList  (oPC, nToken);
+    SocFeedDetail(oPC, nToken);
+    SocFeedStats (oPC, nToken);
+}
+
+void SocReleaseCrystal(object oPC, int nToken, int nCrystalId)
+{
+    json jCrystal = SocGetCrystalById(nCrystalId);
+    if (JsonGetType(jCrystal) == JSON_TYPE_NULL) return;
+
+    int nEssence = JsonGetInt(JsonObjectGet(jCrystal, "essence"));
+    int nTier    = JsonGetInt(JsonObjectGet(jCrystal, "tier"));
+    int nGold    = nTier * 5 + (nEssence / 10);
+    if (nGold < 1) nGold = 1;
+
+    GiveGoldToCreature(oPC, nGold);
+    FloatingTextStringOnCreature(
+        "Duch ulatuje w nicość. Otrzymujesz " + IntToString(nGold) + " sztuk złota.",
+        oPC, FALSE);
+
+    SocRemoveCrystal(nCrystalId);
+    SetLocalInt(oPC, SOC_LVAR_SEL_ID, 0);
+
+    SocFeedList  (oPC, nToken);
+    SocFeedDetail(oPC, nToken);
+    SocFeedStats (oPC, nToken);
+}
+
+// ---------------------------------------------------------------
+// Soul binding — called from sys_on_target.nss
+// ---------------------------------------------------------------
+
+void SocOnPlayerTarget(object oPC, object oTarget)
+{
+    DeleteLocalInt(oPC, SOC_LVAR_BINDING);
+
+    if (!GetIsObjectValid(oTarget) || GetObjectType(oTarget) != OBJECT_TYPE_CREATURE)
+    {
+        SendMessageToPC(oPC, "[Kryształy Dusz] Cel musi być żywą istotą.");
+        return;
+    }
+
+    if (GetIsPC(oTarget))
+    {
+        SendMessageToPC(oPC, "[Kryształy Dusz] Nie możesz schwytać duszy innego gracza.");
+        return;
+    }
+
+    if (GetIsDead(oTarget))
+    {
+        SendMessageToPC(oPC, "[Kryształy Dusz] Stworzenie już nie żyje — duch zdążył uciec.");
+        return;
+    }
+
+    // Must be weakened to ≤25% HP
+    int nMaxHP  = GetMaxHitPoints(oTarget);
+    int nCurHP  = GetCurrentHitPoints(oTarget);
+    if (nCurHP > (nMaxHP / 4))
+    {
+        SendMessageToPC(oPC,
+            "[Kryształy Dusz] Duch jest zbyt mocno osadzony w ciele — najpierw osłab swego wroga.");
+        return;
+    }
+
+    if (SocGetCrystalCount(oPC) >= SOC_MAX_CRYSTALS)
+    {
+        SendMessageToPC(oPC, "[Kryształy Dusz] Wszystkie sloty kryształów są zajęte.");
+        return;
+    }
+
+    string sSoulName = GetName(oTarget);
+    int    nRaceCat  = SocGetRaceCat(oTarget);
+    int    nEssence  = SocGetSoulEssence(oTarget);
+    int    nTier     = SocGetSoulTier(oTarget);
+
+    // Soul rend: kill the target and trigger visual on caster
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectDeath(TRUE, FALSE), oTarget);
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectVisualEffect(VFX_IMP_NEGATIVE_ENERGY), oPC);
+
+    SocAddCrystal(oPC, sSoulName, nRaceCat, nEssence, nTier);
+    SocRecordCapture(oPC);
+
+    FloatingTextStringOnCreature(
+        "Dusza „" + sSoulName + "" uwięziona w krysztale " + SocGetTierName(nTier) +
+        ". Esencja: " + IntToString(nEssence) + ".",
+        oPC, FALSE);
+
+    // Refresh the window if it's open
+    int nToken = NuiFindWindow(oPC, SOC_WINDOW);
+    if (nToken != 0)
+    {
+        SocFeedList (oPC, nToken);
+        SocFeedStats(oPC, nToken);
+    }
+}

--- a/Soul Crystals/Scripts/lib_soc_def.nss
+++ b/Soul Crystals/Scripts/lib_soc_def.nss
@@ -1,0 +1,116 @@
+// lib_soc_def.nss — Soul Crystals: constants, bind names, forward declarations.
+
+#include "lib_nui"
+#include "sql_soc"
+
+// Forward declarations (implementations in lib_soc.nss)
+void SocOpenWindow(object oPC);
+void SocFeedList(object oPC, int nToken);
+void SocFeedDetail(object oPC, int nToken);
+void SocFeedStats(object oPC, int nToken);
+void SocOnPlayerTarget(object oPC, object oTarget);
+void SocConsumeFor(object oPC, int nToken, int nCrystalId, int nConsumeType);
+void SocReleaseCrystal(object oPC, int nToken, int nCrystalId);
+
+// ---------------------------------------------------------------
+// Window / event IDs
+// ---------------------------------------------------------------
+
+const string SOC_WINDOW     = "SOC_WINDOW";
+const string SOC_EV_SCRIPT  = "lib_soc_ev";
+const string SOC_WIN_GEOM   = "soc_win_geom";
+const string SOC_GRP_DETAIL = "soc_grp_detail";  // swappable detail pane
+
+// ---------------------------------------------------------------
+// List binds  (NuiList array-per-row pattern)
+// ---------------------------------------------------------------
+
+const string SOC_BIND_ROW_NAME  = "soc_row_name";
+const string SOC_BIND_ROW_TIER  = "soc_row_tier";
+const string SOC_BIND_ROW_ESS   = "soc_row_ess";
+const string SOC_BIND_ROW_ENC   = "soc_row_enc";
+const string SOC_BIND_ROW_COLOR = "soc_row_color";
+const string SOC_BIND_ROW_COUNT = "soc_row_count";
+
+// ---------------------------------------------------------------
+// Detail pane binds  (set after NuiSetGroupLayout each time)
+// ---------------------------------------------------------------
+
+const string SOC_BIND_DET_NAME     = "soc_det_name";
+const string SOC_BIND_DET_RACE     = "soc_det_race";
+const string SOC_BIND_DET_ESS      = "soc_det_ess";
+const string SOC_BIND_DET_TIER     = "soc_det_tier";
+const string SOC_BIND_BTN_STR_ENA  = "soc_btn_str_ena";
+const string SOC_BIND_BTN_WIS_ENA  = "soc_btn_wis_ena";
+const string SOC_BIND_BTN_AC_ENA   = "soc_btn_ac_ena";
+const string SOC_BIND_BTN_REG_ENA  = "soc_btn_reg_ena";
+const string SOC_BIND_BTN_FULL_ENA = "soc_btn_full_ena";
+const string SOC_BIND_BTN_REL_ENA  = "soc_btn_rel_ena";
+
+// ---------------------------------------------------------------
+// Header / footer binds
+// ---------------------------------------------------------------
+
+const string SOC_BIND_CAP_LBL   = "soc_cap_lbl";
+const string SOC_BIND_STATS_LBL = "soc_stats_lbl";
+const string SOC_BIND_BTN_BIND_ENA = "soc_btn_bnd_ena";
+
+// ---------------------------------------------------------------
+// Button IDs
+// ---------------------------------------------------------------
+
+const string SOC_BTN_CLOSE   = "soc_btn_close";
+const string SOC_BTN_ROW     = "soc_btn_row";
+const string SOC_BTN_BIND    = "soc_btn_bind";
+const string SOC_BTN_STR     = "soc_btn_str";
+const string SOC_BTN_WIS     = "soc_btn_wis";
+const string SOC_BTN_AC      = "soc_btn_ac";
+const string SOC_BTN_REGEN   = "soc_btn_regen";
+const string SOC_BTN_FULL    = "soc_btn_full";
+const string SOC_BTN_RELEASE = "soc_btn_release";
+
+// ---------------------------------------------------------------
+// LVARs on PC
+// ---------------------------------------------------------------
+
+const string SOC_LVAR_SEL_ID  = "SOC_SEL_ID";   // currently selected crystal DB id (0=none)
+const string SOC_LVAR_BINDING = "SOC_BINDING";  // 1 while targeting mode is active
+
+// ---------------------------------------------------------------
+// Race categories
+// ---------------------------------------------------------------
+
+const int SOC_RACE_HUMANOID = 1;  // humans, elves, gnomes, half-*, goblinoids, etc.
+const int SOC_RACE_BEAST    = 2;  // animals, magical beasts, vermin, dragons
+const int SOC_RACE_UNDEAD   = 3;  // undead
+const int SOC_RACE_OUTSIDER = 4;  // outsiders, elementals, fey
+
+// ---------------------------------------------------------------
+// Crystal tiers
+// ---------------------------------------------------------------
+
+const int SOC_TIER_CRACKED  = 1;
+const int SOC_TIER_COMMON   = 2;
+const int SOC_TIER_GREATER  = 3;
+const int SOC_TIER_FLAWLESS = 4;
+
+// ---------------------------------------------------------------
+// Tuning
+// ---------------------------------------------------------------
+
+const int SOC_MAX_CRYSTALS   = 8;    // max crystal slots per player
+
+// Buff duration = (essence / 100) * DUR_PER_100 seconds
+const float SOC_DUR_PER_100  = 120.0;   // 2 minutes per 100 essence
+const float SOC_DUR_MIN      = 60.0;
+const float SOC_DUR_MAX      = 600.0;   // hard cap: 10 minutes
+
+// Full-consume power multiplier uses half-duration but is stronger
+const int SOC_FULL_CD_SECS   = 300;     // 5 minute cooldown between full consumes
+
+// ---------------------------------------------------------------
+// Window layout
+// ---------------------------------------------------------------
+
+const float SOC_WIN_W = 640.0;
+const float SOC_WIN_H = 480.0;

--- a/Soul Crystals/Scripts/lib_soc_ev.nss
+++ b/Soul Crystals/Scripts/lib_soc_ev.nss
@@ -1,0 +1,68 @@
+// lib_soc_ev.nss — Soul Crystals: NUI event handler.
+
+#include "lib_soc"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    if (nToken != NuiFindWindow(oPC, SOC_WINDOW)) return;
+
+    if (sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalInt(oPC, SOC_LVAR_SEL_ID);
+        DeleteLocalInt(oPC, SOC_LVAR_BINDING);
+        return;
+    }
+
+    if (sEvent == EVENT_TYPE_CLICK)
+    {
+        if (sElem == SOC_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        if (sElem == SOC_BTN_BIND)
+        {
+            if (SocGetCrystalCount(oPC) >= SOC_MAX_CRYSTALS)
+            {
+                SendMessageToPC(oPC, "[Kryształy Dusz] Wszystkie sloty kryształów są zajęte.");
+                return;
+            }
+            SetLocalInt(oPC, SOC_LVAR_BINDING, 1);
+            EnterTargetingMode(oPC, OBJECT_TYPE_CREATURE);
+            SendMessageToPC(oPC,
+                "[Kryształy Dusz] Wskaż osłabione stworzenie (HP ≤ 25%), by schwytać jego duszę.");
+            return;
+        }
+
+        // Consume / release buttons — require a selected crystal
+        int nSelId = GetLocalInt(oPC, SOC_LVAR_SEL_ID);
+        if (nSelId <= 0) return;
+
+        if (sElem == SOC_BTN_STR)     { SocConsumeFor(oPC, nToken, nSelId, 1); return; }
+        if (sElem == SOC_BTN_WIS)     { SocConsumeFor(oPC, nToken, nSelId, 2); return; }
+        if (sElem == SOC_BTN_AC)      { SocConsumeFor(oPC, nToken, nSelId, 3); return; }
+        if (sElem == SOC_BTN_REGEN)   { SocConsumeFor(oPC, nToken, nSelId, 4); return; }
+        if (sElem == SOC_BTN_FULL)    { SocConsumeFor(oPC, nToken, nSelId, 5); return; }
+        if (sElem == SOC_BTN_RELEASE) { SocReleaseCrystal(oPC, nToken, nSelId); return; }
+    }
+
+    if (sEvent == EVENT_TYPE_MOUSEDOWN && sElem == SOC_BTN_ROW)
+    {
+        json jCrystals = SocGetCrystals(oPC);
+        if (nIdx < 0 || nIdx >= JsonGetLength(jCrystals)) return;
+
+        json jRow = JsonArrayGet(jCrystals, nIdx);
+        int  nId  = JsonGetInt(JsonObjectGet(jRow, "id"));
+
+        SetLocalInt(oPC, SOC_LVAR_SEL_ID, nId);
+        SocFeedList  (oPC, nToken);
+        SocFeedDetail(oPC, nToken);
+    }
+}

--- a/Soul Crystals/Scripts/sql_soc.nss
+++ b/Soul Crystals/Scripts/sql_soc.nss
@@ -1,0 +1,172 @@
+// sql_soc.nss — Soul Crystals: SQLite schema and query helpers.
+// Campaign DB: "soc"
+
+void SocCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("soc",
+        "CREATE TABLE IF NOT EXISTS soc_crystals ("
+        "  id            INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "  owner_uuid    TEXT    NOT NULL,"
+        "  soul_name     TEXT    NOT NULL DEFAULT 'Duch',"
+        "  race_cat      INTEGER NOT NULL DEFAULT 1,"
+        "  essence       INTEGER NOT NULL DEFAULT 10,"
+        "  tier          INTEGER NOT NULL DEFAULT 1,"
+        "  captured_at   INTEGER DEFAULT (strftime('%s','now'))"
+        ")");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("soc",
+        "CREATE TABLE IF NOT EXISTS soc_players ("
+        "  uuid                 TEXT PRIMARY KEY,"
+        "  total_captured       INTEGER DEFAULT 0,"
+        "  total_essence_spent  INTEGER DEFAULT 0,"
+        "  last_full_consume    INTEGER DEFAULT 0"
+        ")");
+    SqlStep(q);
+}
+
+void SocRegisterPlayer(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("soc",
+        "INSERT OR IGNORE INTO soc_players (uuid) VALUES (@uuid)");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+int SocGetCrystalCount(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("soc",
+        "SELECT COUNT(*) FROM soc_crystals WHERE owner_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if (SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// Returns new crystal id (0 on failure)
+int SocAddCrystal(object oPC, string sSoulName, int nRaceCat, int nEssence, int nTier)
+{
+    sqlquery q = SqlPrepareQueryCampaign("soc",
+        "INSERT INTO soc_crystals (owner_uuid, soul_name, race_cat, essence, tier) "
+        "VALUES (@uuid, @name, @race, @ess, @tier)");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindString(q, "@name", sSoulName);
+    SqlBindInt(q, "@race", nRaceCat);
+    SqlBindInt(q, "@ess",  nEssence);
+    SqlBindInt(q, "@tier", nTier);
+    SqlStep(q);
+    sqlquery qId = SqlPrepareQueryCampaign("soc", "SELECT last_insert_rowid()");
+    if (SqlStep(qId)) return SqlGetInt(qId, 0);
+    return 0;
+}
+
+void SocRemoveCrystal(int nId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("soc",
+        "DELETE FROM soc_crystals WHERE id = @id");
+    SqlBindInt(q, "@id", nId);
+    SqlStep(q);
+}
+
+void SocSetCrystalEssence(int nId, int nNewEssence)
+{
+    sqlquery q = SqlPrepareQueryCampaign("soc",
+        "UPDATE soc_crystals SET essence = @ess WHERE id = @id");
+    SqlBindInt(q, "@ess", nNewEssence);
+    SqlBindInt(q, "@id",  nId);
+    SqlStep(q);
+}
+
+// Returns JsonArray of {id, soul_name, race_cat, essence, tier}
+json SocGetCrystals(object oPC)
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("soc",
+        "SELECT id, soul_name, race_cat, essence, tier "
+        "FROM soc_crystals WHERE owner_uuid = @uuid ORDER BY tier DESC, essence DESC");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    while (SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "id",        JsonInt   (SqlGetInt   (q, 0)));
+        jRow = JsonObjectSet(jRow, "soul_name",  JsonString(SqlGetString(q, 1)));
+        jRow = JsonObjectSet(jRow, "race_cat",   JsonInt   (SqlGetInt   (q, 2)));
+        jRow = JsonObjectSet(jRow, "essence",    JsonInt   (SqlGetInt   (q, 3)));
+        jRow = JsonObjectSet(jRow, "tier",       JsonInt   (SqlGetInt   (q, 4)));
+        jRows = JsonArrayInsert(jRows, jRow);
+    }
+    return jRows;
+}
+
+// Returns single crystal object or JsonNull()
+json SocGetCrystalById(int nId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("soc",
+        "SELECT id, soul_name, race_cat, essence, tier "
+        "FROM soc_crystals WHERE id = @id");
+    SqlBindInt(q, "@id", nId);
+    if (!SqlStep(q)) return JsonNull();
+    json jRow = JsonObject();
+    jRow = JsonObjectSet(jRow, "id",        JsonInt   (SqlGetInt   (q, 0)));
+    jRow = JsonObjectSet(jRow, "soul_name",  JsonString(SqlGetString(q, 1)));
+    jRow = JsonObjectSet(jRow, "race_cat",   JsonInt   (SqlGetInt   (q, 2)));
+    jRow = JsonObjectSet(jRow, "essence",    JsonInt   (SqlGetInt   (q, 3)));
+    jRow = JsonObjectSet(jRow, "tier",       JsonInt   (SqlGetInt   (q, 4)));
+    return jRow;
+}
+
+void SocRecordCapture(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("soc",
+        "UPDATE soc_players SET total_captured = total_captured + 1 WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+void SocRecordEssenceSpent(object oPC, int nAmt)
+{
+    sqlquery q = SqlPrepareQueryCampaign("soc",
+        "UPDATE soc_players SET total_essence_spent = total_essence_spent + @amt WHERE uuid = @uuid");
+    SqlBindInt   (q, "@amt",  nAmt);
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+void SocSetLastFullConsume(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("soc",
+        "UPDATE soc_players SET last_full_consume = strftime('%s','now') WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+int SocGetLastFullConsume(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("soc",
+        "SELECT last_full_consume FROM soc_players WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if (SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// Returns current unix timestamp via SQLite
+int SocGetNowUnix()
+{
+    sqlquery q = SqlPrepareQueryCampaign("soc", "SELECT strftime('%s','now')");
+    if (SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// Returns {total_captured, total_essence_spent, last_full_consume} or JsonNull
+json SocGetPlayerStats(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("soc",
+        "SELECT total_captured, total_essence_spent, last_full_consume "
+        "FROM soc_players WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if (!SqlStep(q)) return JsonNull();
+    json j = JsonObject();
+    j = JsonObjectSet(j, "total_captured",      JsonInt(SqlGetInt(q, 0)));
+    j = JsonObjectSet(j, "total_essence_spent",  JsonInt(SqlGetInt(q, 1)));
+    j = JsonObjectSet(j, "last_full_consume",    JsonInt(SqlGetInt(q, 2)));
+    return j;
+}

--- a/Soul Crystals/Scripts/sys_on_enter.nss
+++ b/Soul Crystals/Scripts/sys_on_enter.nss
@@ -1,0 +1,21 @@
+// sys_on_enter.nss — Soul Crystals: module OnClientEnter hook.
+// Registers the player in the soul tracking table and notifies
+// them if they have stored crystals waiting to be used.
+
+#include "lib_soc"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if (!GetIsPC(oPC)) return;
+
+    SocRegisterPlayer(oPC);
+
+    int nCount = SocGetCrystalCount(oPC);
+    if (nCount > 0)
+    {
+        string sMsg = "[Kryształy Dusz] Posiadasz " + IntToString(nCount)
+            + " schwytanych dusz. Odwiedź Kuźnię Dusz, by je wykorzystać.";
+        DelayCommand(3.0, SendMessageToPC(oPC, sMsg));
+    }
+}

--- a/Soul Crystals/Scripts/sys_on_load.nss
+++ b/Soul Crystals/Scripts/sys_on_load.nss
@@ -1,0 +1,9 @@
+// sys_on_load.nss — Soul Crystals: module OnModuleLoad hook.
+// Creates persistent SQLite tables for the soc campaign database.
+
+#include "lib_soc_def"
+
+void main()
+{
+    SocCreateTables();
+}

--- a/Soul Crystals/Scripts/sys_on_target.nss
+++ b/Soul Crystals/Scripts/sys_on_target.nss
@@ -1,0 +1,16 @@
+// sys_on_target.nss — Soul Crystals: module OnPlayerTarget hook.
+// Forwards targeting events to the soul-binding handler only when
+// the player is in soul-capture mode (SOC_LVAR_BINDING == 1).
+
+#include "lib_soc"
+
+void main()
+{
+    object oPC = GetLastPlayerToSelectTarget();
+    if (!GetIsPC(oPC)) return;
+
+    if (!GetLocalInt(oPC, SOC_LVAR_BINDING)) return;
+
+    object oTarget = GetTargetingModeSelectedObject();
+    SocOnPlayerTarget(oPC, oTarget);
+}

--- a/Soul Crystals/Scripts/test_soc.nss
+++ b/Soul Crystals/Scripts/test_soc.nss
@@ -1,0 +1,15 @@
+// test_soc.nss — Soul Crystals: demo OnUsed script for the Soul Forge placeable.
+// Attach this script to any placeable's OnUsed event to open the Soul Crystals UI.
+// The placeable acts as the Soul Forge — the access point for managing crystals.
+
+#include "lib_soc"
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if (!GetIsPC(oPC)) return;
+
+    // Ensure the player has a row in soc_players before opening the window
+    SocRegisterPlayer(oPC);
+    SocOpenWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

Moduł **Kryształy Dusz** pozwala graczom schwytywać dusze pokonanych wrogów do kryształów, a następnie zużywać zgromadzoną esencję na tymczasowe wzmocnienia bojowe. Całość działa przez dedykowany panel NUI (Kuźnię Dusz) i persystentną bazę SQLite.

## Mechanika

1. **Schwytanie duszy** — gracz klika „Zwiąż Duszę" w oknie Kuźni Dusz, przechodzi w tryb celowania i wskazuje stworzenie z HP ≤ 25%. Stworzenie ginie efektem `EffectDeath`, a jego dusza trafia do slotu kryształowego (max 8 na gracza).

2. **Klasy kryształów** — cztery tiery wyznaczone przez rasę celu i HD: Popękany (humanoid/niskie HD), Zwykły (bestie/HD 4+), Wyższy (nieumarli/HD 8+), Nieskazitelny (przybysze/HD 15+). Tier determinuje kolor wiersza w liście (szary → biały → niebieski → złoty).

3. **Zużycie esencji** — pięć ścieżek:
   - **Moc Siły** — Siła +2…+8 przez 1–10 min, koszt 50% esencji
   - **Bystrość Ducha** — Mądrość + Inteligencja +2…+8, koszt 50%
   - **Pancerz Duszy** — Pancerz unikowy +1…+6, koszt 50%
   - **Regeneracja** — 1–5 HP/rundę, koszt 50%
   - **Wchłonij Całość** — wszystkie efekty + Haste, pełna moc, CD 5 min, usuwa kryształ
   - **Uwolnij Duszę** — zwrot złota zamiast buffa

## Pliki

```
Soul Crystals/
├── Scripts/
│   ├── lib_nui.nss              kopia współdzielona (jak w Mailbox)
│   ├── lib_nui_utility.nss      kopia współdzielona
│   ├── sql_soc.nss              schemat SQLite + wszystkie zapytania
│   ├── lib_soc_def.nss          stałe, ID bindów, ID przycisków, deklaracje
│   ├── lib_soc.nss              rdzeń: NUI builder, logika consume/release/bind
│   ├── lib_soc_ev.nss           handler eventów NUI (switch po sEvent/sElem)
│   ├── sys_on_load.nss          OnModuleLoad → tworzy tabele
│   ├── sys_on_enter.nss         OnClientEnter → rejestracja gracza, powiadomienie
│   ├── sys_on_target.nss        OnPlayerTarget → schwytanie duszy
│   └── test_soc.nss             OnUsed na placeablu Kuźni Dusz
└── INTEGRATION.md               instrukcja podpięcia do istniejącego modułu
```

## Zależności

- **NWN:EE 8193.32+** (NUI + `SqlPrepareQueryCampaign`)
- **Brak NWNX** — wyłącznie wbudowane API
- **Brak haka** — nie ma niestandardowych assetów graficznych

SQLite: kampania `soc` (plik `soc.db`), tabele `soc_crystals` i `soc_players`.

## Jak włączyć w istniejącym module

1. Skopiuj folder `Soul Crystals/Scripts/` do haka modułu lub folderu skryptów.
2. Podepnij hooki:
   - `OnModuleLoad` → `sys_on_load.nss`
   - `OnClientEnter` → `sys_on_enter.nss`
   - `OnPlayerTarget` → `sys_on_target.nss`
3. Postaw placeable (np. ołtarz) z `OnUsed` → `test_soc.nss`.
4. Szczegóły w `Soul Crystals/INTEGRATION.md`.

## Co celowo pominięto

- **Fizyczne itemy kryształów** w ekwipunku — esencja trzymana wyłącznie w SQL; nie było potrzeby haka tylko dla tego.
- **Transfer kryształów** między graczami — zakres modułu to single-player soul management.
- **Efekty cząsteczkowe na krysztale** — wymagałyby niestandardowego VFX w haku.
- **Integracja z Runic Forge** — esencja mogłaby zasilać enkhanty; to naturalne rozszerzenie na przyszłość.
- **Plik .mod** — środowisko nie obsługuje budowania paczki .mod; zamiast tego `INTEGRATION.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XoMJRp5kdeezLQemW6fQse)_