### PR TITLE
feat: Codex Bestiarum

### DIFF
--- a/Bestiary/INTEGRATION.md
+++ b/Bestiary/INTEGRATION.md
@@ -1,0 +1,129 @@
+# Codex Bestiarum — Integration Guide
+
+## Overview
+
+The Bestiary module lets players study creatures they encounter, accumulating
+knowledge per racial type. At three knowledge tiers (5 / 20 / 75 studies) lore
+entries unlock, and at tiers 2–3 passive combat bonuses (+AB, +damage) are
+applied as permanent SupernaturalEffects and restored on every login.
+
+## Quick start (fresh module)
+
+1. Add all files from `scripts/` into your module's HAK or script folder.
+2. Wire up the four module events below.
+3. Place the `test_bst` script on any placeable (a tome, lectern, or notice
+   board) as its **OnUsed** event — this opens the codex UI for the using PC.
+
+## Module event hooks
+
+| Module Event | Script to call |
+|---|---|
+| **OnModuleLoad** | `sys_on_load` |
+| **OnClientEnter** | `sys_on_enter` |
+| **OnPlayerTarget** | `sys_on_target` |
+
+If your module already has scripts for these events, **do not replace them**.
+Instead, call the Bestiary function from within your existing scripts:
+
+```nwscript
+// Inside your existing OnModuleLoad:
+#include "sql_bst"
+// ...
+BstCreateTables();
+
+// Inside your existing OnClientEnter:
+#include "lib_bst"
+// ...
+if(GetIsPC(oPC) && !GetIsDM(oPC)) BstApplyBonuses(oPC);
+
+// Inside your existing OnPlayerTarget:
+#include "lib_bst"
+// ...
+BstHandleTarget(GetLastPlayerToDoTarget());
+```
+
+## Optional: automatic kill registration (no NWNX)
+
+The study mechanic is **player-initiated** (click a creature in the codex).
+If you prefer kills to register automatically when a creature dies, add this
+to whichever script runs as the creature's **OnDeath**:
+
+```nwscript
+#include "lib_bst"
+
+// Inside OnDeath script body:
+object oVictim = OBJECT_SELF;
+object oKiller = GetLastKiller();
+
+// Climb to the PC master (handles henchmen / summoned creatures as killers)
+if(GetIsObjectValid(GetMaster(oKiller))) oKiller = GetMaster(oKiller);
+if(!GetIsPC(oKiller) || GetIsDM(oKiller)) return;
+
+int nType    = GetRacialType(oVictim);
+int nRaceIdx = BstTypeToRaceIndex(nType);
+if(nRaceIdx < 0) return;
+
+// Only register if this creature hasn't been studied manually by this PC
+if(!GetLocalInt(oVictim, BST_LVAR_STUDIED))
+{
+    SetLocalInt(oVictim, BST_LVAR_STUDIED, 1);
+    int nOldKills = BstGetKills(oKiller, nRaceIdx);
+    BstAddStudy(oKiller, nRaceIdx);
+    if(BstGetTier(nOldKills + 1) > BstGetTier(nOldKills))
+        BstApplyBonuses(oKiller);
+}
+```
+
+The typical targets for this OnDeath script are:
+- `nw_c2_default7` replacement in your HAK (affects all creatures with no
+  custom death script)
+- Every custom creature blueprint that has its own OnDeath handler
+
+## NWNX-based automatic kill tracking (optional)
+
+If NWNX_Events is available, you can subscribe in `sys_on_load`:
+
+```nwscript
+#include "nwnx_events"
+// At the end of BstCreateTables() or in OnModuleLoad:
+NWNX_Events_SubscribeEvent("NWNX_ON_CREATURE_KILL_AFTER", "bst_on_nwnx_kill");
+```
+
+Then create `bst_on_nwnx_kill.nss`:
+
+```nwscript
+#include "lib_bst"
+#include "nwnx_events"
+
+void main()
+{
+    object oKiller = OBJECT_SELF;
+    object oVictim = StringToObject(NWNX_Events_GetEventData("TARGET"));
+    if(!GetIsPC(oKiller)) return;
+    int nIdx = BstTypeToRaceIndex(GetRacialType(oVictim));
+    if(nIdx < 0) return;
+    int nOld = BstGetKills(oKiller, nIdx);
+    BstAddStudy(oKiller, nIdx);
+    if(BstGetTier(nOld + 1) > BstGetTier(nOld))
+        BstApplyBonuses(oKiller);
+}
+```
+
+## Dependencies
+
+| Dependency | Required? | Notes |
+|---|---|---|
+| NWN:EE (1.87+) | **Yes** | `TagEffect` / `GetEffectTag` API used for effect management |
+| SQLite campaign DB | **Yes** | DB name: `"bestiary"` — created automatically |
+| NWNX | No | Optional for automatic kill tracking; see above |
+
+## What was intentionally omitted
+
+- **No icon assets** — no custom TGA/DDS files are needed; the codex UI uses
+  standard NWN text elements only.
+- **No item rewards** — tier-up gives passive effects only; distributing
+  physical items on tier-up would require additional item blueprints in the HAK.
+- **No cooldown on study mode** — the one-study-per-creature-instance rule
+  prevents abuse without needing a timer.
+- **No creature sub-type differentiation** — all Undead share one knowledge
+  pool; individual species tracking would multiply tables and UI complexity.

--- a/Bestiary/scripts/lib_bst.nss
+++ b/Bestiary/scripts/lib_bst.nss
@@ -1,0 +1,413 @@
+// lib_bst.nss — Codex Bestiarum: NUI layout, feed functions, bonus management
+#include "lib_bst_def"
+
+// ----------------------------------------------------------------
+// Effect management
+// ----------------------------------------------------------------
+
+void BstRemoveBonuses(object oPC)
+{
+    effect eEff = GetFirstEffect(oPC);
+    while(GetIsEffectValid(eEff))
+    {
+        effect eNext = GetNextEffect(oPC);
+        if(GetEffectTag(eEff) == BST_EFFECT_TAG)
+            RemoveEffect(oPC, eEff);
+        eEff = eNext;
+    }
+}
+
+void BstApplyBonuses(object oPC)
+{
+    int nTier2Count = 0;
+    int nTier3Count = 0;
+    int i;
+    for(i = 0; i < BST_RACE_COUNT; i++)
+    {
+        int nTier = BstGetTier(BstGetKills(oPC, i));
+        if(nTier >= 2) nTier2Count++;
+        if(nTier >= 3) nTier3Count++;
+    }
+
+    int nAB  = nTier2Count < BST_MAX_BONUS_AB  ? nTier2Count  : BST_MAX_BONUS_AB;
+    int nDmg = nTier3Count < BST_MAX_BONUS_DMG ? nTier3Count  : BST_MAX_BONUS_DMG;
+
+    BstRemoveBonuses(oPC);
+
+    if(nAB > 0)
+    {
+        effect eAB = TagEffect(
+            SupernaturalEffect(EffectAttackIncrease(nAB, ATTACK_BONUS_MISC)),
+            BST_EFFECT_TAG);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eAB, oPC);
+    }
+    if(nDmg > 0)
+    {
+        effect eDmg = TagEffect(
+            SupernaturalEffect(EffectDamageIncrease(nDmg, DAMAGE_TYPE_MAGICAL)),
+            BST_EFFECT_TAG);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eDmg, oPC);
+    }
+
+}
+
+// ----------------------------------------------------------------
+// NUI — detail panel layout (swappable group)
+// ----------------------------------------------------------------
+
+json BstBuildDetailEmpty(object oPC)
+{
+    float fBtnH = GetNuiScaleDimension(oPC, 28.0);
+
+    json jHint = NuiLabel(
+        JsonString("Wybierz kategorię po lewej, aby zobaczyć szczegóły."),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+
+    json jStudyBtn = NuiButton(JsonString("Zbadaj stworzenie [+]"));
+    jStudyBtn = NuiId(jStudyBtn, BST_BTN_STUDY);
+    jStudyBtn = NuiEnabled(jStudyBtn, NuiBind(BST_BIND_STUDY_ENA));
+    jStudyBtn = NuiHeight(jStudyBtn, fBtnH);
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jStudyBtn);
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+    jCol = JsonArrayInsert(jCol, jHint);
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+
+    return NuiCol(jCol);
+}
+
+json BstBuildDetailPanel(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 28.0);
+    float fLoreH = GetNuiScaleDimension(oPC, 280.0);
+
+    json jTitle = NuiLabel(NuiBind(BST_BIND_DET_TITLE),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitle = NuiHeight(jTitle, fBtnH);
+
+    json jKillsLbl = NuiLabel(NuiBind(BST_BIND_DET_KILLS),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jKillsLbl = NuiHeight(jKillsLbl, GetNuiScaleDimension(oPC, 22.0));
+
+    json jLore = NuiGroup(NuiText(NuiBind(BST_BIND_DET_LORE), FALSE), TRUE, NUI_SCROLLBARS_AUTO);
+    jLore = NuiHeight(jLore, fLoreH);
+
+    json jBonus = NuiLabel(NuiBind(BST_BIND_DET_BONUS),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_TOP));
+    jBonus = NuiHeight(jBonus, GetNuiScaleDimension(oPC, 56.0));
+
+    json jStudyBtn = NuiButton(JsonString("Zbadaj stworzenie [+]"));
+    jStudyBtn = NuiId(jStudyBtn, BST_BTN_STUDY);
+    jStudyBtn = NuiEnabled(jStudyBtn, NuiBind(BST_BIND_STUDY_ENA));
+    jStudyBtn = NuiHeight(jStudyBtn, fBtnH);
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jStudyBtn);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jTitle);
+    jCol = JsonArrayInsert(jCol, jKillsLbl);
+    jCol = JsonArrayInsert(jCol, jLore);
+    jCol = JsonArrayInsert(jCol, jBonus);
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+
+    return NuiCol(jCol);
+}
+
+// ----------------------------------------------------------------
+// NUI — full window layout
+// ----------------------------------------------------------------
+
+json BstBuildWindow(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 28.0);
+    float fRowH  = GetNuiScaleDimension(oPC, 26.0);
+    float fListW = GetNuiScaleDimension(oPC, BST_LIST_W);
+
+    // ---- top bar ----
+    json jTitle = NuiLabel(JsonString("Codex Bestiarum"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitle = NuiHeight(jTitle, fBtnH);
+
+    json jClose = NuiButton(JsonString("X"));
+    jClose = NuiId(jClose, BST_BTN_CLOSE);
+    jClose = NuiWidth(jClose, GetNuiScaleDimension(oPC, 28.0));
+    jClose = NuiHeight(jClose, fBtnH);
+
+    json jTopRow = JsonArray();
+    jTopRow = JsonArrayInsert(jTopRow, jTitle);
+    jTopRow = JsonArrayInsert(jTopRow, NuiSpacer());
+    jTopRow = JsonArrayInsert(jTopRow, jClose);
+
+    // ---- list column ----
+    json jNameLbl = NuiLabel(NuiBind(BST_BIND_ROW_NAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jNameLbl = NuiStyleForegroundColor(jNameLbl, NuiBind(BST_BIND_ROW_COLOR));
+
+    json jKillsLbl = NuiLabel(NuiBind(BST_BIND_ROW_KILLS),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jKillsLbl = NuiWidth(jKillsLbl, GetNuiScaleDimension(oPC, 36.0));
+    jKillsLbl = NuiStyleForegroundColor(jKillsLbl, NuiBind(BST_BIND_ROW_COLOR));
+
+    json jTierLbl = NuiLabel(NuiBind(BST_BIND_ROW_TIER),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jTierLbl = NuiWidth(jTierLbl, GetNuiScaleDimension(oPC, 58.0));
+    jTierLbl = NuiStyleForegroundColor(jTierLbl, NuiBind(BST_BIND_ROW_COLOR));
+
+    json jCells = JsonArray();
+    jCells = JsonArrayInsert(jCells, jNameLbl);
+    jCells = JsonArrayInsert(jCells, jKillsLbl);
+    jCells = JsonArrayInsert(jCells, jTierLbl);
+
+    json jRowGroup = NuiGroup(NuiRow(jCells), TRUE, NUI_SCROLLBARS_NONE);
+    jRowGroup = NuiId(jRowGroup, BST_BTN_ROW);
+    jRowGroup = NuiEncouraged(jRowGroup, NuiBind(BST_BIND_ROW_ENC));
+
+    json jTmpl = JsonArrayInsert(JsonArray(),
+        NuiListTemplateCell(jRowGroup, 0.0, TRUE));
+
+    float fListH = GetNuiScaleDimension(oPC, (BST_RACE_COUNT * 26) + 4.0);
+    json jList = NuiList(jTmpl, JsonInt(BST_RACE_COUNT), fRowH);
+    jList = NuiHeight(jList, fListH);
+
+    json jListCol = NuiWidth(NuiCol(JsonArrayInsert(JsonArray(), jList)), fListW);
+
+    // ---- detail group (swappable) ----
+    json jDetailGrp = NuiGroup(BstBuildDetailEmpty(oPC), FALSE, NUI_SCROLLBARS_NONE);
+    jDetailGrp = NuiId(jDetailGrp, BST_GRP_DETAIL);
+
+    // ---- horizontal split ----
+    json jSplitRow = JsonArray();
+    jSplitRow = JsonArrayInsert(jSplitRow, jListCol);
+    jSplitRow = JsonArrayInsert(jSplitRow, jDetailGrp);
+
+    // ---- root column ----
+    json jRoot = JsonArray();
+    jRoot = JsonArrayInsert(jRoot, NuiRow(jTopRow));
+    jRoot = JsonArrayInsert(jRoot, NuiRow(jSplitRow));
+
+    return NuiCol(jRoot);
+}
+
+// ----------------------------------------------------------------
+// Window open
+// ----------------------------------------------------------------
+
+void BstOpenCodex(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, BST_WIN_CODEX);
+    if(nToken != 0)
+    {
+        NuiSetGroupLayout(oPC, nToken, BST_GRP_DETAIL, BstBuildDetailEmpty(oPC));
+        BstFeedList(oPC, nToken);
+        NuiSetBind(oPC, nToken, BST_BIND_STUDY_ENA, JsonBool(TRUE));
+        DeleteLocalInt(oPC, BST_LVAR_SEL_IDX);
+        return;
+    }
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))
+                 - GetNuiScaleDimension(oPC, BST_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT))
+                 - GetNuiScaleDimension(oPC, BST_H)) / 2.0;
+
+    json jGeom = NuiRect(fCX, fCY,
+        GetNuiScaleDimension(oPC, BST_W),
+        GetNuiScaleDimension(oPC, BST_H));
+
+    json jWin = NuiWindow(BstBuildWindow(oPC),
+        JsonBool(FALSE),
+        NuiBind(BST_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    nToken = NuiCreate(oPC, jWin, BST_WIN_CODEX, BST_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, BST_WIN_GEOM, jGeom);
+    BstFeedList(oPC, nToken);
+    NuiSetBind(oPC, nToken, BST_BIND_STUDY_ENA, JsonBool(TRUE));
+}
+
+// ----------------------------------------------------------------
+// Feed — list panel
+// ----------------------------------------------------------------
+
+void BstFeedList(object oPC, int nToken)
+{
+    json jNames  = JsonArray();
+    json jKills  = JsonArray();
+    json jTiers  = JsonArray();
+    json jColors = JsonArray();
+    json jEncs   = JsonArray();
+
+    int nSelIdx = GetLocalInt(oPC, BST_LVAR_SEL_IDX) - 1;
+    // -1 == none selected (we store idx+1 so 0 means unset)
+
+    int i;
+    for(i = 0; i < BST_RACE_COUNT; i++)
+    {
+        int nKills = BstGetKills(oPC, i);
+        int nTier  = BstGetTier(nKills);
+
+        jNames  = JsonArrayInsert(jNames,  JsonString(BstRaceIndexToName(i)));
+        jKills  = JsonArrayInsert(jKills,  JsonString(IntToString(nKills)));
+        jTiers  = JsonArrayInsert(jTiers,  JsonString(BstGetTierLabel(nTier)));
+        jColors = JsonArrayInsert(jColors, BstGetTierColor(nTier));
+        jEncs   = JsonArrayInsert(jEncs,   JsonBool(nSelIdx == i));
+    }
+
+    NuiSetBind(oPC, nToken, BST_BIND_ROW_NAME,  jNames);
+    NuiSetBind(oPC, nToken, BST_BIND_ROW_KILLS, jKills);
+    NuiSetBind(oPC, nToken, BST_BIND_ROW_TIER,  jTiers);
+    NuiSetBind(oPC, nToken, BST_BIND_ROW_COLOR, jColors);
+    NuiSetBind(oPC, nToken, BST_BIND_ROW_ENC,   jEncs);
+}
+
+// ----------------------------------------------------------------
+// Feed — detail panel for selected race
+// ----------------------------------------------------------------
+
+void BstFeedDetail(object oPC, int nToken, int nRaceIdx)
+{
+    NuiSetGroupLayout(oPC, nToken, BST_GRP_DETAIL, BstBuildDetailPanel(oPC));
+
+    int nKills = BstGetKills(oPC, nRaceIdx);
+    int nTier  = BstGetTier(nKills);
+
+    // Title shows race name + tier badge
+    string sTierBadge = nTier > 0 ? "  [" + BstGetTierLabel(nTier) + "]" : "";
+    NuiSetBind(oPC, nToken, BST_BIND_DET_TITLE,
+        JsonString(BstRaceIndexToName(nRaceIdx) + sTierBadge));
+
+    // Kill/progress line
+    string sKillsLine;
+    if(nTier == 3)
+    {
+        sKillsLine = "Zbadano: " + IntToString(nKills) + "  (Mistrzostwo osiągnięte)";
+    }
+    else
+    {
+        int nNextThreshold = (nTier == 0) ? BST_TIER1_KILLS
+                           : (nTier == 1) ? BST_TIER2_KILLS
+                                          : BST_TIER3_KILLS;
+        string sNextTier = (nTier == 0) ? "Poznany"
+                         : (nTier == 1) ? "Zbadany"
+                                        : "Mistrz";
+        sKillsLine = "Zbadano: " + IntToString(nKills) + " / " + IntToString(nNextThreshold)
+                   + "  (do: " + sNextTier + ")";
+    }
+    NuiSetBind(oPC, nToken, BST_BIND_DET_KILLS, JsonString(sKillsLine));
+
+    // Lore text
+    NuiSetBind(oPC, nToken, BST_BIND_DET_LORE, JsonString(BstGetLoreText(nRaceIdx, nTier)));
+
+    // Global bonus summary
+    int nTier2Count = 0;
+    int nTier3Count = 0;
+    int j;
+    for(j = 0; j < BST_RACE_COUNT; j++)
+    {
+        int t = BstGetTier(BstGetKills(oPC, j));
+        if(t >= 2) nTier2Count++;
+        if(t >= 3) nTier3Count++;
+    }
+    NuiSetBind(oPC, nToken, BST_BIND_DET_BONUS,
+        JsonString(BstGetBonusText(nTier2Count, nTier3Count)));
+
+    NuiSetBind(oPC, nToken, BST_BIND_STUDY_ENA, JsonBool(TRUE));
+}
+
+// ----------------------------------------------------------------
+// Target handler — called from sys_on_target.nss
+// ----------------------------------------------------------------
+
+void BstHandleTarget(object oPC)
+{
+    if(!GetLocalInt(oPC, BST_LVAR_STUDYING)) return;
+    DeleteLocalInt(oPC, BST_LVAR_STUDYING);
+
+    object oTarget = GetTargetingModeSelectedObject();
+
+    if(!GetIsObjectValid(oTarget)
+       || GetObjectType(oTarget) != OBJECT_TYPE_CREATURE)
+    {
+        SendMessageToPC(oPC, "[Codex] Możesz badać tylko stworzenia.");
+        return;
+    }
+
+    if(GetIsPC(oTarget))
+    {
+        SendMessageToPC(oPC, "[Codex] Nie możesz badać innych graczy.");
+        return;
+    }
+
+    if(GetLocalInt(oTarget, BST_LVAR_STUDIED))
+    {
+        SendMessageToPC(oPC, "[Codex] To stworzenie zostało już przez ciebie zbadane.");
+        return;
+    }
+
+    int nType    = GetRacialType(oTarget);
+    int nRaceIdx = BstTypeToRaceIndex(nType);
+
+    if(nRaceIdx < 0)
+    {
+        SendMessageToPC(oPC, "[Codex] Ten typ stworzenia nie jest ujęty w kodeksie.");
+        return;
+    }
+
+    // Mark this creature instance as studied — prevents repeated study of same body
+    SetLocalInt(oTarget, BST_LVAR_STUDIED, 1);
+
+    int nOldKills = BstGetKills(oPC, nRaceIdx);
+    BstAddStudy(oPC, nRaceIdx);
+    int nNewKills = nOldKills + 1;
+
+    string sRace    = BstRaceIndexToName(nRaceIdx);
+    int    nOldTier = BstGetTier(nOldKills);
+    int    nNewTier = BstGetTier(nNewKills);
+
+    SendMessageToPC(oPC, "[Codex] Zbadano: " + GetName(oTarget) + " (" + sRace + ")."
+                       + "  Obserwacje: " + IntToString(nNewKills) + ".");
+
+    if(nNewTier > nOldTier)
+    {
+        string sMsg;
+        switch(nNewTier)
+        {
+            case 1: sMsg = "Pierwsze obserwacje dotyczące " + sRace
+                          + " zostały zanotowane. Ich słabości zaczynają być widoczne."; break;
+            case 2: sMsg = "Twoje studium " + sRace + " przynosi pierwsze premie bojowe."
+                          + " Wiedza ta jest już częścią twoich instynktów."; break;
+            case 3: sMsg = "Osiągnąłeś mistrzostwo w konfrontacji z " + sRace + "."
+                          + " Żadna z ich sztuczek cię już nie zaskoczy."; break;
+            default: sMsg = ""; break;
+        }
+        if(sMsg != "")
+        {
+            FloatingTextStringOnCreature("[Codex] " + sMsg, oPC, FALSE);
+            SendMessageToPC(oPC, "[Codex] " + sMsg);
+        }
+
+        if(nNewTier >= 2)
+            BstApplyBonuses(oPC);
+    }
+
+    // Refresh open codex window
+    int nToken = NuiFindWindow(oPC, BST_WIN_CODEX);
+    if(nToken != 0)
+    {
+        // Update selection so the studied race is highlighted
+        SetLocalInt(oPC, BST_LVAR_SEL_IDX, nRaceIdx + 1);
+        BstFeedList(oPC, nToken);
+        BstFeedDetail(oPC, nToken, nRaceIdx);
+    }
+}

--- a/Bestiary/scripts/lib_bst_def.nss
+++ b/Bestiary/scripts/lib_bst_def.nss
@@ -1,0 +1,318 @@
+// lib_bst_def.nss — constants, race tables, tier helpers, lore text
+#include "lib_nui"
+#include "sql_bst"
+
+// Forward declarations (defined in lib_bst.nss)
+void BstOpenCodex(object oPC);
+void BstFeedList(object oPC, int nToken);
+void BstFeedDetail(object oPC, int nToken, int nRaceIdx);
+void BstApplyBonuses(object oPC);
+void BstHandleTarget(object oPC);
+
+// ----------------------------------------------------------------
+// Window / event IDs
+// ----------------------------------------------------------------
+
+const string BST_WIN_CODEX  = "BST_WIN_CODEX";
+const string BST_EV_SCRIPT  = "lib_bst_ev";
+const string BST_GRP_DETAIL = "bst_grp_detail";
+const string BST_WIN_GEOM   = "bst_win_geom";
+
+// ----------------------------------------------------------------
+// Bind names
+// ----------------------------------------------------------------
+
+// List panel (array binds)
+const string BST_BIND_ROW_NAME  = "bst_row_name";
+const string BST_BIND_ROW_KILLS = "bst_row_kills";
+const string BST_BIND_ROW_TIER  = "bst_row_tier";
+const string BST_BIND_ROW_COLOR = "bst_row_color";
+const string BST_BIND_ROW_ENC   = "bst_row_enc";
+
+// Detail panel
+const string BST_BIND_DET_TITLE = "bst_det_title";
+const string BST_BIND_DET_KILLS = "bst_det_kills";
+const string BST_BIND_DET_LORE  = "bst_det_lore";
+const string BST_BIND_DET_BONUS = "bst_det_bonus";
+const string BST_BIND_STUDY_ENA = "bst_study_ena";
+
+// ----------------------------------------------------------------
+// Button IDs
+// ----------------------------------------------------------------
+
+const string BST_BTN_CLOSE  = "bst_btn_close";
+const string BST_BTN_ROW    = "bst_btn_row";
+const string BST_BTN_STUDY  = "bst_btn_study";
+
+// ----------------------------------------------------------------
+// Local variable names
+// ----------------------------------------------------------------
+
+const string BST_LVAR_SEL_IDX  = "BST_SEL_IDX";   // selected race index in codex
+const string BST_LVAR_STUDYING = "BST_STUDYING";   // 1 while in targeting mode for study
+
+// Stamped on creature to prevent double-study of same instance
+const string BST_LVAR_STUDIED  = "BST_STUDIED";
+
+// Tag for managed effects (NWN:EE TagEffect API)
+const string BST_EFFECT_TAG    = "bst_bonus";
+
+// ----------------------------------------------------------------
+// Layout constants
+// ----------------------------------------------------------------
+
+const float BST_W      = 720.0;
+const float BST_H      = 500.0;
+const float BST_LIST_W = 270.0;
+
+// ----------------------------------------------------------------
+// Tier thresholds (study points per racial type)
+// ----------------------------------------------------------------
+
+const int BST_TIER1_KILLS = 5;
+const int BST_TIER2_KILLS = 20;
+const int BST_TIER3_KILLS = 75;
+
+// Cumulative bonus caps (across all races)
+const int BST_MAX_BONUS_AB  = 3;
+const int BST_MAX_BONUS_DMG = 2;
+
+// ----------------------------------------------------------------
+// Race table — 14 tracked monster racial types
+// ----------------------------------------------------------------
+
+const int BST_RACE_COUNT = 14;
+
+int BstRaceIndexToType(int nIdx)
+{
+    switch(nIdx)
+    {
+        case 0:  return RACIAL_TYPE_ABERRATION;
+        case 1:  return RACIAL_TYPE_ANIMAL;
+        case 2:  return RACIAL_TYPE_BEAST;
+        case 3:  return RACIAL_TYPE_CONSTRUCT;
+        case 4:  return RACIAL_TYPE_DRAGON;
+        case 5:  return RACIAL_TYPE_ELEMENTAL;
+        case 6:  return RACIAL_TYPE_FEY;
+        case 7:  return RACIAL_TYPE_GIANT;
+        case 8:  return RACIAL_TYPE_HUMANOID_GOBLINOID;
+        case 9:  return RACIAL_TYPE_HUMANOID_MONSTROUS;
+        case 10: return RACIAL_TYPE_HUMANOID_ORC;
+        case 11: return RACIAL_TYPE_MAGICAL_BEAST;
+        case 12: return RACIAL_TYPE_OUTSIDER;
+        case 13: return RACIAL_TYPE_UNDEAD;
+    }
+    return RACIAL_TYPE_INVALID;
+}
+
+// Returns 0..13 or -1 if the racial type is not tracked.
+int BstTypeToRaceIndex(int nType)
+{
+    int i;
+    for(i = 0; i < BST_RACE_COUNT; i++)
+    {
+        if(BstRaceIndexToType(i) == nType) return i;
+    }
+    return -1;
+}
+
+string BstRaceIndexToName(int nIdx)
+{
+    switch(nIdx)
+    {
+        case 0:  return "Aberracje";
+        case 1:  return "Zwierzęta";
+        case 2:  return "Bestie";
+        case 3:  return "Konstrukty";
+        case 4:  return "Smoki";
+        case 5:  return "Żywiołaki";
+        case 6:  return "Leśne Duchy";
+        case 7:  return "Olbrzymy";
+        case 8:  return "Goblinoidy";
+        case 9:  return "Potwory";
+        case 10: return "Orki";
+        case 11: return "Mag. Bestie";
+        case 12: return "Przybysze";
+        case 13: return "Nieumarli";
+    }
+    return "Nieznane";
+}
+
+// ----------------------------------------------------------------
+// Tier helpers
+// ----------------------------------------------------------------
+
+int BstGetTier(int nKills)
+{
+    if(nKills >= BST_TIER3_KILLS) return 3;
+    if(nKills >= BST_TIER2_KILLS) return 2;
+    if(nKills >= BST_TIER1_KILLS) return 1;
+    return 0;
+}
+
+string BstGetTierLabel(int nTier)
+{
+    switch(nTier)
+    {
+        case 1: return "Poznany";
+        case 2: return "Zbadany";
+        case 3: return "Mistrz";
+    }
+    return "-";
+}
+
+json BstGetTierColor(int nTier)
+{
+    switch(nTier)
+    {
+        case 1: return NuiColor(200, 200,  80);   // żółty
+        case 2: return NuiColor( 80, 200, 130);   // zielony
+        case 3: return NuiColor(220,  80,  80);   // czerwony
+    }
+    return NuiColor(120, 120, 120);               // szary
+}
+
+// ----------------------------------------------------------------
+// Lore text (Polish, dark-fantasy flavor)
+// ----------------------------------------------------------------
+
+string BstGetLoreText(int nIdx, int nTier)
+{
+    if(nTier == 0)
+        return "Zbyt mało obserwacji, by odnotować cokolwiek wartościowego."
+             + " Zbadaj więcej stworzeń tej rasy, aby odkryć ich tajemnice.";
+
+    string sT1;
+    switch(nIdx)
+    {
+        case 0:  sT1 = "Aberracje to skrzywione byty spoza porządku natury. Odporne na paraliż"
+                      " i trucizny, reagują boleśnie na zaklęcia przywracające porządek."; break;
+        case 1:  sT1 = "Zwierzęta kierują się instynktem i terytorializmem. Ich wzrok śledzi"
+                      " ruch — bezruch i cierpliwość często skuteczniejsze niż szarża."; break;
+        case 2:  sT1 = "Bestie mają nadnaturalną siłę i żarłoczność. Ognisko i hałas odstraszają"
+                      " słabsze osobniki — silniejsze przyciąga jedynie zapach krwi."; break;
+        case 3:  sT1 = "Konstrukty nie oddychają, nie czują bólu, nie znają zmęczenia."
+                      " Magia umysłu i trucizny są bezużyteczne — atakuj spoiwo formy."; break;
+        case 4:  sT1 = "Smoki pamiętają czasy, gdy bogowie byli młodzi. Każdy kolor kryje"
+                      " inny oddech — czerwień to piekło, biel to grób lodowy."; break;
+        case 5:  sT1 = "Żywiołaki są inkarnacją sił natury. Bez broni +1 lub lepszej"
+                      " twoje ciosy przenikają przez nie jak przez mgłę."; break;
+        case 6:  sT1 = "Leśne duchy drżą przed żelazem i srebrem. Ich czar niewidzialności"
+                      " rozprasza się, gdy dotykają metalu wykutego ludzką ręką."; break;
+        case 7:  sT1 = "Olbrzymy są powolne i przewidywalne. Unik i kontratak — to ich słabość."
+                      " Rzucają głazami z daleka, bo z bliska mają słabe pole widzenia."; break;
+        case 8:  sT1 = "Goblinoidy żyją w klanach z twardą hierarchią. Ich przywódca jest celem"
+                      " priorytetowym — bez niego reszta traci wolę walki."; break;
+        case 9:  sT1 = "Monstrualne humanoidalne stwory są odporne na zastraszenie."
+                      " Każde ma unikalne zdolności — obserwuj wzorzec przed atakiem."; break;
+        case 10: sT1 = "Orki walczą w furii. Wściekłość daje im siłę, ale mąci zmysły."
+                      " Drwina i prowokacja mogą skłonić je do ataku nieprzemyślanego."; break;
+        case 11: sT1 = "Magiczne bestie łączą naturę z nadprzyrodzonością. Dispel Magic"
+                      " osłabia ich wrodzone zdolności jak zimny deszcz gasi żagiew."; break;
+        case 12: sT1 = "Przybysze ze sfer zewnętrznych przynoszą ze sobą obcą logikę bytu."
+                      " Broń Dobra lub Zła, zależnie od ich natury, przebija ich ochronę."; break;
+        case 13: sT1 = "Nieumarli nie znają zmęczenia ani bólu. Magia Dobra, Consecrate"
+                      " i ogień palą tę starą magię, która trzyma ich w świecie żywych."; break;
+        default: sT1 = "Obserwacje są niepełne."; break;
+    }
+
+    if(nTier < 2) return sT1;
+
+    string sT2;
+    switch(nIdx)
+    {
+        case 0:  sT2 = "Studium: Aberracje mają punkty kontroli w ciałach — kryształy,"
+                      " oka lub rdzenie energii. Celny atak w ten punkt niszczy je szybciej."; break;
+        case 1:  sT2 = "Studium: Stado zwierząt można rozproszyć zabijając dominanta."
+                      " Zaklęcia wpływające na Wolę są zaskakująco skuteczne."; break;
+        case 2:  sT2 = "Studium: Bestie atakują w rytm — chwila po ugryzeniu to moment na"
+                      " kontratak. Wyczucie tego rytmu jest trudne, lecz ratuje życie."; break;
+        case 3:  sT2 = "Studium: Konstrukty mają krytyczny punkt łączenia energii."
+                      " Skupiony, silny cios w to miejsce powoduje kaskadową awarię."; break;
+        case 4:  sT2 = "Studium: Skrzydła smoka to jego słabość i siła zarazem."
+                      " Unieruchomienie lotu niweluje mobilność i część ataków obszarowych."; break;
+        case 5:  sT2 = "Studium: Żywiołak ognia boi się wody, żywiołak wody — uderzenia"
+                      " elektryczności. Atak przeciwnym żywiołem zadaje podwójne cierpienie."; break;
+        case 6:  sT2 = "Studium: Leśne duchy tracą moc w otwartej przestrzeni."
+                      " Ciągłe Światło eliminuje ich skrytość i osłabia zdolność ucieczki."; break;
+        case 7:  sT2 = "Studium: Olbrzymy mają niski Refleks, lecz ogromną Fortitudę."
+                      " Zaklęcia unieruchamiające lub spowalniające są najskuteczniejsze."; break;
+        case 8:  sT2 = "Studium: Gdy przywódca pada, goblinoidy uciekają lub dezorganizują się."
+                      " Zamknięta przestrzeń eliminuje tę przewagę — nie daj im drogi odwrotu."; break;
+        case 9:  sT2 = "Studium: Monstrualne humanoidalne stwory często potrafią się regenerować."
+                      " Ogień i kwas zapobiegają odnowie — rany muszą zostać wypalzone."; break;
+        case 10: sT2 = "Studium: Orcka furia ma ograniczony czas. Defensywna taktyka"
+                      " i przeczekanie wściekłości oszczędza siły na decydujący cios."; break;
+        case 11: sT2 = "Studium: Magiczne bestie mają charakterystyczne sekwencje ataków."
+                      " Przerwa między natarciami to twoja szansa na wyprzedzający cios."; break;
+        case 12: sT2 = "Studium: Przybysze mogą przywoływać sojuszników z macierzystych sfer."
+                      " Wyeliminowanie kapłanów lub magów wśród nich przerywa ten proces."; break;
+        case 13: sT2 = "Studium: Nieumarli słabną w polu Consecrate — wnętrze świątyń jest"
+                      " dla nich polem minowym. Kapłan ze zdolnością Turn Undead jest bezcenny."; break;
+        default: sT2 = ""; break;
+    }
+
+    if(nTier < 3) return sT1 + "\n\n" + sT2;
+
+    string sT3;
+    switch(nIdx)
+    {
+        case 0:  sT3 = "Mistrzostwo: Wzorce aberracji są dla ciebie jak otwarta księga."
+                      " Twoje ataki omijają ich ochronne pola z chirurgiczną precyzją."; break;
+        case 1:  sT3 = "Mistrzostwo: Znasz każdy nawyk i rytm zwierząt tych ziem."
+                      " Twoja obecność ich nie płoszy — możesz zbliżyć się bez prowokacji."; break;
+        case 2:  sT3 = "Mistrzostwo: Bestie nie zaskakują cię już nigdy. Każdy ruch"
+                      " przewidujesz, każde zagrożenie czujesz, zanim ono poczuje ciebie."; break;
+        case 3:  sT3 = "Mistrzostwo: Budownicze skonstruowali je z myślą, że nikt nie znajdzie"
+                      " ich słabości. Ty je znalazłeś. Jeden celny cios — i konstrukcja pada."; break;
+        case 4:  sT3 = "Mistrzostwo: Smoki wiedzą, czym jesteś. Ich starożytny strach"
+                      " przestał działać na ciebie — jesteś tak zimny jak sam smoczy oddech."; break;
+        case 5:  sT3 = "Mistrzostwo: Rozumiesz dualizm żywiołów głębiej niż większość magów."
+                      " Przejście żywiołaka między formami to moment, na który czekasz."; break;
+        case 6:  sT3 = "Mistrzostwo: Widzisz leśne duchy nawet ukryte w mroku i liściach."
+                      " Ich złudzenia są dla ciebie przezroczyste jak woda w strumieniu."; break;
+        case 7:  sT3 = "Mistrzostwo: Znasz wszystkie słabe punkty olbrzymów — stawy, ścięgna,"
+                      " kark. Twoje ciosy lądują tam, gdzie ból jest nie do zniesienia."; break;
+        case 8:  sT3 = "Mistrzostwo: Rozumiesz taktykę goblinoidów na wylot. Możesz ich"
+                      " przechytrzyć, zanim zdadzą sobie sprawę, że bitwa już się skończyła."; break;
+        case 9:  sT3 = "Mistrzostwo: Każda monstrualna forma odsłoniła ci swoje tajemnice."
+                      " Instynkt zastąpił teorię — działasz szybciej niż ich ataki."; break;
+        case 10: sT3 = "Mistrzostwo: Doświadczyłeś niezliczonych ataków orkowych hord."
+                      " Ich wzorce, słabości i wrzaski bojowe są dla ciebie jak kołysanka."; break;
+        case 11: sT3 = "Mistrzostwo: Twoja intuicja jest szybsza niż ich wrodzona magia."
+                      " Działasz w przerwach ich sekwencji z precyzją godną starych mistrzów."; break;
+        case 12: sT3 = "Mistrzostwo: Zewnętrzne sfery nie mają już przed tobą tajemnic."
+                      " Przybysze patrzą w twoje oczy i widzą kogoś, kto był tam z nimi."; break;
+        case 13: sT3 = "Mistrzostwo: Twój wzrok przebija mrok nieumarłości. Znasz każdy trik,"
+                      " każdą słabość. Śmierć cię nie przeraża — za dużo jej widziałeś."; break;
+        default: sT3 = ""; break;
+    }
+
+    return sT1 + "\n\n" + sT2 + "\n\n" + sT3;
+}
+
+// ----------------------------------------------------------------
+// Bonus summary text (for detail panel)
+// ----------------------------------------------------------------
+
+string BstGetBonusText(int nTotalTier2, int nTotalTier3)
+{
+    if(nTotalTier2 == 0 && nTotalTier3 == 0)
+        return "Brak aktywnych premii.\nZbadaj więcej ras, aby odblokować bonusy bojowe.";
+
+    int nAB  = nTotalTier2 < BST_MAX_BONUS_AB  ? nTotalTier2  : BST_MAX_BONUS_AB;
+    int nDmg = nTotalTier3 < BST_MAX_BONUS_DMG ? nTotalTier3  : BST_MAX_BONUS_DMG;
+
+    string sResult = "Aktywne premie bojowe:";
+    if(nAB > 0)
+        sResult = sResult + "\n  +" + IntToString(nAB) + " do Ataku"
+                + "  (ze " + IntToString(nTotalTier2) + " zbadanych ras, max " + IntToString(BST_MAX_BONUS_AB) + ")";
+    if(nDmg > 0)
+        sResult = sResult + "\n  +" + IntToString(nDmg) + " do Obrażeń"
+                + "  (z " + IntToString(nTotalTier3) + " opanowanych ras, max " + IntToString(BST_MAX_BONUS_DMG) + ")";
+    if(nAB == 0 && nTotalTier2 > 0)
+        sResult = sResult + "\n  (limit Ataku osiągnięty)";
+    if(nDmg == 0 && nTotalTier3 > 0)
+        sResult = sResult + "\n  (limit Obrażeń osiągnięty)";
+    return sResult;
+}

--- a/Bestiary/scripts/lib_bst_ev.nss
+++ b/Bestiary/scripts/lib_bst_ev.nss
@@ -1,0 +1,63 @@
+// lib_bst_ev.nss — NUI event handler for Codex Bestiarum
+#include "lib_bst"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    if(nToken != NuiFindWindow(oPC, BST_WIN_CODEX)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        // Cancel any pending targeting mode
+        DeleteLocalInt(oPC, BST_LVAR_STUDYING);
+        DeleteLocalInt(oPC, BST_LVAR_SEL_IDX);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == BST_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        if(sElem == BST_BTN_STUDY)
+        {
+            // Disable button while targeting to prevent double-entry
+            NuiSetBind(oPC, nToken, BST_BIND_STUDY_ENA, JsonBool(FALSE));
+            SetLocalInt(oPC, BST_LVAR_STUDYING, 1);
+            EnterTargetingMode(oPC, OBJECT_TYPE_CREATURE);
+            SendMessageToPC(oPC,
+                "[Codex] Kliknij na stworzenie w świecie gry, aby je zbadać."
+                " Każde stworzenie można zbadać tylko raz.");
+            return;
+        }
+    }
+
+    if(sEvent == EVENT_TYPE_MOUSEDOWN && sElem == BST_BTN_ROW)
+    {
+        if(nIdx < 0 || nIdx >= BST_RACE_COUNT) return;
+
+        // Toggle: clicking the already-selected row deselects
+        int nPrev = GetLocalInt(oPC, BST_LVAR_SEL_IDX) - 1;
+        if(nPrev == nIdx)
+        {
+            DeleteLocalInt(oPC, BST_LVAR_SEL_IDX);
+            BstFeedList(oPC, nToken);
+            NuiSetGroupLayout(oPC, nToken, BST_GRP_DETAIL, BstBuildDetailEmpty(oPC));
+            NuiSetBind(oPC, nToken, BST_BIND_STUDY_ENA, JsonBool(TRUE));
+            return;
+        }
+
+        SetLocalInt(oPC, BST_LVAR_SEL_IDX, nIdx + 1);
+        BstFeedList(oPC, nToken);
+        BstFeedDetail(oPC, nToken, nIdx);
+        return;
+    }
+}

--- a/Bestiary/scripts/lib_nui.nss
+++ b/Bestiary/scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Bestiary/scripts/lib_nui_utility.nss
+++ b/Bestiary/scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Bestiary/scripts/sql_bst.nss
+++ b/Bestiary/scripts/sql_bst.nss
@@ -1,0 +1,57 @@
+// sql_bst.nss — SQLite schema and queries for Codex Bestiarum
+// Campaign DB: "bestiary"
+
+void BstCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("bestiary",
+        "CREATE TABLE IF NOT EXISTS bst_knowledge ("
+        "  char_uuid  TEXT    NOT NULL,"
+        "  race_idx   INTEGER NOT NULL,"
+        "  study_count INTEGER DEFAULT 0,"
+        "  PRIMARY KEY (char_uuid, race_idx)"
+        ")");
+    SqlStep(q);
+}
+
+// Returns current study count for this PC + race index.
+int BstGetKills(object oPC, int nRaceIdx)
+{
+    sqlquery q = SqlPrepareQueryCampaign("bestiary",
+        "SELECT study_count FROM bst_knowledge"
+        " WHERE char_uuid = @uuid AND race_idx = @race");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@race", nRaceIdx);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// Increments study count for this PC + race by 1 (upsert).
+void BstAddStudy(object oPC, int nRaceIdx)
+{
+    sqlquery q = SqlPrepareQueryCampaign("bestiary",
+        "INSERT INTO bst_knowledge (char_uuid, race_idx, study_count)"
+        " VALUES (@uuid, @race, 1)"
+        " ON CONFLICT(char_uuid, race_idx)"
+        " DO UPDATE SET study_count = study_count + 1");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@race", nRaceIdx);
+    SqlStep(q);
+}
+
+// Returns a JsonArray of {race_idx, study_count} for all rows of this PC.
+json BstGetAllKills(object oPC)
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("bestiary",
+        "SELECT race_idx, study_count FROM bst_knowledge"
+        " WHERE char_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    while(SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "race_idx",    JsonInt(SqlGetInt(q, 0)));
+        jRow = JsonObjectSet(jRow, "study_count", JsonInt(SqlGetInt(q, 1)));
+        jRows = JsonArrayInsert(jRows, jRow);
+    }
+    return jRows;
+}

--- a/Bestiary/scripts/sys_on_enter.nss
+++ b/Bestiary/scripts/sys_on_enter.nss
@@ -1,0 +1,24 @@
+// sys_on_enter.nss — OnClientEnter: reapply Bestiary combat bonuses
+// Hook: Module Properties -> Events -> OnClientEnter
+#include "lib_bst"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC) || GetIsDM(oPC)) return;
+
+    // Re-examine SQL to determine earned tiers and (re)apply effects.
+    // SupernaturalEffect survives resting but NOT logout, so we reapply here.
+    int nTier2Count = 0;
+    int nTier3Count = 0;
+    int i;
+    for(i = 0; i < BST_RACE_COUNT; i++)
+    {
+        int nTier = BstGetTier(BstGetKills(oPC, i));
+        if(nTier >= 2) nTier2Count++;
+        if(nTier >= 3) nTier3Count++;
+    }
+
+    if(nTier2Count > 0 || nTier3Count > 0)
+        BstApplyBonuses(oPC);
+}

--- a/Bestiary/scripts/sys_on_load.nss
+++ b/Bestiary/scripts/sys_on_load.nss
@@ -1,0 +1,8 @@
+// sys_on_load.nss — OnModuleLoad: initialise Codex Bestiarum tables
+// Hook: Module Properties -> Events -> OnModuleLoad
+#include "sql_bst"
+
+void main()
+{
+    BstCreateTables();
+}

--- a/Bestiary/scripts/sys_on_target.nss
+++ b/Bestiary/scripts/sys_on_target.nss
@@ -1,0 +1,13 @@
+// sys_on_target.nss — OnPlayerTarget: dispatch study targeting for Codex Bestiarum
+// Hook: Module Properties -> Events -> OnPlayerTarget
+//
+// If another module also uses OnPlayerTarget (e.g. Mailbox), do NOT set this
+// script directly. Instead call BstHandleTarget(GetLastPlayerToDoTarget())
+// from your combined dispatcher. See INTEGRATION.md.
+#include "lib_bst"
+
+void main()
+{
+    object oPC = GetLastPlayerToDoTarget();
+    BstHandleTarget(oPC);
+}

--- a/Bestiary/scripts/test_bst.nss
+++ b/Bestiary/scripts/test_bst.nss
@@ -1,0 +1,11 @@
+// test_bst.nss — OnUsed for the Bestiarist's Tome placeable
+// Set this as the OnUsed script on any placeable (e.g. an ancient tome or lectern)
+// to open the Codex Bestiarum for the interacting PC.
+#include "lib_bst"
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+    BstOpenCodex(oPC);
+}


### PR DESCRIPTION
## Co to robi

Codex Bestiarum to system wiedzy o stworzeniach. Gracz bada napotkane istoty przez tryb targetowania wywołany bezpośrednio z okna NUI, zdobywając punkty obserwacji dla 14 kategorii rasowych. Wraz z postępem odblokowują się klimatyczne wpisy lore i pasywne premie bojowe przechowywane trwale w SQLite.

## Mechanika

- **Badanie stworzeń** — gracz otwiera Codex Bestiarum (placeable z `test_bst`) i klika „Zbadaj stworzenie [+]", co wchodzi w tryb targetowania. Kliknięcie na żywego lub właśnie zabitego NPC dodaje 1 punkt obserwacji dla jego rasy. Każde konkretne stworzenie można zbadać tylko raz (local int `BST_STUDIED`).
- **Trzy tiery wiedzy** — progi: 5 / 20 / 75 badań:
  - **Poznany** (tier 1): odblokowuje tekst lore z podstawowymi słabościami
  - **Zbadany** (tier 2): +1 do Ataku (kumulatywnie dla każdej zbadanej rasy, max +3 łącznie)
  - **Mistrz** (tier 3): +1 do Obrażeń (kumulatywnie, max +2 łącznie)
- **Trwałe efekty** — premie aplikowane jako `SupernaturalEffect` (przeżywają odpoczynek); reaplikowane przy każdym logowaniu przez `sys_on_enter`. Zarządzanie efektami przez NWN:EE `TagEffect`/`GetEffectTag` API (tag: `bst_bonus`).
- **NUI** — okno 720×500 z dwoma panelami: lista 14 ras (z kolorami tieru) po lewej, panel szczegółów z lore, postępem i globalnym podsumowaniem premii po prawej.

## Pliki

```
Bestiary/
  INTEGRATION.md                    — instrukcja podpięcia hooków
  scripts/
    lib_bst_def.nss                 — stałe, mapa ras, pomocniki tierów, teksty lore (PL)
    sql_bst.nss                     — schemat SQLite + zapytania (upsert, fetch)
    lib_bst.nss                     — NUI layout, funkcje feed, BstApplyBonuses, BstHandleTarget
    lib_bst_ev.nss                  — handler NUI eventów (click, mousedown, close)
    sys_on_load.nss                 — OnModuleLoad: CREATE TABLE IF NOT EXISTS
    sys_on_enter.nss                — OnClientEnter: reapply premii po logowaniu
    sys_on_target.nss               — OnPlayerTarget: dispatcher do BstHandleTarget
    test_bst.nss                    — OnUsed na placeable: otwiera Codex
    lib_nui.nss / lib_nui_utility.nss — współdzielone utility (kopie jak w innych modułach)
```

Łącznie ~920 LOC NWScript.

## Zależności

| Zależność | Wymagana? | Uwagi |
|---|---|---|
| NWN:EE 1.87+ | **Tak** | `TagEffect`/`GetEffectTag` do zarządzania efektami |
| SQLite (campaign DB) | **Tak** | DB `"bestiary"`, tworzona automatycznie |
| NWNX | Nie | Opcjonalnie do automatycznego liczenia zabić — patrz INTEGRATION.md |

## Jak włączyć w istniejącym module

1. Dodaj pliki z `scripts/` do HAK lub folderu skryptów modułu.
2. Ustaw hooki modułu:
   - **OnModuleLoad** → `sys_on_load`
   - **OnClientEnter** → `sys_on_enter`
   - **OnPlayerTarget** → `sys_on_target`
3. Jeśli moduł już używa tych eventów (np. Mailbox), NIE nadpisuj — zamiast tego wywołaj odpowiednią funkcję z istniejącego handlera (patrz `INTEGRATION.md` z przykładami kodu).
4. Dodaj dowolny placeable (stary tom, lektern) z `test_bst` jako OnUsed.

## Co celowo pominięto

- **Brak assetów graficznych** — okno opiera się na standardowych elementach tekstowych NUI; ikony ras wymagałyby dodatkowych TGA/DDS w HAK.
- **Brak nagród przedmiotowych** — tier-up daje tylko efekt pasywny; rozdawanie fizycznych itemów wymagałoby blueprintów w HAK.
- **Brak cooldownu na tryb badania** — blokada one-per-creature-instance wystarczy bez osobnego timera.
- **Brak podziału na pod-rasy** — wszyscy Nieumarli dzielą jedną pulę wiedzy; tracking per-gatunek mnożyłby tabele i złożoność UI.
- **Brak .mod** — środowisko nie obsługuje pakowania `.mod`; pełna instrukcja integracji w `INTEGRATION.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FAaztwUw4o9NA1JqAc1bBy)_