### PR TITLE
feat: Burial Rites (Obrzędy Pogrzebowe)

### DIFF
--- a/Burial Rites/INTEGRATION.md
+++ b/Burial Rites/INTEGRATION.md
@@ -1,0 +1,79 @@
+# Burial Rites — Instrukcja integracji
+
+## Wymagania
+
+- NWN Enhanced Edition 8193+
+- Standardowa biblioteka NWN EE (`nw_inc_nui`)
+- Brak zależności NWNX
+
+## Hooki modułu
+
+Podepnij poniższe skrypty do odpowiednich zdarzeń modułu w Toolsecie lub
+istniejącym skrypcie `sys_on_*` przez `ExecuteScript`:
+
+| Zdarzenie modułu | Skrypt | Co robi |
+|---|---|---|
+| OnModuleLoad | `sys_on_load.nss` | Tworzy tabele SQLite (`bur_records`) |
+| OnClientEnter | `sys_on_enter.nss` | Rejestruje postać, przywraca trwałe efekty |
+
+Jeśli moduł ma już własne `sys_on_load` i `sys_on_enter`, dodaj na końcu:
+
+```nwscript
+// w sys_on_load:
+ExecuteScript("sys_on_load", GetModule());   // NIE! zamiast tego:
+BurCreateTables();                            // dołącz #include "lib_bur_def"
+
+// w sys_on_enter:
+ExecuteScript("sys_on_enter", GetEnteringObject());
+```
+
+Lub po prostu wywołaj odpowiednie funkcje bezpośrednio po ich dołączeniu.
+
+## Placeable — stół grabarza
+
+1. Stwórz w Toolsecie placeable typu "Altar" lub "Stone Table".
+2. Ustaw skrypt `OnUsed` = `test_bur`.
+3. Opcjonalnie: nadaj tag `BUR_WORKBENCH`.
+
+## Przedmioty (opcjonalne)
+
+Ryty Przyzwoity i Święty wymagają przedmiotów. Stwórz je w Toolsecie
+z tagami (tag = resref dla uproszczenia):
+
+| Przedmiot | Tag | Opis |
+|---|---|---|
+| Świeca Pogrzebowa | `bur_candle` | Mała świeca woskowa |
+| Olejek Ostatni | `bur_oil` | Flakonik z ostatnim namaszczeniem |
+| Pergamin Imion | `bur_scroll` | Pergamin z imionami poległych |
+
+Dodaj te przedmioty do loot tables, sklepu kapłańskiego lub jako nagrody
+questowe. Bez nich gracze mogą korzystać tylko z Ubogiego Pochówku.
+
+## Baza danych
+
+Dane są zapisywane w kampanii SQLite o nazwie `burial` (plik `burial.sqlite`
+w folderze `/modules/<moduł>/`). Tabela:
+
+```sql
+CREATE TABLE IF NOT EXISTS bur_records (
+    pc_uuid TEXT PRIMARY KEY,
+    total_pauper INTEGER DEFAULT 0,
+    total_proper INTEGER DEFAULT 0,
+    total_sacred INTEGER DEFAULT 0,
+    last_pauper_time INTEGER DEFAULT 0
+);
+```
+
+## Mechanika skrótowo
+
+- **Ubogi Pochówek** — bezpłatny, odnowienie 1h; `+1 do obron vs. śmierć` (1h)
+- **Przyzwoity Pochówek** — 50gp + Świeca; `AC+1, obrony+1, regen 1HP/6s` (4h)
+- **Święty Ryt Przejścia** — 200gp + Olejek + Pergamin; `AC+2, obrony+2, regen 2HP/6s, +10% ruchu` (8h)
+- **Piętno Grabarza** (5 świętych rytów) — trwały efekt wizualny, flaga `BUR_LVAR_MARKED`
+- **Błogosławieństwo Spokoju** (25 łącznych) — trwały `+1 obrony vs. śmierć`
+
+## Co celowo pominięto
+
+- Brak fizycznego zbierania zwłok/tokenów — usunięto zależność od OnCreatureDeath
+- Brak animacji grabarza/NPC — czysta mechanika bez dialogów
+- Brak zarządzania grobami na mapie — to materiał na osobny moduł

--- a/Burial Rites/scripts/lib_bur.nss
+++ b/Burial Rites/scripts/lib_bur.nss
@@ -1,0 +1,502 @@
+// lib_bur.nss — core logic, NUI layout, and buff management for Burial Rites
+
+#include "lib_bur_def"
+
+// ----------------------------------------------------------------
+// Effect helpers
+// ----------------------------------------------------------------
+
+// Returns TRUE if oPC has any effect bearing sTag.
+int BurHasTaggedEffect(object oPC, string sTag)
+{
+    effect e = GetFirstEffect(oPC);
+    while(GetIsEffectValid(e))
+    {
+        if(GetEffectTag(e) == sTag) return TRUE;
+        e = GetNextEffect(oPC);
+    }
+    return FALSE;
+}
+
+// Returns 1/2/3 for active pauper/proper/sacred buff, 0 if none.
+int BurGetActiveBuff(object oPC)
+{
+    effect e = GetFirstEffect(oPC);
+    while(GetIsEffectValid(e))
+    {
+        string sTag = GetEffectTag(e);
+        if(sTag == BUR_BUFF_TAG_1) return 1;
+        if(sTag == BUR_BUFF_TAG_2) return 2;
+        if(sTag == BUR_BUFF_TAG_3) return 3;
+        e = GetNextEffect(oPC);
+    }
+    return 0;
+}
+
+// Removes all temporary burial buffs from oPC.
+void BurRemoveBuff(object oPC)
+{
+    effect e = GetFirstEffect(oPC);
+    while(GetIsEffectValid(e))
+    {
+        string sTag = GetEffectTag(e);
+        if(sTag == BUR_BUFF_TAG_1 || sTag == BUR_BUFF_TAG_2 || sTag == BUR_BUFF_TAG_3)
+            RemoveEffect(oPC, e);
+        e = GetNextEffect(oPC);
+    }
+}
+
+// ----------------------------------------------------------------
+// Buff application
+// ----------------------------------------------------------------
+
+void BurApplyBuff(object oPC, int nRiteType)
+{
+    BurRemoveBuff(oPC);
+
+    string sTag;
+    float  fDur;
+    string sMsg;
+
+    if(nRiteType == BUR_RITE_PAUPER)
+    {
+        sTag = BUR_BUFF_TAG_1;
+        fDur = BUR_DUR_PAUPER;
+        sMsg = "Sk\305\202adasz proste modlitwy za poleg\305\202ych. Spok\303\263j n\304\231dzarzy niech ci\304\231 os\305\202ania.";
+
+        effect eSave = TagEffect(EffectSavingThrowIncrease(SAVING_THROW_ALL, 1, SAVING_THROW_TYPE_DEATH), sTag);
+        ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eSave, oPC, fDur);
+    }
+    else if(nRiteType == BUR_RITE_PROPER)
+    {
+        sTag = BUR_BUFF_TAG_2;
+        fDur = BUR_DUR_PROPER;
+        sMsg = "Zapalone \305\233wiece o\305\233wietlaj\304\205 drog\304\231 umar\305\202ym. Pok\303\263j Zmar\305\202ych ogania ci\304\231 niczym p\305\202aszcz.";
+
+        effect eAC    = TagEffect(EffectACIncrease(1, AC_DODGE_BONUS), sTag);
+        effect eSave  = TagEffect(EffectSavingThrowIncrease(SAVING_THROW_ALL, 1), sTag);
+        effect eRegen = TagEffect(EffectRegenerate(1, 6.0), sTag);
+        effect eVFX   = TagEffect(EffectVisualEffect(VFX_DUR_CESSATE_POSITIVE), sTag);
+        ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eAC,    oPC, fDur);
+        ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eSave,  oPC, fDur);
+        ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eRegen, oPC, fDur);
+        ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eVFX,   oPC, fDur);
+    }
+    else // SACRED
+    {
+        sTag = BUR_BUFF_TAG_3;
+        fDur = BUR_DUR_SACRED;
+        sMsg = "Wypowiadasz staro\305\274ytne s\305\202owa przej\305\233cia. B\305\202ogos\305\202awie\305\204stwo Zawi\305\233cia sp\305\202ywa na ciebie.";
+
+        effect eAC    = TagEffect(EffectACIncrease(2, AC_DODGE_BONUS), sTag);
+        effect eSave  = TagEffect(EffectSavingThrowIncrease(SAVING_THROW_ALL, 2), sTag);
+        effect eRegen = TagEffect(EffectRegenerate(2, 6.0), sTag);
+        effect eMove  = TagEffect(EffectMovementSpeedIncrease(10), sTag);
+        effect eVFX   = TagEffect(EffectVisualEffect(VFX_DUR_AURA_PULSE_YELLOW_WHITE), sTag);
+        ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eAC,    oPC, fDur);
+        ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eSave,  oPC, fDur);
+        ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eRegen, oPC, fDur);
+        ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eMove,  oPC, fDur);
+        ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eVFX,   oPC, fDur);
+    }
+
+    // Impact VFX on rite completion
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectVisualEffect(VFX_IMP_HOLY_AID), oPC);
+    SendMessageToPC(oPC, "[Pogrzebnik] " + sMsg);
+}
+
+// ----------------------------------------------------------------
+// Milestone effects (re-applied on login)
+// ----------------------------------------------------------------
+
+void BurRestorePermanentEffects(object oPC)
+{
+    json jRecord = BurGetRecord(oPC);
+    if(JsonGetType(jRecord) == JSON_TYPE_NULL) return;
+
+    int nSacred = JsonGetInt(JsonObjectGet(jRecord, "total_sacred"));
+    int nTotal  = JsonGetInt(JsonObjectGet(jRecord, "total_pauper"))
+                + JsonGetInt(JsonObjectGet(jRecord, "total_proper"))
+                + nSacred;
+
+    if(nSacred >= BUR_MILESTONE_MARKED && !BurHasTaggedEffect(oPC, BUR_PERM_TAG_MARKED))
+    {
+        effect eGlow = TagEffect(EffectVisualEffect(VFX_DUR_GLOW_WHITE), BUR_PERM_TAG_MARKED);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eGlow, oPC);
+        SetLocalInt(oPC, BUR_LVAR_MARKED, 1);
+    }
+
+    if(nTotal >= BUR_MILESTONE_BLESSED && !BurHasTaggedEffect(oPC, BUR_PERM_TAG_BLESSED))
+    {
+        effect eSave = TagEffect(
+            EffectSavingThrowIncrease(SAVING_THROW_ALL, 1, SAVING_THROW_TYPE_DEATH),
+            BUR_PERM_TAG_BLESSED);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eSave, oPC);
+        SetLocalInt(oPC, BUR_LVAR_BLESSED, 1);
+    }
+}
+
+// ----------------------------------------------------------------
+// Milestone check and notification (called after each rite)
+// ----------------------------------------------------------------
+
+void BurCheckMilestones(object oPC)
+{
+    json jRecord = BurGetRecord(oPC);
+    if(JsonGetType(jRecord) == JSON_TYPE_NULL) return;
+
+    int nSacred = JsonGetInt(JsonObjectGet(jRecord, "total_sacred"));
+    int nTotal  = JsonGetInt(JsonObjectGet(jRecord, "total_pauper"))
+                + JsonGetInt(JsonObjectGet(jRecord, "total_proper"))
+                + nSacred;
+
+    if(nSacred == BUR_MILESTONE_MARKED && !GetLocalInt(oPC, BUR_LVAR_MARKED))
+    {
+        SetLocalInt(oPC, BUR_LVAR_MARKED, 1);
+        effect eGlow = TagEffect(EffectVisualEffect(VFX_DUR_GLOW_WHITE), BUR_PERM_TAG_MARKED);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eGlow, oPC);
+        SendMessageToPC(oPC,
+            "[Pogrzebnik] Pi\304\231tno Grabarza sp\305\202yn\304\231\305\202o na ciebie. Duch twego po\305\233wi\304\231cenia trwa wiecznie.");
+        FloatingTextStringOnCreature(
+            "Pi\304\231tno Grabarza — trwa\305\202e pi\304\231tno!",
+            oPC, FALSE);
+    }
+
+    if(nTotal == BUR_MILESTONE_BLESSED && !GetLocalInt(oPC, BUR_LVAR_BLESSED))
+    {
+        SetLocalInt(oPC, BUR_LVAR_BLESSED, 1);
+        effect eSave = TagEffect(
+            EffectSavingThrowIncrease(SAVING_THROW_ALL, 1, SAVING_THROW_TYPE_DEATH),
+            BUR_PERM_TAG_BLESSED);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eSave, oPC);
+        SendMessageToPC(oPC,
+            "[Pogrzebnik] B\305\202ogos\305\202awie\305\204stwo Spokoju — wieczny spok\303\263j pochowanych chroni twoj\304\205 dusz\304\231. (+1 obrony vs. \305\233mier\304\207, trwa\305\202e)");
+        FloatingTextStringOnCreature(
+            "B\305\202ogos\305\202awie\305\224stwo Spokoju — trwa\305\202e!",
+            oPC, FALSE);
+    }
+}
+
+// ----------------------------------------------------------------
+// Rite execution
+// ----------------------------------------------------------------
+
+void BurApplyRite(object oPC, int nRiteType)
+{
+    BurEnsureRecord(oPC);
+
+    if(nRiteType == BUR_RITE_PAUPER)
+    {
+        int nLeft = BurPauperCooldownLeft(oPC);
+        if(nLeft > 0)
+        {
+            int nMin = (nLeft + 59) / 60;
+            SendMessageToPC(oPC,
+                "[Pogrzebnik] Ubogi Poch\303\263wek jest jeszcze na odnowieniu ("
+                + IntToString(nMin) + " min).");
+            return;
+        }
+        BurApplyBuff(oPC, BUR_RITE_PAUPER);
+        BurRecordPauper(oPC);
+    }
+    else if(nRiteType == BUR_RITE_PROPER)
+    {
+        if(GetGold(oPC) < BUR_COST_PROPER_GOLD)
+        {
+            SendMessageToPC(oPC, "[Pogrzebnik] Potrzebujesz co najmniej "
+                + IntToString(BUR_COST_PROPER_GOLD) + " sztuk z\305\202ota.");
+            return;
+        }
+        object oCandle = GetItemPossessedBy(oPC, BUR_TAG_CANDLE);
+        if(!GetIsObjectValid(oCandle))
+        {
+            SendMessageToPC(oPC, "[Pogrzebnik] Potrzebujesz \305\232wiecy Pogrzebowej (tag: "
+                + BUR_TAG_CANDLE + ").");
+            return;
+        }
+        AssignCommand(oPC, TakeGoldFromCreature(BUR_COST_PROPER_GOLD, oPC, TRUE));
+        DestroyObject(oCandle);
+        BurApplyBuff(oPC, BUR_RITE_PROPER);
+        BurRecordProper(oPC);
+    }
+    else // SACRED
+    {
+        if(GetGold(oPC) < BUR_COST_SACRED_GOLD)
+        {
+            SendMessageToPC(oPC, "[Pogrzebnik] Potrzebujesz co najmniej "
+                + IntToString(BUR_COST_SACRED_GOLD) + " sztuk z\305\202ota.");
+            return;
+        }
+        object oOil    = GetItemPossessedBy(oPC, BUR_TAG_OIL);
+        object oScroll = GetItemPossessedBy(oPC, BUR_TAG_SCROLL);
+        if(!GetIsObjectValid(oOil))
+        {
+            SendMessageToPC(oPC, "[Pogrzebnik] Potrzebujesz Olejku Ostatniego (tag: "
+                + BUR_TAG_OIL + ").");
+            return;
+        }
+        if(!GetIsObjectValid(oScroll))
+        {
+            SendMessageToPC(oPC, "[Pogrzebnik] Potrzebujesz Pergaminu Imion (tag: "
+                + BUR_TAG_SCROLL + ").");
+            return;
+        }
+        AssignCommand(oPC, TakeGoldFromCreature(BUR_COST_SACRED_GOLD, oPC, TRUE));
+        DestroyObject(oOil);
+        DestroyObject(oScroll);
+        BurApplyBuff(oPC, BUR_RITE_SACRED);
+        BurRecordSacred(oPC);
+    }
+
+    BurCheckMilestones(oPC);
+
+    int nToken = NuiFindWindow(oPC, BUR_WINDOW);
+    if(nToken != 0)
+        BurFeedWindow(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// NUI — layout
+// ----------------------------------------------------------------
+
+json BurBuildRiteBlock(object oPC,
+                       string sBtnId,
+                       string sBtnLabel,
+                       string sBindEna,
+                       string sBindReqLbl,
+                       string sBindReqCol,
+                       string sEffectText)
+{
+    float fBtnH = GetNuiScaleDimension(oPC, 30.0);
+    float fSmH  = GetNuiScaleDimension(oPC, 22.0);
+
+    json jBtn = NuiButton(JsonString(sBtnLabel));
+    jBtn = NuiId(jBtn, sBtnId);
+    jBtn = NuiEnabled(jBtn, NuiBind(sBindEna));
+    jBtn = NuiHeight(jBtn, fBtnH);
+
+    json jReqLbl = NuiLabel(NuiBind(sBindReqLbl),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jReqLbl = NuiStyleForegroundColor(jReqLbl, NuiBind(sBindReqCol));
+    jReqLbl = NuiHeight(jReqLbl, fSmH);
+
+    json jEffLbl = NuiLabel(JsonString(sEffectText),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jEffLbl = NuiStyleForegroundColor(jEffLbl, NuiColor(180, 180, 180));
+    jEffLbl = NuiHeight(jEffLbl, fSmH);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jBtn)));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jReqLbl)));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jEffLbl)));
+
+    json jGrp = NuiGroup(NuiCol(jCol), TRUE, NUI_SCROLLBARS_NONE);
+    jGrp = NuiHeight(jGrp, GetNuiScaleDimension(oPC, 92.0));
+    return jGrp;
+}
+
+json BurBuildLayout(object oPC)
+{
+    float fBtnH = GetNuiScaleDimension(oPC, 30.0);
+    float fSmH  = GetNuiScaleDimension(oPC, 22.0);
+
+    // Top bar: title + close button
+    json jTitle = NuiLabel(JsonString("Obrz\304\231dy Pogrzebowe"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    json jClose = NuiButton(JsonString("X"));
+    jClose = NuiId(jClose, BUR_BTN_CLOSE);
+    jClose = NuiWidth(jClose, GetNuiScaleDimension(oPC, 30.0));
+    jClose = NuiHeight(jClose, fBtnH);
+    json jTopRow = JsonArray();
+    jTopRow = JsonArrayInsert(jTopRow, jTitle);
+    jTopRow = JsonArrayInsert(jTopRow, NuiSpacer());
+    jTopRow = JsonArrayInsert(jTopRow, jClose);
+
+    // Three rite blocks
+    json jP0 = BurBuildRiteBlock(oPC,
+        BUR_BTN_PAUPER, "Ubogi Poch\303\263wek",
+        BUR_BIND_P0_ENA, BUR_BIND_P0_REQ_LBL, BUR_BIND_P0_REQ_COL,
+        "Efekt: Odpocznienie N\304\231dzarzy (+1 obrona vs. \305\233mier\304\207, 1h)");
+
+    json jP1 = BurBuildRiteBlock(oPC,
+        BUR_BTN_PROPER, "Przyzwoity Poch\303\263wek",
+        BUR_BIND_P1_ENA, BUR_BIND_P1_REQ_LBL, BUR_BIND_P1_REQ_COL,
+        "Efekt: Pok\303\263j Zmar\305\202ych (AC+1, obrony+1, regen HP, 4h)");
+
+    json jP2 = BurBuildRiteBlock(oPC,
+        BUR_BTN_SACRED, "\305\232wi\304\231ty Ryt Przej\305\233cia",
+        BUR_BIND_P2_ENA, BUR_BIND_P2_REQ_LBL, BUR_BIND_P2_REQ_COL,
+        "Efekt: B\305\202ogos\305\202awie\305\204stwo Zawi\305\233cia (AC+2, obrony+2, regen, +ruch, 8h)");
+
+    // Progress + status rows
+    json jProgressLbl = NuiLabel(NuiBind(BUR_BIND_PROGRESS_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jProgressLbl = NuiHeight(jProgressLbl, fSmH);
+
+    json jMilestoneLbl = NuiLabel(NuiBind(BUR_BIND_MILESTONE_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jMilestoneLbl = NuiStyleForegroundColor(jMilestoneLbl, GetNuiColorNwnGold());
+    jMilestoneLbl = NuiHeight(jMilestoneLbl, fSmH);
+
+    json jStatusLbl = NuiLabel(NuiBind(BUR_BIND_STATUS_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jStatusLbl = NuiStyleForegroundColor(jStatusLbl, NuiColor(160, 200, 255));
+    jStatusLbl = NuiHeight(jStatusLbl, fSmH);
+
+    // Main column
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(jTopRow));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jP0);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, jP1);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, jP2);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jProgressLbl)));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jMilestoneLbl)));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jStatusLbl)));
+
+    // Centred with side spacers (Mailbox pattern)
+    json jSide = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    float fContentW = GetNuiScaleDimension(oPC, 460.0);
+    json jMainRow = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiCol(jCol), fContentW));
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    return NuiRow(jMainRow);
+}
+
+// ----------------------------------------------------------------
+// NUI — feed (populate binds with live data)
+// ----------------------------------------------------------------
+
+void BurFeedWindow(object oPC, int nToken)
+{
+    json jRecord = BurGetRecord(oPC);
+    if(JsonGetType(jRecord) == JSON_TYPE_NULL)
+        jRecord = JsonObject(); // fallback with zeros
+
+    int nTotalPauper = JsonGetInt(JsonObjectGet(jRecord, "total_pauper"));
+    int nTotalProper = JsonGetInt(JsonObjectGet(jRecord, "total_proper"));
+    int nTotalSacred = JsonGetInt(JsonObjectGet(jRecord, "total_sacred"));
+    int nTotal       = nTotalPauper + nTotalProper + nTotalSacred;
+
+    int nGold      = GetGold(oPC);
+    int bHasCandle = GetIsObjectValid(GetItemPossessedBy(oPC, BUR_TAG_CANDLE));
+    int bHasOil    = GetIsObjectValid(GetItemPossessedBy(oPC, BUR_TAG_OIL));
+    int bHasScroll = GetIsObjectValid(GetItemPossessedBy(oPC, BUR_TAG_SCROLL));
+
+    json jGreen = NuiColor(100, 220, 100);
+    json jRed   = NuiColor(220, 80,  80);
+
+    // Rite 0 — Pauper
+    int nCooldown  = BurPauperCooldownLeft(oPC);
+    int bP0Enabled = (nCooldown == 0);
+    string sP0Req;
+    if(bP0Enabled)
+        sP0Req = "Gotowe — bez koszt\303\263w";
+    else
+        sP0Req = "Odnowienie: " + IntToString((nCooldown + 59) / 60) + " min";
+
+    // Rite 1 — Proper
+    int bP1Enabled = (nGold >= BUR_COST_PROPER_GOLD && bHasCandle);
+    string sP1Req;
+    if(bP1Enabled)
+        sP1Req = IntToString(BUR_COST_PROPER_GOLD) + "gp + \305\232wieca \342\234\223";
+    else if(nGold < BUR_COST_PROPER_GOLD)
+        sP1Req = "Brakuje z\305\202ota (" + IntToString(BUR_COST_PROPER_GOLD) + "gp)";
+    else
+        sP1Req = "Brak \305\232wiecy Pogrzebowej";
+
+    // Rite 2 — Sacred
+    int bP2Enabled = (nGold >= BUR_COST_SACRED_GOLD && bHasOil && bHasScroll);
+    string sP2Req;
+    if(bP2Enabled)
+        sP2Req = IntToString(BUR_COST_SACRED_GOLD) + "gp + Olejek + Pergamin \342\234\223";
+    else if(nGold < BUR_COST_SACRED_GOLD)
+        sP2Req = "Brakuje z\305\202ota (" + IntToString(BUR_COST_SACRED_GOLD) + "gp)";
+    else if(!bHasOil)
+        sP2Req = "Brak Olejku Ostatniego";
+    else
+        sP2Req = "Brak Pergaminu Imion";
+
+    // Progress line
+    string sProgress = "Poch\303\263wki: " + IntToString(nTotal)
+        + " \342\200\224 proste: " + IntToString(nTotalPauper)
+        + ", przyzwoite: " + IntToString(nTotalProper)
+        + ", \305\233wi\304\231te: " + IntToString(nTotalSacred);
+
+    // Milestone line
+    string sMile1, sMile2;
+    if(nTotalSacred < BUR_MILESTONE_MARKED)
+        sMile1 = "Pi\304\231tno Grabarza: " + IntToString(nTotalSacred)
+                 + "/" + IntToString(BUR_MILESTONE_MARKED);
+    else
+        sMile1 = "Pi\304\231tno Grabarza: ZDOBYTE";
+
+    if(nTotal < BUR_MILESTONE_BLESSED)
+        sMile2 = "  |  B\305\202ogos\305\202.: " + IntToString(nTotal)
+                 + "/" + IntToString(BUR_MILESTONE_BLESSED);
+    else
+        sMile2 = "  |  B\305\202ogos\305\202.: ZDOBYTE";
+
+    // Active buff line
+    int nActiveBuff = BurGetActiveBuff(oPC);
+    string sStatus;
+    if(nActiveBuff == 1)      sStatus = "Aktywny buff: Odpocznienie N\304\231dzarzy (1h)";
+    else if(nActiveBuff == 2) sStatus = "Aktywny buff: Pok\303\263j Zmar\305\202ych (4h)";
+    else if(nActiveBuff == 3) sStatus = "Aktywny buff: B\305\202ogos\305\202awie\305\204stwo Zawi\305\233cia (8h)";
+    else                      sStatus = "Brak aktywnego b\305\202ogos\305\202awie\305\204stwa";
+
+    NuiSetBind(oPC, nToken, BUR_BIND_P0_ENA,       JsonBool(bP0Enabled));
+    NuiSetBind(oPC, nToken, BUR_BIND_P0_REQ_LBL,   JsonString(sP0Req));
+    NuiSetBind(oPC, nToken, BUR_BIND_P0_REQ_COL,   bP0Enabled ? jGreen : jRed);
+    NuiSetBind(oPC, nToken, BUR_BIND_P1_ENA,       JsonBool(bP1Enabled));
+    NuiSetBind(oPC, nToken, BUR_BIND_P1_REQ_LBL,   JsonString(sP1Req));
+    NuiSetBind(oPC, nToken, BUR_BIND_P1_REQ_COL,   bP1Enabled ? jGreen : jRed);
+    NuiSetBind(oPC, nToken, BUR_BIND_P2_ENA,       JsonBool(bP2Enabled));
+    NuiSetBind(oPC, nToken, BUR_BIND_P2_REQ_LBL,   JsonString(sP2Req));
+    NuiSetBind(oPC, nToken, BUR_BIND_P2_REQ_COL,   bP2Enabled ? jGreen : jRed);
+    NuiSetBind(oPC, nToken, BUR_BIND_PROGRESS_LBL,  JsonString(sProgress));
+    NuiSetBind(oPC, nToken, BUR_BIND_MILESTONE_LBL, JsonString(sMile1 + sMile2));
+    NuiSetBind(oPC, nToken, BUR_BIND_STATUS_LBL,    JsonString(sStatus));
+}
+
+// ----------------------------------------------------------------
+// NUI — window create / refresh
+// ----------------------------------------------------------------
+
+void BurShowWindow(object oPC)
+{
+    BurEnsureRecord(oPC);
+
+    int nToken = NuiFindWindow(oPC, BUR_WINDOW);
+    if(nToken != 0)
+    {
+        BurFeedWindow(oPC, nToken);
+        return;
+    }
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))
+                 - GetNuiScaleDimension(oPC, BUR_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT))
+                 - GetNuiScaleDimension(oPC, BUR_H)) / 2.0;
+    json jGeom = NuiRect(fCX, fCY,
+        GetNuiScaleDimension(oPC, BUR_W),
+        GetNuiScaleDimension(oPC, BUR_H));
+
+    json jWin = NuiWindow(
+        BurBuildLayout(oPC),
+        JsonBool(FALSE),
+        NuiBind(BUR_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    nToken = NuiCreate(oPC, jWin, BUR_WINDOW, BUR_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, BUR_WIN_GEOM, jGeom);
+    BurFeedWindow(oPC, nToken);
+}

--- a/Burial Rites/scripts/lib_bur_def.nss
+++ b/Burial Rites/scripts/lib_bur_def.nss
@@ -1,0 +1,109 @@
+// lib_bur_def.nss — constants, IDs and forward declarations for Burial Rites
+
+#include "lib_nui"
+#include "sql_bur"
+
+void BurShowWindow(object oPC);
+void BurFeedWindow(object oPC, int nToken);
+void BurApplyRite(object oPC, int nRiteType);
+void BurRestorePermanentEffects(object oPC);
+
+// ----------------------------------------------------------------
+// Window / event
+// ----------------------------------------------------------------
+
+const string BUR_WINDOW     = "BUR_WINDOW";
+const string BUR_EV_SCRIPT  = "lib_bur_ev";
+const string BUR_WIN_GEOM   = "bur_win_geom";
+
+// ----------------------------------------------------------------
+// Rite type indices
+// ----------------------------------------------------------------
+
+const int BUR_RITE_PAUPER   = 0;
+const int BUR_RITE_PROPER   = 1;
+const int BUR_RITE_SACRED   = 2;
+
+// ----------------------------------------------------------------
+// Item tags (builders set these on the respective items)
+// ----------------------------------------------------------------
+
+const string BUR_TAG_CANDLE  = "bur_candle";   // Swica Pogrzebowa
+const string BUR_TAG_OIL     = "bur_oil";      // Olejek Ostatni
+const string BUR_TAG_SCROLL  = "bur_scroll";   // Pergamin Imion
+
+// ----------------------------------------------------------------
+// Resource costs
+// ----------------------------------------------------------------
+
+const int   BUR_COST_PROPER_GOLD  = 50;
+const int   BUR_COST_SACRED_GOLD  = 200;
+
+// ----------------------------------------------------------------
+// Buff durations (seconds)
+// ----------------------------------------------------------------
+
+const float BUR_DUR_PAUPER   = 3600.0;    // 1h
+const float BUR_DUR_PROPER   = 14400.0;   // 4h
+const float BUR_DUR_SACRED   = 28800.0;   // 8h
+
+// ----------------------------------------------------------------
+// Effect tags — used to identify and remove burial buffs
+// ----------------------------------------------------------------
+
+const string BUR_BUFF_TAG_1  = "BUR_BUFF_PAUPER";
+const string BUR_BUFF_TAG_2  = "BUR_BUFF_PROPER";
+const string BUR_BUFF_TAG_3  = "BUR_BUFF_SACRED";
+
+const string BUR_PERM_TAG_MARKED   = "BUR_PERM_MARKED";
+const string BUR_PERM_TAG_BLESSED  = "BUR_PERM_BLESSED";
+
+// ----------------------------------------------------------------
+// Milestone thresholds
+// ----------------------------------------------------------------
+
+const int BUR_MILESTONE_MARKED   = 5;    // sacred rites -> Pietno Grabarza
+const int BUR_MILESTONE_BLESSED  = 25;   // total burials -> Blogoslawienstwo Spokoju
+
+// ----------------------------------------------------------------
+// Local vars on PC
+// ----------------------------------------------------------------
+
+const string BUR_LVAR_MARKED   = "BUR_LVAR_MARKED";
+const string BUR_LVAR_BLESSED  = "BUR_LVAR_BLESSED";
+
+// ----------------------------------------------------------------
+// NUI bind IDs
+// ----------------------------------------------------------------
+
+const string BUR_BIND_P0_ENA       = "bur_p0_ena";
+const string BUR_BIND_P0_REQ_LBL   = "bur_p0_req";
+const string BUR_BIND_P0_REQ_COL   = "bur_p0_req_col";
+
+const string BUR_BIND_P1_ENA       = "bur_p1_ena";
+const string BUR_BIND_P1_REQ_LBL   = "bur_p1_req";
+const string BUR_BIND_P1_REQ_COL   = "bur_p1_req_col";
+
+const string BUR_BIND_P2_ENA       = "bur_p2_ena";
+const string BUR_BIND_P2_REQ_LBL   = "bur_p2_req";
+const string BUR_BIND_P2_REQ_COL   = "bur_p2_req_col";
+
+const string BUR_BIND_PROGRESS_LBL  = "bur_progress";
+const string BUR_BIND_MILESTONE_LBL = "bur_milestone";
+const string BUR_BIND_STATUS_LBL    = "bur_status";
+
+// ----------------------------------------------------------------
+// NUI button IDs
+// ----------------------------------------------------------------
+
+const string BUR_BTN_CLOSE   = "bur_btn_close";
+const string BUR_BTN_PAUPER  = "bur_btn_p0";
+const string BUR_BTN_PROPER  = "bur_btn_p1";
+const string BUR_BTN_SACRED  = "bur_btn_p2";
+
+// ----------------------------------------------------------------
+// Layout dimensions (pre-scale)
+// ----------------------------------------------------------------
+
+const float BUR_W   = 500.0;
+const float BUR_H   = 460.0;

--- a/Burial Rites/scripts/lib_bur_ev.nss
+++ b/Burial Rites/scripts/lib_bur_ev.nss
@@ -1,0 +1,42 @@
+// lib_bur_ev.nss — NUI event handler for Burial Rites
+
+#include "lib_bur"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+
+    if(nToken != NuiFindWindow(oPC, BUR_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+        return;
+
+    if(sEvent != EVENT_TYPE_CLICK) return;
+
+    if(sElem == BUR_BTN_CLOSE)
+    {
+        NuiDestroy(oPC, nToken);
+        return;
+    }
+
+    if(sElem == BUR_BTN_PAUPER)
+    {
+        BurApplyRite(oPC, BUR_RITE_PAUPER);
+        return;
+    }
+
+    if(sElem == BUR_BTN_PROPER)
+    {
+        BurApplyRite(oPC, BUR_RITE_PROPER);
+        return;
+    }
+
+    if(sElem == BUR_BTN_SACRED)
+    {
+        BurApplyRite(oPC, BUR_RITE_SACRED);
+        return;
+    }
+}

--- a/Burial Rites/scripts/lib_nui.nss
+++ b/Burial Rites/scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Burial Rites/scripts/lib_nui_utility.nss
+++ b/Burial Rites/scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Burial Rites/scripts/sql_bur.nss
+++ b/Burial Rites/scripts/sql_bur.nss
@@ -1,0 +1,78 @@
+// sql_bur.nss — SQL schema and queries for Burial Rites
+
+void BurCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("burial",
+        "CREATE TABLE IF NOT EXISTS bur_records ("
+        "pc_uuid TEXT PRIMARY KEY, "
+        "total_pauper INTEGER DEFAULT 0, "
+        "total_proper INTEGER DEFAULT 0, "
+        "total_sacred INTEGER DEFAULT 0, "
+        "last_pauper_time INTEGER DEFAULT 0"
+        ")");
+    SqlStep(q);
+}
+
+void BurEnsureRecord(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("burial",
+        "INSERT OR IGNORE INTO bur_records (pc_uuid) VALUES (@uuid)");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+json BurGetRecord(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("burial",
+        "SELECT total_pauper, total_proper, total_sacred, last_pauper_time "
+        "FROM bur_records WHERE pc_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(!SqlStep(q)) return JsonNull();
+    json j = JsonObject();
+    j = JsonObjectSet(j, "total_pauper",     JsonInt(SqlGetInt(q, 0)));
+    j = JsonObjectSet(j, "total_proper",     JsonInt(SqlGetInt(q, 1)));
+    j = JsonObjectSet(j, "total_sacred",     JsonInt(SqlGetInt(q, 2)));
+    j = JsonObjectSet(j, "last_pauper_time", JsonInt(SqlGetInt(q, 3)));
+    return j;
+}
+
+// Returns seconds remaining on pauper cooldown (0 = ready).
+int BurPauperCooldownLeft(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("burial",
+        "SELECT MAX(0, 3600 - (CAST(strftime('%s','now') AS INTEGER) - last_pauper_time)) "
+        "FROM bur_records WHERE pc_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+void BurRecordPauper(object oPC)
+{
+    BurEnsureRecord(oPC);
+    sqlquery q = SqlPrepareQueryCampaign("burial",
+        "UPDATE bur_records "
+        "SET total_pauper = total_pauper + 1, "
+        "    last_pauper_time = CAST(strftime('%s','now') AS INTEGER) "
+        "WHERE pc_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+void BurRecordProper(object oPC)
+{
+    BurEnsureRecord(oPC);
+    sqlquery q = SqlPrepareQueryCampaign("burial",
+        "UPDATE bur_records SET total_proper = total_proper + 1 WHERE pc_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+void BurRecordSacred(object oPC)
+{
+    BurEnsureRecord(oPC);
+    sqlquery q = SqlPrepareQueryCampaign("burial",
+        "UPDATE bur_records SET total_sacred = total_sacred + 1 WHERE pc_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}

--- a/Burial Rites/scripts/sys_on_enter.nss
+++ b/Burial Rites/scripts/sys_on_enter.nss
@@ -1,0 +1,28 @@
+// sys_on_enter.nss — module OnClientEnter: register PC and restore permanent effects
+
+#include "lib_bur"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC)) return;
+
+    BurEnsureRecord(oPC);
+
+    // Re-apply permanent milestone effects lost on relog.
+    BurRestorePermanentEffects(oPC);
+
+    json jRecord = BurGetRecord(oPC);
+    if(JsonGetType(jRecord) == JSON_TYPE_NULL) return;
+
+    int nTotal = JsonGetInt(JsonObjectGet(jRecord, "total_pauper"))
+               + JsonGetInt(JsonObjectGet(jRecord, "total_proper"))
+               + JsonGetInt(JsonObjectGet(jRecord, "total_sacred"));
+
+    if(nTotal > 0)
+    {
+        SendMessageToPC(oPC,
+            "[Pogrzebnik] Masz na koncie " + IntToString(nTotal)
+            + " rytua\305\202(\303\263w) pogrzebowych. Podejd\305\272 do kamiennego sto\305\202u grabarza.");
+    }
+}

--- a/Burial Rites/scripts/sys_on_load.nss
+++ b/Burial Rites/scripts/sys_on_load.nss
@@ -1,0 +1,8 @@
+// sys_on_load.nss — module OnModuleLoad: initialise Burial Rites tables
+
+#include "lib_bur_def"
+
+void main()
+{
+    BurCreateTables();
+}

--- a/Burial Rites/scripts/test_bur.nss
+++ b/Burial Rites/scripts/test_bur.nss
@@ -1,0 +1,29 @@
+// test_bur.nss — OnUsed on a placeable; opens the Burial Rites window for the user.
+// Place this on a "Stol Grabarza" (Altar/Workbench) placeable in the toolset.
+// Optionally set tag = "BUR_WORKBENCH" for easy lookup.
+
+#include "lib_bur"
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    // Give the tester one of each optional item so all rites can be tested.
+    // Remove this block in production (items should be acquired normally).
+    if(GetLocalInt(OBJECT_SELF, "BUR_TEST_GIVEN") == 0)
+    {
+        SetLocalInt(OBJECT_SELF, "BUR_TEST_GIVEN", 1);
+        object oCandle = CreateItemOnObject(BUR_TAG_CANDLE, oPC, 3);
+        object oOil    = CreateItemOnObject(BUR_TAG_OIL,    oPC, 3);
+        object oScroll = CreateItemOnObject(BUR_TAG_SCROLL, oPC, 3);
+        if(GetIsObjectValid(oCandle) || GetIsObjectValid(oOil) || GetIsObjectValid(oScroll))
+            SendMessageToPC(oPC,
+                "[Pogrzebnik TEST] Otrzymujesz materia\305\202y testowe (resrefy musz\304\205 istnie\304\207 w haku).");
+        else
+            SendMessageToPC(oPC,
+                "[Pogrzebnik TEST] Brak plik\303\263w item\303\263w w haku \342\200\224 dodaj bur_candle/bur_oil/bur_scroll.");
+    }
+
+    BurShowWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

Moduł **Burial Rites** dodaje stół grabarza — placeable, przy którym gracz może
odprawiać rytuały pogrzebowe w trzech poziomach. Każdy ryt pochłania zasoby
i przyznaje tymczasowy buff. System SQL śledzi postęp i odblokowuje trwałe
nagrody po osiągnięciu progów.

## Mechanika

### Trzy ryty pogrzebowe

| Ryt | Koszt | Buff | Czas |
|---|---|---|---|
| Ubogi Pochówek | bezpłatny, odnowienie 1h | +1 obrona vs. śmierć | 1h |
| Przyzwoity Pochówek | 50gp + Świeca Pogrzebowa | AC+1, obrony+1, regen 1HP/6s | 4h |
| Święty Ryt Przejścia | 200gp + Olejek Ostatni + Pergamin Imion | AC+2, obrony+2, regen 2HP/6s, +10% ruchu | 8h |

### Milestony (SQL per-postać)

- **Piętno Grabarza** (5 świętych rytów) — trwały efekt wizualny + flaga `BUR_LVAR_MARKED`
  dla innych systemów
- **Błogosławieństwo Spokoju** (25 łącznych rytów) — trwały +1 do obron vs. efekty śmierci

Trwałe efekty są przywracane przez `sys_on_enter.nss` po każdym ponownym logowaniu.

### NUI

Okno (500×460) pokazuje trzy bloki rytów z dynamicznie kolorowanymi etykietami
wymogów (zielony = spełnione, czerwony = nie), wiersz postępu i aktywny buff.
Buffy są identyfikowane i usuwane przez `TagEffect`/`GetEffectTag` — brak
konfliktów z innymi systemami.

## Pliki

```
Burial Rites/
├── INTEGRATION.md
└── scripts/
    ├── sql_bur.nss          — schemat SQLite + zapytania
    ├── lib_bur_def.nss      — stałe, ID bindów, ID przycisków
    ├── lib_bur.nss          — rdzeń: buffy, logika, NUI layout + feed
    ├── lib_bur_ev.nss       — handler NUI eventów (switch po element ID)
    ├── sys_on_load.nss      — CREATE TABLE IF NOT EXISTS
    ├── sys_on_enter.nss     — rejestracja PC, przywracanie trwałych efektów
    ├── test_bur.nss         — OnUsed na placeablu; otwiera okno + daje itemy testowe
    ├── lib_nui.nss          — kopia wspólna (jak w Mailbox)
    └── lib_nui_utility.nss  — kopia wspólna
```

## Zależności

- **NWNX:** brak
- **SQL:** kampania `burial` (SQLite), tabela `bur_records`
- **NWN EE API:** `TagEffect`, `GetEffectTag`, `NuiCreate`, `NuiSetBind`, `SqlPrepareQueryCampaign`

## Jak włączyć w istniejącym module

1. Podepnij `sys_on_load.nss` pod zdarzenie `OnModuleLoad`
2. Podepnij `sys_on_enter.nss` pod zdarzenie `OnClientEnter`
3. Stwórz placeable "Stół Grabarza" z `OnUsed = test_bur`
4. Opcjonalnie: dodaj przedmioty z tagami `bur_candle`, `bur_oil`, `bur_scroll`
   do loot tables lub sklepu kapłańskiego

Pełne instrukcje w `INTEGRATION.md`.

## Co celowo pominięto

- **Fizyczne zbieranie zwłok** — zależność od `OnCreatureDeath` usunięta dla
  przenośności; stół działa jako abstrakcyjna usługa pogrzebowa
- **NPC grabarz z dialogami** — poza zakresem; czysty NUI bez konwersacji
- **Mapa grobów** — śledzenie lokalizacji pochówków to materiał na osobny moduł
- **Animacje odprawiania rytu** — `VFX_IMP_HOLY_AID` daje wystarczający feedback bez
  niestandardowych animacji

---
_Generated by [Claude Code](https://claude.ai/code/session_0174oTqj5jB4hx4uenQURpim)_