### PR TITLE
feat: Więzienie Królewskie (Prison System)

### DIFF
--- a/Więzienie/INTEGRATION.md
+++ b/Więzienie/INTEGRATION.md
@@ -1,0 +1,63 @@
+# Więzienie Królewskie — Integracja
+
+## Hooki modułu
+
+| Zdarzenie          | Skrypt                            |
+|--------------------|-----------------------------------|
+| OnModuleLoad       | `sys_on_load`                     |
+| OnClientEnter      | `sys_on_enter` (lub wywołaj z istniejącego) |
+| OnNUIEvent         | `lib_prison_ev` (auto — `NuiCreate` rejestruje go wewnętrznie) |
+
+## Placeable testowy
+
+1. Utwórz w edytorze dowolny placeable (np. kratę, słup ogłoszeń).
+2. Ustaw `OnUsed = test_prison`.
+3. Po kliknięciu placeable'a postać gracza zostaje uwięziona z rosnącym poziomem zbrodni.
+
+## Aresztowanie z innego skryptu
+
+Wywołaj z dowolnego miejsca:
+
+```nss
+#include "lib_prison"
+
+// Arrest a PC for a crime. nCrimeLevel 1-5.
+PrisonArrestPlayer(oPC, 3, "Rozbój na trakcie handlowym");
+```
+
+Możesz też najpierw wystawić nakaz i aresztować gracza przy spotkaniu z wartownikiem:
+
+```nss
+// Issue a warrant (e.g., a guard witnesses a crime):
+PrisonIssueWarrant(oPC, 2, "Kradzież sklepowa");
+
+// Later, a guard NPC checks:
+if(PrisonGetWarrantLevel(oPC) >= 1)
+    PrisonArrestPlayer(oPC, PrisonGetWarrantLevel(oPC), "Realizacja nakazu aresztu");
+```
+
+## Punkty nawigacyjne (Waypoints)
+
+| Tag                  | Opis                                          |
+|----------------------|-----------------------------------------------|
+| `PRISON_CELL_WP`     | Gracz teleportuje się tu przy areszcie        |
+| `PRISON_RELEASE_WP`  | Gracz teleportuje się tu przy zwolnieniu      |
+
+Jeśli waypointy nie istnieją w module, teleport jest pomijany — gracz pozostaje na miejscu.
+
+## Zmienna lokalna na graczu
+
+Zewnętrzne skrypty mogą ustawić `PRISON_CRIME_LEVEL` (int) na obiekcie PC. Nie jest ona automatycznie sprawdzana — służy jako sygnał dla własnych handlerów (np. OnPerception strażnika), które następnie wywołują `PrisonArrestPlayer`.
+
+## Zależności
+
+- **Brak NWNX** — moduł działa na czystym NWN:EE.
+- SQLite: dane globalne w campaign DB `"prison"` (tworzone automatycznie przez `sys_on_load`).
+- Wytrych: sprawdzane tagi `NW_IT_PICKS001` / `002` / `003` (standardowe narzędzia złodziejskie NWN).
+
+## Co celowo pominięto
+
+- **Sędzia / rozprawy sądowe** — wymaga NPC dialogów; poza zakresem modułu.
+- **Kary pieniężne jako alternatywa** — logika trybu grzywny jest zaimplementowana częściowo przez opcję przekupstwa; formalne postępowanie pomięte.
+- **Multiplayer synchronizacja cel** — jeden gracz w jednej celi; listy współwięźniów wymagałyby własnego UI.
+- **Grafika / tło NUI** — moduł nie dostarcza pliku `.hak`; używa domyślnych kontrolek NWN:EE.

--- a/Więzienie/scripts/lib_nui.nss
+++ b/Więzienie/scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Więzienie/scripts/lib_nui_utility.nss
+++ b/Więzienie/scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Więzienie/scripts/lib_prison.nss
+++ b/Więzienie/scripts/lib_prison.nss
@@ -1,0 +1,612 @@
+#include "lib_prison_def"
+
+// ----------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------
+
+string PrisonCrimeLevelLabel(int nLevel)
+{
+    switch(nLevel)
+    {
+        case 1: return "Drobne wykroczenie";
+        case 2: return "Kradzież";
+        case 3: return "Przestępstwo";
+        case 4: return "Ciężka zbrodnia";
+        case 5: return "Zbrodnia przeciw Koronie";
+    }
+    return "Nieznana zbrodnia";
+}
+
+string PrisonOutcomeLabel(string sOutcome)
+{
+    if(sOutcome == "served")   return "Odsiedział";
+    if(sOutcome == "bribed")   return "Przekupił";
+    if(sOutcome == "escaped")  return "Uciekł";
+    if(sOutcome == "recaught") return "Schwytano ponownie";
+    return sOutcome;
+}
+
+json PrisonOutcomeColor(string sOutcome)
+{
+    if(sOutcome == "served")   return NuiColor(180, 180, 180);
+    if(sOutcome == "bribed")   return NuiColor(210, 175,  55);
+    if(sOutcome == "escaped")  return NuiColor( 80, 200,  80);
+    if(sOutcome == "recaught") return NuiColor(200,  80,  80);
+    return NuiColor(160, 160, 160);
+}
+
+// Returns TRUE if oPC has any thieves' tools in inventory.
+int PrisonHasThievesTools(object oPC)
+{
+    if(GetIsObjectValid(GetItemPossessedBy(oPC, "NW_IT_PICKS001"))) return TRUE;
+    if(GetIsObjectValid(GetItemPossessedBy(oPC, "NW_IT_PICKS002"))) return TRUE;
+    if(GetIsObjectValid(GetItemPossessedBy(oPC, "NW_IT_PICKS003"))) return TRUE;
+    return FALSE;
+}
+
+// ----------------------------------------------------------------
+// NUI layout builders
+// ----------------------------------------------------------------
+
+json PrisonBuildStatusPanel(object oPC)
+{
+    float fLblH = GetNuiScaleDimension(oPC, 26.0);
+    float fBtnH = GetNuiScaleDimension(oPC, 34.0);
+    float fBtnW = GetNuiScaleDimension(oPC, 200.0);
+    float fKeyW = GetNuiScaleDimension(oPC, 130.0);
+
+    // ---- Info rows ----
+    json jCrimeKey = NuiLabel(JsonString("Zbrodnia:"),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jCrimeKey = NuiWidth(jCrimeKey, fKeyW);
+    jCrimeKey = NuiHeight(jCrimeKey, fLblH);
+    json jCrimeVal = NuiLabel(NuiBind(PRISON_BIND_CRIME_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jCrimeVal = NuiHeight(jCrimeVal, fLblH);
+    json jCrimeItems = JsonArray();
+    jCrimeItems = JsonArrayInsert(jCrimeItems, jCrimeKey);
+    jCrimeItems = JsonArrayInsert(jCrimeItems, jCrimeVal);
+
+    json jLevelKey = NuiLabel(JsonString("Ciężkość:"),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jLevelKey = NuiWidth(jLevelKey, fKeyW);
+    jLevelKey = NuiHeight(jLevelKey, fLblH);
+    json jLevelVal = NuiLabel(NuiBind(PRISON_BIND_LEVEL_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jLevelVal = NuiHeight(jLevelVal, fLblH);
+    json jLevelItems = JsonArray();
+    jLevelItems = JsonArrayInsert(jLevelItems, jLevelKey);
+    jLevelItems = JsonArrayInsert(jLevelItems, jLevelVal);
+
+    json jSentKey = NuiLabel(JsonString("Wymiar kary:"),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jSentKey = NuiWidth(jSentKey, fKeyW);
+    jSentKey = NuiHeight(jSentKey, fLblH);
+    json jSentVal = NuiLabel(NuiBind(PRISON_BIND_SENT_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jSentVal = NuiHeight(jSentVal, fLblH);
+    json jSentItems = JsonArray();
+    jSentItems = JsonArrayInsert(jSentItems, jSentKey);
+    jSentItems = JsonArrayInsert(jSentItems, jSentVal);
+
+    json jTimeKey = NuiLabel(JsonString("Pozostało:"),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTimeKey = NuiWidth(jTimeKey, fKeyW);
+    jTimeKey = NuiHeight(jTimeKey, fLblH);
+    json jTimeVal = NuiLabel(NuiBind(PRISON_BIND_TIME_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTimeVal = NuiHeight(jTimeVal, fLblH);
+    json jTimeItems = JsonArray();
+    jTimeItems = JsonArrayInsert(jTimeItems, jTimeKey);
+    jTimeItems = JsonArrayInsert(jTimeItems, jTimeVal);
+
+    json jAttKey = NuiLabel(JsonString("Próby ucieczki:"),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jAttKey = NuiWidth(jAttKey, fKeyW);
+    jAttKey = NuiHeight(jAttKey, fLblH);
+    json jAttVal = NuiLabel(NuiBind(PRISON_BIND_ATT_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jAttVal = NuiHeight(jAttVal, fLblH);
+    json jAttItems = JsonArray();
+    jAttItems = JsonArrayInsert(jAttItems, jAttKey);
+    jAttItems = JsonArrayInsert(jAttItems, jAttVal);
+
+    // ---- Escape buttons (2x2 grid) ----
+    json jServeBtn = NuiButton(JsonString("Odsiaduj karę"));
+    jServeBtn = NuiId(jServeBtn, PRISON_BTN_SERVE);
+    jServeBtn = NuiEnabled(jServeBtn, NuiBind(PRISON_BIND_SERVE_ENA));
+    jServeBtn = NuiWidth(jServeBtn, fBtnW);
+    jServeBtn = NuiHeight(jServeBtn, fBtnH);
+    jServeBtn = NuiTooltip(jServeBtn, JsonString(
+        "Poczekaj, aż wyrok minie. Bez ryzyka."));
+
+    json jBribeBtn = NuiButton(JsonString("Przekup strażnika"));
+    jBribeBtn = NuiId(jBribeBtn, PRISON_BTN_BRIBE);
+    jBribeBtn = NuiEnabled(jBribeBtn, NuiBind(PRISON_BIND_BRIBE_ENA));
+    jBribeBtn = NuiWidth(jBribeBtn, fBtnW);
+    jBribeBtn = NuiHeight(jBribeBtn, fBtnH);
+    jBribeBtn = NuiTooltip(jBribeBtn, NuiBind(PRISON_BIND_BRIBE_TIP));
+
+    json jPickBtn = NuiButton(JsonString("Otwórz zamek wytrychem"));
+    jPickBtn = NuiId(jPickBtn, PRISON_BTN_PICK);
+    jPickBtn = NuiEnabled(jPickBtn, NuiBind(PRISON_BIND_PICK_ENA));
+    jPickBtn = NuiWidth(jPickBtn, fBtnW);
+    jPickBtn = NuiHeight(jPickBtn, fBtnH);
+    jPickBtn = NuiTooltip(jPickBtn, NuiBind(PRISON_BIND_PICK_TIP));
+
+    json jOverBtn = NuiButton(JsonString("Obezwładnij strażnika"));
+    jOverBtn = NuiId(jOverBtn, PRISON_BTN_OVERPOWER);
+    jOverBtn = NuiEnabled(jOverBtn, NuiBind(PRISON_BIND_OVER_ENA));
+    jOverBtn = NuiWidth(jOverBtn, fBtnW);
+    jOverBtn = NuiHeight(jOverBtn, fBtnH);
+    jOverBtn = NuiTooltip(jOverBtn, NuiBind(PRISON_BIND_OVER_TIP));
+
+    json jBtnRow1Items = JsonArray();
+    jBtnRow1Items = JsonArrayInsert(jBtnRow1Items, NuiSpacer());
+    jBtnRow1Items = JsonArrayInsert(jBtnRow1Items, jServeBtn);
+    jBtnRow1Items = JsonArrayInsert(jBtnRow1Items, NuiSpacer());
+    jBtnRow1Items = JsonArrayInsert(jBtnRow1Items, jBribeBtn);
+    jBtnRow1Items = JsonArrayInsert(jBtnRow1Items, NuiSpacer());
+
+    json jBtnRow2Items = JsonArray();
+    jBtnRow2Items = JsonArrayInsert(jBtnRow2Items, NuiSpacer());
+    jBtnRow2Items = JsonArrayInsert(jBtnRow2Items, jPickBtn);
+    jBtnRow2Items = JsonArrayInsert(jBtnRow2Items, NuiSpacer());
+    jBtnRow2Items = JsonArrayInsert(jBtnRow2Items, jOverBtn);
+    jBtnRow2Items = JsonArrayInsert(jBtnRow2Items, NuiSpacer());
+
+    // ---- Assemble column ----
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(jCrimeItems));
+    jCol = JsonArrayInsert(jCol, NuiRow(jLevelItems));
+    jCol = JsonArrayInsert(jCol, NuiRow(jSentItems));
+    jCol = JsonArrayInsert(jCol, NuiRow(jTimeItems));
+    jCol = JsonArrayInsert(jCol, NuiRow(jAttItems));
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow1Items));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow2Items));
+
+    return NuiCol(jCol);
+}
+
+json PrisonBuildHistoryPanel(object oPC)
+{
+    float fHdrH = GetNuiScaleDimension(oPC, 22.0);
+    float fRowH = GetNuiScaleDimension(oPC, 26.0);
+    float fDateW = GetNuiScaleDimension(oPC, 80.0);
+    float fOutW  = GetNuiScaleDimension(oPC, 100.0);
+
+    // ---- Header row ----
+    json jHdrCrime = NuiLabel(JsonString("Zbrodnia"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jHdrCrime = NuiHeight(jHdrCrime, fHdrH);
+
+    json jHdrDate = NuiLabel(JsonString("Data"),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jHdrDate = NuiWidth(jHdrDate, fDateW);
+    jHdrDate = NuiHeight(jHdrDate, fHdrH);
+
+    json jHdrOut = NuiLabel(JsonString("Wynik"),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jHdrOut = NuiWidth(jHdrOut, fOutW);
+    jHdrOut = NuiHeight(jHdrOut, fHdrH);
+
+    json jHdrItems = JsonArray();
+    jHdrItems = JsonArrayInsert(jHdrItems, jHdrCrime);
+    jHdrItems = JsonArrayInsert(jHdrItems, jHdrDate);
+    jHdrItems = JsonArrayInsert(jHdrItems, jHdrOut);
+
+    // ---- List template ----
+    json jCrimeLbl = NuiLabel(NuiBind(PRISON_BIND_HIST_CRIME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jCrimeLbl = NuiStyleForegroundColor(jCrimeLbl, NuiBind(PRISON_BIND_HIST_COLOR));
+
+    json jDateLbl = NuiLabel(NuiBind(PRISON_BIND_HIST_DATE),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jDateLbl = NuiWidth(jDateLbl, fDateW);
+    jDateLbl = NuiStyleForegroundColor(jDateLbl, NuiBind(PRISON_BIND_HIST_COLOR));
+
+    json jOutLbl = NuiLabel(NuiBind(PRISON_BIND_HIST_OUT),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jOutLbl = NuiWidth(jOutLbl, fOutW);
+    jOutLbl = NuiStyleForegroundColor(jOutLbl, NuiBind(PRISON_BIND_HIST_COLOR));
+
+    json jCellItems = JsonArray();
+    jCellItems = JsonArrayInsert(jCellItems, jCrimeLbl);
+    jCellItems = JsonArrayInsert(jCellItems, jDateLbl);
+    jCellItems = JsonArrayInsert(jCellItems, jOutLbl);
+
+    json jCell = NuiGroup(NuiRow(jCellItems), FALSE, NUI_SCROLLBARS_NONE);
+
+    json jTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jCell, 0.0, TRUE));
+    json jList = NuiList(jTmpl, NuiBind(PRISON_BIND_HIST_CNT), fRowH);
+    jList = NuiHeight(jList, GetNuiScaleDimension(oPC, 280.0));
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(jHdrItems));
+    jCol = JsonArrayInsert(jCol, jList);
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+
+    return NuiCol(jCol);
+}
+
+// ----------------------------------------------------------------
+// Window creation
+// ----------------------------------------------------------------
+
+void PrisonCreateWindow(object oPC)
+{
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - GetNuiScaleDimension(oPC, PRISON_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - GetNuiScaleDimension(oPC, PRISON_H)) / 2.0;
+    json jGeom = NuiRect(fCX, fCY, GetNuiScaleDimension(oPC, PRISON_W), GetNuiScaleDimension(oPC, PRISON_H));
+
+    float fBtnH = GetNuiScaleDimension(oPC, 28.0);
+    float fTabW = GetNuiScaleDimension(oPC, 120.0);
+
+    // ---- Title bar: label + close ----
+    json jTitle = NuiLabel(JsonString("Więzienie Królewskie"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitle = NuiHeight(jTitle, fBtnH);
+
+    json jClose = NuiButton(JsonString("X"));
+    jClose = NuiId(jClose, PRISON_BTN_CLOSE);
+    jClose = NuiWidth(jClose, GetNuiScaleDimension(oPC, 28.0));
+    jClose = NuiHeight(jClose, fBtnH);
+
+    json jTopItems = JsonArray();
+    jTopItems = JsonArrayInsert(jTopItems, jTitle);
+    jTopItems = JsonArrayInsert(jTopItems, NuiSpacer());
+    jTopItems = JsonArrayInsert(jTopItems, jClose);
+
+    // ---- Tab buttons ----
+    json jTabStatus = NuiButton(JsonString("Stan"));
+    jTabStatus = NuiId(jTabStatus, PRISON_BTN_TAB_STATUS);
+    jTabStatus = NuiWidth(jTabStatus, fTabW);
+    jTabStatus = NuiHeight(jTabStatus, fBtnH);
+
+    json jTabHist = NuiButton(JsonString("Historia"));
+    jTabHist = NuiId(jTabHist, PRISON_BTN_TAB_HISTORY);
+    jTabHist = NuiWidth(jTabHist, fTabW);
+    jTabHist = NuiHeight(jTabHist, fBtnH);
+
+    json jTabItems = JsonArray();
+    jTabItems = JsonArrayInsert(jTabItems, jTabStatus);
+    jTabItems = JsonArrayInsert(jTabItems, jTabHist);
+    jTabItems = JsonArrayInsert(jTabItems, NuiSpacer());
+
+    // ---- Swap group ----
+    json jSwapGrp = NuiGroup(PrisonBuildStatusPanel(oPC), FALSE, NUI_SCROLLBARS_NONE);
+    jSwapGrp = NuiId(jSwapGrp, PRISON_GRP_SWAP);
+
+    // ---- Root column ----
+    json jRootItems = JsonArray();
+    jRootItems = JsonArrayInsert(jRootItems, NuiRow(jTopItems));
+    jRootItems = JsonArrayInsert(jRootItems, NuiRow(jTabItems));
+    jRootItems = JsonArrayInsert(jRootItems, jSwapGrp);
+    json jRoot = NuiCol(jRootItems);
+
+    json jWin = NuiWindow(jRoot,
+        JsonBool(FALSE),
+        NuiBind(PRISON_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE));
+
+    int nToken = NuiCreate(oPC, jWin, PRISON_WINDOW, PRISON_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, PRISON_WIN_GEOM, jGeom);
+
+    PrisonRefreshStatus(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// View switching
+// ----------------------------------------------------------------
+
+void PrisonOpenStatus(object oPC, int nToken)
+{
+    NuiSetGroupLayout(oPC, nToken, PRISON_GRP_SWAP, PrisonBuildStatusPanel(oPC));
+    PrisonRefreshStatus(oPC, nToken);
+}
+
+void PrisonOpenHistory(object oPC, int nToken)
+{
+    NuiSetGroupLayout(oPC, nToken, PRISON_GRP_SWAP, PrisonBuildHistoryPanel(oPC));
+
+    json jHistory = PrisonGetHistory(oPC);
+    int nCount = JsonGetLength(jHistory);
+
+    json jCrimes = JsonArray();
+    json jDates  = JsonArray();
+    json jOuts   = JsonArray();
+    json jColors = JsonArray();
+
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jRow    = JsonArrayGet(jHistory, i);
+        string sCrime = JsonGetString(JsonObjectGet(jRow, "crime_desc"));
+        int nAt      = JsonGetInt   (JsonObjectGet(jRow, "arrested_at"));
+        string sOut  = JsonGetString(JsonObjectGet(jRow, "outcome"));
+
+        jCrimes = JsonArrayInsert(jCrimes, JsonString(sCrime));
+        jDates  = JsonArrayInsert(jDates,  JsonString(PrisonFormatDateSQL(nAt)));
+        jOuts   = JsonArrayInsert(jOuts,   JsonString(PrisonOutcomeLabel(sOut)));
+        jColors = JsonArrayInsert(jColors, PrisonOutcomeColor(sOut));
+    }
+
+    NuiSetBind(oPC, nToken, PRISON_BIND_HIST_CRIME, jCrimes);
+    NuiSetBind(oPC, nToken, PRISON_BIND_HIST_DATE,  jDates);
+    NuiSetBind(oPC, nToken, PRISON_BIND_HIST_OUT,   jOuts);
+    NuiSetBind(oPC, nToken, PRISON_BIND_HIST_COLOR, jColors);
+    NuiSetBind(oPC, nToken, PRISON_BIND_HIST_CNT,   JsonInt(nCount));
+}
+
+// ----------------------------------------------------------------
+// Feed — populate status binds
+// ----------------------------------------------------------------
+
+void PrisonRefreshStatus(object oPC, int nToken)
+{
+    json jRec = PrisonGetActiveRecord(oPC);
+    if(JsonGetType(jRec) == JSON_TYPE_NULL) return;
+
+    int nLevel    = JsonGetInt   (JsonObjectGet(jRec, "crime_level"));
+    string sDesc  = JsonGetString(JsonObjectGet(jRec, "crime_desc"));
+    int nSentSec  = JsonGetInt   (JsonObjectGet(jRec, "sentence_sec"));
+    int nEscAtt   = JsonGetInt   (JsonObjectGet(jRec, "esc_attempts"));
+    int nRemaining = PrisonGetSecondsRemaining(oPC);
+
+    int bLockdown = (nEscAtt >= PRISON_MAX_ESC_ATTEMPTS);
+    int nBribeCost = PRISON_BRIBE_COST_BASE * nLevel;
+    int bCanAfford = (GetGold(oPC) >= nBribeCost);
+
+    int nPickDC = PRISON_PICK_DC_BASE + nLevel * 2;
+    int nOverDC = PRISON_OVER_DC_BASE + nLevel * 2;
+
+    string sSentMin = PrisonFormatSeconds(nSentSec);
+    string sRemMin  = PrisonFormatSeconds((nRemaining > 0) ? nRemaining : 0);
+
+    NuiSetBind(oPC, nToken, PRISON_BIND_CRIME_LBL, JsonString(sDesc));
+    NuiSetBind(oPC, nToken, PRISON_BIND_LEVEL_LBL, JsonString(PrisonCrimeLevelLabel(nLevel)));
+    NuiSetBind(oPC, nToken, PRISON_BIND_SENT_LBL,  JsonString(sSentMin));
+    NuiSetBind(oPC, nToken, PRISON_BIND_TIME_LBL,  JsonString(sRemMin));
+    NuiSetBind(oPC, nToken, PRISON_BIND_ATT_LBL,
+        JsonString(IntToString(nEscAtt) + " / " + IntToString(PRISON_MAX_ESC_ATTEMPTS) +
+            (bLockdown ? "  [ZAKAZ PRÓB]" : "")));
+
+    NuiSetBind(oPC, nToken, PRISON_BIND_SERVE_ENA, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, PRISON_BIND_BRIBE_ENA, JsonBool(!bLockdown));
+    NuiSetBind(oPC, nToken, PRISON_BIND_PICK_ENA,  JsonBool(!bLockdown && PrisonHasThievesTools(oPC)));
+    NuiSetBind(oPC, nToken, PRISON_BIND_OVER_ENA,  JsonBool(!bLockdown));
+
+    NuiSetBind(oPC, nToken, PRISON_BIND_BRIBE_TIP,
+        JsonString("Koszt: " + IntToString(nBribeCost) + " gp. Szansa: " +
+            IntToString(PRISON_BRIBE_CHANCE) + "%. Przy niepowodzeniu — kara rośnie."));
+    NuiSetBind(oPC, nToken, PRISON_BIND_PICK_TIP,
+        JsonString("Wymaga wytrycha. Trudność zamku: DC " + IntToString(nPickDC) +
+            ". Przy niepowodzeniu — nowe próby blokowane."));
+    NuiSetBind(oPC, nToken, PRISON_BIND_OVER_TIP,
+        JsonString("Test Siły DC " + IntToString(nOverDC) +
+            ". Przy niepowodzeniu — 2 minuty dodatkowe i ogłuszenie."));
+}
+
+// ----------------------------------------------------------------
+// Entry point
+// ----------------------------------------------------------------
+
+void PrisonShowWindow(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, PRISON_WINDOW);
+    if(nToken != 0)
+    {
+        PrisonOpenStatus(oPC, nToken);
+        return;
+    }
+    PrisonCreateWindow(oPC);
+}
+
+// ----------------------------------------------------------------
+// Heartbeat — checks countdown every 60 s
+// ----------------------------------------------------------------
+
+void PrisonHeartbeat(object oPC)
+{
+    if(!GetIsObjectValid(oPC)) return;
+    if(!PrisonIsActive(oPC))
+    {
+        DeleteLocalInt(oPC, PRISON_LVAR_HB);
+        return;
+    }
+
+    int nRemaining = PrisonGetSecondsRemaining(oPC);
+    if(nRemaining <= 0)
+    {
+        PrisonReleasePlayer(oPC, "served");
+        return;
+    }
+
+    int nToken = NuiFindWindow(oPC, PRISON_WINDOW);
+    if(nToken != 0)
+        PrisonRefreshStatus(oPC, nToken);
+
+    DelayCommand(60.0, PrisonHeartbeat(oPC));
+}
+
+// ----------------------------------------------------------------
+// Core mechanics
+// ----------------------------------------------------------------
+
+void PrisonArrestPlayer(object oPC, int nCrimeLevel, string sCrimeDesc)
+{
+    if(nCrimeLevel < 1) nCrimeLevel = 1;
+    if(nCrimeLevel > 5) nCrimeLevel = 5;
+
+    int nSentenceSec = PRISON_SENTENCE_BASE * nCrimeLevel;
+
+    PrisonWriteActive(oPC, nCrimeLevel, sCrimeDesc, nSentenceSec);
+    PrisonIssueWarrant(oPC, nCrimeLevel, sCrimeDesc);
+
+    // Teleport to cell if waypoint exists
+    object oCell = GetWaypointByTag("PRISON_CELL_WP");
+    if(GetIsObjectValid(oCell))
+        AssignCommand(oPC, JumpToObject(oCell));
+
+    // Apply dazed visual
+    effect eVfx = EffectVisualEffect(VFX_DUR_PROT_EPIC_ARMOR);
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eVfx, oPC, 3.0);
+
+    SendMessageToPC(oPC, "[Więzienie] Zostałeś aresztowany za: " + sCrimeDesc +
+        ". Wyrok: " + PrisonFormatSeconds(nSentenceSec) + ".");
+    SendMessageToPC(oPC, "[Więzienie] Cela zamknięta. Poczekaj lub spróbuj uciec.");
+
+    // Delete any existing crime level var
+    DeleteLocalInt(oPC, "PRISON_CRIME_LEVEL");
+
+    PrisonShowWindow(oPC);
+
+    // Start heartbeat if not already running
+    if(!GetLocalInt(oPC, PRISON_LVAR_HB))
+    {
+        SetLocalInt(oPC, PRISON_LVAR_HB, 1);
+        DelayCommand(60.0, PrisonHeartbeat(oPC));
+    }
+}
+
+void PrisonReleasePlayer(object oPC, string sOutcome)
+{
+    json jRec = PrisonGetActiveRecord(oPC);
+    if(JsonGetType(jRec) == JSON_TYPE_NULL) return;
+
+    int nLevel   = JsonGetInt   (JsonObjectGet(jRec, "crime_level"));
+    string sDesc = JsonGetString(JsonObjectGet(jRec, "crime_desc"));
+    int nArr     = JsonGetInt   (JsonObjectGet(jRec, "arrested_at"));
+    int nSent    = JsonGetInt   (JsonObjectGet(jRec, "sentence_sec"));
+
+    PrisonWriteRecord(oPC, nLevel, sDesc, nArr, nSent, sOutcome);
+    PrisonDeleteActive(oPC);
+    PrisonClearWarrant(oPC);
+    DeleteLocalInt(oPC, PRISON_LVAR_HB);
+
+    // Close window
+    int nToken = NuiFindWindow(oPC, PRISON_WINDOW);
+    if(nToken != 0)
+        NuiDestroy(oPC, nToken);
+
+    // Teleport to release point if it exists
+    object oRelease = GetWaypointByTag("PRISON_RELEASE_WP");
+    if(GetIsObjectValid(oRelease))
+        AssignCommand(oPC, JumpToObject(oRelease));
+
+    string sMsgMap = "";
+    if(sOutcome == "served")
+        sMsgMap = "Kara odsiadzona. Bramy więzienia otwierają się przed tobą.";
+    else if(sOutcome == "bribed")
+        sMsgMap = "Strażnik chowa monety i uchyla kratę. Wolność smakuje złotem.";
+    else if(sOutcome == "escaped")
+        sMsgMap = "Zamek ustępuje. Uciekasz, nim ktokolwiek zauważy.";
+
+    if(sMsgMap != "")
+        SendMessageToPC(oPC, "[Więzienie] " + sMsgMap);
+}
+
+// ----------------------------------------------------------------
+// Escape attempts
+// ----------------------------------------------------------------
+
+void PrisonTryBribe(object oPC, int nToken)
+{
+    json jRec = PrisonGetActiveRecord(oPC);
+    if(JsonGetType(jRec) == JSON_TYPE_NULL) return;
+
+    int nLevel   = JsonGetInt(JsonObjectGet(jRec, "crime_level"));
+    int nCost    = PRISON_BRIBE_COST_BASE * nLevel;
+
+    if(GetGold(oPC) < nCost)
+    {
+        SendMessageToPC(oPC, "[Więzienie] Nie masz dość złota. Potrzebujesz " +
+            IntToString(nCost) + " gp.");
+        return;
+    }
+
+    AssignCommand(oPC, TakeGoldFromCreature(nCost, oPC, TRUE));
+
+    int bSuccess = (d100() <= PRISON_BRIBE_CHANCE);
+    if(bSuccess)
+    {
+        SendMessageToPC(oPC, "[Więzienie] Strażnik liczy monety i kiwa głową. Szybko — nim zmieni zdanie.");
+        PrisonReleasePlayer(oPC, "bribed");
+    }
+    else
+    {
+        int nExtra = PRISON_BRIBE_FAIL_EXTRA * nLevel;
+        PrisonAddExtraTime(oPC, nExtra);
+        PrisonIncrEscapeAttempts(oPC);
+        SendMessageToPC(oPC, "[Więzienie] Strażnik bierze złoto i woła wartę. Kara wydłużona o " +
+            IntToString(nExtra / 60) + " minut.");
+        PrisonRefreshStatus(oPC, nToken);
+    }
+}
+
+void PrisonTryPickLock(object oPC, int nToken)
+{
+    if(!PrisonHasThievesTools(oPC))
+    {
+        SendMessageToPC(oPC, "[Więzienie] Nie masz wytrycha.");
+        return;
+    }
+
+    json jRec = PrisonGetActiveRecord(oPC);
+    if(JsonGetType(jRec) == JSON_TYPE_NULL) return;
+
+    int nLevel = JsonGetInt(JsonObjectGet(jRec, "crime_level"));
+    int nDC    = PRISON_PICK_DC_BASE + nLevel * 2;
+
+    int bSuccess = GetIsSkillSuccessful(oPC, SKILL_OPEN_LOCK, nDC);
+    if(bSuccess)
+    {
+        SendMessageToPC(oPC, "[Więzienie] Zamek ustępuje z cichym kliknięciem. Wolność.");
+        PrisonReleasePlayer(oPC, "escaped");
+    }
+    else
+    {
+        PrisonIncrEscapeAttempts(oPC);
+        int nEscAtt = JsonGetInt(JsonObjectGet(PrisonGetActiveRecord(oPC), "esc_attempts"));
+        if(nEscAtt >= PRISON_MAX_ESC_ATTEMPTS)
+            SendMessageToPC(oPC, "[Więzienie] Strażnik słyszy skrzypienie. Kraty zostaną wzmocnione — nie masz już szans na ucieczkę.");
+        else
+            SendMessageToPC(oPC, "[Więzienie] Wytrych łamie się w zamku. Próba nieudana.");
+        PrisonRefreshStatus(oPC, nToken);
+    }
+}
+
+void PrisonTryOverpower(object oPC, int nToken)
+{
+    json jRec = PrisonGetActiveRecord(oPC);
+    if(JsonGetType(jRec) == JSON_TYPE_NULL) return;
+
+    int nLevel = JsonGetInt(JsonObjectGet(jRec, "crime_level"));
+    int nDC    = PRISON_OVER_DC_BASE + nLevel * 2;
+    int nRoll  = d20() + GetAbilityModifier(ABILITY_STRENGTH, oPC);
+
+    if(nRoll >= nDC)
+    {
+        SendMessageToPC(oPC, "[Więzienie] Rzucasz się na strażnika. Pada bez świadomości.");
+        PrisonReleasePlayer(oPC, "escaped");
+    }
+    else
+    {
+        PrisonAddExtraTime(oPC, PRISON_OVER_FAIL_EXTRA);
+        PrisonIncrEscapeAttempts(oPC);
+        // Apply stun
+        effect eStun = EffectStunned();
+        ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eStun, oPC, 30.0);
+        int nEscAtt = JsonGetInt(JsonObjectGet(PrisonGetActiveRecord(oPC), "esc_attempts"));
+        if(nEscAtt >= PRISON_MAX_ESC_ATTEMPTS)
+            SendMessageToPC(oPC, "[Więzienie] Strażnik rzuca cię o ziemię. Następują kajdany. Nie wstaniesz stąd siłą.");
+        else
+            SendMessageToPC(oPC, "[Więzienie] Strażnik okazuje się silniejszy. Dostajesz obuchem w głowę.");
+        PrisonRefreshStatus(oPC, nToken);
+    }
+}

--- a/Więzienie/scripts/lib_prison_def.nss
+++ b/Więzienie/scripts/lib_prison_def.nss
@@ -1,0 +1,86 @@
+#include "lib_nui"
+#include "sql_prison"
+
+// Forward declarations
+void PrisonArrestPlayer(object oPC, int nCrimeLevel, string sCrimeDesc);
+void PrisonReleasePlayer(object oPC, string sOutcome);
+void PrisonShowWindow(object oPC);
+void PrisonRefreshStatus(object oPC, int nToken);
+void PrisonHeartbeat(object oPC);
+
+// ----------------------------------------------------------------
+// Window / group IDs
+// ----------------------------------------------------------------
+
+const string PRISON_WINDOW       = "PRISON_WINDOW";
+const string PRISON_EV_SCRIPT    = "lib_prison_ev";
+const string PRISON_GRP_SWAP     = "PRISON_GRP_SWAP";
+const string PRISON_WIN_GEOM     = "prison_win_geom";
+
+// ----------------------------------------------------------------
+// Binds — status panel
+// ----------------------------------------------------------------
+
+const string PRISON_BIND_HEADER_LBL  = "prison_header";
+const string PRISON_BIND_CRIME_LBL   = "prison_crime_lbl";
+const string PRISON_BIND_LEVEL_LBL   = "prison_level_lbl";
+const string PRISON_BIND_SENT_LBL    = "prison_sent_lbl";
+const string PRISON_BIND_TIME_LBL    = "prison_time_lbl";
+const string PRISON_BIND_ATT_LBL     = "prison_att_lbl";
+const string PRISON_BIND_BRIBE_TIP   = "prison_bribe_tip";
+const string PRISON_BIND_PICK_TIP    = "prison_pick_tip";
+const string PRISON_BIND_OVER_TIP    = "prison_over_tip";
+
+// Escape button enabled binds
+const string PRISON_BIND_SERVE_ENA   = "prison_serve_ena";
+const string PRISON_BIND_BRIBE_ENA   = "prison_bribe_ena";
+const string PRISON_BIND_PICK_ENA    = "prison_pick_ena";
+const string PRISON_BIND_OVER_ENA    = "prison_over_ena";
+
+// ----------------------------------------------------------------
+// Binds — history panel
+// ----------------------------------------------------------------
+
+const string PRISON_BIND_HIST_CRIME  = "prison_hist_crime";
+const string PRISON_BIND_HIST_DATE   = "prison_hist_date";
+const string PRISON_BIND_HIST_OUT    = "prison_hist_out";
+const string PRISON_BIND_HIST_COLOR  = "prison_hist_color";
+const string PRISON_BIND_HIST_CNT    = "prison_hist_cnt";
+
+// ----------------------------------------------------------------
+// Button IDs
+// ----------------------------------------------------------------
+
+const string PRISON_BTN_CLOSE        = "prison_btn_close";
+const string PRISON_BTN_TAB_STATUS   = "prison_tab_status";
+const string PRISON_BTN_TAB_HISTORY  = "prison_tab_hist";
+const string PRISON_BTN_SERVE        = "prison_btn_serve";
+const string PRISON_BTN_BRIBE        = "prison_btn_bribe";
+const string PRISON_BTN_PICK         = "prison_btn_pick";
+const string PRISON_BTN_OVERPOWER    = "prison_btn_over";
+
+// ----------------------------------------------------------------
+// LVARs on PC object
+// ----------------------------------------------------------------
+
+const string PRISON_LVAR_HB          = "PRISON_HB";        // 1 = heartbeat running
+
+// ----------------------------------------------------------------
+// Game constants
+// ----------------------------------------------------------------
+
+const int PRISON_SENTENCE_BASE       = 120;   // seconds per crime level
+const int PRISON_BRIBE_COST_BASE     = 50;    // gold per crime level
+const int PRISON_BRIBE_CHANCE        = 80;    // percent chance of success
+const int PRISON_BRIBE_FAIL_EXTRA    = 90;    // extra seconds per level on failed bribe
+const int PRISON_PICK_DC_BASE        = 10;    // Open Lock DC = base + crime_level * 2
+const int PRISON_OVER_DC_BASE        = 12;    // STR check DC = base + crime_level * 2
+const int PRISON_OVER_FAIL_EXTRA     = 120;   // extra seconds on failed overpower
+const int PRISON_MAX_ESC_ATTEMPTS    = 3;     // failed attempts before lockdown
+
+// ----------------------------------------------------------------
+// Layout
+// ----------------------------------------------------------------
+
+const float PRISON_W                 = 500.0;
+const float PRISON_H                 = 400.0;

--- a/Więzienie/scripts/lib_prison_ev.nss
+++ b/Więzienie/scripts/lib_prison_ev.nss
@@ -1,0 +1,64 @@
+#include "lib_prison"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+
+    if(nToken != NuiFindWindow(oPC, PRISON_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        // Window closed — heartbeat keeps running; no state to clean.
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == PRISON_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        if(sElem == PRISON_BTN_TAB_STATUS)
+        {
+            PrisonOpenStatus(oPC, nToken);
+            return;
+        }
+
+        if(sElem == PRISON_BTN_TAB_HISTORY)
+        {
+            PrisonOpenHistory(oPC, nToken);
+            return;
+        }
+
+        if(sElem == PRISON_BTN_SERVE)
+        {
+            // Serve time: close window and let the heartbeat do its work.
+            SendMessageToPC(oPC, "[Więzienie] Siadasz na pryczy. Czas przecieka przez palce niczym piasek.");
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        if(sElem == PRISON_BTN_BRIBE)
+        {
+            PrisonTryBribe(oPC, nToken);
+            return;
+        }
+
+        if(sElem == PRISON_BTN_PICK)
+        {
+            PrisonTryPickLock(oPC, nToken);
+            return;
+        }
+
+        if(sElem == PRISON_BTN_OVERPOWER)
+        {
+            PrisonTryOverpower(oPC, nToken);
+            return;
+        }
+    }
+}

--- a/Więzienie/scripts/sql_prison.nss
+++ b/Więzienie/scripts/sql_prison.nss
@@ -1,0 +1,202 @@
+void PrisonCreateTables()
+{
+    sqlquery q;
+
+    q = SqlPrepareQueryCampaign("prison",
+        "CREATE TABLE IF NOT EXISTS prison_active ("
+        "  uuid          TEXT PRIMARY KEY,"
+        "  char_name     TEXT    DEFAULT '',"
+        "  crime_level   INTEGER DEFAULT 1,"
+        "  crime_desc    TEXT    DEFAULT '',"
+        "  arrested_at   INTEGER DEFAULT 0,"
+        "  sentence_sec  INTEGER DEFAULT 0,"
+        "  esc_attempts  INTEGER DEFAULT 0"
+        ")");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("prison",
+        "CREATE TABLE IF NOT EXISTS prison_records ("
+        "  id           INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "  uuid         TEXT    NOT NULL,"
+        "  char_name    TEXT    DEFAULT '',"
+        "  crime_desc   TEXT    DEFAULT '',"
+        "  crime_level  INTEGER DEFAULT 0,"
+        "  arrested_at  INTEGER DEFAULT 0,"
+        "  sentence_sec INTEGER DEFAULT 0,"
+        "  outcome      TEXT    DEFAULT 'served',"
+        "  released_at  INTEGER DEFAULT 0"
+        ")");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("prison",
+        "CREATE TABLE IF NOT EXISTS prison_warrants ("
+        "  uuid        TEXT PRIMARY KEY,"
+        "  char_name   TEXT    DEFAULT '',"
+        "  crime_level INTEGER DEFAULT 0,"
+        "  crime_desc  TEXT    DEFAULT '',"
+        "  issued_at   INTEGER DEFAULT 0"
+        ")");
+    SqlStep(q);
+}
+
+void PrisonWriteActive(object oPC, int nCrimeLevel, string sCrimeDesc, int nSentenceSec)
+{
+    sqlquery q = SqlPrepareQueryCampaign("prison",
+        "INSERT OR REPLACE INTO prison_active "
+        "(uuid, char_name, crime_level, crime_desc, arrested_at, sentence_sec, esc_attempts) "
+        "VALUES (@uuid, @name, @lvl, @desc, CAST(strftime('%s','now') AS INTEGER), @sent, 0)");
+    SqlBindString(q, "@uuid",  GetObjectUUID(oPC));
+    SqlBindString(q, "@name",  GetName(oPC));
+    SqlBindInt   (q, "@lvl",   nCrimeLevel);
+    SqlBindString(q, "@desc",  sCrimeDesc);
+    SqlBindInt   (q, "@sent",  nSentenceSec);
+    SqlStep(q);
+}
+
+int PrisonIsActive(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("prison",
+        "SELECT COUNT(*) FROM prison_active WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+json PrisonGetActiveRecord(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("prison",
+        "SELECT uuid, char_name, crime_level, crime_desc, arrested_at, sentence_sec, esc_attempts "
+        "FROM prison_active WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(!SqlStep(q)) return JsonNull();
+    json j = JsonObject();
+    j = JsonObjectSet(j, "uuid",         JsonString(SqlGetString(q, 0)));
+    j = JsonObjectSet(j, "char_name",    JsonString(SqlGetString(q, 1)));
+    j = JsonObjectSet(j, "crime_level",  JsonInt   (SqlGetInt   (q, 2)));
+    j = JsonObjectSet(j, "crime_desc",   JsonString(SqlGetString(q, 3)));
+    j = JsonObjectSet(j, "arrested_at",  JsonInt   (SqlGetInt   (q, 4)));
+    j = JsonObjectSet(j, "sentence_sec", JsonInt   (SqlGetInt   (q, 5)));
+    j = JsonObjectSet(j, "esc_attempts", JsonInt   (SqlGetInt   (q, 6)));
+    return j;
+}
+
+void PrisonIncrEscapeAttempts(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("prison",
+        "UPDATE prison_active SET esc_attempts = esc_attempts + 1 WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+void PrisonAddExtraTime(object oPC, int nExtraSec)
+{
+    sqlquery q = SqlPrepareQueryCampaign("prison",
+        "UPDATE prison_active SET sentence_sec = sentence_sec + @extra WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid",  GetObjectUUID(oPC));
+    SqlBindInt   (q, "@extra", nExtraSec);
+    SqlStep(q);
+}
+
+void PrisonDeleteActive(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("prison",
+        "DELETE FROM prison_active WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+void PrisonWriteRecord(object oPC, int nCrimeLevel, string sCrimeDesc,
+                       int nArrestedAt, int nSentenceSec, string sOutcome)
+{
+    sqlquery q = SqlPrepareQueryCampaign("prison",
+        "INSERT INTO prison_records "
+        "(uuid, char_name, crime_desc, crime_level, arrested_at, sentence_sec, outcome, released_at) "
+        "VALUES (@uuid, @name, @desc, @lvl, @arr, @sent, @out, CAST(strftime('%s','now') AS INTEGER))");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindString(q, "@name", GetName(oPC));
+    SqlBindString(q, "@desc", sCrimeDesc);
+    SqlBindInt   (q, "@lvl",  nCrimeLevel);
+    SqlBindInt   (q, "@arr",  nArrestedAt);
+    SqlBindInt   (q, "@sent", nSentenceSec);
+    SqlBindString(q, "@out",  sOutcome);
+    SqlStep(q);
+}
+
+json PrisonGetHistory(object oPC)
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("prison",
+        "SELECT crime_desc, crime_level, arrested_at, outcome "
+        "FROM prison_records WHERE uuid = @uuid "
+        "ORDER BY arrested_at DESC LIMIT 10");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    while(SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "crime_desc",  JsonString(SqlGetString(q, 0)));
+        jRow = JsonObjectSet(jRow, "crime_level", JsonInt   (SqlGetInt   (q, 1)));
+        jRow = JsonObjectSet(jRow, "arrested_at", JsonInt   (SqlGetInt   (q, 2)));
+        jRow = JsonObjectSet(jRow, "outcome",     JsonString(SqlGetString(q, 3)));
+        jRows = JsonArrayInsert(jRows, jRow);
+    }
+    return jRows;
+}
+
+void PrisonIssueWarrant(object oPC, int nCrimeLevel, string sCrimeDesc)
+{
+    sqlquery q = SqlPrepareQueryCampaign("prison",
+        "INSERT OR REPLACE INTO prison_warrants "
+        "(uuid, char_name, crime_level, crime_desc, issued_at) "
+        "VALUES (@uuid, @name, @lvl, @desc, CAST(strftime('%s','now') AS INTEGER))");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindString(q, "@name", GetName(oPC));
+    SqlBindInt   (q, "@lvl",  nCrimeLevel);
+    SqlBindString(q, "@desc", sCrimeDesc);
+    SqlStep(q);
+}
+
+void PrisonClearWarrant(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("prison",
+        "DELETE FROM prison_warrants WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+int PrisonGetWarrantLevel(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("prison",
+        "SELECT crime_level FROM prison_warrants WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// Returns seconds remaining in sentence (negative = overdue for release).
+int PrisonGetSecondsRemaining(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("prison",
+        "SELECT (arrested_at + sentence_sec) - CAST(strftime('%s','now') AS INTEGER) "
+        "FROM prison_active WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return -1;
+}
+
+string PrisonFormatSeconds(int nSec)
+{
+    if(nSec <= 0) return "0:00";
+    int nMin = nSec / 60;
+    int nS   = nSec - (nMin * 60);
+    string sPad = (nS < 10) ? "0" : "";
+    return IntToString(nMin) + ":" + sPad + IntToString(nS);
+}
+
+string PrisonFormatDateSQL(int nUnix)
+{
+    sqlquery q = SqlPrepareQueryCampaign("prison",
+        "SELECT strftime('%d.%m.%Y', @ts, 'unixepoch')");
+    SqlBindInt(q, "@ts", nUnix);
+    if(SqlStep(q)) return SqlGetString(q, 0);
+    return "";
+}

--- a/Więzienie/scripts/sys_on_enter.nss
+++ b/Więzienie/scripts/sys_on_enter.nss
@@ -1,0 +1,34 @@
+#include "lib_prison"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC) || GetIsDMPossessed(oPC)) return;
+
+    // If player had an active sentence when they logged out, restore it.
+    if(!PrisonIsActive(oPC)) return;
+
+    int nRemaining = PrisonGetSecondsRemaining(oPC);
+    if(nRemaining <= 0)
+    {
+        // Sentence expired while offline — release immediately.
+        PrisonReleasePlayer(oPC, "served");
+        return;
+    }
+
+    // Teleport back to cell
+    object oCell = GetWaypointByTag("PRISON_CELL_WP");
+    if(GetIsObjectValid(oCell))
+        AssignCommand(oPC, JumpToObject(oCell));
+
+    SendMessageToPC(oPC, "[Więzienie] Twoja kara trwa. Pozostało: " +
+        PrisonFormatSeconds(nRemaining) + ".");
+
+    // Restart heartbeat
+    if(!GetLocalInt(oPC, PRISON_LVAR_HB))
+    {
+        SetLocalInt(oPC, PRISON_LVAR_HB, 1);
+        DelayCommand(3.0, PrisonShowWindow(oPC));
+        DelayCommand(60.0, PrisonHeartbeat(oPC));
+    }
+}

--- a/Więzienie/scripts/sys_on_load.nss
+++ b/Więzienie/scripts/sys_on_load.nss
@@ -1,0 +1,6 @@
+#include "lib_prison_def"
+
+void main()
+{
+    PrisonCreateTables();
+}

--- a/Więzienie/scripts/test_prison.nss
+++ b/Więzienie/scripts/test_prison.nss
@@ -1,0 +1,35 @@
+#include "lib_prison"
+
+// Place this script on the OnUsed event of a placeable (e.g., a guard post or jail door).
+// Using the placeable arrests the activating PC with a demo crime.
+// The crime level cycles 1-5 based on how many times the PC has been arrested before.
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    if(PrisonIsActive(oPC))
+    {
+        SendMessageToPC(oPC, "[Więzienie] Już jesteś za kratami.");
+        PrisonShowWindow(oPC);
+        return;
+    }
+
+    // Pick a rotating demo crime so each test looks different.
+    int nPrevRecords = JsonGetLength(PrisonGetHistory(oPC));
+    int nLevel = (nPrevRecords % 5) + 1;
+
+    string sCrime;
+    switch(nLevel)
+    {
+        case 1: sCrime = "Zakłócenie porządku publicznego";        break;
+        case 2: sCrime = "Kradzież kieszeniowa na targu";          break;
+        case 3: sCrime = "Napad z bronią na mieszczanina";         break;
+        case 4: sCrime = "Przemyt zakazanych artefaktów";          break;
+        case 5: sCrime = "Zamach na życie przedstawiciela Korony"; break;
+        default: sCrime = "Podejrzane zachowanie";
+    }
+
+    PrisonArrestPlayer(oPC, nLevel, sCrime);
+}


### PR DESCRIPTION
## Co to robi

System więzienia dla dark fantasy CRPG. Gracz może zostać uwięziony przez dowolny zewnętrzny skrypt (strażnik NPC, quest, wykrycie przestępstwa). Otwiera się okno NUI z odliczaniem wyroku i czterema opcjami wyjścia z celi. Historia kar przechowywana jest trwale w SQLite per-postać.

## Mechanika

**Aresztowanie** — dowolny skrypt wywołuje `PrisonArrestPlayer(oPC, nCrimeLevel, sCrimeDesc)`. Poziom zbrodni (1–5) wyznacza długość wyroku (`120 sek × poziom`) i trudność ucieczek. Gracz teleportuje się do waypointu `PRISON_CELL_WP` (opcjonalny).

**Okno NUI — dwa panele (zakładki):**
- **Stan**: zbrodnia, ciężkość, wyrok w minutach, odliczanie, licznik prób ucieczki (maks. 3 nieudane → blokada)
- **Historia**: lista poprzednich wyroków z datą i wynikiem (NuiList, ostatnie 10)

**Cztery opcje ucieczki:**

| Opcja | Mechanika | Koszt porażki |
|---|---|---|
| Odsiaduj karę | Zamknij okno, poczekaj — automatyczne zwolnienie | brak |
| Przekup strażnika | Kosztuje `50 gp × poziom`; 80% szans | złoto przepada + kara `90 sek × poziom` |
| Wytrych | Wymaga narzędzi złodziejskich; `GetIsSkillSuccessful(SKILL_OPEN_LOCK, DC 10+lvl×2)` | próba zablokowana |
| Obezwładnij | `d20 + STR mod ≥ DC 12+lvl×2` | +120 sek + ogłuszenie 30 sek |

**Heartbeat** — `DelayCommand(60.0, PrisonHeartbeat(oPC))` odpytuje DB co minutę; zwalnia gracza automatycznie gdy czas minie. Przy rozłączeniu `sys_on_enter` wykrywa aktywny wyrok i wznawia heartbeat (lub zwalnia natychmiast, jeśli kara upłynęła offline).

## Pliki

```
Więzienie/
├── INTEGRATION.md
└── scripts/
    ├── sql_prison.nss       — schema SQLite + zapytania
    ├── lib_prison_def.nss   — stałe, bind keys, forward decl
    ├── lib_prison.nss       — builderzy NUI, logika gry
    ├── lib_prison_ev.nss    — handler NUI eventów
    ├── sys_on_load.nss      — CREATE TABLE IF NOT EXISTS
    ├── sys_on_enter.nss     — restore / release po reconnect
    ├── test_prison.nss      — OnUsed na placeable (demo)
    ├── lib_nui.nss          — shared (skopiowane z Mailbox)
    └── lib_nui_utility.nss  — shared (skopiowane z Mailbox)
```

## Zależności (NWNX? SQL?)

- **Brak NWNX** — działa na czystym NWN:EE.
- SQLite: campaign DB `"prison"` (tworzona automatycznie).
- Wytrych: tagi `NW_IT_PICKS001/002/003` (standardowe narzędzia złodziejskie NWN).

## Jak włączyć w istniejącym module

1. `OnModuleLoad` → wywołaj `sys_on_load` (lub dodaj `#include "lib_prison_def"` + `PrisonCreateTables();` do istniejącego handlera).
2. `OnClientEnter` → wywołaj `sys_on_enter` (lub wklej jego zawartość do istniejącego handlera).
3. `OnNUIEvent` → obsługiwane automatycznie przez `NuiCreate(..., PRISON_EV_SCRIPT)`.
4. Na placeable testowym: `OnUsed = test_prison`.
5. Opcjonalnie: ustaw waypointy `PRISON_CELL_WP` i `PRISON_RELEASE_WP`.

Aresztowanie z własnego skryptu strażnika:
```nss
#include "lib_prison"
PrisonArrestPlayer(oPC, 3, "Napad z bronią na kupca");
```

## Co celowo pominięto

- **Grafika / tło NUI** — brak pliku `.hak`; moduł używa domyślnych kontrolek NWN:EE.
- **Sędzia / rozprawa sądowa** — wymagałoby rozbudowanego systemu dialogów NPC.
- **Listy współwięźniów w UI** — każdy gracz widzi tylko swój stan; synchronizacja wielu cel to osobny system.
- **Kary pieniężne jako pełna alternatywa aresztu** — przekupstwo jest mechanicznie zbliżone; formalne postępowanie wykracza poza zakres.
- **Integracja z konkretnym modułem** — brak twardych zależności od innych modułów; API jest minimalne i ortogonalne.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XxjS8Ps11t2tDQkSycKdcJ)_