### PR TITLE
feat: Herbarium (Zielarz)

### DIFF
--- a/Herbarium/INTEGRATION.md
+++ b/Herbarium/INTEGRATION.md
@@ -1,0 +1,59 @@
+# Herbarium — Integracja z istniejącym modułem
+
+## Wymagania
+
+- NWN 1.87+ (UUID, SqlPrepareQueryCampaign, NUI)
+- NWNX: **nie wymagany**
+- Hak: musi zawierać `lib_nui.nss` i `lib_nui_utility.nss` (standardowe dla tego repo)
+
+## Hooki modułu
+
+| Zdarzenie         | Podłącz skrypt         |
+|-------------------|------------------------|
+| OnModuleLoad      | `sys_on_load`          |
+| OnClientEnter     | `sys_on_enter` (opcja) |
+
+> `sys_on_enter` jest opcjonalny — jedynie powiadamia gracza o zasobach ziół.
+
+## Węzły ziół (placeables)
+
+1. Umieść dowolny placeable w obszarze (np. `PLC_MushMoss`, krzewy).
+2. Ustaw jego **OnUsed** script na `test_herb`.
+3. Dodaj zmienną lokalną `HERB_TYPE` (Integer) = 1–8:
+
+| Wartość | Zioło              | Sezon   |
+|---------|--------------------|---------|
+| 1       | Krwawnik           | Jesień  |
+| 2       | Nocny Cień         | Zima    |
+| 3       | Słonecznik Polny   | Wiosna  |
+| 4       | Strach-Ziele       | Każda   |
+| 5       | Żelazokora         | Lato    |
+| 6       | Grobowamiętka      | Zima    |
+| 7       | Pustokwiat         | Każda   |
+| 8       | Wiedźmia Koniczyna | Każda   |
+
+Każdy węzeł ma 3 plony; odnawiają się po 24 godzinach rzeczywistych od ostatniego zbioru.
+
+## Dziennik Zielarza (stand)
+
+Umieść dodatkowy placeable (np. stół aptekarza) z `OnUsed = test_herb`  
+i **bez** zmiennej `HERB_TYPE` (lub z wartością 0) — otworzy sam dziennik.
+
+## Baza danych
+
+Dwie tabele w campaign DB `herbarium`:
+
+- `herb_nodes` — stan plonów per węzeł (PK: tag placeable)
+- `herb_player` — zasoby i wiedza per postać (PK: uuid + herb_type)
+
+Obie tabele tworzone idempotentnie przez `HerbCreateTables()` w `sys_on_load`.
+
+## Co celowo pominięto
+
+- **Craftowanie** — zioła są zużywane bezpośrednio; integracja z systemem alchemii
+  możliwa przez wywołanie `HerbPlayerConsume()` z zewnętrznego modułu.
+- **Ikony ziół** — wymagałyby dedykowanych zasobów w hak; zastąpione opisem tekstowym.
+- **Odnawianie przez heartbeat** — regen obliczany lazily przy otwarciu okna (oszczędność
+  skryptów modułowych).
+- **Limity per postać** — brak maksymalnej liczby ziół w sakwie; można dodać
+  górny próg w `HerbPlayerGive()`.

--- a/Herbarium/scripts/lib_herb.nss
+++ b/Herbarium/scripts/lib_herb.nss
@@ -1,0 +1,456 @@
+#include "lib_herb_def"
+
+// ----------------------------------------------------------------
+// Forward declarations
+// ----------------------------------------------------------------
+
+void OpenHarvestWindow(object oPC, object oNode);
+void FeedHarvestWindow(object oPC, int nToken);
+void OpenJournalWindow(object oPC);
+void FeedJournalWindow(object oPC, int nToken);
+
+// ================================================================
+// Herb data — name, lore, effect description, season
+// ================================================================
+
+string HerbGetName(int nType)
+{
+    switch(nType)
+    {
+        case HERB_BLOODMOSS:    return "Krwawnik";
+        case HERB_NIGHTSHADE:   return "Nocny Cień";
+        case HERB_SUNROOT:      return "Słonecznik Polny";
+        case HERB_GHOSTWEED:    return "Strach-Ziele";
+        case HERB_IRONBARK:     return "Żelazokora";
+        case HERB_GRAVEMINT:    return "Grobowamiętka";
+        case HERB_VOIDFERN:     return "Pustokwiat";
+        case HERB_WITCH_CLOVER: return "Wiedźmia Koniczyna";
+    }
+    return "Nieznane Zioło";
+}
+
+string HerbGetDesc(int nType)
+{
+    switch(nType)
+    {
+        case HERB_BLOODMOSS:
+            return "Ciemnoczerwony mech rosnący na mokrych kamieniach i spróchniałych pniach. "
+                   "Zbierany jesienią, gdy deszcze nasycają go żelazistą wodą. Przyłożony do "
+                   "rany natychmiast zaciska naczynia krwionośne. Zielarki mówią, że pamięta "
+                   "smak każdej przelanej krwi.";
+        case HERB_NIGHTSHADE:
+            return "Czarne jagody o mdlącym, słodkawym aromacie. Mała dawka paradoksalnie "
+                   "uodparnia mięśnie na toksyny paraliżujące — większa zabija. Rośnie jedynie "
+                   "zimą, w cieniu głazów pokrytych lodem. Zbieranie bez rękawic jest szaleństwem.";
+        case HERB_SUNROOT:
+            return "Żółty korzeń wyrastający z wiosennego błota przy rzekach. Spożywany surowy "
+                   "smakuje jak świeża trawa i miód. Ciepło, które daje, rozchodzi się po ciele "
+                   "od żołądka ku kończynom, łatając drobne uszkodzenia ciała.";
+        case HERB_GHOSTWEED:
+            return "Blada, niemal przezroczysta trawa rosnąca na pobojowiskach i cmentarzach. "
+                   "Mówi się, że wyrasta tam, gdzie duchy nie chcą odejść. Rozgryziona tuż przed "
+                   "bitwą wypędza strach z serca — nie dlatego, że go nie ma, lecz dlatego, "
+                   "że przestaje mieć znaczenie.";
+        case HERB_IRONBARK:
+            return "Łuszcząca się kora drzew rosnących przy złożach żelaznej rudy. Latem, "
+                   "gdy słońce wypala z niej wilgoć, staje się twarda jak łupek. Zielarze "
+                   "moczą ją w oleju i wcierają w skórę — twardnieje ona wtedy jak skórzana zbroja.";
+        case HERB_GRAVEMINT:
+            return "Mięta o lodowato niebieskich liściach, rosnąca przy studniach, fontannach "
+                   "i w wilgotnych jaskiniach. Zimą kwitnie maleńkimi kryształkami lodu zamiast "
+                   "kwiatów. Przeżuta chroni przed mrozem i wychłodzeniem — krew płynie szybciej, "
+                   "choć oddech paruje gęstym obłokiem.";
+        case HERB_VOIDFERN:
+            return "Paproć o czarnych, aksamitnych zarodnikach, rosnąca wyłącznie tam, gdzie "
+                   "magia się skupia — w jaskiniach starych magów, przy runie spalonych świątyń. "
+                   "Zarodniki wdychane przez zielarza wyostrzają percepcję do granic bólu: "
+                   "aurę magii widać jak dym, a iluzje rozpadają się w pył.";
+        case HERB_WITCH_CLOVER:
+            return "Czterolistna koniczyna o złotawym odcieniu, spotykana raz na tysiąc łąk. "
+                   "Noszący ją przy sobie twierdzą, że los się do nich uśmiecha — strzały lecą "
+                   "o cal za daleko, kamień spada o chwilę za wcześnie. Wiedźmy zbierają ją "
+                   "w noc nowiu i nie powiedzą, do czego naprawdę służy.";
+    }
+    return "Zioło o nieznanym przeznaczeniu.";
+}
+
+string HerbGetEffect(int nType)
+{
+    switch(nType)
+    {
+        case HERB_BLOODMOSS:    return "Przywraca 5 PŻ.";
+        case HERB_NIGHTSHADE:   return "Odporność na paraliż przez 10 minut.";
+        case HERB_SUNROOT:      return "Przywraca 8 PŻ.";
+        case HERB_GHOSTWEED:    return "Odporność na strach przez 10 minut.";
+        case HERB_IRONBARK:     return "Naturalny pancerz +2 przez 10 minut.";
+        case HERB_GRAVEMINT:    return "Odporność na zimno (5 pkt) przez 10 minut.";
+        case HERB_VOIDFERN:     return "Prawdziwe widzenie przez 10 minut.";
+        case HERB_WITCH_CLOVER: return "+2 do wszystkich rzutów obronnych przez 10 minut.";
+    }
+    return "Brak efektu.";
+}
+
+// Returns SEASON_* constant, or -1 for year-round herbs
+int HerbGetSeason(int nType)
+{
+    switch(nType)
+    {
+        case HERB_BLOODMOSS:    return SEASON_AUTUMN;
+        case HERB_NIGHTSHADE:   return SEASON_WINTER;
+        case HERB_SUNROOT:      return SEASON_SPRING;
+        case HERB_GHOSTWEED:    return -1;
+        case HERB_IRONBARK:     return SEASON_SUMMER;
+        case HERB_GRAVEMINT:    return SEASON_WINTER;
+        case HERB_VOIDFERN:     return -1;
+        case HERB_WITCH_CLOVER: return -1;
+    }
+    return -1;
+}
+
+string HerbGetSeasonName(int nSeason)
+{
+    switch(nSeason)
+    {
+        case SEASON_SPRING: return "Wiosna";
+        case SEASON_SUMMER: return "Lato";
+        case SEASON_AUTUMN: return "Jesień";
+        case SEASON_WINTER: return "Zima";
+    }
+    return "Każda";
+}
+
+string HerbGetSeasonForType(int nType)
+{
+    int nSeas = HerbGetSeason(nType);
+    if(nSeas < 0) return "Każda pora";
+    return HerbGetSeasonName(nSeas);
+}
+
+int HerbGetCurrentSeason()
+{
+    int nMonth = GetCalendarMonth();
+    if(nMonth >= 3 && nMonth <= 5)  return SEASON_SPRING;
+    if(nMonth >= 6 && nMonth <= 8)  return SEASON_SUMMER;
+    if(nMonth >= 9 && nMonth <= 11) return SEASON_AUTUMN;
+    return SEASON_WINTER;
+}
+
+int HerbIsInSeason(int nType)
+{
+    int nSeas = HerbGetSeason(nType);
+    if(nSeas < 0) return TRUE;
+    return (nSeas == HerbGetCurrentSeason());
+}
+
+// ================================================================
+// Apply herb effect to PC
+// ================================================================
+
+void HerbApplyEffect(object oPC, int nType)
+{
+    switch(nType)
+    {
+        case HERB_BLOODMOSS:
+            ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectHeal(5), oPC);
+            SendMessageToPC(oPC, "[Zielarz] Krwawnik zatamował krew. Rany powoli się zamykają.");
+            break;
+        case HERB_NIGHTSHADE:
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                EffectImmunity(IMMUNITY_TYPE_PARALYSIS), oPC, HERB_EFFECT_DUR);
+            SendMessageToPC(oPC, "[Zielarz] Gorycz Nocnego Cienia przenika nerwy. Paraliż cię nie dosięgnie.");
+            break;
+        case HERB_SUNROOT:
+            ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectHeal(8), oPC);
+            SendMessageToPC(oPC, "[Zielarz] Słonecznik Polny krzepi ciało i przywraca ciepło.");
+            break;
+        case HERB_GHOSTWEED:
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                EffectImmunity(IMMUNITY_TYPE_FEAR), oPC, HERB_EFFECT_DUR);
+            SendMessageToPC(oPC, "[Zielarz] Strach-Ziele wypaliło lęk z twojego serca. Strach przestał mieć znaczenie.");
+            break;
+        case HERB_IRONBARK:
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                EffectACIncrease(2, AC_NATURAL_BONUS), oPC, HERB_EFFECT_DUR);
+            SendMessageToPC(oPC, "[Zielarz] Żelazokora twardnieje na skórze. Czujesz się odporniejszy na ciosy.");
+            break;
+        case HERB_GRAVEMINT:
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                EffectDamageResistance(DAMAGE_TYPE_COLD, 5, 0), oPC, HERB_EFFECT_DUR);
+            SendMessageToPC(oPC, "[Zielarz] Lodowata Grobowamiętka chroni przed mrozem. Krew płynie szybciej.");
+            break;
+        case HERB_VOIDFERN:
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                EffectTrueSeeing(), oPC, HERB_EFFECT_DUR);
+            SendMessageToPC(oPC, "[Zielarz] Zarodniki Pustokwiatu wyostrzają zmysły. Magia staje się widoczna jak dym.");
+            break;
+        case HERB_WITCH_CLOVER:
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                EffectSavingThrowIncrease(SAVING_THROW_ALL, 2), oPC, HERB_EFFECT_DUR);
+            SendMessageToPC(oPC, "[Zielarz] Wiedźmia Koniczyna przynosi łut szczęścia. Los się uśmiecha.");
+            break;
+    }
+}
+
+// ================================================================
+// Harvest window
+// ================================================================
+
+void OpenHarvestWindow(object oPC, object oNode)
+{
+    if(NuiFindWindow(oPC, HERB_WIN_HARVEST) != 0)
+        NuiDestroy(oPC, NuiFindWindow(oPC, HERB_WIN_HARVEST));
+
+    string sTag  = GetTag(oNode);
+    int    nType = HerbNodeGetType(sTag);
+
+    SetLocalString(oPC, HERB_LVAR_NODE,  sTag);
+    SetLocalInt   (oPC, HERB_LVAR_NTYPE, nType);
+
+    float fW    = GetNuiScaleDimension(oPC, HERB_HW);
+    float fH    = GetNuiScaleDimension(oPC, HERB_HH);
+    float fBtnH = GetNuiScaleDimension(oPC, 30.0);
+    float fX    = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - fW) / 2.0;
+    float fY    = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - fH) / 2.0;
+    json jGeom  = NuiRect(fX, fY, fW, fH);
+
+    // Name label (larger, centered)
+    json jName = NuiLabel(NuiBind(HERB_BIND_H_NAME), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jName = NuiHeight(jName, GetNuiScaleDimension(oPC, 34.0));
+
+    // Scrollable description
+    json jDesc = NuiGroup(NuiText(NuiBind(HERB_BIND_H_DESC), FALSE), TRUE, NUI_SCROLLBARS_NONE);
+    jDesc = NuiHeight(jDesc, GetNuiScaleDimension(oPC, 80.0));
+
+    // Charges remaining
+    json jChrg = NuiLabel(NuiBind(HERB_BIND_H_CHRG), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jChrg = NuiHeight(jChrg, GetNuiScaleDimension(oPC, 22.0));
+
+    // Season bonus indicator
+    json jBonus = NuiLabel(NuiBind(HERB_BIND_H_BONUS), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jBonus = NuiHeight(jBonus, GetNuiScaleDimension(oPC, 20.0));
+
+    json jHarvestBtn = NuiButton(JsonString("Zbierz"));
+    jHarvestBtn = NuiId(jHarvestBtn, HERB_BTN_HARVEST);
+    jHarvestBtn = NuiEnabled(jHarvestBtn, NuiBind(HERB_BIND_H_ENA));
+    jHarvestBtn = NuiWidth(jHarvestBtn,  GetNuiScaleDimension(oPC, 120.0));
+    jHarvestBtn = NuiHeight(jHarvestBtn, fBtnH);
+
+    json jJournalBtn = NuiButton(JsonString("Dziennik"));
+    jJournalBtn = NuiId(jJournalBtn, HERB_BTN_JOURNAL);
+    jJournalBtn = NuiWidth(jJournalBtn,  GetNuiScaleDimension(oPC, 110.0));
+    jJournalBtn = NuiHeight(jJournalBtn, fBtnH);
+
+    json jCloseBtn = NuiButton(JsonString("X"));
+    jCloseBtn = NuiId(jCloseBtn, HERB_BTN_CLOSE_H);
+    jCloseBtn = NuiWidth(jCloseBtn,  GetNuiScaleDimension(oPC, 30.0));
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, jHarvestBtn);
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jJournalBtn);
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jCloseBtn);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jName);
+    jCol = JsonArrayInsert(jCol, jDesc);
+    jCol = JsonArrayInsert(jCol, jChrg);
+    jCol = JsonArrayInsert(jCol, jBonus);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+
+    json jWin = NuiWindow(NuiCol(jCol),
+        JsonBool(FALSE),
+        NuiBind(HERB_BIND_H_GEOM),
+        JsonBool(FALSE), JsonBool(FALSE), JsonBool(TRUE),
+        JsonBool(FALSE), JsonBool(FALSE));
+
+    int nToken = NuiCreate(oPC, jWin, HERB_WIN_HARVEST, HERB_EV);
+    NuiSetBind(oPC, nToken, HERB_BIND_H_GEOM, jGeom);
+    FeedHarvestWindow(oPC, nToken);
+}
+
+void FeedHarvestWindow(object oPC, int nToken)
+{
+    string sTag   = GetLocalString(oPC, HERB_LVAR_NODE);
+    int    nType  = GetLocalInt   (oPC, HERB_LVAR_NTYPE);
+
+    HerbNodeRegen(sTag, HERB_REGEN_SECS);
+    int nCharges = HerbNodeGetCharges(sTag);
+    int bSeason  = HerbIsInSeason(nType);
+
+    string sBonus = bSeason
+        ? "★ Sezon zbiorów — dodatkowy plon!"
+        : "Poza sezonem zbiorów.";
+
+    NuiSetBind(oPC, nToken, HERB_BIND_H_NAME,  JsonString(HerbGetName(nType)));
+    NuiSetBind(oPC, nToken, HERB_BIND_H_DESC,  JsonString(HerbGetDesc(nType)));
+    NuiSetBind(oPC, nToken, HERB_BIND_H_CHRG,
+        JsonString("Plony: " + IntToString(nCharges) + " / " + IntToString(HERB_NODE_CHARGES)));
+    NuiSetBind(oPC, nToken, HERB_BIND_H_BONUS, JsonString(sBonus));
+    NuiSetBind(oPC, nToken, HERB_BIND_H_ENA,   JsonBool(nCharges > 0));
+}
+
+// ================================================================
+// Journal window
+// ================================================================
+
+json BuildJournalLayout(object oPC)
+{
+    float fBtnH = GetNuiScaleDimension(oPC, 30.0);
+    float fRowH = GetNuiScaleDimension(oPC, 28.0);
+
+    float fNameW = GetNuiScaleDimension(oPC, 190.0);
+    float fCntW  = GetNuiScaleDimension(oPC, 62.0);
+    float fSeasW = GetNuiScaleDimension(oPC, 100.0);
+
+    // List row template: name | count | season
+    json jNameLbl = NuiLabel(NuiBind(HERB_BIND_J_RNAME), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jNameLbl = NuiStyleForegroundColor(jNameLbl, NuiBind(HERB_BIND_J_RCOL));
+
+    json jCntLbl = NuiLabel(NuiBind(HERB_BIND_J_RCNT), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jCntLbl = NuiWidth(jCntLbl, fCntW);
+    jCntLbl = NuiStyleForegroundColor(jCntLbl, NuiBind(HERB_BIND_J_RCOL));
+
+    json jSeasLbl = NuiLabel(NuiBind(HERB_BIND_J_RSEAS), JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jSeasLbl = NuiWidth(jSeasLbl, fSeasW);
+    jSeasLbl = NuiStyleForegroundColor(jSeasLbl, NuiBind(HERB_BIND_J_RCOL));
+
+    json jCellRow = JsonArray();
+    jCellRow = JsonArrayInsert(jCellRow,
+        NuiWidth(NuiCol(JsonArrayInsert(JsonArray(), jNameLbl)), fNameW));
+    jCellRow = JsonArrayInsert(jCellRow, jCntLbl);
+    jCellRow = JsonArrayInsert(jCellRow, jSeasLbl);
+
+    json jCell = NuiGroup(NuiRow(jCellRow), TRUE, NUI_SCROLLBARS_NONE);
+    jCell = NuiId(jCell, HERB_BTN_ROW);
+    jCell = NuiEncouraged(jCell, NuiBind(HERB_BIND_J_RENC));
+
+    json jTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jCell, 0.0, TRUE));
+    float fListH = GetNuiScaleDimension(oPC, 200.0);
+    json jList = NuiList(jTmpl, NuiBind(HERB_BIND_J_ROWS), fRowH);
+    jList = NuiHeight(jList, fListH);
+
+    // Lore panel: selected herb name + desc + effect
+    json jLoreN = NuiLabel(NuiBind(HERB_BIND_LORE_N), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jLoreN = NuiHeight(jLoreN, GetNuiScaleDimension(oPC, 24.0));
+
+    json jLoreT = NuiGroup(NuiText(NuiBind(HERB_BIND_LORE_T), FALSE), TRUE, NUI_SCROLLBARS_NONE);
+    jLoreT = NuiHeight(jLoreT, GetNuiScaleDimension(oPC, 95.0));
+
+    json jLoreP = NuiLabel(NuiBind(HERB_BIND_LORE_P), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jLoreP = NuiHeight(jLoreP, GetNuiScaleDimension(oPC, 22.0));
+
+    // Use / Close buttons
+    json jUseBtn = NuiButton(NuiBind(HERB_BIND_USE_LBL));
+    jUseBtn = NuiId(jUseBtn, HERB_BTN_USE);
+    jUseBtn = NuiEnabled(jUseBtn, NuiBind(HERB_BIND_USE_ENA));
+    jUseBtn = NuiWidth(jUseBtn,  GetNuiScaleDimension(oPC, 150.0));
+    jUseBtn = NuiHeight(jUseBtn, fBtnH);
+
+    json jCloseBtn = NuiButton(JsonString("Zamknij"));
+    jCloseBtn = NuiId(jCloseBtn, HERB_BTN_CLOSE_J);
+    jCloseBtn = NuiWidth(jCloseBtn,  GetNuiScaleDimension(oPC, 90.0));
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jBotRow = JsonArray();
+    jBotRow = JsonArrayInsert(jBotRow, jUseBtn);
+    jBotRow = JsonArrayInsert(jBotRow, NuiSpacer());
+    jBotRow = JsonArrayInsert(jBotRow, jCloseBtn);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jList);
+    jCol = JsonArrayInsert(jCol, jLoreN);
+    jCol = JsonArrayInsert(jCol, jLoreT);
+    jCol = JsonArrayInsert(jCol, jLoreP);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBotRow));
+
+    return NuiCol(jCol);
+}
+
+void OpenJournalWindow(object oPC)
+{
+    if(NuiFindWindow(oPC, HERB_WIN_JOURNAL) != 0)
+    {
+        FeedJournalWindow(oPC, NuiFindWindow(oPC, HERB_WIN_JOURNAL));
+        return;
+    }
+
+    float fW  = GetNuiScaleDimension(oPC, HERB_JW);
+    float fH  = GetNuiScaleDimension(oPC, HERB_JH);
+    float fX  = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - fW) / 2.0;
+    float fY  = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - fH) / 2.0;
+    json jGeom = NuiRect(fX, fY, fW, fH);
+
+    json jWin = NuiWindow(BuildJournalLayout(oPC),
+        JsonString("Dziennik Zielarza"),
+        NuiBind(HERB_BIND_J_GEOM),
+        JsonBool(TRUE), JsonBool(FALSE), JsonBool(TRUE),
+        JsonBool(TRUE),  JsonBool(FALSE));
+
+    int nToken = NuiCreate(oPC, jWin, HERB_WIN_JOURNAL, HERB_EV);
+    NuiSetBind(oPC, nToken, HERB_BIND_J_GEOM, jGeom);
+    SetLocalInt(oPC, HERB_LVAR_SEL, 0);
+    FeedJournalWindow(oPC, nToken);
+}
+
+void FeedJournalWindow(object oPC, int nToken)
+{
+    json jAll   = HerbPlayerGetAll(oPC);
+    int  nCount = JsonGetLength(jAll);
+    int  nSel   = GetLocalInt(oPC, HERB_LVAR_SEL);
+    int  nCurSeas = HerbGetCurrentSeason();
+
+    json jNames = JsonArray();
+    json jCnts  = JsonArray();
+    json jSeas  = JsonArray();
+    json jEncs  = JsonArray();
+    json jCols  = JsonArray();
+
+    json jGreen = NuiColor(100, 220, 100);
+    json jWhite = NuiColor(210, 210, 210);
+
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jRow  = JsonArrayGet(jAll, i);
+        int  nType = JsonGetInt(JsonObjectGet(jRow, "type"));
+        int  nCnt  = JsonGetInt(JsonObjectGet(jRow, "count"));
+        int  nSeas = HerbGetSeason(nType);
+        int  bIn   = (nSeas < 0 || nSeas == nCurSeas);
+
+        jNames = JsonArrayInsert(jNames, JsonString(HerbGetName(nType)));
+        jCnts  = JsonArrayInsert(jCnts,  JsonString(IntToString(nCnt) + " szt."));
+        jSeas  = JsonArrayInsert(jSeas,  JsonString(HerbGetSeasonForType(nType)));
+        jEncs  = JsonArrayInsert(jEncs,  JsonBool(nType == nSel));
+        jCols  = JsonArrayInsert(jCols,  bIn ? jGreen : jWhite);
+    }
+
+    NuiSetBind(oPC, nToken, HERB_BIND_J_RNAME, jNames);
+    NuiSetBind(oPC, nToken, HERB_BIND_J_RCNT,  jCnts);
+    NuiSetBind(oPC, nToken, HERB_BIND_J_RSEAS, jSeas);
+    NuiSetBind(oPC, nToken, HERB_BIND_J_RENC,  jEncs);
+    NuiSetBind(oPC, nToken, HERB_BIND_J_RCOL,  jCols);
+    NuiSetBind(oPC, nToken, HERB_BIND_J_ROWS,  JsonInt(nCount));
+
+    if(nSel > 0)
+    {
+        int nHave = HerbPlayerGetCount(oPC, nSel);
+        NuiSetBind(oPC, nToken, HERB_BIND_LORE_N, JsonString("▸ " + HerbGetName(nSel)));
+        NuiSetBind(oPC, nToken, HERB_BIND_LORE_T, JsonString(HerbGetDesc(nSel)));
+        NuiSetBind(oPC, nToken, HERB_BIND_LORE_P, JsonString("Efekt: " + HerbGetEffect(nSel)));
+        NuiSetBind(oPC, nToken, HERB_BIND_USE_ENA, JsonBool(nHave > 0));
+        NuiSetBind(oPC, nToken, HERB_BIND_USE_LBL,
+            JsonString("Zażyj (" + IntToString(nHave) + " szt.)"));
+    }
+    else
+    {
+        NuiSetBind(oPC, nToken, HERB_BIND_LORE_N,  JsonString("Wybierz zioło z listy."));
+        NuiSetBind(oPC, nToken, HERB_BIND_LORE_T,  JsonString(""));
+        NuiSetBind(oPC, nToken, HERB_BIND_LORE_P,  JsonString(""));
+        NuiSetBind(oPC, nToken, HERB_BIND_USE_ENA, JsonBool(FALSE));
+        NuiSetBind(oPC, nToken, HERB_BIND_USE_LBL, JsonString("Zażyj"));
+    }
+}

--- a/Herbarium/scripts/lib_herb_def.nss
+++ b/Herbarium/scripts/lib_herb_def.nss
@@ -1,0 +1,94 @@
+#include "lib_nui"
+#include "sql_herb"
+
+// ----------------------------------------------------------------
+// Herb types (1-indexed; 0 = none/invalid)
+// ----------------------------------------------------------------
+
+const int HERB_BLOODMOSS     = 1;
+const int HERB_NIGHTSHADE    = 2;
+const int HERB_SUNROOT       = 3;
+const int HERB_GHOSTWEED     = 4;
+const int HERB_IRONBARK      = 5;
+const int HERB_GRAVEMINT     = 6;
+const int HERB_VOIDFERN      = 7;
+const int HERB_WITCH_CLOVER  = 8;
+const int HERB_TYPE_COUNT    = 8;
+
+// Seasons (aligned with NWN months 1-12):
+//   Spring: 3-5 | Summer: 6-8 | Autumn: 9-11 | Winter: 12,1,2
+const int SEASON_SPRING  = 0;
+const int SEASON_SUMMER  = 1;
+const int SEASON_AUTUMN  = 2;
+const int SEASON_WINTER  = 3;
+
+// Effect duration in seconds (10 real minutes)
+const float HERB_EFFECT_DUR  = 600.0;
+
+// Node config
+const int HERB_NODE_CHARGES  = 3;
+const int HERB_REGEN_SECS    = 86400;  // one real day per charge regen
+
+// ----------------------------------------------------------------
+// NUI — window IDs
+// ----------------------------------------------------------------
+
+const string HERB_WIN_HARVEST  = "HERB_WIN_HARVEST";
+const string HERB_WIN_JOURNAL  = "HERB_WIN_JOURNAL";
+const string HERB_EV           = "lib_herb_ev";
+
+// ----------------------------------------------------------------
+// NUI — harvest window binds
+// ----------------------------------------------------------------
+
+const string HERB_BIND_H_GEOM  = "herb_h_geom";
+const string HERB_BIND_H_NAME  = "herb_h_name";
+const string HERB_BIND_H_DESC  = "herb_h_desc";
+const string HERB_BIND_H_CHRG  = "herb_h_chrg";
+const string HERB_BIND_H_BONUS = "herb_h_bonus";
+const string HERB_BIND_H_ENA   = "herb_h_ena";
+
+// ----------------------------------------------------------------
+// NUI — journal window binds
+// ----------------------------------------------------------------
+
+const string HERB_BIND_J_GEOM  = "herb_j_geom";
+const string HERB_BIND_J_RNAME = "herb_j_rname";
+const string HERB_BIND_J_RCNT  = "herb_j_rcnt";
+const string HERB_BIND_J_RSEAS = "herb_j_rseas";
+const string HERB_BIND_J_RENC  = "herb_j_renc";
+const string HERB_BIND_J_RCOL  = "herb_j_rcol";
+const string HERB_BIND_J_ROWS  = "herb_j_rows";
+const string HERB_BIND_LORE_N  = "herb_lore_n";
+const string HERB_BIND_LORE_T  = "herb_lore_t";
+const string HERB_BIND_LORE_P  = "herb_lore_p";
+const string HERB_BIND_USE_ENA = "herb_use_ena";
+const string HERB_BIND_USE_LBL = "herb_use_lbl";
+
+// ----------------------------------------------------------------
+// NUI — button IDs
+// ----------------------------------------------------------------
+
+const string HERB_BTN_HARVEST  = "herb_btn_harv";
+const string HERB_BTN_JOURNAL  = "herb_btn_jour";
+const string HERB_BTN_CLOSE_H  = "herb_btn_clh";
+const string HERB_BTN_ROW      = "herb_btn_row";
+const string HERB_BTN_USE      = "herb_btn_use";
+const string HERB_BTN_CLOSE_J  = "herb_btn_clj";
+
+// ----------------------------------------------------------------
+// Local vars on PC
+// ----------------------------------------------------------------
+
+const string HERB_LVAR_NODE    = "HERB_NODE_TAG";
+const string HERB_LVAR_NTYPE   = "HERB_NODE_TYPE";
+const string HERB_LVAR_SEL     = "HERB_SEL_TYPE";
+
+// ----------------------------------------------------------------
+// Window dimensions (pre-scale)
+// ----------------------------------------------------------------
+
+const float HERB_HW = 400.0;
+const float HERB_HH = 240.0;
+const float HERB_JW = 580.0;
+const float HERB_JH = 480.0;

--- a/Herbarium/scripts/lib_herb_ev.nss
+++ b/Herbarium/scripts/lib_herb_ev.nss
@@ -1,0 +1,149 @@
+#include "lib_herb"
+
+// ----------------------------------------------------------------
+// Harvest: skill check then deplete node
+// ----------------------------------------------------------------
+
+void HerbHandleHarvest(object oPC, int nToken)
+{
+    string sTag  = GetLocalString(oPC, HERB_LVAR_NODE);
+    int    nType = GetLocalInt   (oPC, HERB_LVAR_NTYPE);
+
+    if(HerbNodeGetCharges(sTag) <= 0)
+    {
+        SendMessageToPC(oPC, "[Zielarz] Roślina jest wyczerpana. Wróć po jakimś czasie.");
+        FeedHarvestWindow(oPC, nToken);
+        return;
+    }
+
+    // Survival DC 10 — on failure charges still depleted (plant damaged)
+    int nSkill   = GetSkillRank(SKILL_SURVIVAL, oPC);
+    int nRoll    = Random(20) + 1;
+    int bSuccess = (nRoll + nSkill >= 10);
+
+    HerbNodeHarvest(sTag);
+
+    if(!bSuccess)
+    {
+        SendMessageToPC(oPC, "[Zielarz] Nieudany zbiór (rzut " + IntToString(nRoll)
+            + " + " + IntToString(nSkill) + " = " + IntToString(nRoll + nSkill)
+            + " vs 10). Zioło zniszczone przy wyrywaniu.");
+        FeedHarvestWindow(oPC, nToken);
+        return;
+    }
+
+    // +1 yield when in season
+    int nYield = 1 + (HerbIsInSeason(nType) ? 1 : 0);
+    HerbPlayerGive(oPC, nType, nYield);
+
+    string sMsg = "[Zielarz] Zebrano " + IntToString(nYield) + "x " + HerbGetName(nType) + ".";
+    if(HerbIsInSeason(nType))
+        sMsg = sMsg + " (sezon zbiorów — dodatkowy plon)";
+    SendMessageToPC(oPC, sMsg);
+
+    FeedHarvestWindow(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Journal: consume one herb and apply its effect
+// ----------------------------------------------------------------
+
+void HerbHandleUse(object oPC, int nToken)
+{
+    int nType = GetLocalInt(oPC, HERB_LVAR_SEL);
+    if(nType <= 0)
+    {
+        SendMessageToPC(oPC, "[Zielarz] Nie wybrano żadnego ziołą.");
+        return;
+    }
+
+    int nHave = HerbPlayerGetCount(oPC, nType);
+    if(nHave <= 0)
+    {
+        SendMessageToPC(oPC, "[Zielarz] Brak ziół tego rodzaju w sakwie.");
+        FeedJournalWindow(oPC, nToken);
+        return;
+    }
+
+    HerbPlayerConsume(oPC, nType, 1);
+    HerbApplyEffect(oPC, nType);
+    FeedJournalWindow(oPC, nToken);
+}
+
+// ================================================================
+// Main NUI event handler
+// ================================================================
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    // ---- Harvest window ----
+    if(nToken == NuiFindWindow(oPC, HERB_WIN_HARVEST))
+    {
+        if(sEvent == EVENT_TYPE_CLICK)
+        {
+            if(sElem == HERB_BTN_CLOSE_H)
+            {
+                NuiDestroy(oPC, nToken);
+                return;
+            }
+            if(sElem == HERB_BTN_HARVEST)
+            {
+                HerbHandleHarvest(oPC, nToken);
+                return;
+            }
+            if(sElem == HERB_BTN_JOURNAL)
+            {
+                OpenJournalWindow(oPC);
+                return;
+            }
+        }
+        if(sEvent == EVENT_TYPE_CLOSE)
+        {
+            DeleteLocalString(oPC, HERB_LVAR_NODE);
+            DeleteLocalInt   (oPC, HERB_LVAR_NTYPE);
+        }
+        return;
+    }
+
+    // ---- Journal window ----
+    if(nToken == NuiFindWindow(oPC, HERB_WIN_JOURNAL))
+    {
+        if(sEvent == EVENT_TYPE_CLOSE)
+        {
+            DeleteLocalInt(oPC, HERB_LVAR_SEL);
+            return;
+        }
+
+        if(sEvent == EVENT_TYPE_CLICK)
+        {
+            if(sElem == HERB_BTN_CLOSE_J)
+            {
+                NuiDestroy(oPC, nToken);
+                return;
+            }
+            if(sElem == HERB_BTN_USE)
+            {
+                HerbHandleUse(oPC, nToken);
+                return;
+            }
+        }
+
+        if(sEvent == EVENT_TYPE_MOUSEDOWN && sElem == HERB_BTN_ROW)
+        {
+            json jAll = HerbPlayerGetAll(oPC);
+            if(nIdx < 0 || nIdx >= JsonGetLength(jAll)) return;
+
+            json jRow  = JsonArrayGet(jAll, nIdx);
+            int  nType = JsonGetInt(JsonObjectGet(jRow, "type"));
+            SetLocalInt(oPC, HERB_LVAR_SEL, nType);
+            FeedJournalWindow(oPC, nToken);
+            return;
+        }
+    }
+}

--- a/Herbarium/scripts/sql_herb.nss
+++ b/Herbarium/scripts/sql_herb.nss
@@ -1,0 +1,146 @@
+// ----------------------------------------------------------------
+// Herbarium — SQL layer
+// Campaign DB: "herbarium"
+// ----------------------------------------------------------------
+
+void HerbCreateTables()
+{
+    sqlquery q;
+
+    q = SqlPrepareQueryCampaign("herbarium",
+        "CREATE TABLE IF NOT EXISTS herb_nodes ("
+        "  node_tag  TEXT    PRIMARY KEY,"
+        "  herb_type INTEGER NOT NULL DEFAULT 1,"
+        "  charges   INTEGER NOT NULL DEFAULT 3,"
+        "  max_chrg  INTEGER NOT NULL DEFAULT 3,"
+        "  last_harv INTEGER NOT NULL DEFAULT 0"
+        ")");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("herbarium",
+        "CREATE TABLE IF NOT EXISTS herb_player ("
+        "  player_uuid TEXT    NOT NULL,"
+        "  herb_type   INTEGER NOT NULL,"
+        "  total_count INTEGER NOT NULL DEFAULT 0,"
+        "  known       INTEGER NOT NULL DEFAULT 0,"
+        "  PRIMARY KEY (player_uuid, herb_type)"
+        ")");
+    SqlStep(q);
+}
+
+// Idempotent — safe to call on every node OnUsed
+void HerbNodeEnsure(string sTag, int nType, int nMax)
+{
+    sqlquery q = SqlPrepareQueryCampaign("herbarium",
+        "INSERT OR IGNORE INTO herb_nodes"
+        "  (node_tag, herb_type, charges, max_chrg, last_harv)"
+        "  VALUES (@tag, @type, @max, @max, 0)");
+    SqlBindString(q, "@tag",  sTag);
+    SqlBindInt   (q, "@type", nType);
+    SqlBindInt   (q, "@max",  nMax);
+    SqlStep(q);
+}
+
+int HerbNodeGetCharges(string sTag)
+{
+    sqlquery q = SqlPrepareQueryCampaign("herbarium",
+        "SELECT charges FROM herb_nodes WHERE node_tag = @tag");
+    SqlBindString(q, "@tag", sTag);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+int HerbNodeGetType(string sTag)
+{
+    sqlquery q = SqlPrepareQueryCampaign("herbarium",
+        "SELECT herb_type FROM herb_nodes WHERE node_tag = @tag");
+    SqlBindString(q, "@tag", sTag);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// Restores one charge if enough real time has passed since last harvest
+void HerbNodeRegen(string sTag, int nRegenSecs)
+{
+    sqlquery q = SqlPrepareQueryCampaign("herbarium",
+        "UPDATE herb_nodes"
+        "  SET charges   = MIN(max_chrg, charges + 1),"
+        "      last_harv = strftime('%s','now')"
+        "  WHERE node_tag = @tag"
+        "    AND charges  < max_chrg"
+        "    AND strftime('%s','now') - last_harv >= @regen");
+    SqlBindString(q, "@tag",   sTag);
+    SqlBindInt   (q, "@regen", nRegenSecs);
+    SqlStep(q);
+}
+
+// Returns 1 on success, 0 if already depleted
+int HerbNodeHarvest(string sTag)
+{
+    int nBefore = HerbNodeGetCharges(sTag);
+    if(nBefore <= 0) return 0;
+
+    sqlquery q = SqlPrepareQueryCampaign("herbarium",
+        "UPDATE herb_nodes"
+        "  SET charges   = charges - 1,"
+        "      last_harv = strftime('%s','now')"
+        "  WHERE node_tag = @tag AND charges > 0");
+    SqlBindString(q, "@tag", sTag);
+    SqlStep(q);
+    return 1;
+}
+
+void HerbPlayerGive(object oPC, int nType, int nAmount)
+{
+    sqlquery q = SqlPrepareQueryCampaign("herbarium",
+        "INSERT INTO herb_player (player_uuid, herb_type, total_count, known)"
+        "  VALUES (@uuid, @type, @amt, 1)"
+        "  ON CONFLICT(player_uuid, herb_type) DO UPDATE"
+        "  SET total_count = total_count + @amt, known = 1");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@type", nType);
+    SqlBindInt   (q, "@amt",  nAmount);
+    SqlStep(q);
+}
+
+void HerbPlayerConsume(object oPC, int nType, int nAmount)
+{
+    sqlquery q = SqlPrepareQueryCampaign("herbarium",
+        "UPDATE herb_player"
+        "  SET total_count = MAX(0, total_count - @amt)"
+        "  WHERE player_uuid = @uuid AND herb_type = @type");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@type", nType);
+    SqlBindInt   (q, "@amt",  nAmount);
+    SqlStep(q);
+}
+
+int HerbPlayerGetCount(object oPC, int nType)
+{
+    sqlquery q = SqlPrepareQueryCampaign("herbarium",
+        "SELECT total_count FROM herb_player"
+        "  WHERE player_uuid = @uuid AND herb_type = @type");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@type", nType);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// Returns JsonArray of {type, count, known} for all herbs the PC knows
+json HerbPlayerGetAll(object oPC)
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("herbarium",
+        "SELECT herb_type, total_count FROM herb_player"
+        "  WHERE player_uuid = @uuid AND known = 1"
+        "  ORDER BY herb_type");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    while(SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "type",  JsonInt(SqlGetInt(q, 0)));
+        jRow = JsonObjectSet(jRow, "count", JsonInt(SqlGetInt(q, 1)));
+        jRows = JsonArrayInsert(jRows, jRow);
+    }
+    return jRows;
+}

--- a/Herbarium/scripts/sys_on_enter.nss
+++ b/Herbarium/scripts/sys_on_enter.nss
@@ -1,0 +1,15 @@
+#include "lib_herb_def"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC)) return;
+
+    // Herb knowledge is accumulated on first harvest of each type;
+    // no player registration needed. Trigger node regen lazily on open.
+    int nKnown = JsonGetLength(HerbPlayerGetAll(oPC));
+    if(nKnown > 0)
+        SendMessageToPC(oPC,
+            "[Zielarz] Twoja sakwa zawiera " + IntToString(nKnown)
+            + " rodzaj(ów) ziół. Otwórz Dziennik Zielarza, aby sprawdzić zasoby.");
+}

--- a/Herbarium/scripts/sys_on_load.nss
+++ b/Herbarium/scripts/sys_on_load.nss
@@ -1,0 +1,6 @@
+#include "sql_herb"
+
+void main()
+{
+    HerbCreateTables();
+}

--- a/Herbarium/scripts/test_herb.nss
+++ b/Herbarium/scripts/test_herb.nss
@@ -1,0 +1,30 @@
+#include "lib_herb"
+
+// OnUsed script for herb-node placeables and the herbalist's journal stand.
+//
+// Herb node setup (in toolset):
+//   Tag    — unique per node instance (used as SQL primary key)
+//   Local Int "HERB_TYPE" = 1..8  (matches HERB_* constants)
+//
+// Journal stand: same script, HERB_TYPE = 0 or omitted -> opens journal only.
+
+void main()
+{
+    object oPC   = GetLastUsedBy();
+    object oSelf = OBJECT_SELF;
+
+    if(!GetIsPC(oPC)) return;
+
+    int nType = GetLocalInt(oSelf, "HERB_TYPE");
+
+    if(nType < 1 || nType > HERB_TYPE_COUNT)
+    {
+        // Acts as a pure journal stand
+        OpenJournalWindow(oPC);
+        return;
+    }
+
+    // Register node in SQL on first use (idempotent)
+    HerbNodeEnsure(GetTag(oSelf), nType, HERB_NODE_CHARGES);
+    OpenHarvestWindow(oPC, oSelf);
+}


### PR DESCRIPTION
## Co to robi

System zbierania ziół z węzłami surowców rozsianych po świecie, trwałym dziennikiem per postać i efektami bezpośrednio aplikowanymi na gracza. Klimat: gotycki zielarz, mroczna medycyna polowa, wiedźmie receptury.

## Mechanika

- **Węzły ziół** — placeables z lokalną zmienną `HERB_TYPE` (1–8). Każdy ma 3 plony regenerujące się co 24 godziny rzeczywiste (obliczane lazily przy otwarciu okna, bez heartbeat). Plony śledzące w SQLite per tag.
- **Zbieranie** — Survival DC 10. Sukces: 1 plon (+1 w sezonie rośliny). Porażka: plon stracony, roślina uszkodzona.
- **8 typów ziół** z sezonami (wiosna/lato/jesień/zima) i unikalnymi efektami:
  - Krwawnik (jesień) — +5 HP
  - Nocny Cień (zima) — odporność na paraliż 10 min
  - Słonecznik Polny (wiosna) — +8 HP
  - Strach-Ziele (każda) — odporność na strach 10 min
  - Żelazokora (lato) — naturalny pancerz +2, 10 min
  - Grobowamiętka (zima) — odporność na zimno 5 pkt, 10 min
  - Pustokwiat (każda, jaskinie) — Prawdziwe Widzenie 10 min
  - Wiedźmia Koniczyna (każda, rzadka) — +2 do wszystkich rzutów obronnych, 10 min
- **Dziennik Zielarza** — lista zebranych ziół z liczebnością, sezonem (kolor zielony = aktualny sezon), lore i przyciskiem „Zażyj". Historia wiedzy per postać w SQL.

## Pliki

| Plik | Rola |
|------|------|
| `scripts/sql_herb.nss` | Schemat SQLite, zapytania do herb_nodes i herb_player |
| `scripts/lib_herb_def.nss` | Stałe, ID bindów NUI, wymiary okien |
| `scripts/lib_herb.nss` | Rdzeń: dane ziół, builderzy NUI, Feed/Open |
| `scripts/lib_herb_ev.nss` | Handler eventów NUI (harvest, use, row click) |
| `scripts/sys_on_load.nss` | `HerbCreateTables()` — init DB |
| `scripts/sys_on_enter.nss` | Powiadomienie o zasobach przy logowaniu |
| `scripts/test_herb.nss` | OnUsed: otwiera harvest lub journal |
| `INTEGRATION.md` | Instrukcja integracji, tabela typów ziół |

## Zależności (NWNX? SQL?)

- **NWNX: brak** — tylko NWN 1.87+ (UUID, SqlPrepareQueryCampaign, NUI)
- Campaign DB: `herbarium` (dwie tabele, auto-migrated)

## Jak włączyć w istniejącym module

1. Dodaj `sys_on_load` do OnModuleLoad (lub wywołaj `HerbCreateTables()` z istniejącego on_load)
2. Opcjonalnie: dodaj `sys_on_enter` do OnClientEnter
3. Rozstaw placeables z `OnUsed = test_herb` i `HERB_TYPE = 1..8`
4. Opcjonalnie: dodaj placeable bez `HERB_TYPE` jako stół dziennika

## Co celowo pominięto

- **Ikony ziół** — wymagałyby zasobów w hak; zastąpione opisem tekstowym i nazwą
- **Craftowanie** — zioła zużywane bezpośrednio; `HerbPlayerConsume()` jest publiczna, integracja z alchemią możliwa z zewnątrz
- **Heartbeat regen** — regen obliczany lazily przy otwarciu okna (0 skryptów modułowych per-tick)
- **Limit sakwy** — brak górnego progu liczby ziół; można dodać w `HerbPlayerGive()`

---
_Generated by [Claude Code](https://claude.ai/code/session_015sL95dgfRHvCnciCgM94nR)_