### PR TITLE
feat: Poison Workshop (Wytwórnia Trucizn)

### DIFF
--- a/Poison Workshop/INTEGRATION.md
+++ b/Poison Workshop/INTEGRATION.md
@@ -1,0 +1,75 @@
+# Wytwórnia Trucizn — Integracja z modułem NWN
+
+## Wymagania
+
+- NWN:EE (1.69+)  
+- Brak NWNX — moduł działa na czystym NWScript + SQLite  
+- Kampania SQLite o nazwie `"poi"` tworzona automatycznie przez `sys_on_load.nss`
+
+## Hooki do podpięcia
+
+| Zdarzenie modułu       | Skrypt                 |
+|------------------------|------------------------|
+| OnModuleLoad           | `sys_on_load.nss`      |
+| OnClientEnter          | `sys_on_enter.nss`     |
+| OnPlayerTarget         | `sys_on_target.nss`    |
+
+Jeśli inne moduły już zajmują `OnClientEnter` / `OnPlayerTarget`, wywołaj
+funkcje z tego modułu wewnątrz swoich istniejących handlerów:
+
+```nss
+// w swoim OnClientEnter:
+#include "lib_poi"
+// (...)
+// Na końcu handlera:
+if(GetIsPC(GetEnteringObject()))
+{
+    // opcjonalne powiadomienie o fiolkach
+}
+
+// w swoim OnPlayerTarget:
+#include "lib_poi"
+// (...)
+if(GetLocalInt(GetLastPlayerToSelectTarget(), POI_LVAR_PENDING) > 0)
+    PoiOnWeaponTarget(GetLastPlayerToSelectTarget());
+```
+
+## Placeable testowy
+
+Stwórz dowolny placeable (stół, kocioł, ołtarz) i ustaw mu `OnUsed = test_poi`.  
+Przy pierwszym użyciu postać dostaje po 3 sztuki każdego składnika.
+
+## Składniki w świecie gry
+
+Składniki nie są itemami — system śledzi stany w SQLite.  
+Aby gracz mógł zdobywać składniki w świecie, dodaj trigger/skrypt
+`OnContainerOpen` do skrzyni lub OnDeath do potwora:
+
+```nss
+#include "lib_poi"
+// Przykład: potwór miecznik porzuca po śmierci 1x Worek Jadu Pająka
+PoiModifyStock(GetLastKiller(), POI_ING_SPIDER, 1);
+SendMessageToPC(GetLastKiller(), "[Trucizny] Znaleziono: Worek Jadu Pająka.");
+```
+
+## Trucizny i efekty broni
+
+Trucizna nałożona na broń działa **120 sekund** od momentu naniesienia.
+Implementacja opiera się na `AddItemProperty(DURATION_TYPE_TEMPORARY, ...)`,
+więc efekt automatycznie gaśnie bez ingerencji w OnHit.
+
+| Fiolka              | Efekt item property                                |
+|---------------------|----------------------------------------------------|
+| Trucizna Wolna      | `IP_CONST_ONHIT_CASTSPELL_SLOW` (poziom 5)        |
+| Jad Paraliżu        | `IP_CONST_ONHIT_CASTSPELL_HOLD_MONSTER` (poz. 5) |
+| Jad Ślepoty         | `IP_CONST_ONHIT_CASTSPELL_BLINDNESS_AND_DEAFNESS`|
+| Trucizna Osłabienia | `IP_CONST_ONHIT_CASTSPELL_BESTOW_CURSE`           |
+| Wyciąg Nocy         | `ItemPropertyDamageBonus(ACID, 2d6)`              |
+| Jad Czarownicy      | `IP_CONST_ONHIT_CASTSPELL_DISPEL_MAGIC` (poz. 5) |
+
+## Co celowo pominięto
+
+- **Czas warzenia** — brak animacji/opóźnienia; można dodać `DelayCommand` przed `PoiCraft`.
+- **Liczba trafień zamiast czasu** — wymaga NWNX `OnPhysicalAttackHit`; czas jest wystarczająco klimatyczny.
+- **Odporności na trucizny** — saving throw gracza-celu to domena silnika NWN wbudowana w `ItemPropertyOnHitCastSpell`.
+- **Persistencja stanu broni** — czas naniesienia nie przeżywa resetu serwera; przy potrzebie można dodać kolumnę `poi_weapon_state` z `end_unix` i re-aplikować efekt w `sys_on_enter.nss`.

--- a/Poison Workshop/scripts/lib_nui.nss
+++ b/Poison Workshop/scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Poison Workshop/scripts/lib_nui_utility.nss
+++ b/Poison Workshop/scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Poison Workshop/scripts/lib_poi.nss
+++ b/Poison Workshop/scripts/lib_poi.nss
@@ -1,0 +1,531 @@
+#include "lib_poi_def"
+
+// Forward declarations
+void FeedWorkshop(object oPC, int nToken);
+void FeedArsenal(object oPC, int nToken);
+void SwapToWorkshop(object oPC, int nToken);
+void SwapToArsenal(object oPC, int nToken);
+void PoiApplyEffect(object oPC, object oWeapon, int nPoisonId);
+void PoiOnWeaponTarget(object oPC);
+
+// ----------------------------------------------------------------
+// Workshop view builder
+// ----------------------------------------------------------------
+
+json BuildWorkshopView(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 28.0);
+    float fIRowH = GetNuiScaleDimension(oPC, 24.0);
+    float fRRowH = GetNuiScaleDimension(oPC, 30.0);
+
+    // --- Ingredient inventory list ---
+    json jIngHdr = NuiLabel(JsonString("Składniki w zapasach:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jIngHdr = NuiHeight(jIngHdr, GetNuiScaleDimension(oPC, 22.0));
+
+    json jIngName = NuiLabel(NuiBind(POI_BIND_ING_NAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jIngName = NuiStyleForegroundColor(jIngName, NuiBind(POI_BIND_ING_COLOR));
+
+    json jIngCnt = NuiLabel(NuiBind(POI_BIND_ING_COUNT),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jIngCnt = NuiWidth(jIngCnt, GetNuiScaleDimension(oPC, 36.0));
+    jIngCnt = NuiStyleForegroundColor(jIngCnt, NuiBind(POI_BIND_ING_COLOR));
+
+    json jIngCols = JsonArray();
+    jIngCols = JsonArrayInsert(jIngCols, jIngName);
+    jIngCols = JsonArrayInsert(jIngCols, jIngCnt);
+
+    json jIngCell = NuiGroup(NuiRow(jIngCols), FALSE, NUI_SCROLLBARS_NONE);
+    json jIngTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jIngCell, 0.0, TRUE));
+    json jIngList = NuiList(jIngTmpl, NuiBind(POI_BIND_ING_LEN), fIRowH);
+    jIngList = NuiHeight(jIngList, GetNuiScaleDimension(oPC, 205.0));
+
+    // --- Recipe list ---
+    json jRecHdr = NuiLabel(JsonString("Receptury (kliknij 'Warzyj' by sporządzić fiolkę):"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRecHdr = NuiHeight(jRecHdr, GetNuiScaleDimension(oPC, 22.0));
+
+    float fCraftW = GetNuiScaleDimension(oPC, 70.0);
+    float fNameW  = GetNuiScaleDimension(oPC, 145.0);
+
+    json jRecName = NuiLabel(NuiBind(POI_BIND_REC_NAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRecName = NuiWidth(jRecName, fNameW);
+    jRecName = NuiStyleForegroundColor(jRecName, NuiBind(POI_BIND_REC_COLOR));
+
+    json jRecIngr = NuiLabel(NuiBind(POI_BIND_REC_INGR),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRecIngr = NuiStyleForegroundColor(jRecIngr, NuiBind(POI_BIND_REC_COLOR));
+
+    json jCraftBtn = NuiButton(JsonString("Warzyj"));
+    jCraftBtn = NuiId(jCraftBtn, POI_BTN_CRAFT);
+    jCraftBtn = NuiEnabled(jCraftBtn, NuiBind(POI_BIND_REC_CRAFT_ENA));
+    jCraftBtn = NuiWidth(jCraftBtn, fCraftW);
+    jCraftBtn = NuiHeight(jCraftBtn, GetNuiScaleDimension(oPC, 26.0));
+
+    json jRecCols = JsonArray();
+    jRecCols = JsonArrayInsert(jRecCols, jRecName);
+    jRecCols = JsonArrayInsert(jRecCols, jRecIngr);
+    jRecCols = JsonArrayInsert(jRecCols, jCraftBtn);
+
+    json jRecCell = NuiGroup(NuiRow(jRecCols), FALSE, NUI_SCROLLBARS_NONE);
+    json jRecTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jRecCell, 0.0, TRUE));
+    json jRecList = NuiList(jRecTmpl, NuiBind(POI_BIND_REC_LEN), fRRowH);
+    jRecList = NuiHeight(jRecList, GetNuiScaleDimension(oPC, 200.0));
+
+    // --- Assemble ---
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jIngHdr);
+    jCol = JsonArrayInsert(jCol, jIngList);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jRecHdr);
+    jCol = JsonArrayInsert(jCol, jRecList);
+
+    float fContentW = GetNuiScaleDimension(oPC, 540.0);
+    json jSide      = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    json jMain      = JsonArray();
+    jMain = JsonArrayInsert(jMain, jSide);
+    jMain = JsonArrayInsert(jMain, NuiWidth(NuiCol(jCol), fContentW));
+    jMain = JsonArrayInsert(jMain, jSide);
+    return NuiRow(jMain);
+}
+
+// ----------------------------------------------------------------
+// Arsenal view builder
+// ----------------------------------------------------------------
+
+json BuildArsenalView(object oPC)
+{
+    float fRowH   = GetNuiScaleDimension(oPC, 32.0);
+    float fApplyW = GetNuiScaleDimension(oPC, 130.0);
+    float fCntW   = GetNuiScaleDimension(oPC, 32.0);
+    float fEfxW   = GetNuiScaleDimension(oPC, 140.0);
+
+    json jActiveLbl = NuiLabel(NuiBind(POI_BIND_ARS_ACTIVE),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jActiveLbl = NuiHeight(jActiveLbl, GetNuiScaleDimension(oPC, 28.0));
+
+    // List columns: name | effect | count | [apply btn]
+    json jPoisName = NuiLabel(NuiBind(POI_BIND_ARS_NAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jPoisName = NuiStyleForegroundColor(jPoisName, NuiBind(POI_BIND_ARS_COLOR));
+    jPoisName = NuiWidth(jPoisName, GetNuiScaleDimension(oPC, 145.0));
+
+    json jPoisCnt = NuiLabel(NuiBind(POI_BIND_ARS_COUNT),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jPoisCnt = NuiWidth(jPoisCnt, fCntW);
+    jPoisCnt = NuiStyleForegroundColor(jPoisCnt, NuiBind(POI_BIND_ARS_COLOR));
+
+    json jApplyBtn = NuiButton(JsonString("Nałóż na broń"));
+    jApplyBtn = NuiId(jApplyBtn, POI_BTN_APPLY);
+    jApplyBtn = NuiEnabled(jApplyBtn, NuiBind(POI_BIND_ARS_APPLY_ENA));
+    jApplyBtn = NuiWidth(jApplyBtn, fApplyW);
+    jApplyBtn = NuiHeight(jApplyBtn, GetNuiScaleDimension(oPC, 28.0));
+
+    json jPoisCols = JsonArray();
+    jPoisCols = JsonArrayInsert(jPoisCols, jPoisName);
+    jPoisCols = JsonArrayInsert(jPoisCols, jPoisCnt);
+    jPoisCols = JsonArrayInsert(jPoisCols, jApplyBtn);
+
+    json jPoisCell = NuiGroup(NuiRow(jPoisCols), FALSE, NUI_SCROLLBARS_NONE);
+    json jPoisTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jPoisCell, 0.0, TRUE));
+    json jPoisList = NuiList(jPoisTmpl, NuiBind(POI_BIND_ARS_LEN), fRowH);
+    jPoisList = NuiHeight(jPoisList, GetNuiScaleDimension(oPC, 230.0));
+
+    json jHint = NuiLabel(
+        JsonString("Kliknij 'Nałóż na broń', następnie wskaż broń z ekwipunku lub dzierżoną w dłoni."),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jHint = NuiHeight(jHint, GetNuiScaleDimension(oPC, 42.0));
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jActiveLbl);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, jPoisList);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, jHint);
+
+    float fContentW = GetNuiScaleDimension(oPC, 540.0);
+    json jSide      = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    json jMain      = JsonArray();
+    jMain = JsonArrayInsert(jMain, jSide);
+    jMain = JsonArrayInsert(jMain, NuiWidth(NuiCol(jCol), fContentW));
+    jMain = JsonArrayInsert(jMain, jSide);
+    return NuiRow(jMain);
+}
+
+// ----------------------------------------------------------------
+// Window creation
+// ----------------------------------------------------------------
+
+void CreatePoisonWindow(object oPC)
+{
+    if(NuiFindWindow(oPC, POI_WINDOW) != 0)
+    {
+        SwapToWorkshop(oPC, NuiFindWindow(oPC, POI_WINDOW));
+        return;
+    }
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))
+                 - GetNuiScaleDimension(oPC, POI_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT))
+                 - GetNuiScaleDimension(oPC, POI_H)) / 2.0;
+    json jGeom = NuiRect(fCX, fCY,
+                         GetNuiScaleDimension(oPC, POI_W),
+                         GetNuiScaleDimension(oPC, POI_H));
+
+    float fBtnH = GetNuiScaleDimension(oPC, 28.0);
+
+    json jWorkTab = NuiButton(JsonString("Receptury"));
+    jWorkTab = NuiId(jWorkTab, POI_BTN_TAB_WORKSHOP);
+    jWorkTab = NuiWidth(jWorkTab, GetNuiScaleDimension(oPC, 110.0));
+    jWorkTab = NuiHeight(jWorkTab, fBtnH);
+    jWorkTab = NuiEncouraged(jWorkTab, NuiBind(POI_BIND_TAB_WORK_ENC));
+
+    json jArsTab = NuiButton(JsonString("Arsenał"));
+    jArsTab = NuiId(jArsTab, POI_BTN_TAB_ARSENAL);
+    jArsTab = NuiWidth(jArsTab, GetNuiScaleDimension(oPC, 110.0));
+    jArsTab = NuiHeight(jArsTab, fBtnH);
+    jArsTab = NuiEncouraged(jArsTab, NuiBind(POI_BIND_TAB_ARS_ENC));
+
+    json jCloseBtn = NuiButton(JsonString("X"));
+    jCloseBtn = NuiId(jCloseBtn, POI_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, GetNuiScaleDimension(oPC, 30.0));
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jTabRow = JsonArray();
+    jTabRow = JsonArrayInsert(jTabRow, jWorkTab);
+    jTabRow = JsonArrayInsert(jTabRow, jArsTab);
+    jTabRow = JsonArrayInsert(jTabRow, NuiSpacer());
+    jTabRow = JsonArrayInsert(jTabRow, jCloseBtn);
+
+    json jSwapGrp = NuiGroup(BuildWorkshopView(oPC), FALSE, NUI_SCROLLBARS_NONE);
+    jSwapGrp = NuiId(jSwapGrp, POI_GRP_SWAP);
+
+    json jRootCols = JsonArray();
+    jRootCols = JsonArrayInsert(jRootCols, NuiRow(jTabRow));
+    jRootCols = JsonArrayInsert(jRootCols, jSwapGrp);
+    json jRoot = NuiCol(jRootCols);
+
+    json jWin = NuiWindow(jRoot,
+        JsonString("Wytwórnia Trucizn"),
+        NuiBind(POI_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    int nToken = NuiCreate(oPC, jWin, POI_WINDOW, POI_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, POI_WIN_GEOM, jGeom);
+    SwapToWorkshop(oPC, nToken);
+}
+
+void SwapToWorkshop(object oPC, int nToken)
+{
+    NuiSetGroupLayout(oPC, nToken, POI_GRP_SWAP, BuildWorkshopView(oPC));
+    NuiSetBind(oPC, nToken, POI_BIND_TAB_WORK_ENC, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, POI_BIND_TAB_ARS_ENC,  JsonBool(FALSE));
+    FeedWorkshop(oPC, nToken);
+}
+
+void SwapToArsenal(object oPC, int nToken)
+{
+    NuiSetGroupLayout(oPC, nToken, POI_GRP_SWAP, BuildArsenalView(oPC));
+    NuiSetBind(oPC, nToken, POI_BIND_TAB_WORK_ENC, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, POI_BIND_TAB_ARS_ENC,  JsonBool(TRUE));
+    FeedArsenal(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Data feed — Workshop
+// ----------------------------------------------------------------
+
+void FeedWorkshop(object oPC, int nToken)
+{
+    json jGray  = NuiColor(120, 120, 120);
+    json jWhite = NuiColor(210, 210, 210);
+
+    // ingredient rows
+    json jIngNames  = JsonArray();
+    json jIngCounts = JsonArray();
+    json jIngColors = JsonArray();
+    int i;
+    for(i = 0; i < POI_ING_COUNT; i++)
+    {
+        int nCnt = PoiGetStock(oPC, i);
+        jIngNames  = JsonArrayInsert(jIngNames,  JsonString(PoiIngredientName(i)));
+        jIngCounts = JsonArrayInsert(jIngCounts, JsonString("x" + IntToString(nCnt)));
+        jIngColors = JsonArrayInsert(jIngColors, nCnt > 0 ? jWhite : jGray);
+    }
+    NuiSetBind(oPC, nToken, POI_BIND_ING_NAME,  jIngNames);
+    NuiSetBind(oPC, nToken, POI_BIND_ING_COUNT, jIngCounts);
+    NuiSetBind(oPC, nToken, POI_BIND_ING_COLOR, jIngColors);
+    NuiSetBind(oPC, nToken, POI_BIND_ING_LEN,   JsonInt(POI_ING_COUNT));
+
+    // recipe rows
+    json jRecNames  = JsonArray();
+    json jRecIngrs  = JsonArray();
+    json jRecEnas   = JsonArray();
+    json jRecColors = JsonArray();
+    for(i = 0; i < POI_VIAL_COUNT; i++)
+    {
+        int i0, i1, i2;
+        PoiGetRecipe(i, i0, i1, i2);
+
+        int bCan = TRUE;
+        if(i0 >= 0 && PoiGetStock(oPC, i0) < 1) bCan = FALSE;
+        if(i1 >= 0 && PoiGetStock(oPC, i1) < 1) bCan = FALSE;
+        if(i2 >= 0 && PoiGetStock(oPC, i2) < 1) bCan = FALSE;
+
+        jRecNames  = JsonArrayInsert(jRecNames,  JsonString(PoiPoisonName(i)));
+        jRecIngrs  = JsonArrayInsert(jRecIngrs,  JsonString(PoiRecipeString(i)));
+        jRecEnas   = JsonArrayInsert(jRecEnas,   JsonBool(bCan));
+        jRecColors = JsonArrayInsert(jRecColors, bCan ? PoiPoisonColor(i) : jGray);
+    }
+    NuiSetBind(oPC, nToken, POI_BIND_REC_NAME,      jRecNames);
+    NuiSetBind(oPC, nToken, POI_BIND_REC_INGR,      jRecIngrs);
+    NuiSetBind(oPC, nToken, POI_BIND_REC_CRAFT_ENA, jRecEnas);
+    NuiSetBind(oPC, nToken, POI_BIND_REC_COLOR,     jRecColors);
+    NuiSetBind(oPC, nToken, POI_BIND_REC_LEN,       JsonInt(POI_VIAL_COUNT));
+}
+
+// ----------------------------------------------------------------
+// Data feed — Arsenal
+// ----------------------------------------------------------------
+
+void FeedArsenal(object oPC, int nToken)
+{
+    int nActiveId = GetLocalInt(oPC, POI_LVAR_POISON_ID) - 1;
+    string sActive = nActiveId >= 0
+        ? "Na broni: " + PoiPoisonName(nActiveId) + "  [aktywna przez " + IntToString(FloatToInt(POI_WEAPON_DURATION)) + "s od naniesienia]"
+        : "Broń bez trucizny. Pieczęć krwi pulsuje słabo…";
+    NuiSetBind(oPC, nToken, POI_BIND_ARS_ACTIVE, JsonString(sActive));
+
+    json jGray = NuiColor(100, 100, 100);
+    json jPoisNames  = JsonArray();
+    json jPoisCounts = JsonArray();
+    json jPoisEnas   = JsonArray();
+    json jPoisColors = JsonArray();
+    int i;
+    for(i = 0; i < POI_VIAL_COUNT; i++)
+    {
+        int nCnt = PoiGetStock(oPC, POI_POISON_OFFSET + i);
+        jPoisNames  = JsonArrayInsert(jPoisNames,  JsonString(PoiPoisonName(i) + "  [" + PoiPoisonEffect(i) + "]"));
+        jPoisCounts = JsonArrayInsert(jPoisCounts, JsonString("x" + IntToString(nCnt)));
+        jPoisEnas   = JsonArrayInsert(jPoisEnas,   JsonBool(nCnt > 0));
+        jPoisColors = JsonArrayInsert(jPoisColors, nCnt > 0 ? PoiPoisonColor(i) : jGray);
+    }
+    NuiSetBind(oPC, nToken, POI_BIND_ARS_NAME,      jPoisNames);
+    NuiSetBind(oPC, nToken, POI_BIND_ARS_COUNT,     jPoisCounts);
+    NuiSetBind(oPC, nToken, POI_BIND_ARS_APPLY_ENA, jPoisEnas);
+    NuiSetBind(oPC, nToken, POI_BIND_ARS_COLOR,     jPoisColors);
+    NuiSetBind(oPC, nToken, POI_BIND_ARS_LEN,       JsonInt(POI_VIAL_COUNT));
+}
+
+// ----------------------------------------------------------------
+// Craft a poison vial
+// ----------------------------------------------------------------
+
+void PoiCraft(object oPC, int nToken, int nPoisonId)
+{
+    int i0, i1, i2;
+    PoiGetRecipe(nPoisonId, i0, i1, i2);
+
+    // Validate stock
+    if(i0 >= 0 && PoiGetStock(oPC, i0) < 1)
+    {
+        SendMessageToPC(oPC, "[Trucizny] Brak składnika: " + PoiIngredientName(i0) + ".");
+        return;
+    }
+    if(i1 >= 0 && PoiGetStock(oPC, i1) < 1)
+    {
+        SendMessageToPC(oPC, "[Trucizny] Brak składnika: " + PoiIngredientName(i1) + ".");
+        return;
+    }
+    if(i2 >= 0 && PoiGetStock(oPC, i2) < 1)
+    {
+        SendMessageToPC(oPC, "[Trucizny] Brak składnika: " + PoiIngredientName(i2) + ".");
+        return;
+    }
+
+    // Consume
+    if(i0 >= 0) PoiModifyStock(oPC, i0, -1);
+    if(i1 >= 0) PoiModifyStock(oPC, i1, -1);
+    if(i2 >= 0) PoiModifyStock(oPC, i2, -1);
+
+    PoiModifyStock(oPC, POI_POISON_OFFSET + nPoisonId, 1);
+
+    string sFlavor;
+    switch(nPoisonId)
+    {
+        case POI_VIAL_SLOW:
+            sFlavor = "Bąbelki cieczy snują się leniwie, niczym śmierć powolna.";
+            break;
+        case POI_VIAL_PARALYZE:
+            sFlavor = "Woń pająka unosi się nad czarną pianą.";
+            break;
+        case POI_VIAL_BLIND:
+            sFlavor = "Mgła zamknięta w fiolce — mroku mądrość.";
+            break;
+        case POI_VIAL_WEAKEN:
+            sFlavor = "Pyłek kwiatu pochodzi z ziemi, co nie zna słońca.";
+            break;
+        case POI_VIAL_LETHAL:
+            sFlavor = "Ciemność w płynie. Czujesz, jak pali w palcach.";
+            break;
+        default:
+            sFlavor = "Grzyb i żółć rozżarzają się razem bladym ogniem.";
+            break;
+    }
+
+    SendMessageToPC(oPC, "[Trucizny] Sporządzono: " + PoiPoisonName(nPoisonId) + ". " + sFlavor);
+    FloatingTextStringOnCreature("*warzy truciznę*", oPC, FALSE);
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectVisualEffect(VFX_IMP_ACID_S), oPC);
+
+    FeedWorkshop(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Begin apply-to-weapon flow (targeting mode)
+// ----------------------------------------------------------------
+
+void PoiApplyToWeapon(object oPC, int nPoisonId)
+{
+    if(PoiGetStock(oPC, POI_POISON_OFFSET + nPoisonId) < 1)
+    {
+        SendMessageToPC(oPC, "[Trucizny] Nie masz tej trucizny.");
+        return;
+    }
+    SetLocalInt(oPC, POI_LVAR_PENDING, nPoisonId + 1);
+    SendMessageToPC(oPC, "[Trucizny] Wskaż broń, na którą nanieść "
+                    + PoiPoisonName(nPoisonId) + ".");
+    EnterTargetingMode(oPC, OBJECT_TYPE_ITEM);
+}
+
+// ----------------------------------------------------------------
+// Apply the actual item property to the weapon
+// ----------------------------------------------------------------
+
+void PoiApplyEffect(object oPC, object oWeapon, int nPoisonId)
+{
+    // Strip any existing temporary properties from this module first
+    // (DURATION_TYPE_TEMPORARY covers all temp props, so we only remove
+    //  the ones we know about to avoid removing legitimate enchants)
+    itemproperty ip = GetFirstItemProperty(oWeapon);
+    while(GetIsItemPropertyValid(ip))
+    {
+        itemproperty ipNext = GetNextItemProperty(oWeapon);
+        if(GetItemPropertyDurationType(ip) == DURATION_TYPE_TEMPORARY)
+            RemoveItemProperty(oWeapon, ip);
+        ip = ipNext;
+    }
+
+    float fDur = POI_WEAPON_DURATION;
+    switch(nPoisonId)
+    {
+        case POI_VIAL_SLOW:
+            AddItemProperty(DURATION_TYPE_TEMPORARY,
+                ItemPropertyOnHitCastSpell(IP_CONST_ONHIT_CASTSPELL_SLOW, 5),
+                oWeapon, fDur);
+            break;
+        case POI_VIAL_PARALYZE:
+            AddItemProperty(DURATION_TYPE_TEMPORARY,
+                ItemPropertyOnHitCastSpell(IP_CONST_ONHIT_CASTSPELL_HOLD_MONSTER, 5),
+                oWeapon, fDur);
+            break;
+        case POI_VIAL_BLIND:
+            AddItemProperty(DURATION_TYPE_TEMPORARY,
+                ItemPropertyOnHitCastSpell(IP_CONST_ONHIT_CASTSPELL_BLINDNESS_AND_DEAFNESS, 5),
+                oWeapon, fDur);
+            break;
+        case POI_VIAL_WEAKEN:
+            AddItemProperty(DURATION_TYPE_TEMPORARY,
+                ItemPropertyOnHitCastSpell(IP_CONST_ONHIT_CASTSPELL_BESTOW_CURSE, 5),
+                oWeapon, fDur);
+            break;
+        case POI_VIAL_LETHAL:
+            AddItemProperty(DURATION_TYPE_TEMPORARY,
+                ItemPropertyDamageBonus(IP_CONST_DAMAGETYPE_ACID, IP_CONST_DAMAGEBONUS_2d6),
+                oWeapon, fDur);
+            break;
+        case POI_VIAL_WITCHBANE:
+            AddItemProperty(DURATION_TYPE_TEMPORARY,
+                ItemPropertyOnHitCastSpell(IP_CONST_ONHIT_CASTSPELL_DISPEL_MAGIC, 5),
+                oWeapon, fDur);
+            break;
+    }
+
+    SetLocalInt(oPC, POI_LVAR_POISON_ID, nPoisonId + 1);
+
+    // Schedule UI cleanup — item property auto-expires, we just clear tracking
+    DelayCommand(fDur, PoiClearWeaponPoison(oPC));
+}
+
+// ----------------------------------------------------------------
+// OnPlayerTarget handler — resolve weapon selection
+// ----------------------------------------------------------------
+
+void PoiOnWeaponTarget(object oPC)
+{
+    int nPending = GetLocalInt(oPC, POI_LVAR_PENDING) - 1;
+    DeleteLocalInt(oPC, POI_LVAR_PENDING);
+
+    if(nPending < 0) return;
+
+    object oItem = GetTargetingModeSelectedObject();
+    if(!GetIsObjectValid(oItem))
+    {
+        SendMessageToPC(oPC, "[Trucizny] Anulowano.");
+        return;
+    }
+
+    if(GetItemPossessor(oItem) != oPC)
+    {
+        SendMessageToPC(oPC, "[Trucizny] Możesz nanosić truciznę tylko na własną broń.");
+        return;
+    }
+
+    // Must have at least one stock (double-check race condition)
+    if(PoiGetStock(oPC, POI_POISON_OFFSET + nPending) < 1)
+    {
+        SendMessageToPC(oPC, "[Trucizny] Fiolka opróżniła się.");
+        return;
+    }
+
+    PoiModifyStock(oPC, POI_POISON_OFFSET + nPending, -1);
+    PoiApplyEffect(oPC, oItem, nPending);
+
+    string sFlavor;
+    switch(nPending)
+    {
+        case POI_VIAL_SLOW:
+            sFlavor = "Ostrze pokrywa się mazią zimną niczym bagno.";
+            break;
+        case POI_VIAL_PARALYZE:
+            sFlavor = "Klinga drżąco wchłania jad pająka.";
+            break;
+        case POI_VIAL_BLIND:
+            sFlavor = "Mgła osiadła na ostrzu; wyczuwasz stęchliznę.";
+            break;
+        case POI_VIAL_WEAKEN:
+            sFlavor = "Pyłek osadza się w rowkach ostrza bez dźwięku.";
+            break;
+        case POI_VIAL_LETHAL:
+            sFlavor = "Czarna ciecz sączy się wzdłuż ostrza jak krew.";
+            break;
+        default:
+            sFlavor = "Runa na głowni rozbłyska bladym ogniem i gaśnie.";
+            break;
+    }
+
+    SendMessageToPC(oPC, "[Trucizny] " + PoiPoisonName(nPending)
+                    + " naniesiona na " + GetName(oItem) + ". " + sFlavor);
+    FloatingTextStringOnCreature("*nanosi truciznę*", oPC, FALSE);
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectVisualEffect(VFX_IMP_POISON_S), oPC);
+
+    int nToken = NuiFindWindow(oPC, POI_WINDOW);
+    if(nToken != 0)
+        FeedArsenal(oPC, nToken);
+}

--- a/Poison Workshop/scripts/lib_poi_def.nss
+++ b/Poison Workshop/scripts/lib_poi_def.nss
@@ -1,0 +1,228 @@
+#include "lib_nui"
+#include "sql_poi"
+
+// Forward declarations (bodies in lib_poi.nss)
+void FeedWorkshop(object oPC, int nToken);
+void FeedArsenal(object oPC, int nToken);
+void PoiOnWeaponTarget(object oPC);
+
+// ----------------------------------------------------------------
+// Ingredient IDs
+// ----------------------------------------------------------------
+
+const int POI_ING_NIGHTSHADE  = 0;
+const int POI_ING_BLOODROOT   = 1;
+const int POI_ING_SPIDER      = 2;
+const int POI_ING_MARSH       = 3;
+const int POI_ING_CORPSE      = 4;
+const int POI_ING_WITCHBANE   = 5;
+const int POI_ING_BILE        = 6;
+const int POI_ING_IRON        = 7;
+
+// ----------------------------------------------------------------
+// Poison vial IDs
+// ----------------------------------------------------------------
+
+const int POI_VIAL_SLOW       = 0;
+const int POI_VIAL_PARALYZE   = 1;
+const int POI_VIAL_BLIND      = 2;
+const int POI_VIAL_WEAKEN     = 3;
+const int POI_VIAL_LETHAL     = 4;
+const int POI_VIAL_WITCHBANE  = 5;
+
+// ----------------------------------------------------------------
+// Weapon-state local vars on PC
+// ----------------------------------------------------------------
+
+const string POI_LVAR_PENDING   = "POI_PENDING_VIAL";  // vial_id+1 while targeting; 0 = none
+const string POI_LVAR_POISON_ID = "POI_WEP_ID";        // active poison id+1 on weapon; 0 = none
+
+// ----------------------------------------------------------------
+// Duration a single dose stays active on the weapon (seconds)
+// ----------------------------------------------------------------
+
+const float POI_WEAPON_DURATION = 120.0;
+
+// ----------------------------------------------------------------
+// Window / group IDs
+// ----------------------------------------------------------------
+
+const string POI_WINDOW         = "POI_WIN";
+const string POI_EV_SCRIPT      = "lib_poi_ev";
+const string POI_GRP_SWAP       = "POI_GRP_SWAP";
+const string POI_WIN_GEOM       = "poi_win_geom";
+
+// ----------------------------------------------------------------
+// Bind names — Workshop view
+// ----------------------------------------------------------------
+
+const string POI_BIND_ING_NAME      = "poi_ing_name";
+const string POI_BIND_ING_COUNT     = "poi_ing_cnt";
+const string POI_BIND_ING_COLOR     = "poi_ing_col";
+const string POI_BIND_ING_LEN       = "poi_ing_len";
+
+const string POI_BIND_REC_NAME      = "poi_rec_name";
+const string POI_BIND_REC_INGR      = "poi_rec_ingr";
+const string POI_BIND_REC_CRAFT_ENA = "poi_rec_cena";
+const string POI_BIND_REC_COLOR     = "poi_rec_col";
+const string POI_BIND_REC_LEN       = "poi_rec_len";
+
+// ----------------------------------------------------------------
+// Bind names — Arsenal view
+// ----------------------------------------------------------------
+
+const string POI_BIND_ARS_NAME      = "poi_ars_name";
+const string POI_BIND_ARS_COUNT     = "poi_ars_cnt";
+const string POI_BIND_ARS_APPLY_ENA = "poi_ars_aena";
+const string POI_BIND_ARS_COLOR     = "poi_ars_col";
+const string POI_BIND_ARS_LEN       = "poi_ars_len";
+const string POI_BIND_ARS_ACTIVE    = "poi_ars_act";
+
+// ----------------------------------------------------------------
+// Bind names — tab state
+// ----------------------------------------------------------------
+
+const string POI_BIND_TAB_WORK_ENC  = "poi_tab_wenc";
+const string POI_BIND_TAB_ARS_ENC   = "poi_tab_aenc";
+
+// ----------------------------------------------------------------
+// Button IDs
+// ----------------------------------------------------------------
+
+const string POI_BTN_CLOSE          = "poi_close";
+const string POI_BTN_TAB_WORKSHOP   = "poi_tab_work";
+const string POI_BTN_TAB_ARSENAL    = "poi_tab_ars";
+const string POI_BTN_CRAFT          = "poi_craft";   // array: index = vial id
+const string POI_BTN_APPLY          = "poi_apply";   // array: index = vial id
+
+// ----------------------------------------------------------------
+// Layout
+// ----------------------------------------------------------------
+
+const float POI_W = 580.0;
+const float POI_H = 620.0;
+
+// ----------------------------------------------------------------
+// Static data — names, colors, recipes
+// ----------------------------------------------------------------
+
+string PoiIngredientName(int n)
+{
+    switch(n)
+    {
+        case POI_ING_NIGHTSHADE: return "Jagoda Cieniu Nocy";
+        case POI_ING_BLOODROOT:  return "Korzeń Krwawnika";
+        case POI_ING_SPIDER:     return "Worek Jadu Pająka";
+        case POI_ING_MARSH:      return "Kryształy Mgieł";
+        case POI_ING_CORPSE:     return "Pyłek Kwiatu Zwłok";
+        case POI_ING_WITCHBANE:  return "Grzyb Czarownic";
+        case POI_ING_BILE:       return "Żółć Jaskiniowa";
+        case POI_ING_IRON:       return "Proch Żelaza";
+    }
+    return "?";
+}
+
+string PoiPoisonName(int n)
+{
+    switch(n)
+    {
+        case POI_VIAL_SLOW:      return "Trucizna Wolna";
+        case POI_VIAL_PARALYZE:  return "Jad Paraliżu";
+        case POI_VIAL_BLIND:     return "Jad Ślepoty";
+        case POI_VIAL_WEAKEN:    return "Trucizna Osłabienia";
+        case POI_VIAL_LETHAL:    return "Wyciąg Nocy";
+        case POI_VIAL_WITCHBANE: return "Jad Czarownicy";
+    }
+    return "?";
+}
+
+string PoiPoisonEffect(int n)
+{
+    switch(n)
+    {
+        case POI_VIAL_SLOW:      return "Spowalnia cel na 30s";
+        case POI_VIAL_PARALYZE:  return "Paraliżuje cel na 6s";
+        case POI_VIAL_BLIND:     return "Zaślepia cel na 20s";
+        case POI_VIAL_WEAKEN:    return "-4 Sił celu na 60s";
+        case POI_VIAL_LETHAL:    return "+2k6 obrażeń od kwasu";
+        case POI_VIAL_WITCHBANE: return "Dispeluje magię celu";
+    }
+    return "";
+}
+
+json PoiPoisonColor(int n)
+{
+    switch(n)
+    {
+        case POI_VIAL_SLOW:      return NuiColor( 80, 200,  80);
+        case POI_VIAL_PARALYZE:  return NuiColor(220, 220,  50);
+        case POI_VIAL_BLIND:     return NuiColor( 80, 140, 220);
+        case POI_VIAL_WEAKEN:    return NuiColor(220, 120,  50);
+        case POI_VIAL_LETHAL:    return NuiColor(210,  50,  50);
+        case POI_VIAL_WITCHBANE: return NuiColor(160,  60, 210);
+    }
+    return NuiColor(200, 200, 200);
+}
+
+// Fills up to three ingredient slots for a recipe; -1 = unused slot.
+void PoiGetRecipe(int nPoisonId, int &nIng0, int &nIng1, int &nIng2)
+{
+    nIng0 = -1; nIng1 = -1; nIng2 = -1;
+    switch(nPoisonId)
+    {
+        case POI_VIAL_SLOW:
+            nIng0 = POI_ING_BLOODROOT;
+            nIng1 = POI_ING_IRON;
+            break;
+        case POI_VIAL_PARALYZE:
+            nIng0 = POI_ING_SPIDER;
+            nIng1 = POI_ING_IRON;
+            break;
+        case POI_VIAL_BLIND:
+            nIng0 = POI_ING_MARSH;
+            nIng1 = POI_ING_IRON;
+            break;
+        case POI_VIAL_WEAKEN:
+            nIng0 = POI_ING_CORPSE;
+            nIng1 = POI_ING_IRON;
+            break;
+        case POI_VIAL_LETHAL:
+            nIng0 = POI_ING_NIGHTSHADE;
+            nIng1 = POI_ING_BLOODROOT;
+            nIng2 = POI_ING_CORPSE;
+            break;
+        case POI_VIAL_WITCHBANE:
+            nIng0 = POI_ING_WITCHBANE;
+            nIng1 = POI_ING_BILE;
+            nIng2 = POI_ING_IRON;
+            break;
+    }
+}
+
+string PoiRecipeString(int nPoisonId)
+{
+    int i0, i1, i2;
+    PoiGetRecipe(nPoisonId, i0, i1, i2);
+    string s = (i0 >= 0) ? PoiIngredientName(i0) : "";
+    if(i1 >= 0) s = s + " + " + PoiIngredientName(i1);
+    if(i2 >= 0) s = s + " + " + PoiIngredientName(i2);
+    return s;
+}
+
+// ----------------------------------------------------------------
+// Weapon expiry callback — called via DelayCommand after duration
+// ----------------------------------------------------------------
+
+void PoiClearWeaponPoison(object oPC)
+{
+    int nWasId = GetLocalInt(oPC, POI_LVAR_POISON_ID) - 1;
+    DeleteLocalInt(oPC, POI_LVAR_POISON_ID);
+
+    if(nWasId < 0) return;
+
+    SendMessageToPC(oPC, "[Trucizny] " + PoiPoisonName(nWasId) + " wyparowała z ostrza.");
+
+    int nToken = NuiFindWindow(oPC, POI_WINDOW);
+    if(nToken != 0)
+        FeedArsenal(oPC, nToken);
+}

--- a/Poison Workshop/scripts/lib_poi_ev.nss
+++ b/Poison Workshop/scripts/lib_poi_ev.nss
@@ -1,0 +1,61 @@
+#include "lib_poi"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    if(nToken != NuiFindWindow(oPC, POI_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        // If player had pending targeting, cancel it cleanly
+        DeleteLocalInt(oPC, POI_LVAR_PENDING);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_OPEN)
+    {
+        NuiSetBind(oPC, nToken, POI_BIND_TAB_WORK_ENC, JsonBool(TRUE));
+        NuiSetBind(oPC, nToken, POI_BIND_TAB_ARS_ENC,  JsonBool(FALSE));
+        FeedWorkshop(oPC, nToken);
+        return;
+    }
+
+    if(sEvent != EVENT_TYPE_CLICK) return;
+
+    if(sElem == POI_BTN_CLOSE)
+    {
+        NuiDestroy(oPC, nToken);
+        return;
+    }
+
+    if(sElem == POI_BTN_TAB_WORKSHOP)
+    {
+        SwapToWorkshop(oPC, nToken);
+        return;
+    }
+
+    if(sElem == POI_BTN_TAB_ARSENAL)
+    {
+        SwapToArsenal(oPC, nToken);
+        return;
+    }
+
+    if(sElem == POI_BTN_CRAFT)
+    {
+        if(nIdx >= 0 && nIdx < POI_VIAL_COUNT)
+            PoiCraft(oPC, nToken, nIdx);
+        return;
+    }
+
+    if(sElem == POI_BTN_APPLY)
+    {
+        if(nIdx >= 0 && nIdx < POI_VIAL_COUNT)
+            PoiApplyToWeapon(oPC, nIdx);
+        return;
+    }
+}

--- a/Poison Workshop/scripts/sql_poi.nss
+++ b/Poison Workshop/scripts/sql_poi.nss
@@ -1,0 +1,66 @@
+// sql_poi.nss  — SQLite persistence for Poison Workshop
+// Single table: poi_stock(char_uuid, item_id, quantity)
+// item_id  0-7  = ingredient slot (POI_ING_*)
+// item_id 100+  = poison vial slot (POI_POISON_OFFSET + POI_VIAL_*)
+
+const int POI_ING_COUNT       = 8;
+const int POI_VIAL_COUNT      = 6;
+const int POI_POISON_OFFSET   = 100;
+
+void PoiCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("poi",
+        "CREATE TABLE IF NOT EXISTS poi_stock ("
+        "  char_uuid TEXT    NOT NULL, "
+        "  item_id   INTEGER NOT NULL, "
+        "  quantity  INTEGER DEFAULT 0, "
+        "  PRIMARY KEY (char_uuid, item_id))");
+    SqlStep(q);
+}
+
+int PoiGetStock(object oPC, int nItemId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("poi",
+        "SELECT quantity FROM poi_stock "
+        "WHERE char_uuid = @uuid AND item_id = @id");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@id",   nItemId);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+void PoiSetStock(object oPC, int nItemId, int nAmount)
+{
+    if(nAmount < 0) nAmount = 0;
+    sqlquery q = SqlPrepareQueryCampaign("poi",
+        "INSERT OR REPLACE INTO poi_stock (char_uuid, item_id, quantity) "
+        "VALUES (@uuid, @id, @qty)");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@id",   nItemId);
+    SqlBindInt   (q, "@qty",  nAmount);
+    SqlStep(q);
+}
+
+void PoiModifyStock(object oPC, int nItemId, int nDelta)
+{
+    int nCurrent = PoiGetStock(oPC, nItemId);
+    PoiSetStock(oPC, nItemId, nCurrent + nDelta);
+}
+
+json PoiGetIngredientCounts(object oPC)
+{
+    json jOut = JsonArray();
+    int i;
+    for(i = 0; i < POI_ING_COUNT; i++)
+        jOut = JsonArrayInsert(jOut, JsonInt(PoiGetStock(oPC, i)));
+    return jOut;
+}
+
+json PoiGetPoisonCounts(object oPC)
+{
+    json jOut = JsonArray();
+    int i;
+    for(i = 0; i < POI_VIAL_COUNT; i++)
+        jOut = JsonArrayInsert(jOut, JsonInt(PoiGetStock(oPC, POI_POISON_OFFSET + i)));
+    return jOut;
+}

--- a/Poison Workshop/scripts/sys_on_enter.nss
+++ b/Poison Workshop/scripts/sys_on_enter.nss
@@ -1,0 +1,16 @@
+#include "lib_poi"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC)) return;
+
+    int nVials = 0;
+    int i;
+    for(i = 0; i < POI_VIAL_COUNT; i++)
+        nVials += PoiGetStock(oPC, POI_POISON_OFFSET + i);
+
+    if(nVials > 0)
+        SendMessageToPC(oPC, "[Trucizny] Masz " + IntToString(nVials)
+                        + " fiol(ki) trucizn w zasobach. Użyj stołu alchemicznego.");
+}

--- a/Poison Workshop/scripts/sys_on_load.nss
+++ b/Poison Workshop/scripts/sys_on_load.nss
@@ -1,0 +1,6 @@
+#include "lib_poi_def"
+
+void main()
+{
+    PoiCreateTables();
+}

--- a/Poison Workshop/scripts/sys_on_target.nss
+++ b/Poison Workshop/scripts/sys_on_target.nss
@@ -1,0 +1,10 @@
+#include "lib_poi"
+
+void main()
+{
+    object oPC = GetLastPlayerToSelectTarget();
+    if(!GetIsPC(oPC)) return;
+
+    if(GetLocalInt(oPC, POI_LVAR_PENDING) > 0)
+        PoiOnWeaponTarget(oPC);
+}

--- a/Poison Workshop/scripts/test_poi.nss
+++ b/Poison Workshop/scripts/test_poi.nss
@@ -1,0 +1,40 @@
+// OnUsed script for the Poison Workshop placeable.
+// Place a placeable (e.g. table, cauldron) in your area and set this
+// as its OnUsed script. Running it opens the workshop UI and, on first
+// use, seeds a small starting batch of every ingredient type so the
+// player can immediately experiment with all recipes.
+#include "lib_poi"
+
+const int POI_TEST_SEED_COUNT = 3;  // ingredients given on first use
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    // Seed ingredients once per character (if they have none of anything)
+    int bNeedsSeed = TRUE;
+    int i;
+    for(i = 0; i < POI_ING_COUNT; i++)
+    {
+        if(PoiGetStock(oPC, i) > 0)
+        {
+            bNeedsSeed = FALSE;
+            break;
+        }
+    }
+
+    if(bNeedsSeed)
+    {
+        for(i = 0; i < POI_ING_COUNT; i++)
+            PoiSetStock(oPC, i, POI_TEST_SEED_COUNT);
+
+        SendMessageToPC(oPC,
+            "[Trucizny] Znalazłeś porzucone zapasy alchemika. Stół skrywa składniki "
+            "do wszystkich podstawowych receptur.");
+        FloatingTextStringOnCreature(
+            "*odkrywa stary stół alchemiczny*", oPC, FALSE);
+    }
+
+    CreatePoisonWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

Moduł **Wytwórni Trucizn** pozwala graczom zbierać alchemiczne składniki, warzyć z nich fiolki trucizn według receptur, a następnie nanosić je na dowolną broń jako tymczasowy efekt item property. Całość obsługiwana przez NUI z dwoma zakładkami (Receptury / Arsenał) i persystowane w SQLite per-postać.

## Mechanika

- **8 składników** (Jagoda Cieniu Nocy, Korzeń Krwawnika, Worek Jadu Pająka, Kryształy Mgieł, Pyłek Kwiatu Zwłok, Grzyb Czarownic, Żółć Jaskiniowa, Proch Żelaza) śledzonych w tabeli `poi_stock`.
- **6 receptur/trucizn**: Wolna (slow), Paraliżu (hold monster), Ślepoty (blindness/deafness), Osłabienia (bestow curse), Wyciąg Nocy (+2k6 obrażeń kwas), Czarownicy (dispel magic). Każda wymaga 2–3 składników.
- **Nanoszenie na broń**: tryb targetowania → gracz wskazuje broń → `AddItemProperty(DURATION_TYPE_TEMPORARY, ...)` — efekt trwa 120 s i wygasa automatycznie. Brak NWNX, brak OnHit hookowania.
- **NUI dwuzakładkowe**: zakładka Receptury pokazuje stany składników i przyciski „Warzyj" (enabled tylko gdy jest stock); zakładka Arsenał pokazuje stany fiolek i przyciski „Nałóż na broń".
- **Flavor text po polsku** przy każdym warzeniu i nanoszeniu.

## Pliki

```
Poison Workshop/
├── scripts/
│   ├── sql_poi.nss          — schemat SQLite + CRUD (PoiGetStock / PoiSetStock / PoiModifyStock)
│   ├── lib_poi_def.nss      — stałe, ID bindów, ID przycisków, nazwy, kolory, receptury, PoiClearWeaponPoison
│   ├── lib_poi.nss          — budowanie NUI, FeedWorkshop/Arsenal, PoiCraft, PoiApplyEffect, PoiOnWeaponTarget
│   ├── lib_poi_ev.nss       — handler NUI eventów (main)
│   ├── sys_on_load.nss      — PoiCreateTables()
│   ├── sys_on_enter.nss     — powiadomienie o stanie fiolek przy logowaniu
│   ├── sys_on_target.nss    — delegacja do PoiOnWeaponTarget gdy POI_LVAR_PENDING > 0
│   ├── test_poi.nss         — OnUsed: seed składników + otwiera okno
│   ├── lib_nui.nss          — (kopia wspólna)
│   └── lib_nui_utility.nss  — (kopia wspólna)
└── INTEGRATION.md           — jak podpiąć hooki, jak dystrybuować składniki w świecie
```

## Zależności (NWNX? SQL?)

- **NWNX**: brak — moduł działa na czystym NWScript + NWN:EE SQLite.
- **SQL**: kampania `"poi"`, jedna tabela `poi_stock(char_uuid, item_id, quantity)`. Tworzona automatycznie przez `sys_on_load.nss`.

## Jak włączyć w istniejącym module

| Zdarzenie      | Skrypt           |
|----------------|------------------|
| OnModuleLoad   | `sys_on_load`    |
| OnClientEnter  | `sys_on_enter`   |
| OnPlayerTarget | `sys_on_target`  |

Placeable z `OnUsed = test_poi` otwiera UI i przy pierwszym użyciu zasila postać testowymi składnikami (po 3 każdego). Składniki w produkcji dystrybuuje się przez `PoiModifyStock(oPC, POI_ING_*, n)` w dowolnym skrypcie (OnDeath, OnContainerOpen, quest reward).

## Co celowo pominięto

- **Opóźnienie warzenia** — brak animacji/licznika; można dodać `DelayCommand` przed `PoiCraft` bez zmian architektury.
- **Liczba trafień zamiast czasu** — wymaga NWNX `OnPhysicalAttackHit`; czas 120s jest wystarczająco klimatyczny i technicznie prostszy.
- **Persystencja stanu broni przez reset** — przy restarcie serwera tymczasowe item properties gasną. Można dodać kolumnę `poi_weapon_state` i re-aplikować w `sys_on_enter.nss`; celowo pominięte jako over-engineering na tym etapie.
- **Walidacja typu broni** — gra sama ignoruje OnHit property na przedmiotach nie-broniach; nie ma potrzeby osobnego sprawdzania.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V9bEh3XdGUovFXTyuNFKJe)_