### PR TITLE
feat: Cmentarz — System Pogrzebu i Grabieży Grobów

### DIFF
--- a/Cmentarz/INTEGRATION.md
+++ b/Cmentarz/INTEGRATION.md
@@ -1,0 +1,84 @@
+# Cmentarz — Instrukcja integracji
+
+## Opis modułu
+
+System pogrzebu i grabieży grobów. Gracze mogą grzebać poległych wrogów lub
+postacie NPC, zdobywając walutę „Łaska Kości" (ŁK). Za ŁK grabarz udziela
+tymczasowych błogosławieństw. Zbezczeszczenie grobów przynosi złoto, ale
+nakłada trwałe klątwy (Piętno Zbezczeszczenia).
+
+## Hooki do podpięcia
+
+| Zdarzenie                  | Skrypt            |
+|----------------------------|-------------------|
+| OnModuleLoad               | `sys_on_load`     |
+| OnClientEnterArea          | `sys_on_enter`    |
+| OnUsed (placeable Głaz)    | `test_grv`        |
+
+## Tworzenie placeabli testowych
+
+### 1. Cmentarny Głaz (otwiera okno pochówku)
+- Typ: dowolny placeable (np. Altar, Gravestone)
+- Tag: `GRV_BURIAL_STONE` (lub cokolwiek — skrypt sprawdza OnUsed)
+- Script OnUsed: `test_grv`
+
+### 2. Grób do zbadania
+- Tag: `GRV_TEST_GRAVE`
+- Local Int `GRV_GRAVE_ID` = ID z tabeli `grv_graves` (po pierwszym pochówku = 1)
+- Script OnUsed: `test_grv`
+
+## Baza danych SQLite
+
+Moduł używa kampanii o nazwie `graveyard`. Tabele tworzone automatycznie
+przez `sys_on_load`:
+
+- `grv_graves` — każdy grób: właściciel, imię zmarłego, typ, złoto, data, flaga zbezczeszczenia
+- `grv_players` — per-gracz: Łaska Kości, Piętno Zbezczeszczenia
+- `grv_pray_log` — czas ostatniej modlitwy przy danym grobie (cooldown 24h)
+
+## Zależności NWNX
+
+**Brak.** Moduł nie wymaga żadnych pluginów NWNX. Używa wyłącznie NWN:EE API:
+- `NuiCreate`, `NuiBind`, `NuiList` — system NUI
+- `SqlPrepareQueryCampaign` — SQLite campaign DB
+- standardowe efekty (`EffectSavingThrowDecrease`, `EffectImmunity`, itp.)
+
+## Konfiguracja równowagi (w `lib_grv_def.nss`)
+
+| Stała                     | Domyślnie | Opis                              |
+|---------------------------|-----------|-----------------------------------|
+| `GRV_GOLD_MOUND`          | 0         | Koszt pochówku Mogily             |
+| `GRV_GOLD_STONE`          | 50        | Koszt Kamiennego Nagrobka         |
+| `GRV_GOLD_CRYPT`          | 200       | Koszt Krypty Szlacheckiej         |
+| `GRV_GRACE_MOUND`         | 1         | ŁK za Mogiłę                     |
+| `GRV_GRACE_STONE`         | 3         | ŁK za Nagrobek                   |
+| `GRV_GRACE_CRYPT`         | 10        | ŁK za Kryptę                     |
+| `GRV_GHOST_GOLD_MIN`      | 50        | Min złoto ofiarne dla ducha       |
+| `GRV_GHOST_CHANCE_BASE`   | 25        | Bazowa szansa (%) na ducha        |
+| `GRV_DESEC_CURSE_THRESHOLD`| 5        | Piętno przed klątwą słabą         |
+| `GRV_DESEC_HEAVY_THRESHOLD`| 10       | Piętno przed klątwą ciężką        |
+
+## Sklep Grabarza — błogosławieństwa
+
+| Nazwa                    | Koszt | Efekt                                |
+|--------------------------|-------|--------------------------------------|
+| Pokora Kości             | 3 ŁK  | Leczenie 2k8 HP (natychmiastowe)     |
+| Pieczęć Przed Zepsuciem  | 5 ŁK  | +2 AC (Dodge), 8 godzin              |
+| Wzrok Przez Zasłonę      | 8 ŁK  | True Seeing, 1 godzina               |
+| Tarcza Przed Śmiercią    | 15 ŁK | Odporność na śmierć i neg. poziomy, 1h|
+| Rozgrzeszenie            | 10 ŁK | Usuwa 1 Piętno Zbezczeszczenia (1/dobę)|
+
+## Co celowo pominięto
+
+- **Spawning fizycznych towarzyszy (duchy)**: Duch pochówku manifestuje się
+  jako tymczasowy efekt mechaniczny (+1 do ataków i rzutów, 30 min).
+  Prawdziwe creature-companion wymagałoby NWNX_Companion lub ręcznej
+  konfiguracji AI placeable'a — wykracza poza zakres demo.
+- **Zlokalizowane placeables grobów na mapie**: Moduł zapisuje groby w DB,
+  ale nie spawna placeabli przy lokacji pochówku. W pełnej integracji:
+  po `GrvInsertGrave` wywołaj `CreateObject(OBJECT_TYPE_PLACEABLE, "grv_grave_stone", loc)`
+  z LocalInt `GRV_GRAVE_ID = nGraveId` i OnUsed = `test_grv`.
+- **Limit grobów per obszar**: Nie ma cap'u na liczbę grobów. W dużym
+  module warto dodać `COUNT(*) FROM grv_graves WHERE area_resref = @area`.
+- **Eksportowanie listy grobów**: Nie ma widoku „Lista wszystkich grobów
+  w obszarze" — taki feature wymagałby dodatkowego okna NUI z NuiList.

--- a/Cmentarz/scripts/lib_grv.nss
+++ b/Cmentarz/scripts/lib_grv.nss
@@ -1,0 +1,599 @@
+#include "lib_grv_def"
+
+// ----------------------------------------------------------------
+// Burial window layout
+// ----------------------------------------------------------------
+
+json GrvBuildBurialContent(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 30.0);
+    float fTypeBtnW = GetNuiScaleDimension(oPC, 140.0);
+    float fLblH  = GetNuiScaleDimension(oPC, 22.0);
+
+    // Deceased name input
+    json jDecLabel = NuiLabel(JsonString("Imię zmarłego:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jDecLabel = NuiWidth(jDecLabel, GetNuiScaleDimension(oPC, 110.0));
+    jDecLabel = NuiHeight(jDecLabel, fBtnH);
+
+    json jDecField = NuiTextEdit(JsonString("Nieznany..."), NuiBind(GRV_BIND_DECEASED), 60, FALSE);
+    jDecField = NuiHeight(jDecField, fBtnH);
+
+    json jDecRow = JsonArray();
+    jDecRow = JsonArrayInsert(jDecRow, jDecLabel);
+    jDecRow = JsonArrayInsert(jDecRow, jDecField);
+
+    // Type selection buttons (encouraged = selected)
+    json jType0 = NuiButton(JsonString("Usypana Mogiła"));
+    jType0 = NuiId(jType0, GRV_BTN_TYPE0);
+    jType0 = NuiEncouraged(jType0, NuiBind(GRV_BIND_TYPE0_ENC));
+    jType0 = NuiWidth(jType0, fTypeBtnW);
+    jType0 = NuiHeight(jType0, fBtnH);
+
+    json jType1 = NuiButton(JsonString("Kamienny Nagrobek"));
+    jType1 = NuiId(jType1, GRV_BTN_TYPE1);
+    jType1 = NuiEncouraged(jType1, NuiBind(GRV_BIND_TYPE1_ENC));
+    jType1 = NuiWidth(jType1, fTypeBtnW);
+    jType1 = NuiHeight(jType1, fBtnH);
+
+    json jType2 = NuiButton(JsonString("Krypta Szlachecka"));
+    jType2 = NuiId(jType2, GRV_BTN_TYPE2);
+    jType2 = NuiEncouraged(jType2, NuiBind(GRV_BIND_TYPE2_ENC));
+    jType2 = NuiWidth(jType2, fTypeBtnW);
+    jType2 = NuiHeight(jType2, fBtnH);
+
+    json jTypeRow = JsonArray();
+    jTypeRow = JsonArrayInsert(jTypeRow, jType0);
+    jTypeRow = JsonArrayInsert(jTypeRow, NuiSpacer());
+    jTypeRow = JsonArrayInsert(jTypeRow, jType1);
+    jTypeRow = JsonArrayInsert(jTypeRow, NuiSpacer());
+    jTypeRow = JsonArrayInsert(jTypeRow, jType2);
+
+    // Materials & grace reward
+    json jMatLbl = NuiLabel(NuiBind(GRV_BIND_MAT_DESC),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jMatLbl = NuiHeight(jMatLbl, fLblH);
+
+    json jGraceLbl = NuiLabel(NuiBind(GRV_BIND_GRACE_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jGraceLbl = NuiHeight(jGraceLbl, fLblH);
+    jGraceLbl = NuiStyleForegroundColor(jGraceLbl, NuiColor(180, 230, 180));
+
+    // Offering gold
+    json jGoldLabel = NuiLabel(JsonString("Złoto ofiarne:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jGoldLabel = NuiWidth(jGoldLabel, GetNuiScaleDimension(oPC, 110.0));
+    jGoldLabel = NuiHeight(jGoldLabel, fBtnH);
+
+    json jGoldField = NuiTextEdit(JsonString("0"), NuiBind(GRV_BIND_GOLD_TXT), 7, FALSE);
+    jGoldField = NuiWidth(jGoldField, GetNuiScaleDimension(oPC, 100.0));
+    jGoldField = NuiHeight(jGoldField, fBtnH);
+
+    json jGoldHint = NuiLabel(JsonString("(szansa na ducha pogrzebanego)"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+
+    json jGoldRow = JsonArray();
+    jGoldRow = JsonArrayInsert(jGoldRow, jGoldLabel);
+    jGoldRow = JsonArrayInsert(jGoldRow, jGoldField);
+    jGoldRow = JsonArrayInsert(jGoldRow, jGoldHint);
+
+    // Piętno / marks status
+    json jMarksLbl = NuiLabel(NuiBind(GRV_BIND_MARKS_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jMarksLbl = NuiHeight(jMarksLbl, fLblH);
+    jMarksLbl = NuiStyleForegroundColor(jMarksLbl, NuiColor(220, 100, 80));
+
+    // Status feedback
+    json jStatusLbl = NuiLabel(NuiBind(GRV_BIND_STATUS_LBL),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jStatusLbl = NuiHeight(jStatusLbl, fLblH);
+    jStatusLbl = NuiStyleForegroundColor(jStatusLbl, NuiColor(200, 200, 120));
+
+    // Bottom bar: Shop + Bury
+    json jShopBtn = NuiButton(JsonString("Sklep Grabarza"));
+    jShopBtn = NuiId(jShopBtn, GRV_BTN_OPEN_SHOP);
+    jShopBtn = NuiWidth(jShopBtn, GetNuiScaleDimension(oPC, 130.0));
+    jShopBtn = NuiHeight(jShopBtn, fBtnH);
+
+    json jBuryBtn = NuiButton(JsonString("Pochowaj"));
+    jBuryBtn = NuiId(jBuryBtn, GRV_BTN_BURY);
+    jBuryBtn = NuiEnabled(jBuryBtn, NuiBind(GRV_BIND_BURY_ENA));
+    jBuryBtn = NuiWidth(jBuryBtn, GetNuiScaleDimension(oPC, 110.0));
+    jBuryBtn = NuiHeight(jBuryBtn, fBtnH);
+
+    json jBotRow = JsonArray();
+    jBotRow = JsonArrayInsert(jBotRow, jShopBtn);
+    jBotRow = JsonArrayInsert(jBotRow, NuiSpacer());
+    jBotRow = JsonArrayInsert(jBotRow, jBuryBtn);
+
+    // Assemble column
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jDecRow));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jTypeRow));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, jMatLbl);
+    jCol = JsonArrayInsert(jCol, jGraceLbl);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jGoldRow));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, jMarksLbl);
+    jCol = JsonArrayInsert(jCol, jStatusLbl);
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+    jCol = JsonArrayInsert(jCol, NuiRow(jBotRow));
+
+    float fContentW = GetNuiScaleDimension(oPC, GRV_WIN_W - 40.0);
+    json jSide = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    json jMainRow = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiCol(jCol), fContentW));
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    return NuiRow(jMainRow);
+}
+
+// ----------------------------------------------------------------
+// Shop window layout
+// ----------------------------------------------------------------
+
+json GrvBuildShopContent(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 30.0);
+    float fRowH  = GetNuiScaleDimension(oPC, 50.0);
+    float fLblH  = GetNuiScaleDimension(oPC, 18.0);
+
+    // Grace balance header
+    json jGraceHdr = NuiLabel(NuiBind(GRV_BIND_SHOP_GRACE),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jGraceHdr = NuiHeight(jGraceHdr, fBtnH);
+    jGraceHdr = NuiStyleForegroundColor(jGraceHdr, NuiColor(180, 230, 180));
+
+    // Item list: name, cost, description, buy button as a NuiList
+    json jNameLbl = NuiLabel(NuiBind(GRV_BIND_SHOP_ROWNAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+
+    json jDescLbl = NuiLabel(NuiBind(GRV_BIND_SHOP_ROWDESC),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jDescLbl = NuiStyleForegroundColor(jDescLbl, NuiColor(170, 170, 170));
+
+    json jTextCol = JsonArray();
+    jTextCol = JsonArrayInsert(jTextCol, jNameLbl);
+    jTextCol = JsonArrayInsert(jTextCol, jDescLbl);
+
+    json jCostLbl = NuiLabel(NuiBind(GRV_BIND_SHOP_ROWCOST),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jCostLbl = NuiWidth(jCostLbl, GetNuiScaleDimension(oPC, 50.0));
+    jCostLbl = NuiStyleForegroundColor(jCostLbl, NuiColor(180, 230, 180));
+
+    json jBuyBtn = NuiButton(JsonString("Kup"));
+    jBuyBtn = NuiId(jBuyBtn, GRV_BTN_BUY);
+    jBuyBtn = NuiEnabled(jBuyBtn, NuiBind(GRV_BIND_SHOP_ROWENA));
+    jBuyBtn = NuiEncouraged(jBuyBtn, NuiBind(GRV_BIND_SHOP_ROWENC));
+    jBuyBtn = NuiWidth(jBuyBtn, GetNuiScaleDimension(oPC, 60.0));
+    jBuyBtn = NuiHeight(jBuyBtn, fBtnH);
+
+    json jCellRow = JsonArray();
+    jCellRow = JsonArrayInsert(jCellRow, NuiCol(jTextCol));
+    jCellRow = JsonArrayInsert(jCellRow, jCostLbl);
+    jCellRow = JsonArrayInsert(jCellRow, jBuyBtn);
+
+    json jCell = NuiGroup(NuiRow(jCellRow), TRUE, NUI_SCROLLBARS_NONE);
+
+    json jTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jCell, 0.0, TRUE));
+    json jList = NuiList(jTmpl, NuiBind(GRV_BIND_SHOP_COUNT), fRowH);
+    jList = NuiHeight(jList, GetNuiScaleDimension(oPC, GRV_SHOP_H - 120.0));
+
+    json jCloseBtn = NuiButton(JsonString("Zamknij"));
+    jCloseBtn = NuiId(jCloseBtn, GRV_BTN_SHOP_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, GetNuiScaleDimension(oPC, 90.0));
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jBotRow = JsonArray();
+    jBotRow = JsonArrayInsert(jBotRow, NuiSpacer());
+    jBotRow = JsonArrayInsert(jBotRow, jCloseBtn);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jGraceHdr);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jList);
+    jCol = JsonArrayInsert(jCol, NuiRow(jBotRow));
+
+    float fContentW = GetNuiScaleDimension(oPC, GRV_SHOP_W - 40.0);
+    json jSide = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    json jMainRow = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiCol(jCol), fContentW));
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    return NuiRow(jMainRow);
+}
+
+// ----------------------------------------------------------------
+// Grave interaction window layout
+// ----------------------------------------------------------------
+
+json GrvBuildGraveContent(object oPC)
+{
+    float fBtnH = GetNuiScaleDimension(oPC, 30.0);
+    float fLblH = GetNuiScaleDimension(oPC, 22.0);
+
+    json jTitle = NuiLabel(NuiBind(GRV_BIND_GRAVE_TITLE),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitle = NuiHeight(jTitle, fBtnH);
+    jTitle = NuiStyleForegroundColor(jTitle, NuiColor(220, 200, 150));
+
+    json jInfo = NuiGroup(
+        NuiText(NuiBind(GRV_BIND_GRAVE_INFO), FALSE),
+        TRUE, NUI_SCROLLBARS_NONE);
+    jInfo = NuiHeight(jInfo, GetNuiScaleDimension(oPC, 120.0));
+
+    json jPrayBtn = NuiButton(NuiBind(GRV_BIND_PRAY_LBL));
+    jPrayBtn = NuiId(jPrayBtn, GRV_BTN_PRAY);
+    jPrayBtn = NuiEnabled(jPrayBtn, NuiBind(GRV_BIND_PRAY_ENA));
+    jPrayBtn = NuiWidth(jPrayBtn, GetNuiScaleDimension(oPC, 160.0));
+    jPrayBtn = NuiHeight(jPrayBtn, fBtnH);
+
+    json jDesecBtn = NuiButton(JsonString("Zbezcześć"));
+    jDesecBtn = NuiId(jDesecBtn, GRV_BTN_DESECRATE);
+    jDesecBtn = NuiEnabled(jDesecBtn, NuiBind(GRV_BIND_GRAVE_DESEC));
+    jDesecBtn = NuiWidth(jDesecBtn, GetNuiScaleDimension(oPC, 120.0));
+    jDesecBtn = NuiHeight(jDesecBtn, fBtnH);
+
+    json jCloseBtn = NuiButton(JsonString("Zamknij"));
+    jCloseBtn = NuiId(jCloseBtn, GRV_BTN_GRAVE_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, GetNuiScaleDimension(oPC, 90.0));
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jActRow = JsonArray();
+    jActRow = JsonArrayInsert(jActRow, jPrayBtn);
+    jActRow = JsonArrayInsert(jActRow, NuiSpacer());
+    jActRow = JsonArrayInsert(jActRow, jDesecBtn);
+    jActRow = JsonArrayInsert(jActRow, NuiSpacer());
+    jActRow = JsonArrayInsert(jActRow, jCloseBtn);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jTitle);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, jInfo);
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+    jCol = JsonArrayInsert(jCol, NuiRow(jActRow));
+
+    float fContentW = GetNuiScaleDimension(oPC, GRV_GRAVE_W - 40.0);
+    json jSide = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    json jMainRow = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiCol(jCol), fContentW));
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    return NuiRow(jMainRow);
+}
+
+// ----------------------------------------------------------------
+// Window create / open
+// ----------------------------------------------------------------
+
+void GrvCreateBurialWindow(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, GRV_WINDOW);
+    if(nToken != 0)
+    {
+        GrvFeedBurialWindow(oPC, nToken);
+        return;
+    }
+
+    float fW = GetNuiScaleDimension(oPC, GRV_WIN_W);
+    float fH = GetNuiScaleDimension(oPC, GRV_WIN_H);
+    float fX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - fW) / 2.0;
+    float fY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - fH) / 2.0;
+
+    json jCloseBtn = NuiButton(JsonString("X"));
+    jCloseBtn = NuiId(jCloseBtn, GRV_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, GetNuiScaleDimension(oPC, 30.0));
+    jCloseBtn = NuiHeight(jCloseBtn, GetNuiScaleDimension(oPC, 30.0));
+
+    json jTopRow = JsonArray();
+    jTopRow = JsonArrayInsert(jTopRow, NuiSpacer());
+    jTopRow = JsonArrayInsert(jTopRow, jCloseBtn);
+
+    json jSwapGrp = NuiGroup(GrvBuildBurialContent(oPC), FALSE, NUI_SCROLLBARS_NONE);
+    jSwapGrp = NuiId(jSwapGrp, GRV_GRP_SWAP);
+
+    json jRoot = NuiCol(JsonArrayInsert(
+        JsonArrayInsert(JsonArray(), NuiRow(jTopRow)),
+        jSwapGrp));
+
+    json jWin = NuiWindow(jRoot,
+        JsonString("Cmentarz — Obrzęd Pochówku"),
+        NuiBind(GRV_BIND_WIN_GEOM),
+        JsonBool(FALSE), JsonBool(FALSE), JsonBool(FALSE),
+        JsonBool(TRUE), JsonBool(FALSE));
+
+    nToken = NuiCreate(oPC, jWin, GRV_WINDOW, GRV_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, GRV_BIND_WIN_GEOM, NuiRect(fX, fY, fW, fH));
+    NuiSetBind(oPC, nToken, GRV_BIND_GOLD_TXT, JsonString("0"));
+    NuiSetBindWatch(oPC, nToken, GRV_BIND_GOLD_TXT, TRUE);
+
+    SetLocalInt(oPC, GRV_LVAR_TYPE, GRV_TYPE_MOUND);
+    GrvFeedBurialWindow(oPC, nToken);
+}
+
+void GrvCreateShopWindow(object oPC)
+{
+    if(NuiFindWindow(oPC, GRV_WIN_SHOP) != 0)
+    {
+        GrvFeedShopWindow(oPC, NuiFindWindow(oPC, GRV_WIN_SHOP));
+        return;
+    }
+
+    float fW = GetNuiScaleDimension(oPC, GRV_SHOP_W);
+    float fH = GetNuiScaleDimension(oPC, GRV_SHOP_H);
+    float fX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - fW) / 2.0;
+    float fY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - fH) / 2.0;
+
+    json jWin = NuiWindow(GrvBuildShopContent(oPC),
+        JsonString("Sklep Grabarza — Błogosławieństwa"),
+        NuiBind(GRV_BIND_SHOP_GEOM),
+        JsonBool(FALSE), JsonBool(FALSE), JsonBool(TRUE),
+        JsonBool(FALSE), JsonBool(TRUE));
+
+    int nToken = NuiCreate(oPC, jWin, GRV_WIN_SHOP, GRV_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, GRV_BIND_SHOP_GEOM, NuiRect(fX, fY, fW, fH));
+    GrvFeedShopWindow(oPC, nToken);
+}
+
+void GrvCreateGraveWindow(object oPC, int nGraveId)
+{
+    if(NuiFindWindow(oPC, GRV_WIN_GRAVE) != 0)
+        NuiDestroy(oPC, NuiFindWindow(oPC, GRV_WIN_GRAVE));
+
+    float fW = GetNuiScaleDimension(oPC, GRV_GRAVE_W);
+    float fH = GetNuiScaleDimension(oPC, GRV_GRAVE_H);
+    float fX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - fW) / 2.0;
+    float fY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - fH) / 2.0;
+
+    json jWin = NuiWindow(GrvBuildGraveContent(oPC),
+        JsonString("Grób"),
+        NuiBind(GRV_BIND_GRAVE_GEOM),
+        JsonBool(FALSE), JsonBool(FALSE), JsonBool(TRUE),
+        JsonBool(FALSE), JsonBool(TRUE));
+
+    SetLocalInt(oPC, GRV_LVAR_GRAVE_ID, nGraveId);
+    int nToken = NuiCreate(oPC, jWin, GRV_WIN_GRAVE, GRV_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, GRV_BIND_GRAVE_GEOM, NuiRect(fX, fY, fW, fH));
+    GrvFeedGraveWindow(oPC, nToken, nGraveId);
+}
+
+// ----------------------------------------------------------------
+// Feed functions
+// ----------------------------------------------------------------
+
+void GrvFeedBurialWindow(object oPC, int nToken)
+{
+    int nType  = GetLocalInt(oPC, GRV_LVAR_TYPE);
+    int nMarks = GrvGetDesecMarks(oPC);
+    int nGrace = GrvGetBoneGrace(oPC);
+
+    NuiSetBind(oPC, nToken, GRV_BIND_TYPE0_ENC, JsonBool(nType == GRV_TYPE_MOUND));
+    NuiSetBind(oPC, nToken, GRV_BIND_TYPE1_ENC, JsonBool(nType == GRV_TYPE_STONE));
+    NuiSetBind(oPC, nToken, GRV_BIND_TYPE2_ENC, JsonBool(nType == GRV_TYPE_CRYPT));
+
+    NuiSetBind(oPC, nToken, GRV_BIND_MAT_DESC,  JsonString(GrvGetGraveTypeMaterials(nType)));
+    NuiSetBind(oPC, nToken, GRV_BIND_GRACE_LBL, JsonString(
+        "Nagroda: +" + IntToString(GrvGetGraveTypeGrace(nType)) + " Łaska Kości   (posiadasz: " + IntToString(nGrace) + ")"));
+
+    string sMarksLbl = "";
+    if(nMarks > 0)
+    {
+        sMarksLbl = "Piętno Zbezczeszczenia: " + IntToString(nMarks);
+        if(nMarks >= GRV_DESEC_HEAVY_THRESHOLD)
+            sMarksLbl = sMarksLbl + " — CIĘŻKA KLĄTWA";
+        else if(nMarks >= GRV_DESEC_CURSE_THRESHOLD)
+            sMarksLbl = sMarksLbl + " — przeklęty";
+    }
+    NuiSetBind(oPC, nToken, GRV_BIND_MARKS_LBL, JsonString(sMarksLbl));
+    NuiSetBind(oPC, nToken, GRV_BIND_STATUS_LBL, JsonString(""));
+
+    NuiSetBind(oPC, nToken, GRV_BIND_BURY_ENA, JsonBool(TRUE));
+}
+
+void GrvFeedShopWindow(object oPC, int nToken)
+{
+    int nGrace = GrvGetBoneGrace(oPC);
+    NuiSetBind(oPC, nToken, GRV_BIND_SHOP_GRACE,
+        JsonString("Twoja Łaska Kości: " + IntToString(nGrace)));
+
+    json jNames = JsonArray();
+    json jCosts = JsonArray();
+    json jEnas  = JsonArray();
+    json jEncs  = JsonArray();
+    json jDescs = JsonArray();
+
+    int i;
+    for(i = 0; i < GRV_SHOP_COUNT; i++)
+    {
+        int nCost = GrvGetShopItemCost(i);
+        int bCan  = (nGrace >= nCost);
+
+        // Forgiveness: extra cooldown via pray_log with grave_id = 0
+        if(i == 4)
+        {
+            if(GrvHasPrayed(oPC, 0)) bCan = FALSE;
+            if(GrvGetDesecMarks(oPC) <= 0) bCan = FALSE;
+        }
+
+        jNames = JsonArrayInsert(jNames, JsonString(GrvGetShopItemName(i)));
+        jCosts = JsonArrayInsert(jCosts, JsonString(IntToString(nCost) + " ŁK"));
+        jEnas  = JsonArrayInsert(jEnas,  JsonBool(bCan));
+        jEncs  = JsonArrayInsert(jEncs,  JsonBool(FALSE));
+        jDescs = JsonArrayInsert(jDescs, JsonString(GrvGetShopItemDesc(i)));
+    }
+
+    NuiSetBind(oPC, nToken, GRV_BIND_SHOP_ROWNAME,  jNames);
+    NuiSetBind(oPC, nToken, GRV_BIND_SHOP_ROWCOST,  jCosts);
+    NuiSetBind(oPC, nToken, GRV_BIND_SHOP_ROWENA,   jEnas);
+    NuiSetBind(oPC, nToken, GRV_BIND_SHOP_ROWENC,   jEncs);
+    NuiSetBind(oPC, nToken, GRV_BIND_SHOP_ROWDESC,  jDescs);
+    NuiSetBind(oPC, nToken, GRV_BIND_SHOP_COUNT,    JsonInt(GRV_SHOP_COUNT));
+}
+
+void GrvFeedGraveWindow(object oPC, int nToken, int nGraveId)
+{
+    json jGrave = GrvGetGrave(nGraveId);
+    if(JsonGetType(jGrave) == JSON_TYPE_NULL)
+    {
+        NuiSetBind(oPC, nToken, GRV_BIND_GRAVE_TITLE, JsonString("Grób nie istnieje."));
+        NuiSetBind(oPC, nToken, GRV_BIND_GRAVE_INFO,  JsonString(""));
+        NuiSetBind(oPC, nToken, GRV_BIND_GRAVE_DESEC, JsonBool(FALSE));
+        NuiSetBind(oPC, nToken, GRV_BIND_PRAY_ENA,    JsonBool(FALSE));
+        NuiSetBind(oPC, nToken, GRV_BIND_PRAY_LBL,    JsonString("Módl się"));
+        return;
+    }
+
+    string sDeceased = JsonGetString(JsonObjectGet(jGrave, "deceased_name"));
+    string sOwner    = JsonGetString(JsonObjectGet(jGrave, "owner_name"));
+    int    nType     = JsonGetInt   (JsonObjectGet(jGrave, "grave_type"));
+    int    nGold     = JsonGetInt   (JsonObjectGet(jGrave, "gold_buried"));
+    int    nAt       = JsonGetInt   (JsonObjectGet(jGrave, "created_at"));
+    int    bDesec    = JsonGetInt   (JsonObjectGet(jGrave, "is_desecrated"));
+
+    string sTitle = GrvGetGraveTypeName(nType) + ": " + sDeceased;
+
+    string sInfo = "Typ: " + GrvGetGraveTypeName(nType) + "\n";
+    sInfo = sInfo + "Pogrzebany przez: " + sOwner + "\n";
+    sInfo = sInfo + "Data: " + GrvFormatDate(nAt) + "\n";
+    if(nGold > 0)
+        sInfo = sInfo + "Złoto złożone: " + IntToString(nGold) + " monet\n";
+    if(bDesec)
+        sInfo = sInfo + "\n[Grób zbezczeszczony — kości nie dają spokoju...]";
+
+    int bHasPrayed = GrvHasPrayed(oPC, nGraveId);
+    string sPrayLbl = bHasPrayed ? "Módliłeś się tu (odczekaj dobę)" : "Módl się (+2 do rzutów obronnych, 8h)";
+
+    NuiSetBind(oPC, nToken, GRV_BIND_GRAVE_TITLE, JsonString(sTitle));
+    NuiSetBind(oPC, nToken, GRV_BIND_GRAVE_INFO,  JsonString(sInfo));
+    NuiSetBind(oPC, nToken, GRV_BIND_GRAVE_DESEC, JsonBool(!bDesec));
+    NuiSetBind(oPC, nToken, GRV_BIND_PRAY_ENA,    JsonBool(!bHasPrayed));
+    NuiSetBind(oPC, nToken, GRV_BIND_PRAY_LBL,    JsonString(sPrayLbl));
+}
+
+// ----------------------------------------------------------------
+// Action handlers
+// ----------------------------------------------------------------
+
+void GrvHandleBury(object oPC, int nToken)
+{
+    int    nType    = GetLocalInt(oPC, GRV_LVAR_TYPE);
+    int    nGoldCost = GrvGetGraveTypeGoldCost(nType);
+    string sGoldStr = JsonGetString(NuiGetBind(oPC, nToken, GRV_BIND_GOLD_TXT));
+    int    nOffering = StringToInt(sGoldStr);
+    int    nTotal    = nGoldCost + (nOffering > 0 ? nOffering : 0);
+
+    if(nOffering < 0)
+    {
+        NuiSetBind(oPC, nToken, GRV_BIND_STATUS_LBL, JsonString("Ofiara nie może być ujemna."));
+        return;
+    }
+
+    if(GetGold(oPC) < nTotal)
+    {
+        NuiSetBind(oPC, nToken, GRV_BIND_STATUS_LBL,
+            JsonString("Nie masz wystarczająco złota (" + IntToString(nTotal) + " wymagane)."));
+        return;
+    }
+
+    string sDeceased = JsonGetString(NuiGetBind(oPC, nToken, GRV_BIND_DECEASED));
+    if(sDeceased == "" || sDeceased == "Nieznany...")
+        sDeceased = "Nieznany";
+
+    if(nTotal > 0)
+        AssignCommand(oPC, TakeGoldFromCreature(nTotal, oPC, TRUE));
+
+    string sArea = GetResRef(GetArea(oPC));
+    int nGraveId = GrvInsertGrave(oPC, sDeceased, nType, nOffering, sArea);
+
+    int nGrace = GrvGetGraveTypeGrace(nType);
+    GrvAddBoneGrace(oPC, nGrace);
+
+    string sMsg = "Pochowałeś " + sDeceased + " jako " + GrvGetGraveTypeName(nType) + ".";
+    sMsg = sMsg + " Łaska Kości: +" + IntToString(nGrace) + ".";
+    SendMessageToPC(oPC, "[Cmentarz] " + sMsg);
+    NuiSetBind(oPC, nToken, GRV_BIND_STATUS_LBL, JsonString(sMsg));
+
+    PlaySound("as_pl_coinsdrop1");
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectVisualEffect(VFX_IMP_HEAD_HOLY), oPC);
+
+    GrvTrySpawnGhost(oPC, sDeceased, nOffering);
+    GrvFeedBurialWindow(oPC, nToken);
+}
+
+void GrvHandleTypeSelect(object oPC, int nToken, int nType)
+{
+    SetLocalInt(oPC, GRV_LVAR_TYPE, nType);
+    GrvFeedBurialWindow(oPC, nToken);
+}
+
+void GrvHandleBuy(object oPC, int nShopToken, int nIdx)
+{
+    int nCost = GrvGetShopItemCost(nIdx);
+    if(!GrvSpendBoneGrace(oPC, nCost))
+    {
+        SendMessageToPC(oPC, "[Cmentarz] Zbyt mało Łaski Kości.");
+        return;
+    }
+
+    GrvApplyShopEffect(oPC, nIdx);
+    GrvFeedShopWindow(oPC, nShopToken);
+
+    int nBurToken = NuiFindWindow(oPC, GRV_WINDOW);
+    if(nBurToken != 0)
+        GrvFeedBurialWindow(oPC, nBurToken);
+}
+
+void GrvHandlePray(object oPC, int nToken, int nGraveId)
+{
+    if(GrvHasPrayed(oPC, nGraveId))
+    {
+        SendMessageToPC(oPC, "[Cmentarz] Już modliłeś się przy tym grobie. Wróć jutro.");
+        return;
+    }
+
+    GrvLogPrayer(oPC, nGraveId);
+    GrvApplyPrayerBuff(oPC);
+
+    SendMessageToPC(oPC, "[Cmentarz] Modlitwa zostaje wysłuchana. +2 do wszystkich rzutów obronnych przez 8 godzin.");
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectVisualEffect(VFX_IMP_HEAD_HOLY), oPC);
+    GrvFeedGraveWindow(oPC, nToken, nGraveId);
+}
+
+void GrvHandleDesecrate(object oPC, int nToken, int nGraveId)
+{
+    json jGrave = GrvGetGrave(nGraveId);
+    if(JsonGetType(jGrave) == JSON_TYPE_NULL) return;
+    if(JsonGetInt(JsonObjectGet(jGrave, "is_desecrated"))) return;
+
+    int nType     = JsonGetInt(JsonObjectGet(jGrave, "grave_type"));
+    int nBuried   = JsonGetInt(JsonObjectGet(jGrave, "gold_buried"));
+
+    int nLoot = 0;
+    switch(nType)
+    {
+        case GRV_TYPE_MOUND: nLoot = Random(31);                         break;
+        case GRV_TYPE_STONE: nLoot = 30 + Random(71);                   break;
+        case GRV_TYPE_CRYPT: nLoot = 100 + Random(301) + (nBuried / 2); break;
+    }
+
+    GrvMarkDesecrated(nGraveId);
+    GrvAddDesecMark(oPC);
+
+    if(nLoot > 0)
+        GiveGoldToCreature(oPC, nLoot);
+
+    int nMarks = GrvGetDesecMarks(oPC);
+
+    string sMsg = "Zbezcześciłeś grób i znalazłeś " + IntToString(nLoot) + " sztuk złota.";
+    sMsg = sMsg + " Piętno Zbezczeszczenia: " + IntToString(nMarks) + ".";
+    SendMessageToPC(oPC, "[Cmentarz] " + sMsg);
+
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectVisualEffect(VFX_IMP_HEAD_EVIL), oPC);
+    GrvApplyCursePenalties(oPC, nMarks);
+    GrvFeedGraveWindow(oPC, nToken, nGraveId);
+}

--- a/Cmentarz/scripts/lib_grv_def.nss
+++ b/Cmentarz/scripts/lib_grv_def.nss
@@ -1,0 +1,302 @@
+#include "lib_nui"
+#include "sql_grv"
+
+void GrvCreateBurialWindow(object oPC);
+void GrvCreateShopWindow(object oPC);
+void GrvCreateGraveWindow(object oPC, int nGraveId);
+void GrvFeedBurialWindow(object oPC, int nToken);
+void GrvFeedShopWindow(object oPC, int nToken);
+void GrvFeedGraveWindow(object oPC, int nToken, int nGraveId);
+
+// ----------------------------------------------------------------
+// Window IDs
+// ----------------------------------------------------------------
+
+const string GRV_WINDOW        = "GRV_WINDOW";
+const string GRV_WIN_SHOP      = "GRV_WIN_SHOP";
+const string GRV_WIN_GRAVE     = "GRV_WIN_GRAVE";
+const string GRV_EV_SCRIPT     = "lib_grv_ev";
+
+const string GRV_GRP_SWAP      = "GRV_GRP_SWAP";
+
+// ----------------------------------------------------------------
+// Burial window binds
+// ----------------------------------------------------------------
+
+const string GRV_BIND_WIN_GEOM      = "grv_win_geom";
+const string GRV_BIND_DECEASED      = "grv_deceased";
+const string GRV_BIND_TYPE0_ENC     = "grv_type0_enc";
+const string GRV_BIND_TYPE1_ENC     = "grv_type1_enc";
+const string GRV_BIND_TYPE2_ENC     = "grv_type2_enc";
+const string GRV_BIND_MAT_DESC      = "grv_mat_desc";
+const string GRV_BIND_GRACE_LBL     = "grv_grace_lbl";
+const string GRV_BIND_GOLD_TXT      = "grv_gold_txt";
+const string GRV_BIND_BURY_ENA      = "grv_bury_ena";
+const string GRV_BIND_STATUS_LBL    = "grv_status_lbl";
+const string GRV_BIND_MARKS_LBL     = "grv_marks_lbl";
+
+// ----------------------------------------------------------------
+// Shop window binds
+// ----------------------------------------------------------------
+
+const string GRV_BIND_SHOP_GEOM     = "grv_shop_geom";
+const string GRV_BIND_SHOP_GRACE    = "grv_shop_grace";
+const string GRV_BIND_SHOP_ROWNAME  = "grv_shop_rowname";
+const string GRV_BIND_SHOP_ROWCOST  = "grv_shop_rowcost";
+const string GRV_BIND_SHOP_ROWENA   = "grv_shop_rowena";
+const string GRV_BIND_SHOP_ROWENC   = "grv_shop_rowenc";
+const string GRV_BIND_SHOP_ROWDESC  = "grv_shop_rowdesc";
+const string GRV_BIND_SHOP_COUNT    = "grv_shop_count";
+
+// ----------------------------------------------------------------
+// Grave interaction window binds
+// ----------------------------------------------------------------
+
+const string GRV_BIND_GRAVE_GEOM    = "grv_grave_geom";
+const string GRV_BIND_GRAVE_TITLE   = "grv_grave_title";
+const string GRV_BIND_GRAVE_INFO    = "grv_grave_info";
+const string GRV_BIND_GRAVE_DESEC   = "grv_grave_desec_ena";
+const string GRV_BIND_PRAY_ENA      = "grv_pray_ena";
+const string GRV_BIND_PRAY_LBL      = "grv_pray_lbl";
+
+// ----------------------------------------------------------------
+// Buttons
+// ----------------------------------------------------------------
+
+const string GRV_BTN_CLOSE          = "grv_btn_close";
+const string GRV_BTN_TYPE0          = "grv_btn_type0";
+const string GRV_BTN_TYPE1          = "grv_btn_type1";
+const string GRV_BTN_TYPE2          = "grv_btn_type2";
+const string GRV_BTN_BURY           = "grv_btn_bury";
+const string GRV_BTN_OPEN_SHOP      = "grv_btn_shop";
+const string GRV_BTN_SHOP_CLOSE     = "grv_btn_shopclose";
+const string GRV_BTN_BUY            = "grv_btn_buy";
+const string GRV_BTN_GRAVE_CLOSE    = "grv_btn_graveclose";
+const string GRV_BTN_PRAY           = "grv_btn_pray";
+const string GRV_BTN_DESECRATE      = "grv_btn_desecrate";
+
+// ----------------------------------------------------------------
+// Local vars on PC
+// ----------------------------------------------------------------
+
+const string GRV_LVAR_TYPE          = "GRV_BURIAL_TYPE";
+const string GRV_LVAR_GRAVE_ID      = "GRV_ACTIVE_GRAVE";
+
+// ----------------------------------------------------------------
+// Grave types
+// ----------------------------------------------------------------
+
+const int GRV_TYPE_MOUND   = 0;
+const int GRV_TYPE_STONE   = 1;
+const int GRV_TYPE_CRYPT   = 2;
+
+// ----------------------------------------------------------------
+// Balance constants
+// ----------------------------------------------------------------
+
+const int GRV_GOLD_MOUND   = 0;
+const int GRV_GOLD_STONE   = 50;
+const int GRV_GOLD_CRYPT   = 200;
+
+const int GRV_GRACE_MOUND  = 1;
+const int GRV_GRACE_STONE  = 3;
+const int GRV_GRACE_CRYPT  = 10;
+
+const int GRV_GHOST_GOLD_MIN    = 50;
+const int GRV_GHOST_CHANCE_BASE = 25;
+
+const int GRV_DESEC_CURSE_THRESHOLD = 5;
+const int GRV_DESEC_HEAVY_THRESHOLD = 10;
+const int GRV_FORGIVE_COOLDOWN_SEC  = 86400;
+
+// Shop
+const int GRV_SHOP_COUNT = 5;
+
+// ----------------------------------------------------------------
+// Layout
+// ----------------------------------------------------------------
+
+const float GRV_WIN_W    = 480.0;
+const float GRV_WIN_H    = 400.0;
+const float GRV_SHOP_W   = 440.0;
+const float GRV_SHOP_H   = 340.0;
+const float GRV_GRAVE_W  = 400.0;
+const float GRV_GRAVE_H  = 290.0;
+
+// ----------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------
+
+string GrvGetGraveTypeName(int nType)
+{
+    if(nType == GRV_TYPE_STONE) return "Kamienny Nagrobek";
+    if(nType == GRV_TYPE_CRYPT) return "Krypta Szlachecka";
+    return "Usypana Mogiła";
+}
+
+string GrvGetGraveTypeMaterials(int nType)
+{
+    if(nType == GRV_TYPE_STONE) return "Koszt: 50 sztuk złota";
+    if(nType == GRV_TYPE_CRYPT) return "Koszt: 200 sztuk złota";
+    return "Koszt: bezpłatnie";
+}
+
+int GrvGetGraveTypeGoldCost(int nType)
+{
+    if(nType == GRV_TYPE_STONE) return GRV_GOLD_STONE;
+    if(nType == GRV_TYPE_CRYPT) return GRV_GOLD_CRYPT;
+    return GRV_GOLD_MOUND;
+}
+
+int GrvGetGraveTypeGrace(int nType)
+{
+    if(nType == GRV_TYPE_STONE) return GRV_GRACE_STONE;
+    if(nType == GRV_TYPE_CRYPT) return GRV_GRACE_CRYPT;
+    return GRV_GRACE_MOUND;
+}
+
+string GrvGetShopItemName(int nIdx)
+{
+    switch(nIdx)
+    {
+        case 0: return "Pokora Kości";
+        case 1: return "Pieczęć Przed Zepsuciem";
+        case 2: return "Wzrok Przez Zasłonę";
+        case 3: return "Tarcza Przed Śmiercią";
+        case 4: return "Rozgrzeszenie";
+    }
+    return "";
+}
+
+string GrvGetShopItemDesc(int nIdx)
+{
+    switch(nIdx)
+    {
+        case 0: return "Grabarz odmawia modlitwę — odzysk 2k8 HP";
+        case 1: return "Starożytna pieczęć — +2 do AC (8h)";
+        case 2: return "Oczy widzą to, co ukryte — True Seeing (1h)";
+        case 3: return "Sam Śmierć cofnie się przed tobą — Death Ward (1h)";
+        case 4: return "Ceremonialnie zdejmuje z ciebie jedno Piętno Zbezczeszczenia";
+    }
+    return "";
+}
+
+int GrvGetShopItemCost(int nIdx)
+{
+    switch(nIdx)
+    {
+        case 0: return 3;
+        case 1: return 5;
+        case 2: return 8;
+        case 3: return 15;
+        case 4: return 10;
+    }
+    return 999;
+}
+
+void GrvApplyShopEffect(object oPC, int nIdx)
+{
+    switch(nIdx)
+    {
+        case 0:
+        {
+            int nHeal = d8(2);
+            effect eHeal = EffectHeal(nHeal);
+            ApplyEffectToObject(DURATION_TYPE_INSTANT, eHeal, oPC);
+            FloatingTextStringOnCreature("Kości cicho szepczą... +" + IntToString(nHeal) + " HP", oPC, FALSE);
+            break;
+        }
+        case 1:
+        {
+            effect eAC = EffectACIncrease(2, AC_DODGE_BONUS);
+            eAC = EffectLinkEffects(eAC, EffectVisualEffect(VFX_DUR_PROTECTION_GOOD_MINOR));
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eAC, oPC, 28800.0);
+            FloatingTextStringOnCreature("Pieczęć pulsuje na twojej skórze...", oPC, FALSE);
+            break;
+        }
+        case 2:
+        {
+            effect eSight = EffectTrueSeeing();
+            eSight = EffectLinkEffects(eSight, EffectVisualEffect(VFX_DUR_SPELL_TRUE_SEEING));
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eSight, oPC, 3600.0);
+            FloatingTextStringOnCreature("Zasłona między światami staje się przezroczysta...", oPC, FALSE);
+            break;
+        }
+        case 3:
+        {
+            effect eDW = EffectImmunity(IMMUNITY_TYPE_DEATH);
+            eDW = EffectLinkEffects(eDW, EffectImmunity(IMMUNITY_TYPE_NEGATIVE_LEVEL));
+            eDW = EffectLinkEffects(eDW, EffectVisualEffect(VFX_DUR_PROTECTION_GOOD_MAJOR));
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eDW, oPC, 3600.0);
+            FloatingTextStringOnCreature("Śmierć omija cię szerokim łukiem...", oPC, FALSE);
+            break;
+        }
+        case 4:
+        {
+            GrvRemoveDesecMark(oPC);
+            GrvLogPrayer(oPC, 0);
+            FloatingTextStringOnCreature("Piętno Zbezczeszczenia słabnie...", oPC, FALSE);
+            break;
+        }
+    }
+}
+
+void GrvApplyCursePenalties(object oPC, int nMarks)
+{
+    if(nMarks < GRV_DESEC_CURSE_THRESHOLD) return;
+
+    // Remove old graveyard curse before applying new
+    effect eCurrent = GetFirstEffect(oPC);
+    while(GetIsEffectValid(eCurrent))
+    {
+        if(GetEffectTag(eCurrent) == "GRV_DESEC_CURSE")
+            RemoveEffect(oPC, eCurrent);
+        eCurrent = GetNextEffect(oPC);
+    }
+
+    effect eCurse;
+    if(nMarks >= GRV_DESEC_HEAVY_THRESHOLD)
+    {
+        eCurse = EffectSavingThrowDecrease(SAVING_THROW_ALL, 4);
+        eCurse = EffectLinkEffects(eCurse, EffectAbilityDecrease(ABILITY_WISDOM, 2));
+        eCurse = EffectLinkEffects(eCurse, EffectVisualEffect(VFX_DUR_DARKNESS));
+        FloatingTextStringOnCreature("Kości martwych krzyczą w twojej głowie...", oPC, FALSE);
+    }
+    else
+    {
+        eCurse = EffectSavingThrowDecrease(SAVING_THROW_ALL, 2);
+        eCurse = EffectLinkEffects(eCurse, EffectVisualEffect(VFX_DUR_BLUR));
+        FloatingTextStringOnCreature("Cień wisi nad tobą niewidzialny...", oPC, FALSE);
+    }
+
+    eCurse = TagEffect(eCurse, "GRV_DESEC_CURSE");
+    ApplyEffectToObject(DURATION_TYPE_PERMANENT, eCurse, oPC);
+}
+
+void GrvApplyPrayerBuff(object oPC)
+{
+    effect eBuff = EffectSavingThrowIncrease(SAVING_THROW_ALL, 2, SAVING_THROW_TYPE_ALL);
+    eBuff = EffectLinkEffects(eBuff, EffectVisualEffect(VFX_DUR_PROTECTION_GOOD_MINOR));
+    eBuff = TagEffect(eBuff, "GRV_PRAYER_BUFF");
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eBuff, oPC, 28800.0);
+}
+
+void GrvTrySpawnGhost(object oPC, string sDeceasedName, int nGoldBuried)
+{
+    if(nGoldBuried < GRV_GHOST_GOLD_MIN) return;
+
+    int nChance = GRV_GHOST_CHANCE_BASE + (nGoldBuried / 20);
+    if(nChance > 75) nChance = 75;
+    if(d100() > nChance) return;
+
+    // Ghost manifests as a spectral blessing rather than a creature (no NWNX required)
+    effect eGhost = EffectSavingThrowIncrease(SAVING_THROW_ALL, 1, SAVING_THROW_TYPE_ALL);
+    eGhost = EffectLinkEffects(eGhost, EffectAttackIncrease(1));
+    eGhost = EffectLinkEffects(eGhost, EffectVisualEffect(VFX_DUR_GHOSTLY_VISAGE));
+    eGhost = TagEffect(eGhost, "GRV_GHOST_BLESS");
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eGhost, oPC, 1800.0);
+
+    string sMsg = "Duch " + sDeceasedName + " pojawia się przy twoim boku i czuwa przez chwilę...";
+    FloatingTextStringOnCreature(sMsg, oPC, FALSE);
+    SendMessageToPC(oPC, "[Cmentarz] " + sMsg);
+}

--- a/Cmentarz/scripts/lib_grv_ev.nss
+++ b/Cmentarz/scripts/lib_grv_ev.nss
@@ -1,0 +1,125 @@
+#include "lib_grv"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    // ----------------------------------------------------------------
+    // Grave interaction window
+    // ----------------------------------------------------------------
+
+    if(nToken == NuiFindWindow(oPC, GRV_WIN_GRAVE))
+    {
+        if(sEvent == EVENT_TYPE_CLOSE)
+        {
+            DeleteLocalInt(oPC, GRV_LVAR_GRAVE_ID);
+            return;
+        }
+
+        if(sEvent == EVENT_TYPE_CLICK)
+        {
+            if(sElem == GRV_BTN_GRAVE_CLOSE)
+            {
+                NuiDestroy(oPC, nToken);
+                return;
+            }
+            if(sElem == GRV_BTN_PRAY)
+            {
+                int nId = GetLocalInt(oPC, GRV_LVAR_GRAVE_ID);
+                GrvHandlePray(oPC, nToken, nId);
+                return;
+            }
+            if(sElem == GRV_BTN_DESECRATE)
+            {
+                int nId = GetLocalInt(oPC, GRV_LVAR_GRAVE_ID);
+                GrvHandleDesecrate(oPC, nToken, nId);
+                return;
+            }
+        }
+        return;
+    }
+
+    // ----------------------------------------------------------------
+    // Shop window
+    // ----------------------------------------------------------------
+
+    if(nToken == NuiFindWindow(oPC, GRV_WIN_SHOP))
+    {
+        if(sEvent == EVENT_TYPE_CLICK)
+        {
+            if(sElem == GRV_BTN_SHOP_CLOSE)
+            {
+                NuiDestroy(oPC, nToken);
+                return;
+            }
+            if(sElem == GRV_BTN_BUY && nIdx >= 0 && nIdx < GRV_SHOP_COUNT)
+            {
+                GrvHandleBuy(oPC, nToken, nIdx);
+                return;
+            }
+        }
+        return;
+    }
+
+    // ----------------------------------------------------------------
+    // Burial window
+    // ----------------------------------------------------------------
+
+    if(nToken != NuiFindWindow(oPC, GRV_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalInt(oPC, GRV_LVAR_TYPE);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == GRV_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+        if(sElem == GRV_BTN_TYPE0)
+        {
+            GrvHandleTypeSelect(oPC, nToken, GRV_TYPE_MOUND);
+            return;
+        }
+        if(sElem == GRV_BTN_TYPE1)
+        {
+            GrvHandleTypeSelect(oPC, nToken, GRV_TYPE_STONE);
+            return;
+        }
+        if(sElem == GRV_BTN_TYPE2)
+        {
+            GrvHandleTypeSelect(oPC, nToken, GRV_TYPE_CRYPT);
+            return;
+        }
+        if(sElem == GRV_BTN_BURY)
+        {
+            GrvHandleBury(oPC, nToken);
+            return;
+        }
+        if(sElem == GRV_BTN_OPEN_SHOP)
+        {
+            GrvCreateShopWindow(oPC);
+            return;
+        }
+    }
+
+    if(sEvent == EVENT_TYPE_WATCH && sElem == GRV_BIND_GOLD_TXT)
+    {
+        string sVal = JsonGetString(NuiGetBind(oPC, nToken, GRV_BIND_GOLD_TXT));
+        int nVal    = StringToInt(sVal);
+        if(sVal != "" && sVal != "0" && nVal <= 0)
+            NuiSetBind(oPC, nToken, GRV_BIND_STATUS_LBL,
+                JsonString("Ofiara musi być liczbą całkowitą dodatnią."));
+        else
+            NuiSetBind(oPC, nToken, GRV_BIND_STATUS_LBL, JsonString(""));
+        return;
+    }
+}

--- a/Cmentarz/scripts/sql_grv.nss
+++ b/Cmentarz/scripts/sql_grv.nss
@@ -1,0 +1,181 @@
+const int GRV_PRAY_COOLDOWN_SEC = 86400;
+
+void GrvCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("graveyard",
+        "CREATE TABLE IF NOT EXISTS grv_graves ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "owner_uuid TEXT NOT NULL,"
+        "owner_name TEXT DEFAULT '',"
+        "deceased_name TEXT DEFAULT 'Nieznany',"
+        "grave_type INTEGER DEFAULT 0,"
+        "gold_buried INTEGER DEFAULT 0,"
+        "area_resref TEXT DEFAULT '',"
+        "created_at INTEGER DEFAULT 0,"
+        "is_desecrated INTEGER DEFAULT 0"
+        ")");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("graveyard",
+        "CREATE TABLE IF NOT EXISTS grv_players ("
+        "uuid TEXT PRIMARY KEY,"
+        "char_name TEXT DEFAULT '',"
+        "bone_grace INTEGER DEFAULT 0,"
+        "desec_marks INTEGER DEFAULT 0,"
+        "last_online INTEGER DEFAULT 0"
+        ")");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("graveyard",
+        "CREATE TABLE IF NOT EXISTS grv_pray_log ("
+        "player_uuid TEXT NOT NULL,"
+        "grave_id INTEGER NOT NULL,"
+        "prayed_at INTEGER DEFAULT 0,"
+        "PRIMARY KEY (player_uuid, grave_id)"
+        ")");
+    SqlStep(q);
+}
+
+void GrvRegisterPlayer(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("graveyard",
+        "INSERT OR IGNORE INTO grv_players (uuid, char_name, last_online) "
+        "VALUES (@uuid, @name, strftime('%s','now'))");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindString(q, "@name", GetName(oPC));
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("graveyard",
+        "UPDATE grv_players SET char_name = @name, last_online = strftime('%s','now') "
+        "WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindString(q, "@name", GetName(oPC));
+    SqlStep(q);
+}
+
+int GrvGetBoneGrace(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("graveyard",
+        "SELECT bone_grace FROM grv_players WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+int GrvGetDesecMarks(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("graveyard",
+        "SELECT desec_marks FROM grv_players WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+void GrvAddBoneGrace(object oPC, int nAmount)
+{
+    sqlquery q = SqlPrepareQueryCampaign("graveyard",
+        "UPDATE grv_players SET bone_grace = MAX(0, bone_grace + @amt) WHERE uuid = @uuid");
+    SqlBindInt   (q, "@amt",  nAmount);
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+int GrvSpendBoneGrace(object oPC, int nCost)
+{
+    if(GrvGetBoneGrace(oPC) < nCost) return FALSE;
+    GrvAddBoneGrace(oPC, -nCost);
+    return TRUE;
+}
+
+void GrvAddDesecMark(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("graveyard",
+        "UPDATE grv_players SET desec_marks = desec_marks + 1 WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+void GrvRemoveDesecMark(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("graveyard",
+        "UPDATE grv_players SET desec_marks = MAX(0, desec_marks - 1) WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+int GrvInsertGrave(object oPC, string sDeceasedName, int nType, int nGold, string sArea)
+{
+    sqlquery q = SqlPrepareQueryCampaign("graveyard",
+        "INSERT INTO grv_graves "
+        "(owner_uuid, owner_name, deceased_name, grave_type, gold_buried, area_resref, created_at) "
+        "VALUES (@uuid, @oname, @dname, @type, @gold, @area, strftime('%s','now'))");
+    SqlBindString(q, "@uuid",  GetObjectUUID(oPC));
+    SqlBindString(q, "@oname", GetName(oPC));
+    SqlBindString(q, "@dname", sDeceasedName);
+    SqlBindInt   (q, "@type",  nType);
+    SqlBindInt   (q, "@gold",  nGold);
+    SqlBindString(q, "@area",  sArea);
+    SqlStep(q);
+
+    sqlquery qId = SqlPrepareQueryCampaign("graveyard", "SELECT last_insert_rowid()");
+    if(SqlStep(qId)) return SqlGetInt(qId, 0);
+    return 0;
+}
+
+json GrvGetGrave(int nId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("graveyard",
+        "SELECT id, owner_name, deceased_name, grave_type, gold_buried, created_at, is_desecrated "
+        "FROM grv_graves WHERE id = @id");
+    SqlBindInt(q, "@id", nId);
+    if(!SqlStep(q)) return JsonNull();
+
+    json j = JsonObject();
+    j = JsonObjectSet(j, "id",            JsonInt   (SqlGetInt   (q, 0)));
+    j = JsonObjectSet(j, "owner_name",    JsonString(SqlGetString(q, 1)));
+    j = JsonObjectSet(j, "deceased_name", JsonString(SqlGetString(q, 2)));
+    j = JsonObjectSet(j, "grave_type",    JsonInt   (SqlGetInt   (q, 3)));
+    j = JsonObjectSet(j, "gold_buried",   JsonInt   (SqlGetInt   (q, 4)));
+    j = JsonObjectSet(j, "created_at",    JsonInt   (SqlGetInt   (q, 5)));
+    j = JsonObjectSet(j, "is_desecrated", JsonInt   (SqlGetInt   (q, 6)));
+    return j;
+}
+
+void GrvMarkDesecrated(int nId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("graveyard",
+        "UPDATE grv_graves SET is_desecrated = 1 WHERE id = @id");
+    SqlBindInt(q, "@id", nId);
+    SqlStep(q);
+}
+
+int GrvHasPrayed(object oPC, int nId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("graveyard",
+        "SELECT 1 FROM grv_pray_log "
+        "WHERE player_uuid = @uuid AND grave_id = @gid "
+        "AND prayed_at > strftime('%s','now') - @cd");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@gid",  nId);
+    SqlBindInt   (q, "@cd",   GRV_PRAY_COOLDOWN_SEC);
+    return SqlStep(q);
+}
+
+void GrvLogPrayer(object oPC, int nId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("graveyard",
+        "INSERT OR REPLACE INTO grv_pray_log (player_uuid, grave_id, prayed_at) "
+        "VALUES (@uuid, @gid, strftime('%s','now'))");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@gid",  nId);
+    SqlStep(q);
+}
+
+string GrvFormatDate(int nUnix)
+{
+    sqlquery q = SqlPrepareQueryCampaign("graveyard",
+        "SELECT strftime('%d.%m.%Y', @ts, 'unixepoch')");
+    SqlBindInt(q, "@ts", nUnix);
+    if(SqlStep(q)) return SqlGetString(q, 0);
+    return "??";
+}

--- a/Cmentarz/scripts/sys_on_enter.nss
+++ b/Cmentarz/scripts/sys_on_enter.nss
@@ -1,0 +1,30 @@
+#include "lib_grv"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC)) return;
+
+    GrvRegisterPlayer(oPC);
+
+    int nMarks = GrvGetDesecMarks(oPC);
+    int nGrace = GrvGetBoneGrace(oPC);
+
+    if(nMarks >= GRV_DESEC_CURSE_THRESHOLD)
+    {
+        // Re-apply curse on login (curses are permanent until cleansed)
+        DelayCommand(3.0, GrvApplyCursePenalties(oPC, nMarks));
+
+        string sWarn = nMarks >= GRV_DESEC_HEAVY_THRESHOLD
+            ? "[Cmentarz] Ciężka klątwa zbezczeszczenia spoczywa na tobie. Poszukaj grabarza, by cię rozgrzeszył."
+            : "[Cmentarz] Cień zbezczeszczenia spoczywa na tobie (" + IntToString(nMarks) + " Piętno). Odwiedź grabarza.";
+        DelayCommand(4.0, SendMessageToPC(oPC, sWarn));
+        DelayCommand(4.0, FloatingTextStringOnCreature(sWarn, oPC, FALSE));
+    }
+
+    if(nGrace > 0)
+    {
+        string sNotify = "[Cmentarz] Posiadasz " + IntToString(nGrace) + " Łaski Kości. Skorzystaj ze Sklepu Grabarza.";
+        DelayCommand(5.0, SendMessageToPC(oPC, sNotify));
+    }
+}

--- a/Cmentarz/scripts/sys_on_load.nss
+++ b/Cmentarz/scripts/sys_on_load.nss
@@ -1,0 +1,6 @@
+#include "lib_grv_def"
+
+void main()
+{
+    GrvCreateTables();
+}

--- a/Cmentarz/scripts/test_grv.nss
+++ b/Cmentarz/scripts/test_grv.nss
@@ -1,0 +1,31 @@
+#include "lib_grv"
+
+// OnUsed script for the "Cmentarny Głaz" (Graveyard Stone) placeable.
+// Place this placeable in your area and assign this script to its OnUsed event.
+// A second placeable with tag "GRV_TEST_GRAVE" and a local int "GRV_GRAVE_ID" set
+// to a valid grave ID can be used to test the grave interaction window.
+
+void main()
+{
+    object oPC   = GetLastUsedBy();
+    object oSelf = OBJECT_SELF;
+
+    if(!GetIsPC(oPC)) return;
+
+    string sTag = GetTag(oSelf);
+
+    if(sTag == "GRV_TEST_GRAVE")
+    {
+        int nId = GetLocalInt(oSelf, "GRV_GRAVE_ID");
+        if(nId <= 0)
+        {
+            SendMessageToPC(oPC, "[Cmentarz] Ten grób nie ma rekordu w bazie.");
+            return;
+        }
+        GrvCreateGraveWindow(oPC, nId);
+    }
+    else
+    {
+        GrvCreateBurialWindow(oPC);
+    }
+}


### PR DESCRIPTION
## Co to robi

Moduł **Cmentarz** pozwala graczom grzebać poległych wrogów i postacie NPC,
zarabiając walutę „Łaska Kości" (ŁK). Za ŁK grabarz udziela tymczasowych
błogosławieństw (leczenie, ochrona, True Seeing, Death Ward, rozgrzeszenie).
Gracze mogą też zbezcześcić groby po złoto, ryzykując trwałą klątwę.

## Mechanika

- **Pochówek**: 3 typy grobów (Usypana Mogiła 0gp / Kamienny Nagrobek 50gp /
  Krypta Szlachecka 200gp). Opcjonalne złoto ofiarne zwiększa szansę na
  manifest ducha (tymczasowy buff).
- **Łaska Kości**: waluta zdobywana za pochówki (1 / 3 / 10 ŁK). Wydawana
  w sklepie grabarza na 5 błogosławieństw, w tym „Rozgrzeszenie" (usuwa piętno).
- **Zbezczeszczenie**: natychmiastowe złoto (0–300+ gp zależnie od typu grobu),
  +1 Piętno. Przy ≥5 piętno: klątwa −2 do rzutów obronnych. Przy ≥10: klątwa
  ciężka −4 saves + −2 WIS. Klątwa jest trwała i wraca po reloginie.
- **Modlitwa**: raz na 24h przy każdym grobie → +2 do wszystkich rzutów
  obronnych przez 8 godzin (tracked per-player per-grave w DB).

## Pliki

```
Cmentarz/
├── INTEGRATION.md
└── scripts/
    ├── sql_grv.nss        — tabele SQLite + zapytania (181 LOC)
    ├── lib_grv_def.nss    — stałe, bindy NUI, helpery efektów (302 LOC)
    ├── lib_grv.nss        — budowa 3 okien NUI, feed pipeline, handlery akcji (599 LOC)
    ├── lib_grv_ev.nss     — router eventów NUI (125 LOC)
    ├── sys_on_load.nss    — OnModuleLoad: CREATE TABLE IF NOT EXISTS
    ├── sys_on_enter.nss   — OnClientEnter: rejestracja gracza, re-apply klątwy
    └── test_grv.nss       — OnUsed placeable: otwiera okno pochówku lub grobu
```

**Łącznie: 1274 LOC NWScript**

## Zależności (NWNX? SQL?)

- **NWNX: brak.** Wyłącznie NWN:EE API.
- **SQL**: kampania `graveyard` (3 tabele: `grv_graves`, `grv_players`,
  `grv_pray_log`). Idempotentna migracja przez `CREATE TABLE IF NOT EXISTS`.

## Jak włączyć w istniejącym module

1. Dodaj skrypty do hak/override.
2. Na **OnModuleLoad** wywołaj lub dołącz `sys_on_load`.
3. Na **OnClientEnterArea** wywołaj lub dołącz `sys_on_enter`.
4. Umieść placeable z tagem dowolnym i przypisz `test_grv` jako OnUsed
   → otwiera okno pochówku.
5. Dla grobu do zbadania: placeable z tagem `GRV_TEST_GRAVE`,
   local int `GRV_GRAVE_ID` = ID z tabeli → otwiera okno interakcji z grobem.

Szczegóły w `Cmentarz/INTEGRATION.md`.

## Co celowo pominięto

- **Fizyczne placeables grobów na mapie**: moduł zapisuje groby w DB, ale nie
  spawna placeabli przy lokacji pochówku — w pełnej integracji należy
  `CreateObject(OBJECT_TYPE_PLACEABLE, "grv_grave_stone", GetLocation(oPC))`
  z lokalną zmienną `GRV_GRAVE_ID` po każdym pochówku.
- **Widoczne duchy-towarzysze**: duch manifestuje się jako efekt mechaniczny
  (+1 ataki + saving throws, 30 min). Prawdziwy creature companion wymaga
  NWNX lub ręcznej konfiguracji AI.
- **Cap grobów per obszar**: brak limitu; można dodać `COUNT(*)` z filtriem
  `area_resref`.
- **sys_on_target.nss**: nie wymaga trybu celowania; interakcja przez OnUsed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JEAjRTkBQpPNSxRKQ9sw1C)_