### PR TITLE
feat: Wytrzymałość (Durability System)

### DIFF
--- a/Durability/INTEGRATION.md
+++ b/Durability/INTEGRATION.md
@@ -1,0 +1,116 @@
+# Wytrzymałość — Durability System
+
+System trwałości ekwipunku dla dark fantasy CRPG opartych na NWN EE.
+Brak zależności od NWNX — działa na czystym silniku.
+
+---
+
+## Jak to działa
+
+Każdy z 7 śledzonych slotów wyposażenia (broń główna, lewa ręka,
+zbroja, hełm, buty, rękawice, peleryna) ma wartość wytrzymałości 0–100
+zapisaną w kampanijnej bazie SQLite (`durability`).
+
+Podczas walki (co ~60 sekund, `sys_module_hb.nss`) sprzęt traci punkt(y)
+wytrzymałości. Przy przekroczeniu progów 75 / 50 / 25 / 0 nakładane są
+supernaturalne kary do ataku i/lub KP.
+
+| Stan        | Próg  | Kara broni | Kara zbroi/tarczy |
+|-------------|-------|------------|-------------------|
+| Dobry       | ≥ 75  | 0          | 0                 |
+| Zużyty      | ≥ 50  | −1         | −1                |
+| Uszkodzony  | ≥ 25  | −2         | −2                |
+| Złamany     | > 0   | −4         | −4                |
+| Zniszczony  | = 0   | −6         | −6                |
+
+Naprawa dostępna przy kuźni (tańsza) lub w polu (3× drożej + zestaw
+z tagiem `dur_repair_kit`).
+
+---
+
+## Pliki
+
+| Plik                          | Rola                                                  |
+|-------------------------------|-------------------------------------------------------|
+| `Scripts/sql_dur.nss`         | Schemat SQLite + wszystkie zapytania                  |
+| `Scripts/lib_dur_def.nss`     | Stałe, ID bindów NUI, ID przycisków, helpery slotów  |
+| `Scripts/lib_dur.nss`         | Rdzeń: logika kar, decay, budowa NUI, feed, naprawa  |
+| `Scripts/lib_dur_ev.nss`      | Handler zdarzeń NUI                                   |
+| `Scripts/sys_on_load.nss`     | Inicjalizacja tabel (OnModuleLoad)                    |
+| `Scripts/sys_on_enter.nss`    | Przywracanie kar przy wejściu gracza                  |
+| `Scripts/sys_module_hb.nss`   | Heartbeat — decay podczas walki                       |
+| `Scripts/test_dur.nss`        | OnUsed na kuźni/placeable — otwiera UI                |
+| `Scripts/lib_nui.nss`         | Kopia wspólnego helperów NUI (GUI scale etc.)         |
+| `Scripts/lib_nui_utility.nss` | Kopia wspólnych utilsów NUI                           |
+
+---
+
+## Jak włączyć w istniejącym module
+
+### 1. Skopiuj skrypty
+
+Wszystkie pliki z `Durability/Scripts/` do folderu skryptów modułu
+(lub do paczki HAK).
+
+Jeśli moduł już korzysta z `lib_nui.nss` / `lib_nui_utility.nss`,
+pomiń te pliki — zawartość jest identyczna.
+
+### 2. Podepnij hooki
+
+| Zdarzenie modułu   | Skrypt do dodania (lub wywołania)     |
+|--------------------|---------------------------------------|
+| OnModuleLoad       | `sys_on_load.nss`                     |
+| OnClientEnter      | `sys_on_enter.nss`                    |
+| OnHeartbeat        | `sys_module_hb.nss`                   |
+
+Jeśli któryś hook już istnieje, dołącz wywołanie na końcu:
+
+```nss
+// w istniejącym sys_on_enter.nss:
+#include "lib_dur"
+// ...
+DelayCommand(2.0, DurCheckAllSlots(oPC));
+```
+
+### 3. Umieść kuźnię w świecie gry
+
+Dodaj placeable (np. `plc_wdragonforge`, `plc_cobblestone`) i ustaw
+skrypt `test_dur.nss` jako `OnUsed`. Gracze muszą kliknąć kuźnię,
+by naprawić ekwipunek taniej niż w terenie.
+
+### 4. (Opcjonalnie) Zestaw naprawczy w terenie
+
+Stwórz item z tagiem `dur_repair_kit` (np. zestaw narzędzi kowalskich,
+zakupiony u handlarza). Pozwoli graczom naprawiać ekwipunek poza kuźnią
+za 3× cenę złota.
+
+---
+
+## Zależności NWNX
+
+**Brak.** System korzysta wyłącznie z czystego NWN EE (NUI, SQLite,
+efekty supernaturalne).
+
+---
+
+## Potencjalne konflikty
+
+- System używa `SUBTYPE_SUPERNATURAL` do oznaczenia kar. Inne systemy,
+  które nakładają permanentne supernaturalne efekty `ATTACK_DECREASE`
+  lub `AC_DECREASE` na gracza, mogą zostać omyłkowo usunięte przy
+  przeliczeniu. Jeśli moduł posiada taki system, podepnij NWNX_Effect
+  do tagowania efektów i zmodyfikuj `DurClearPenaltyEffects` w
+  `lib_dur.nss`.
+
+---
+
+## Co celowo pominięto
+
+- **Trwałość ekwipunku NPC** — zbędna złożoność bez mechanicznej wartości.
+- **Estetyczne zmiany wyglądu** (lodowe pęknięcia itp.) — wymaga HAK/NWNX.
+- **Decay poza walką** — zbyt karzący; można włączyć zmieniając warunek
+  `GetIsInCombat` w `sys_module_hb.nss`.
+- **Naprawa niestandardowymi materiałami** (rudy, skóra) — złoto jako
+  universal resource jest prostsze i nie wymaga nowych itemów w HAK.
+- **Różna max wytrzymałość per base item type** — uniform 100 upraszcza
+  balans; można rozbudować przez tabelę per `GetBaseItemType`.

--- a/Durability/Scripts/lib_dur.nss
+++ b/Durability/Scripts/lib_dur.nss
@@ -1,0 +1,553 @@
+#include "lib_dur_def"
+
+// ----------------------------------------------------------------
+// Penalty effect management
+// Uses SUBTYPE_SUPERNATURAL to distinguish from spell/ability effects.
+// Removes all supernatural ATTACK_DECREASE / AC_DECREASE, then
+// re-applies our totals. May conflict if another system also places
+// permanent supernatural decreases on PCs — see INTEGRATION.md.
+// ----------------------------------------------------------------
+
+void DurClearPenaltyEffects(object oPC)
+{
+    effect e = GetFirstEffect(oPC);
+    while(GetIsEffectValid(e))
+    {
+        effect eNext = GetNextEffect(oPC);
+        int nType = GetEffectType(e);
+        if(GetEffectSubType(e) == SUBTYPE_SUPERNATURAL &&
+           (nType == EFFECT_TYPE_ATTACK_DECREASE ||
+            nType == EFFECT_TYPE_AC_DECREASE))
+            RemoveEffect(oPC, e);
+        e = eNext;
+    }
+}
+
+void DurApplyPenaltyEffects(object oPC, int nAttPen, int nACPen)
+{
+    DurClearPenaltyEffects(oPC);
+    if(nAttPen > 0)
+    {
+        effect eAtt = SupernaturalEffect(EffectAttackDecrease(nAttPen));
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eAtt, oPC);
+    }
+    if(nACPen > 0)
+    {
+        effect eAC = SupernaturalEffect(EffectACDecrease(nACPen));
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eAC, oPC);
+    }
+}
+
+void DurRecalcPenalties(object oPC)
+{
+    int nAttPen = 0;
+    int nACPen  = 0;
+    int i;
+    for(i = 0; i < DUR_SLOT_COUNT; i++)
+    {
+        object oItem = GetItemInSlot(DurGetInventorySlot(i), oPC);
+        if(!GetIsObjectValid(oItem)) continue;
+
+        int nDur = DurGetDurability(oItem);
+        int nPen = DurGetPenalty(nDur);
+        if(nPen <= 0) continue;
+
+        if(DurIsWeaponSlot(i, oItem) && nPen > nAttPen)
+            nAttPen = nPen;
+
+        if(DurIsArmorSlot(i, oItem))
+            nACPen += nPen;
+    }
+
+    DurApplyPenaltyEffects(oPC, nAttPen, nACPen);
+}
+
+// ----------------------------------------------------------------
+// Decay — one call per ~60-second combat cycle from module HB
+// ----------------------------------------------------------------
+
+void DurDecayCombatPC(object oPC)
+{
+    int nChanged = FALSE;
+    int i;
+    for(i = 0; i < DUR_SLOT_COUNT; i++)
+    {
+        object oItem = GetItemInSlot(DurGetInventorySlot(i), oPC);
+        if(!GetIsObjectValid(oItem)) continue;
+
+        DurEnsureItem(oItem, oPC, i);
+        if(DurGetDurability(oItem) <= 0) continue;
+
+        // Weapons decay faster; each call is ~60 s of combat
+        int nAmt = (i == 0 || i == 1) ? 2 : 1;
+        DurDecayItem(oItem, nAmt);
+        nChanged = TRUE;
+
+        // Warn player at key thresholds
+        int nDur = DurGetDurability(oItem);
+        if(nDur == DUR_THR_WORN - 1 || nDur == DUR_THR_DAMAGED - 1 ||
+           nDur == DUR_THR_BROKEN - 1 || nDur == 0)
+        {
+            SendMessageToPC(oPC,
+                "[Wytrzymałość] " + GetName(oItem) + ": " +
+                DurGetStatusText(nDur) + "! (" + IntToString(nDur) + "/100)");
+        }
+    }
+
+    if(nChanged)
+    {
+        DurRecalcPenalties(oPC);
+        int nToken = NuiFindWindow(oPC, DUR_WINDOW);
+        if(nToken != 0)
+            DurFeedWindow(oPC, nToken);
+    }
+}
+
+void DurCheckAllSlots(object oPC)
+{
+    int i;
+    for(i = 0; i < DUR_SLOT_COUNT; i++)
+    {
+        object oItem = GetItemInSlot(DurGetInventorySlot(i), oPC);
+        if(GetIsObjectValid(oItem))
+            DurEnsureItem(oItem, oPC, i);
+    }
+    DurRecalcPenalties(oPC);
+}
+
+// ----------------------------------------------------------------
+// NUI layout builders
+// ----------------------------------------------------------------
+
+json DurBuildSlotList(object oPC)
+{
+    float fRowH  = GetNuiScaleDimension(oPC, 30.0);
+    float fSlotW = GetNuiScaleDimension(oPC, 110.0);
+    float fBarW  = GetNuiScaleDimension(oPC, 110.0);
+    float fStatW = GetNuiScaleDimension(oPC, 90.0);
+    float fListH = GetNuiScaleDimension(oPC, 224.0);
+
+    json jSlotLbl = NuiLabel(NuiBind(DUR_BIND_SLOT_NAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    json jSlotCol = NuiWidth(NuiCol(JsonArrayInsert(JsonArray(), jSlotLbl)), fSlotW);
+
+    json jItemLbl = NuiLabel(NuiBind(DUR_BIND_ITEM_NAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jItemLbl = NuiStyleForegroundColor(jItemLbl, NuiBind(DUR_BIND_STAT_COLOR));
+
+    json jBar = NuiProgressBar(NuiBind(DUR_BIND_SLOT_PCT));
+    jBar = NuiStyleForegroundColor(jBar, NuiBind(DUR_BIND_BAR_COLOR));
+    json jBarCol = NuiWidth(NuiCol(JsonArrayInsert(JsonArray(), jBar)), fBarW);
+
+    json jStatLbl = NuiLabel(NuiBind(DUR_BIND_SLOT_STATUS),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jStatLbl = NuiStyleForegroundColor(jStatLbl, NuiBind(DUR_BIND_STAT_COLOR));
+    json jStatCol = NuiWidth(NuiCol(JsonArrayInsert(JsonArray(), jStatLbl)), fStatW);
+
+    json jCols = JsonArray();
+    jCols = JsonArrayInsert(jCols, jSlotCol);
+    jCols = JsonArrayInsert(jCols, jItemLbl);
+    jCols = JsonArrayInsert(jCols, jBarCol);
+    jCols = JsonArrayInsert(jCols, jStatCol);
+
+    json jRowCell = NuiGroup(NuiRow(jCols), FALSE, NUI_SCROLLBARS_NONE);
+    jRowCell = NuiId(jRowCell, DUR_BTN_ROW);
+    jRowCell = NuiEncouraged(jRowCell, NuiBind(DUR_BIND_ROW_ENC));
+
+    json jTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jRowCell, 0.0, TRUE));
+    json jList = NuiList(jTmpl, NuiBind(DUR_BIND_ROWCOUNT), fRowH);
+    jList = NuiHeight(jList, fListH);
+    return jList;
+}
+
+json DurBuildDetailPanel(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 32.0);
+    float fBtnW  = GetNuiScaleDimension(oPC, 200.0);
+    float fInfoH = GetNuiScaleDimension(oPC, 130.0);
+
+    json jNameLbl = NuiLabel(NuiBind(DUR_BIND_DETAIL_NAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jNameLbl = NuiHeight(jNameLbl, GetNuiScaleDimension(oPC, 24.0));
+
+    json jInfoTxt = NuiGroup(NuiText(NuiBind(DUR_BIND_DETAIL_INFO), FALSE),
+        TRUE, NUI_SCROLLBARS_NONE);
+    jInfoTxt = NuiHeight(jInfoTxt, fInfoH);
+
+    json jRepairBtn = NuiButton(JsonString("Napraw (Kuźnia)"));
+    jRepairBtn = NuiId(jRepairBtn, DUR_BTN_REPAIR);
+    jRepairBtn = NuiEnabled(jRepairBtn, NuiBind(DUR_BIND_REPAIR_ENA));
+    jRepairBtn = NuiWidth(jRepairBtn, fBtnW);
+    jRepairBtn = NuiHeight(jRepairBtn, fBtnH);
+    jRepairBtn = NuiTooltip(jRepairBtn,
+        JsonString("Naprawa przy kowalskim ogniu — pełna restauracja."));
+
+    json jFieldBtn = NuiButton(JsonString("Napraw w Polu"));
+    jFieldBtn = NuiId(jFieldBtn, DUR_BTN_FIELD);
+    jFieldBtn = NuiEnabled(jFieldBtn, NuiBind(DUR_BIND_FIELD_ENA));
+    jFieldBtn = NuiWidth(jFieldBtn, fBtnW);
+    jFieldBtn = NuiHeight(jFieldBtn, fBtnH);
+    jFieldBtn = NuiTooltip(jFieldBtn,
+        JsonString("Zużywa zestaw naprawczy (dur_repair_kit) + 3× cena złota."));
+
+    json jBtnCol = JsonArray();
+    jBtnCol = JsonArrayInsert(jBtnCol, jRepairBtn);
+    jBtnCol = JsonArrayInsert(jBtnCol, CreateEmptyRow(oPC, 4.0));
+    jBtnCol = JsonArrayInsert(jBtnCol, jFieldBtn);
+
+    json jPanel = JsonArray();
+    jPanel = JsonArrayInsert(jPanel, jNameLbl);
+    jPanel = JsonArrayInsert(jPanel, jInfoTxt);
+    jPanel = JsonArrayInsert(jPanel, NuiCol(jBtnCol));
+
+    return NuiCol(jPanel);
+}
+
+json DurBuildWindow(object oPC)
+{
+    float fBtnH   = GetNuiScaleDimension(oPC, 32.0);
+    float fListW  = GetNuiScaleDimension(oPC, 390.0);
+    float fPanelW = GetNuiScaleDimension(oPC, 230.0);
+
+    json jTitle = NuiLabel(
+        JsonString("Kuźnia — Stan Ekwipunku"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitle = NuiHeight(jTitle, GetNuiScaleDimension(oPC, 26.0));
+
+    // Column headers above the list
+    json jHdrSlot = NuiLabel(JsonString("Slot"),
+        JsonInt(NUI_HALIGN_LEFT),   JsonInt(NUI_VALIGN_MIDDLE));
+    jHdrSlot = NuiWidth(jHdrSlot, GetNuiScaleDimension(oPC, 110.0));
+
+    json jHdrItem = NuiLabel(JsonString("Przedmiot"),
+        JsonInt(NUI_HALIGN_LEFT),   JsonInt(NUI_VALIGN_MIDDLE));
+
+    json jHdrBar = NuiLabel(JsonString("Wytrzymałość"),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jHdrBar = NuiWidth(jHdrBar, GetNuiScaleDimension(oPC, 110.0));
+
+    json jHdrStat = NuiLabel(JsonString("Stan"),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jHdrStat = NuiWidth(jHdrStat, GetNuiScaleDimension(oPC, 90.0));
+
+    json jHdrRow = JsonArray();
+    jHdrRow = JsonArrayInsert(jHdrRow, jHdrSlot);
+    jHdrRow = JsonArrayInsert(jHdrRow, jHdrItem);
+    jHdrRow = JsonArrayInsert(jHdrRow, jHdrBar);
+    jHdrRow = JsonArrayInsert(jHdrRow, jHdrStat);
+
+    // Left column: headers + list
+    json jLeft = JsonArray();
+    jLeft = JsonArrayInsert(jLeft, NuiRow(jHdrRow));
+    jLeft = JsonArrayInsert(jLeft, DurBuildSlotList(oPC));
+    json jLeftCol = NuiWidth(NuiCol(jLeft), fListW);
+
+    // Right column: detail panel
+    json jRightCol = NuiWidth(DurBuildDetailPanel(oPC), fPanelW);
+
+    json jMainRow = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jLeftCol);
+    jMainRow = JsonArrayInsert(jMainRow, NuiSpacer());
+    jMainRow = JsonArrayInsert(jMainRow, jRightCol);
+
+    // Bottom bar
+    json jRepAllBtn = NuiButton(JsonString("Napraw Wszystko"));
+    jRepAllBtn = NuiId(jRepAllBtn, DUR_BTN_REPALL);
+    jRepAllBtn = NuiEnabled(jRepAllBtn, NuiBind(DUR_BIND_REPALL_ENA));
+    jRepAllBtn = NuiWidth(jRepAllBtn, GetNuiScaleDimension(oPC, 150.0));
+    jRepAllBtn = NuiHeight(jRepAllBtn, fBtnH);
+    jRepAllBtn = NuiTooltip(jRepAllBtn,
+        JsonString("Naprawia wszystkie uszkodzone przedmioty (wymaga kuźni)."));
+
+    json jStatusLbl = NuiLabel(NuiBind(DUR_BIND_STATUS_MSG),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jStatusLbl = NuiStyleForegroundColor(jStatusLbl, NuiColor(220, 200, 80));
+
+    json jCloseBtn = NuiButton(JsonString("Zamknij"));
+    jCloseBtn = NuiId(jCloseBtn, DUR_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, GetNuiScaleDimension(oPC, 80.0));
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jBotRow = JsonArray();
+    jBotRow = JsonArrayInsert(jBotRow, jRepAllBtn);
+    jBotRow = JsonArrayInsert(jBotRow, NuiSpacer());
+    jBotRow = JsonArrayInsert(jBotRow, jStatusLbl);
+    jBotRow = JsonArrayInsert(jBotRow, NuiSpacer());
+    jBotRow = JsonArrayInsert(jBotRow, jCloseBtn);
+
+    json jRoot = JsonArray();
+    jRoot = JsonArrayInsert(jRoot, jTitle);
+    jRoot = JsonArrayInsert(jRoot, CreateEmptyRow(oPC, 4.0));
+    jRoot = JsonArrayInsert(jRoot, NuiRow(jMainRow));
+    jRoot = JsonArrayInsert(jRoot, CreateEmptyRow(oPC, 6.0));
+    jRoot = JsonArrayInsert(jRoot, NuiRow(jBotRow));
+
+    return NuiCol(jRoot);
+}
+
+// ----------------------------------------------------------------
+// Window lifecycle
+// ----------------------------------------------------------------
+
+void DurCreateWindow(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, DUR_WINDOW);
+    if(nToken != 0)
+    {
+        DurFeedWindow(oPC, nToken);
+        return;
+    }
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  -
+                 GetNuiScaleDimension(oPC, DUR_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) -
+                 GetNuiScaleDimension(oPC, DUR_H)) / 2.0;
+    json jGeom = NuiRect(fCX, fCY,
+        GetNuiScaleDimension(oPC, DUR_W),
+        GetNuiScaleDimension(oPC, DUR_H));
+
+    json jWin = NuiWindow(
+        DurBuildWindow(oPC),
+        JsonString("Wytrzymałość Ekwipunku"),
+        NuiBind(DUR_WIN_GEOM),
+        JsonBool(TRUE),   // resizable
+        JsonBool(FALSE),
+        JsonBool(TRUE),   // closable
+        JsonBool(FALSE),
+        JsonBool(TRUE));  // border
+
+    nToken = NuiCreate(oPC, jWin, DUR_WINDOW, DUR_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, DUR_WIN_GEOM, jGeom);
+
+    SetLocalInt(oPC, DUR_LVAR_SEL, -1);
+    DurFeedWindow(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Feed — populate NuiList binds and detail panel
+// ----------------------------------------------------------------
+
+void DurFeedDetail(object oPC, int nToken, int nSlotIdx)
+{
+    if(nSlotIdx < 0 || nSlotIdx >= DUR_SLOT_COUNT)
+    {
+        NuiSetBind(oPC, nToken, DUR_BIND_DETAIL_NAME,
+            JsonString("Wybierz slot z listy powyżej."));
+        NuiSetBind(oPC, nToken, DUR_BIND_DETAIL_INFO, JsonString(""));
+        NuiSetBind(oPC, nToken, DUR_BIND_REPAIR_ENA,  JsonBool(FALSE));
+        NuiSetBind(oPC, nToken, DUR_BIND_FIELD_ENA,   JsonBool(FALSE));
+        return;
+    }
+
+    object oItem = GetItemInSlot(DurGetInventorySlot(nSlotIdx), oPC);
+    if(!GetIsObjectValid(oItem))
+    {
+        NuiSetBind(oPC, nToken, DUR_BIND_DETAIL_NAME,
+            JsonString(DurGetSlotLabel(nSlotIdx) + ": (pusty slot)"));
+        NuiSetBind(oPC, nToken, DUR_BIND_DETAIL_INFO, JsonString(""));
+        NuiSetBind(oPC, nToken, DUR_BIND_REPAIR_ENA,  JsonBool(FALSE));
+        NuiSetBind(oPC, nToken, DUR_BIND_FIELD_ENA,   JsonBool(FALSE));
+        return;
+    }
+
+    DurEnsureItem(oItem, oPC, nSlotIdx);
+    int nDur     = DurGetDurability(oItem);
+    int nMaxDur  = DurGetMaxDurability(oItem);
+    int nMissing = nMaxDur - nDur;
+    int nPen     = DurGetPenalty(nDur);
+
+    string sHeader = DurGetSlotLabel(nSlotIdx) + ": " + GetName(oItem);
+
+    string sInfo = "Wytrzymałość: " + IntToString(nDur) + " / " + IntToString(nMaxDur) + "\n";
+    sInfo = sInfo + "Stan: " + DurGetStatusText(nDur) + "\n";
+
+    if(nPen > 0)
+    {
+        string sPenType = DurIsWeaponSlot(nSlotIdx, oItem) ? " do ataku" : " do KP";
+        sInfo = sInfo + "Kara: -" + IntToString(nPen) + sPenType + "\n";
+    }
+
+    int bNeedsRepair = (nMissing > 0);
+    if(bNeedsRepair)
+    {
+        int nForgeCost = DurRepairCost(nMissing, FALSE);
+        int nFieldCost = DurRepairCost(nMissing, TRUE);
+        sInfo = sInfo + "\nKuźnia: " + IntToString(nForgeCost) + " sz\n";
+        sInfo = sInfo + "Polowa: "  + IntToString(nFieldCost) + " sz + zestaw";
+    }
+    else
+        sInfo = sInfo + "\nStan idealny — naprawa zbędna.";
+
+    int bAtForge    = GetLocalInt(oPC, DUR_LVAR_FORGE);
+    int bHasKit     = GetIsObjectValid(GetItemPossessedBy(oPC, DUR_TAG_KIT));
+    int nPlayerGold = GetGold(oPC);
+
+    int bCanForge = bAtForge && bNeedsRepair &&
+                    (nPlayerGold >= DurRepairCost(nMissing, FALSE));
+    int bCanField = bNeedsRepair && bHasKit &&
+                    (nPlayerGold >= DurRepairCost(nMissing, TRUE));
+
+    NuiSetBind(oPC, nToken, DUR_BIND_DETAIL_NAME, JsonString(sHeader));
+    NuiSetBind(oPC, nToken, DUR_BIND_DETAIL_INFO, JsonString(sInfo));
+    NuiSetBind(oPC, nToken, DUR_BIND_REPAIR_ENA,  JsonBool(bCanForge));
+    NuiSetBind(oPC, nToken, DUR_BIND_FIELD_ENA,   JsonBool(bCanField));
+}
+
+void DurFeedWindow(object oPC, int nToken)
+{
+    json jSlotNames  = JsonArray();
+    json jItemNames  = JsonArray();
+    json jPcts       = JsonArray();
+    json jBarColors  = JsonArray();
+    json jStatTexts  = JsonArray();
+    json jStatColors = JsonArray();
+    json jEncs       = JsonArray();
+
+    int nSelIdx = GetLocalInt(oPC, DUR_LVAR_SEL);
+    int nAnyDmg = FALSE;
+
+    int i;
+    for(i = 0; i < DUR_SLOT_COUNT; i++)
+    {
+        object oItem = GetItemInSlot(DurGetInventorySlot(i), oPC);
+        int bHasItem = GetIsObjectValid(oItem);
+
+        int nDur = 100;
+        if(bHasItem)
+        {
+            DurEnsureItem(oItem, oPC, i);
+            nDur = DurGetDurability(oItem);
+        }
+
+        float fPct    = bHasItem ? IntToFloat(nDur) / 100.0 : 1.0;
+        string sStatus = bHasItem ? DurGetStatusText(nDur) : "";
+        json jColor   = bHasItem ? DurGetStatusColor(nDur) : NuiColor(100, 100, 100);
+
+        if(bHasItem && nDur < DUR_THR_WORN)
+            nAnyDmg = TRUE;
+
+        jSlotNames  = JsonArrayInsert(jSlotNames,  JsonString(DurGetSlotLabel(i)));
+        jItemNames  = JsonArrayInsert(jItemNames,  JsonString(bHasItem ? GetName(oItem) : "(brak)"));
+        jPcts       = JsonArrayInsert(jPcts,       JsonFloat(fPct));
+        jBarColors  = JsonArrayInsert(jBarColors,  jColor);
+        jStatTexts  = JsonArrayInsert(jStatTexts,  JsonString(sStatus));
+        jStatColors = JsonArrayInsert(jStatColors, jColor);
+        jEncs       = JsonArrayInsert(jEncs,       JsonBool(i == nSelIdx));
+    }
+
+    NuiSetBind(oPC, nToken, DUR_BIND_SLOT_NAME,   jSlotNames);
+    NuiSetBind(oPC, nToken, DUR_BIND_ITEM_NAME,   jItemNames);
+    NuiSetBind(oPC, nToken, DUR_BIND_SLOT_PCT,    jPcts);
+    NuiSetBind(oPC, nToken, DUR_BIND_BAR_COLOR,   jBarColors);
+    NuiSetBind(oPC, nToken, DUR_BIND_SLOT_STATUS, jStatTexts);
+    NuiSetBind(oPC, nToken, DUR_BIND_STAT_COLOR,  jStatColors);
+    NuiSetBind(oPC, nToken, DUR_BIND_ROW_ENC,     jEncs);
+    NuiSetBind(oPC, nToken, DUR_BIND_ROWCOUNT,    JsonInt(DUR_SLOT_COUNT));
+    NuiSetBind(oPC, nToken, DUR_BIND_REPALL_ENA,  JsonBool(nAnyDmg && GetLocalInt(oPC, DUR_LVAR_FORGE)));
+    NuiSetBind(oPC, nToken, DUR_BIND_STATUS_MSG,  JsonString(""));
+
+    DurFeedDetail(oPC, nToken, nSelIdx);
+}
+
+// ----------------------------------------------------------------
+// Repair actions (called from event handler)
+// ----------------------------------------------------------------
+
+void DurDoRepair(object oPC, int nToken, int nSlotIdx, int bField)
+{
+    if(nSlotIdx < 0 || nSlotIdx >= DUR_SLOT_COUNT) return;
+
+    object oItem = GetItemInSlot(DurGetInventorySlot(nSlotIdx), oPC);
+    if(!GetIsObjectValid(oItem)) return;
+
+    int nDur     = DurGetDurability(oItem);
+    int nMaxDur  = DurGetMaxDurability(oItem);
+    int nMissing = nMaxDur - nDur;
+
+    if(nMissing <= 0)
+    {
+        NuiSetBind(oPC, nToken, DUR_BIND_STATUS_MSG,
+            JsonString("Przedmiot nie wymaga naprawy."));
+        return;
+    }
+
+    int nCost = DurRepairCost(nMissing, bField);
+    if(GetGold(oPC) < nCost)
+    {
+        NuiSetBind(oPC, nToken, DUR_BIND_STATUS_MSG,
+            JsonString("Za mało złota! Potrzebujesz " + IntToString(nCost) + " sz."));
+        return;
+    }
+
+    if(bField)
+    {
+        object oKit = GetItemPossessedBy(oPC, DUR_TAG_KIT);
+        if(!GetIsObjectValid(oKit))
+        {
+            NuiSetBind(oPC, nToken, DUR_BIND_STATUS_MSG,
+                JsonString("Brak zestawu naprawczego (dur_repair_kit) w ekwipunku."));
+            return;
+        }
+        DestroyObject(oKit);
+    }
+
+    AssignCommand(oPC, TakeGoldFromCreature(nCost, oPC, TRUE));
+    DurFullRepair(oItem);
+    DurRecalcPenalties(oPC);
+
+    string sHow = bField ? "w polu" : "przy kuźni";
+    NuiSetBind(oPC, nToken, DUR_BIND_STATUS_MSG,
+        JsonString("Naprawiono " + GetName(oItem) + " " + sHow +
+                   ". Koszt: " + IntToString(nCost) + " sz."));
+
+    DurFeedWindow(oPC, nToken);
+}
+
+void DurDoRepairAll(object oPC, int nToken)
+{
+    if(!GetLocalInt(oPC, DUR_LVAR_FORGE))
+    {
+        NuiSetBind(oPC, nToken, DUR_BIND_STATUS_MSG,
+            JsonString("Naprawa wszystkich wymaga kuźni."));
+        return;
+    }
+
+    int nTotalCost = 0;
+    int i;
+    for(i = 0; i < DUR_SLOT_COUNT; i++)
+    {
+        object oItem = GetItemInSlot(DurGetInventorySlot(i), oPC);
+        if(!GetIsObjectValid(oItem)) continue;
+        DurEnsureItem(oItem, oPC, i);
+        int nMissing = DurGetMaxDurability(oItem) - DurGetDurability(oItem);
+        nTotalCost += DurRepairCost(nMissing, FALSE);
+    }
+
+    if(nTotalCost <= 0)
+    {
+        NuiSetBind(oPC, nToken, DUR_BIND_STATUS_MSG,
+            JsonString("Cały ekwipunek w doskonałym stanie."));
+        return;
+    }
+
+    if(GetGold(oPC) < nTotalCost)
+    {
+        NuiSetBind(oPC, nToken, DUR_BIND_STATUS_MSG,
+            JsonString("Za mało złota! Potrzebujesz " + IntToString(nTotalCost) + " sz."));
+        return;
+    }
+
+    AssignCommand(oPC, TakeGoldFromCreature(nTotalCost, oPC, TRUE));
+
+    for(i = 0; i < DUR_SLOT_COUNT; i++)
+    {
+        object oItem = GetItemInSlot(DurGetInventorySlot(i), oPC);
+        if(GetIsObjectValid(oItem))
+            DurFullRepair(oItem);
+    }
+
+    DurRecalcPenalties(oPC);
+    NuiSetBind(oPC, nToken, DUR_BIND_STATUS_MSG,
+        JsonString("Cały ekwipunek naprawiony. Koszt: " + IntToString(nTotalCost) + " sz."));
+    DurFeedWindow(oPC, nToken);
+}

--- a/Durability/Scripts/lib_dur_def.nss
+++ b/Durability/Scripts/lib_dur_def.nss
@@ -1,0 +1,188 @@
+#include "lib_nui"
+#include "sql_dur"
+
+void DurCreateWindow(object oPC);
+void DurFeedWindow(object oPC, int nToken);
+void DurFeedDetail(object oPC, int nToken, int nSlotIdx);
+void DurRecalcPenalties(object oPC);
+void DurDecayCombatPC(object oPC);
+void DurCheckAllSlots(object oPC);
+void DurDoRepair(object oPC, int nToken, int nSlotIdx, int bField);
+void DurDoRepairAll(object oPC, int nToken);
+
+// ----------------------------------------------------------------
+// Window / event IDs
+// ----------------------------------------------------------------
+
+const string DUR_WINDOW    = "DUR_WINDOW";
+const string DUR_EV_SCRIPT = "lib_dur_ev";
+const string DUR_WIN_GEOM  = "dur_win_geom";
+
+// ----------------------------------------------------------------
+// NuiList array binds (one value per row in the slot list)
+// ----------------------------------------------------------------
+
+const string DUR_BIND_SLOT_NAME   = "dur_slot_name";   // string  — slot label
+const string DUR_BIND_ITEM_NAME   = "dur_item_name";   // string  — item name or "(brak)"
+const string DUR_BIND_SLOT_PCT    = "dur_slot_pct";    // float   — 0.0–1.0 for progress bar
+const string DUR_BIND_BAR_COLOR   = "dur_bar_col";     // NuiColor
+const string DUR_BIND_SLOT_STATUS = "dur_slot_stat";   // string  — "Dobry" / "Zużyty" etc.
+const string DUR_BIND_STAT_COLOR  = "dur_stat_col";    // NuiColor
+const string DUR_BIND_ROW_ENC     = "dur_row_enc";     // bool    — currently selected row
+const string DUR_BIND_ROWCOUNT    = "dur_rowcount";    // int     — number of rows
+
+// ----------------------------------------------------------------
+// Detail panel binds (scalar, updated on row select)
+// ----------------------------------------------------------------
+
+const string DUR_BIND_DETAIL_NAME = "dur_detail_name"; // string  — "Naprawiasz: <name>"
+const string DUR_BIND_DETAIL_INFO = "dur_detail_info"; // string  — cost text block
+const string DUR_BIND_REPAIR_ENA  = "dur_repair_ena";  // bool    — forge repair available
+const string DUR_BIND_FIELD_ENA   = "dur_field_ena";   // bool    — field repair available
+const string DUR_BIND_REPALL_ENA  = "dur_repall_ena";  // bool    — repair-all available
+const string DUR_BIND_STATUS_MSG  = "dur_status_msg";  // string  — feedback line
+
+// ----------------------------------------------------------------
+// Button IDs
+// ----------------------------------------------------------------
+
+const string DUR_BTN_ROW    = "dur_btn_row";
+const string DUR_BTN_REPAIR = "dur_btn_repair";
+const string DUR_BTN_FIELD  = "dur_btn_field";
+const string DUR_BTN_REPALL = "dur_btn_repall";
+const string DUR_BTN_CLOSE  = "dur_btn_close";
+
+// ----------------------------------------------------------------
+// PC local vars
+// ----------------------------------------------------------------
+
+const string DUR_LVAR_SEL    = "DUR_SEL_SLOT";   // int — selected slot index (0..DUR_SLOT_COUNT-1)
+const string DUR_LVAR_FORGE  = "DUR_AT_FORGE";   // int 1 if opened at a forge placeable
+
+// ----------------------------------------------------------------
+// Layout
+// ----------------------------------------------------------------
+
+const float DUR_W = 660.0;
+const float DUR_H = 510.0;
+
+// ----------------------------------------------------------------
+// Tracked inventory slots (indices 0–6)
+// ----------------------------------------------------------------
+
+const int DUR_SLOT_COUNT = 7;
+
+// ----------------------------------------------------------------
+// Durability thresholds & penalties
+// ----------------------------------------------------------------
+
+const int DUR_THR_WORN    = 75;   // 75–100: no penalty
+const int DUR_THR_DAMAGED = 50;   // 50–74: -1 to attack / AC
+const int DUR_THR_BROKEN  = 25;   // 25–49: -2 to attack / AC
+                                   //  1–24: -4 to attack / AC
+                                   //     0: -6 to attack / AC (destroyed)
+
+// Gold cost per missing durability point for forge repair
+const int DUR_GOLD_PER_POINT    = 8;
+// Field repair: 3× the forge cost, no forge needed
+const int DUR_FIELD_REPAIR_MULT = 3;
+// Field repair kit item tag (module author assigns to any item)
+const string DUR_TAG_KIT        = "dur_repair_kit";
+
+// ----------------------------------------------------------------
+// Slot mapping helpers
+// ----------------------------------------------------------------
+
+int DurGetInventorySlot(int nIdx)
+{
+    switch(nIdx)
+    {
+        case 0: return INVENTORY_SLOT_RIGHTHAND;
+        case 1: return INVENTORY_SLOT_LEFTHAND;
+        case 2: return INVENTORY_SLOT_CHEST;
+        case 3: return INVENTORY_SLOT_HEAD;
+        case 4: return INVENTORY_SLOT_BOOTS;
+        case 5: return INVENTORY_SLOT_ARMS;
+        case 6: return INVENTORY_SLOT_CLOAK;
+    }
+    return INVENTORY_SLOT_RIGHTHAND;
+}
+
+string DurGetSlotLabel(int nIdx)
+{
+    switch(nIdx)
+    {
+        case 0: return "Broń Główna";
+        case 1: return "Lewa Ręka";
+        case 2: return "Zbroja";
+        case 3: return "Hełm";
+        case 4: return "Buty";
+        case 5: return "Rękawice";
+        case 6: return "Peleryna";
+    }
+    return "Nieznany";
+}
+
+int DurGetPenalty(int nDurability)
+{
+    if(nDurability >= DUR_THR_WORN)    return 0;
+    if(nDurability >= DUR_THR_DAMAGED) return 1;
+    if(nDurability >= DUR_THR_BROKEN)  return 2;
+    if(nDurability > 0)                return 4;
+    return 6;
+}
+
+string DurGetStatusText(int nDurability)
+{
+    if(nDurability >= DUR_THR_WORN)    return "Dobry";
+    if(nDurability >= DUR_THR_DAMAGED) return "Zużyty";
+    if(nDurability >= DUR_THR_BROKEN)  return "Uszkodzony";
+    if(nDurability > 0)                return "Złamany";
+    return "Zniszczony";
+}
+
+json DurGetStatusColor(int nDurability)
+{
+    if(nDurability >= DUR_THR_WORN)    return NuiColor( 80, 200,  80);
+    if(nDurability >= DUR_THR_DAMAGED) return NuiColor(220, 200,  60);
+    if(nDurability >= DUR_THR_BROKEN)  return NuiColor(220, 120,  40);
+    return NuiColor(200, 40, 40);
+}
+
+// Returns TRUE if the item in this slot contributes to attack penalty
+int DurIsWeaponSlot(int nIdx, object oItem)
+{
+    if(nIdx == 0) return TRUE;
+    if(nIdx == 1)
+    {
+        int nBase = GetBaseItemType(oItem);
+        if(nBase == BASE_ITEM_SMALLSHIELD ||
+           nBase == BASE_ITEM_LARGESHIELD ||
+           nBase == BASE_ITEM_TOWERSHIELD)
+            return FALSE;
+        return TRUE;
+    }
+    return FALSE;
+}
+
+// Returns TRUE if this slot contributes to AC penalty (armor / shield)
+int DurIsArmorSlot(int nIdx, object oItem)
+{
+    if(nIdx == 2) return TRUE;
+    if(nIdx == 1)
+    {
+        int nBase = GetBaseItemType(oItem);
+        if(nBase == BASE_ITEM_SMALLSHIELD ||
+           nBase == BASE_ITEM_LARGESHIELD ||
+           nBase == BASE_ITEM_TOWERSHIELD)
+            return TRUE;
+    }
+    return FALSE;
+}
+
+// Gold repair cost for nMissing durability points
+int DurRepairCost(int nMissing, int bField)
+{
+    int nBase = nMissing * DUR_GOLD_PER_POINT;
+    return bField ? nBase * DUR_FIELD_REPAIR_MULT : nBase;
+}

--- a/Durability/Scripts/lib_dur_ev.nss
+++ b/Durability/Scripts/lib_dur_ev.nss
@@ -1,0 +1,65 @@
+#include "lib_dur"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    if(nToken != NuiFindWindow(oPC, DUR_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalInt(oPC, DUR_LVAR_SEL);
+        DeleteLocalInt(oPC, DUR_LVAR_FORGE);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == DUR_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        if(sElem == DUR_BTN_REPAIR)
+        {
+            int nSel = GetLocalInt(oPC, DUR_LVAR_SEL);
+            DurDoRepair(oPC, nToken, nSel, FALSE);
+            return;
+        }
+
+        if(sElem == DUR_BTN_FIELD)
+        {
+            int nSel = GetLocalInt(oPC, DUR_LVAR_SEL);
+            DurDoRepair(oPC, nToken, nSel, TRUE);
+            return;
+        }
+
+        if(sElem == DUR_BTN_REPALL)
+        {
+            DurDoRepairAll(oPC, nToken);
+            return;
+        }
+    }
+
+    if(sEvent == EVENT_TYPE_MOUSEDOWN && sElem == DUR_BTN_ROW)
+    {
+        if(nIdx < 0 || nIdx >= DUR_SLOT_COUNT) return;
+
+        SetLocalInt(oPC, DUR_LVAR_SEL, nIdx);
+
+        // Update row highlight array
+        json jEncs = JsonArray();
+        int i;
+        for(i = 0; i < DUR_SLOT_COUNT; i++)
+            jEncs = JsonArrayInsert(jEncs, JsonBool(i == nIdx));
+        NuiSetBind(oPC, nToken, DUR_BIND_ROW_ENC, jEncs);
+
+        DurFeedDetail(oPC, nToken, nIdx);
+        return;
+    }
+}

--- a/Durability/Scripts/lib_nui.nss
+++ b/Durability/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Durability/Scripts/lib_nui_utility.nss
+++ b/Durability/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Durability/Scripts/sql_dur.nss
+++ b/Durability/Scripts/sql_dur.nss
@@ -1,0 +1,105 @@
+// Campaign DB identifier
+const string DUR_DB = "durability";
+
+void DurCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign(DUR_DB,
+        "CREATE TABLE IF NOT EXISTS dur_items ("
+        "item_uuid     TEXT PRIMARY KEY, "
+        "owner_uuid    TEXT DEFAULT '', "
+        "inv_slot      INTEGER DEFAULT -1, "
+        "durability    INTEGER DEFAULT 100, "
+        "max_durability INTEGER DEFAULT 100, "
+        "last_decay    INTEGER DEFAULT 0)");
+    SqlStep(q);
+}
+
+// Returns current durability; 100 if item not yet tracked (treated as fresh)
+int DurGetDurability(object oItem)
+{
+    if(!GetIsObjectValid(oItem)) return 100;
+    sqlquery q = SqlPrepareQueryCampaign(DUR_DB,
+        "SELECT durability FROM dur_items WHERE item_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oItem));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 100;
+}
+
+int DurGetMaxDurability(object oItem)
+{
+    if(!GetIsObjectValid(oItem)) return 100;
+    sqlquery q = SqlPrepareQueryCampaign(DUR_DB,
+        "SELECT max_durability FROM dur_items WHERE item_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oItem));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 100;
+}
+
+// Creates row if absent; idempotent
+void DurEnsureItem(object oItem, object oOwner, int nSlot)
+{
+    if(!GetIsObjectValid(oItem)) return;
+    sqlquery q = SqlPrepareQueryCampaign(DUR_DB,
+        "INSERT OR IGNORE INTO dur_items (item_uuid, owner_uuid, inv_slot) "
+        "VALUES (@uuid, @owner, @slot)");
+    SqlBindString(q, "@uuid",  GetObjectUUID(oItem));
+    SqlBindString(q, "@owner", GetObjectUUID(oOwner));
+    SqlBindInt   (q, "@slot",  nSlot);
+    SqlStep(q);
+}
+
+void DurSetDurability(object oItem, int nVal)
+{
+    if(!GetIsObjectValid(oItem)) return;
+    if(nVal < 0)   nVal = 0;
+    if(nVal > 100) nVal = 100;
+    sqlquery q = SqlPrepareQueryCampaign(DUR_DB,
+        "UPDATE dur_items SET durability = @val WHERE item_uuid = @uuid");
+    SqlBindInt   (q, "@val",  nVal);
+    SqlBindString(q, "@uuid", GetObjectUUID(oItem));
+    SqlStep(q);
+}
+
+void DurDecayItem(object oItem, int nAmount)
+{
+    if(!GetIsObjectValid(oItem) || nAmount <= 0) return;
+    sqlquery q = SqlPrepareQueryCampaign(DUR_DB,
+        "UPDATE dur_items "
+        "SET durability = MAX(0, durability - @amt), "
+        "    last_decay = strftime('%s','now') "
+        "WHERE item_uuid = @uuid");
+    SqlBindInt   (q, "@amt",  nAmount);
+    SqlBindString(q, "@uuid", GetObjectUUID(oItem));
+    SqlStep(q);
+}
+
+void DurRepairItem(object oItem, int nAmount)
+{
+    if(!GetIsObjectValid(oItem) || nAmount <= 0) return;
+    sqlquery q = SqlPrepareQueryCampaign(DUR_DB,
+        "UPDATE dur_items "
+        "SET durability = MIN(max_durability, durability + @amt) "
+        "WHERE item_uuid = @uuid");
+    SqlBindInt   (q, "@amt",  nAmount);
+    SqlBindString(q, "@uuid", GetObjectUUID(oItem));
+    SqlStep(q);
+}
+
+void DurFullRepair(object oItem)
+{
+    if(!GetIsObjectValid(oItem)) return;
+    sqlquery q = SqlPrepareQueryCampaign(DUR_DB,
+        "UPDATE dur_items SET durability = max_durability WHERE item_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oItem));
+    SqlStep(q);
+}
+
+// Returns 1 if this item has an entry, 0 otherwise
+int DurItemExists(object oItem)
+{
+    if(!GetIsObjectValid(oItem)) return 0;
+    sqlquery q = SqlPrepareQueryCampaign(DUR_DB,
+        "SELECT 1 FROM dur_items WHERE item_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oItem));
+    return SqlStep(q);
+}

--- a/Durability/Scripts/sys_module_hb.nss
+++ b/Durability/Scripts/sys_module_hb.nss
@@ -1,0 +1,22 @@
+#include "lib_dur"
+
+// Fires every 6 seconds (NWN default module heartbeat).
+// Every 10th tick (~60 s) we apply combat-based durability decay to
+// all PCs currently fighting. Counters persist only for this session;
+// a server restart resets them, which is acceptable.
+
+void main()
+{
+    int nTick = GetLocalInt(GetModule(), "DUR_HB_TICK") + 1;
+    SetLocalInt(GetModule(), "DUR_HB_TICK", nTick);
+
+    if(nTick % 10 != 0) return;
+
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        if(!GetIsDMPossessed(oPC) && GetIsInCombat(oPC))
+            DurDecayCombatPC(oPC);
+        oPC = GetNextPC();
+    }
+}

--- a/Durability/Scripts/sys_on_enter.nss
+++ b/Durability/Scripts/sys_on_enter.nss
@@ -1,0 +1,29 @@
+#include "lib_dur"
+
+void DurWarnDamagedOnEnter(object oPC)
+{
+    int nWorn = 0;
+    int i;
+    for(i = 0; i < DUR_SLOT_COUNT; i++)
+    {
+        object oItem = GetItemInSlot(DurGetInventorySlot(i), oPC);
+        if(!GetIsObjectValid(oItem)) continue;
+        if(DurGetDurability(oItem) < DUR_THR_WORN)
+            nWorn++;
+    }
+    if(nWorn > 0)
+        SendMessageToPC(oPC,
+            "[Wytrzymałość] Uwaga: " + IntToString(nWorn) +
+            " przedmiot(ów) wymaga naprawy. Odwiedź kowala.");
+}
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC) || GetIsDMPossessed(oPC)) return;
+
+    // Initialise all equipped items in DB and restore active penalties.
+    // 2-second delay so inventory OnEquip hooks fire first.
+    DelayCommand(2.0, DurCheckAllSlots(oPC));
+    DelayCommand(3.0, DurWarnDamagedOnEnter(oPC));
+}

--- a/Durability/Scripts/sys_on_load.nss
+++ b/Durability/Scripts/sys_on_load.nss
@@ -1,0 +1,6 @@
+#include "lib_dur_def"
+
+void main()
+{
+    DurCreateTables();
+}

--- a/Durability/Scripts/test_dur.nss
+++ b/Durability/Scripts/test_dur.nss
@@ -1,0 +1,14 @@
+#include "lib_dur"
+
+// OnUsed script for a "Forge" / "Kowalskie Zaplecze" placeable.
+// Place this on any workbench, forge, or blacksmith placeable to
+// give players access to the durability repair panel.
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    SetLocalInt(oPC, DUR_LVAR_FORGE, 1);
+    DurCreateWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

System trwałości ekwipunku (`Durability/`). Każdy z 7 śledzonych slotów
wyposażenia (broń, lewa ręka, zbroja, hełm, buty, rękawice, peleryna)
ma wartość wytrzymałości 0–100 zapisaną w SQLite. Podczas walki sprzęt
zużywa się i nakładane są supernaturalne kary do ataku / KP. Gracz naprawia
ekwipunek przy kuźni lub — drożej — w terenie zestawem naprawczym.

## Mechanika

| Stan        | Próg  | Kara broni | Kara zbroi/tarczy |
|-------------|-------|------------|-------------------|
| Dobry       | ≥ 75  | 0          | 0                 |
| Zużyty      | ≥ 50  | −1         | −1                |
| Uszkodzony  | ≥ 25  | −2         | −2                |
| Złamany     | > 0   | −4         | −4                |
| Zniszczony  | = 0   | −6         | −6                |

- Decay co ~60 sekund **podczas walki** (`GetIsInCombat`), bronie −2/min,
  pozostałe sloty −1/min.
- Kary nakładane jako `SUBTYPE_SUPERNATURAL` `EffectAttackDecrease` /
  `EffectACDecrease` (czyste NWN EE, bez NWNX).
- NUI 660×510: `NuiList` z paskami postępu w kolorach zielony→czerwony,
  panel szczegółów z kosztami, przyciski *Napraw*, *Napraw w Polu*,
  *Napraw Wszystko*.
- Naprawa w kuźni: `(100 − dur) × 8 sz`.
- Naprawa polowa: `3× złota + zestaw naprawczy` (item z tagiem `dur_repair_kit`).
- Progi wyzwalają komunikat w czacie gracza.

## Pliki

```
Durability/
├── INTEGRATION.md
└── Scripts/
    ├── sql_dur.nss          — schemat SQLite + CRUD
    ├── lib_dur_def.nss      — stałe, ID bindów, helpery slotów/kar
    ├── lib_dur.nss          — rdzeń: NUI, penalties, decay, naprawa (~550 LOC)
    ├── lib_dur_ev.nss       — handler zdarzeń NUI
    ├── sys_on_load.nss      — CREATE TABLE IF NOT EXISTS
    ├── sys_on_enter.nss     — init slotów + ostrzeżenie o uszkodzeniach
    ├── sys_module_hb.nss    — heartbeat decay (co 10 ticków ≈ 60 s)
    ├── test_dur.nss         — OnUsed na kuźni/placeable
    ├── lib_nui.nss          — kopia wspólnego helpera GUI
    └── lib_nui_utility.nss  — kopia wspólnych utilsów NUI
```

Łączna objętość kodu własnego (bez lib_nui*): **911 LOC**.

## Zależności (NWNX? SQL?)

- **SQL**: kampanijna baza `durability` (`SqlPrepareQueryCampaign`).
  Tabela `dur_items` z kluczem `item_uuid`.
- **NWNX**: **brak** — system działa na czystym NWN EE.

## Jak włączyć w istniejącym module

1. Skopiuj `Durability/Scripts/*.nss` do skryptów modułu.
2. Podepnij hooki modułu:
   - `OnModuleLoad` → `sys_on_load.nss`
   - `OnClientEnter` → `sys_on_enter.nss`
   - `OnHeartbeat` → `sys_module_hb.nss`
3. Umieść placeable (kuźnia / kowadło) z `OnUsed = test_dur.nss`.
4. (Opcja) Stwórz item z tagiem `dur_repair_kit` dostępny u handlarza.

Szczegóły i uwagi dot. konfliktu efektów: `Durability/INTEGRATION.md`.

## Co celowo pominięto

- Trwałość ekwipunku NPC — zbędna złożoność.
- Estetyczne zmiany wyglądu uszkodzonego ekwipunku — wymaga HAK/NWNX.
- Decay poza walką — zbyt karzący; warunek w `sys_module_hb.nss` łatwy do zmiany.
- Naprawa materiałami (rudy, skóra) — złoto jako universal resource, brak konieczności nowych itemów w HAK.
- Różna max-durability per typ bazy — uniform 100 upraszcza balans.


---
_Generated by [Claude Code](https://claude.ai/code/session_017kAe5j11ifSKrHmXZTHAPn)_