### PR TITLE
feat: Trophy Hall (Sala Trofeów)

### DIFF
--- a/Trophy Hall/INTEGRATION.md
+++ b/Trophy Hall/INTEGRATION.md
@@ -1,0 +1,135 @@
+# Trophy Hall — Instrukcja integracji
+
+## Co to robi
+
+Sala Trofeów pozwala graczom zbierać trofea z pobitych stworów
+(czaszki, łuski, kły…), deponować je w specjalnym miejscu
+i wykuwać talizmany z bonusami do walki przeciw danemu typowi wroga.
+Pięcioosobowy ranking myśliwych na serwer pokazuje, kto poluje
+najefektywniej.
+
+## Wymagania
+
+- NWN:EE ≥ 8193.36 (NUI + SqlPrepareQueryCampaign + JSON)
+- NWNX: opcjonalny (tylko dla haka „wszystkie śmierci stworów")
+- Plik kampanii SQLite: `trph.nwn` (tworzony automatycznie przez `sys_on_load`)
+
+## Kroki integracji
+
+### 1. OnModuleLoad
+
+Dodaj wywołanie do istniejącego skryptu ładowania modułu:
+
+```nwscript
+ExecuteScript("sys_on_load", GetModule());
+```
+
+lub włącz `sys_on_load.nss` jako jeden z wywołań w swoim
+`module_on_load.nss`.
+
+### 2. OnClientEnter
+
+Dodaj:
+
+```nwscript
+ExecuteScript("sys_on_enter", GetEnteringObject());
+```
+
+### 3. Hak śmierci stworów (wybierz opcję A lub B)
+
+#### Opcja A — Toolset (bez NWNX)
+
+W edytorze przypisz `sys_on_death` jako skrypt OnDeath każdej
+kreaturze, z której chcesz, żeby spadały trofea. Możesz zrobić
+to zbiorczo przez Properties > Scripts dla blueprint'ów kreatur.
+
+Jeśli kreatura ma już OnDeath (własny skrypt lub domyślny
+`nw_c2_default7`), utwórz wrapper:
+
+```nwscript
+// moj_on_death.nss
+void main() {
+    ExecuteScript("nw_c2_default7", OBJECT_SELF);   // oryginalny
+    ExecuteScript("sys_on_death",   OBJECT_SELF);   // trofea
+}
+```
+
+#### Opcja B — NWNX_Events (zalecane dla dużych modułów)
+
+Wymagane: NWNX `Events` plugin.
+
+```nwscript
+// w OnModuleLoad:
+NWNX_Events_SubscribeEvent("NWNX_ON_CREATURE_KILL_AFTER", "trph_on_kill");
+```
+
+Utwórz `trph_on_kill.nss`:
+
+```nwscript
+#include "nwnx_events"
+void main() {
+    object oKilled = NWNX_Events_GetEventDataObject("KILLED");
+    ExecuteScript("sys_on_death", oKilled);
+}
+```
+
+### 4. Placeable „Sala Trofeów"
+
+Stwórz w toolsecie placeable (np. szafa z trofeami, witryna)
+i ustaw jego skrypt OnUsed na `test_trph`.
+
+Dla RP-bossów i Named NPC ustaw na kreaturze zmienną lokalną:
+
+```
+TRPH_FORCE_DROP  (int)  = 1
+```
+
+To gwarantuje drop trofeum niezależnie od losowania 40%.
+
+### 5. HAK (opcjonalny, ale zalecany)
+
+System działa bez HAK-a, używając fallback resrefów z gry
+bazowej. Żeby mieć własne grafiki trofeów i talizmanów:
+
+| Resref            | Opis                         |
+|-------------------|------------------------------|
+| `trph_trophy_0`   | Czaszka nieumarłego          |
+| `trph_trophy_1`   | Demoniczny kieł              |
+| `trph_trophy_2`   | Smocza łuska                 |
+| `trph_trophy_3`   | Kły bestii                   |
+| `trph_trophy_4`   | Skalp                        |
+| `trph_trophy_5`   | Rdzeń golema                 |
+| `trph_tal_0_min`  | Talizman mały — nieumarli    |
+| `trph_tal_0_maj`  | Talizman wielki — nieumarli  |
+| *(analogicznie dla kat. 1–5)* |                |
+
+Fallback dla trofeów: `nw_it_msmlmisc22` (drobne przedmioty misc).
+Fallback dla talizmanów: `nw_it_mneck001` (amulet) z dynamicznymi
+właściwościami.
+
+## Co celowo pominięto
+
+- **Szybki zapis animacji** ani efektów wizualnych na placeable —
+  to decyzja stylistyczna serwera.
+- **Osobny ekwipunek/magazyn trofeów** w NUI — gracz trzyma je
+  w inventory jak normalny item, dopóki nie złoży w Sali.
+- **Powiadomienie o nowym rekordzie** (serwer-wide) — można dodać
+  jako rozszerzenie w `TrphAddDeposit`, jeśli potrzebne.
+- **Limity talizmanów** (jeden na typ per postać) — można dodać
+  przez sprawdzenie GetItemPossessedBy lub SQL.
+
+## SQL — schemat
+
+```sql
+CREATE TABLE IF NOT EXISTS trph_records (
+    pc_uuid       TEXT NOT NULL,
+    pc_name       TEXT NOT NULL DEFAULT '',
+    cat_id        INTEGER NOT NULL,
+    deposited     INTEGER NOT NULL DEFAULT 0,
+    crafted_minor INTEGER NOT NULL DEFAULT 0,
+    crafted_major INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (pc_uuid, cat_id)
+);
+```
+
+Plik kampanii: `trph` → na dysku `trph.nwn` obok pliku modułu.

--- a/Trophy Hall/Scripts/lib_nui.nss
+++ b/Trophy Hall/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Trophy Hall/Scripts/lib_nui_utility.nss
+++ b/Trophy Hall/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Trophy Hall/Scripts/lib_trph.nss
+++ b/Trophy Hall/Scripts/lib_trph.nss
@@ -1,0 +1,411 @@
+// lib_trph.nss — Trophy Hall: NUI layout, feed functions, deposit + crafting logic
+
+#include "lib_trph_def"
+
+// ============================================================
+// Forward declarations
+// ============================================================
+
+void TrphCreateWindow(object oPC);
+void TrphFeedCategories(object oPC, int nToken);
+void TrphFeedDetail(object oPC, int nToken, int nCat);
+int  TrphCountInInventory(object oPC, int nCat);
+int  TrphDepositTrophies(object oPC, int nCat);
+void TrphForgeTalisman(object oPC, int nToken, int nCat, int bMajor);
+
+// ============================================================
+// NUI — Category list (left column)
+// ============================================================
+
+json TrphBuildCatList(object oPC)
+{
+    float fRowH  = GetNuiScaleDimension(oPC, 38.0);
+    float fListH = GetNuiScaleDimension(oPC, 400.0);
+    float fW     = GetNuiScaleDimension(oPC, 160.0);
+
+    json jNameCell = NuiLabel(
+        NuiBind(TRPH_BIND_CAT_LABEL),
+        JsonInt(NUI_HALIGN_LEFT),
+        JsonInt(NUI_VALIGN_MIDDLE));
+
+    json jCellGrp = NuiGroup(
+        NuiRow(JsonArrayInsert(JsonArray(), jNameCell)),
+        TRUE, NUI_SCROLLBARS_NONE);
+    jCellGrp = NuiId(jCellGrp, TRPH_BTN_CAT_ROW);
+    jCellGrp = NuiEncouraged(jCellGrp, NuiBind(TRPH_BIND_CAT_ENC));
+
+    json jTmpl = JsonArrayInsert(
+        JsonArray(),
+        NuiListTemplateCell(jCellGrp, 0.0, TRUE));
+
+    json jList = NuiList(jTmpl, JsonInt(TRPH_CAT_COUNT), fRowH);
+    jList = NuiHeight(jList, fListH);
+
+    return NuiWidth(NuiCol(JsonArrayInsert(JsonArray(), jList)), fW);
+}
+
+// ============================================================
+// NUI — Detail panel (right column)
+// ============================================================
+
+json TrphBuildDetailPanel(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 32.0);
+    float fFlvH  = GetNuiScaleDimension(oPC, 90.0);
+    float fLbH   = GetNuiScaleDimension(oPC, 132.0);
+    float fRowH  = GetNuiScaleDimension(oPC, 24.0);
+    float fLblH  = GetNuiScaleDimension(oPC, 24.0);
+
+    // ---- Title ----
+    json jTitle = NuiLabel(
+        NuiBind(TRPH_BIND_DET_TITLE),
+        JsonInt(NUI_HALIGN_LEFT),
+        JsonInt(NUI_VALIGN_MIDDLE));
+    jTitle = NuiHeight(jTitle, GetNuiScaleDimension(oPC, 30.0));
+
+    // ---- Flavor text (scrollable block) ----
+    json jFlavor = NuiGroup(
+        NuiText(NuiBind(TRPH_BIND_DET_FLAVOR), FALSE),
+        TRUE, NUI_SCROLLBARS_NONE);
+    jFlavor = NuiHeight(jFlavor, fFlvH);
+
+    // ---- "Twoje trofea: X dostępnych" ----
+    json jMyCount = NuiLabel(
+        NuiBind(TRPH_BIND_MY_COUNT),
+        JsonInt(NUI_HALIGN_LEFT),
+        JsonInt(NUI_VALIGN_MIDDLE));
+    jMyCount = NuiHeight(jMyCount, fLblH);
+
+    // ---- Craft cost reminder ----
+    json jCraftInfo = NuiLabel(
+        NuiBind(TRPH_BIND_CRAFT_INFO),
+        JsonInt(NUI_HALIGN_LEFT),
+        JsonInt(NUI_VALIGN_MIDDLE));
+    jCraftInfo = NuiHeight(jCraftInfo, fLblH);
+
+    // ---- Leaderboard header ----
+    json jLbHdr = NuiLabel(
+        JsonString("Ranking myśliwych:"),
+        JsonInt(NUI_HALIGN_LEFT),
+        JsonInt(NUI_VALIGN_MIDDLE));
+    jLbHdr = NuiHeight(jLbHdr, GetNuiScaleDimension(oPC, 20.0));
+
+    // ---- Leaderboard list (fixed TRPH_LB_ROWS rows) ----
+    json jLbName  = NuiLabel(NuiBind(TRPH_BIND_LB_NAME),  JsonInt(NUI_HALIGN_LEFT),  JsonInt(NUI_VALIGN_MIDDLE));
+    json jLbCount = NuiLabel(NuiBind(TRPH_BIND_LB_COUNT), JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jLbCount = NuiWidth(jLbCount, GetNuiScaleDimension(oPC, 60.0));
+
+    json jLbCellRow = JsonArray();
+    jLbCellRow = JsonArrayInsert(jLbCellRow, jLbName);
+    jLbCellRow = JsonArrayInsert(jLbCellRow, jLbCount);
+
+    json jLbCell = NuiGroup(NuiRow(jLbCellRow), FALSE, NUI_SCROLLBARS_NONE);
+    json jLbTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jLbCell, 0.0, TRUE));
+    json jLbList = NuiList(jLbTmpl, JsonInt(TRPH_LB_ROWS), fRowH);
+    jLbList = NuiHeight(jLbList, fLbH);
+
+    // ---- Action buttons ----
+    json jDepBtn = NuiButton(JsonString("Złóż trofea"));
+    jDepBtn = NuiId(jDepBtn, TRPH_BTN_DEPOSIT);
+    jDepBtn = NuiEnabled(jDepBtn, NuiBind(TRPH_BIND_DEP_ENA));
+    jDepBtn = NuiWidth(jDepBtn, GetNuiScaleDimension(oPC, 140.0));
+    jDepBtn = NuiHeight(jDepBtn, fBtnH);
+
+    json jFMinBtn = NuiButton(JsonString("Wykuj Talizman  (5)"));
+    jFMinBtn = NuiId(jFMinBtn, TRPH_BTN_FORGE_MINOR);
+    jFMinBtn = NuiEnabled(jFMinBtn, NuiBind(TRPH_BIND_FMIN_ENA));
+    jFMinBtn = NuiWidth(jFMinBtn, GetNuiScaleDimension(oPC, 180.0));
+    jFMinBtn = NuiHeight(jFMinBtn, fBtnH);
+
+    json jFMajBtn = NuiButton(JsonString("Wykuj Wielki Talizman  (15)"));
+    jFMajBtn = NuiId(jFMajBtn, TRPH_BTN_FORGE_MAJOR);
+    jFMajBtn = NuiEnabled(jFMajBtn, NuiBind(TRPH_BIND_FMAJ_ENA));
+    jFMajBtn = NuiWidth(jFMajBtn, GetNuiScaleDimension(oPC, 220.0));
+    jFMajBtn = NuiHeight(jFMajBtn, fBtnH);
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, jDepBtn);
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jFMinBtn);
+    jBtnRow = JsonArrayInsert(jBtnRow, jFMajBtn);
+
+    // ---- Assemble detail column ----
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jTitle);
+    jCol = JsonArrayInsert(jCol, jFlavor);
+    jCol = JsonArrayInsert(jCol, jMyCount);
+    jCol = JsonArrayInsert(jCol, jCraftInfo);
+    jCol = JsonArrayInsert(jCol, jLbHdr);
+    jCol = JsonArrayInsert(jCol, jLbList);
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+
+    return NuiCol(jCol);
+}
+
+// ============================================================
+// Window creation / refresh
+// ============================================================
+
+void TrphCreateWindow(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, TRPH_WINDOW);
+    if(nToken != 0)
+    {
+        // Already open — just refresh data
+        TrphFeedCategories(oPC, nToken);
+        TrphFeedDetail(oPC, nToken, GetLocalInt(oPC, TRPH_LVAR_SEL_CAT));
+        return;
+    }
+
+    float fW = GetNuiScaleDimension(oPC, TRPH_W);
+    float fH = GetNuiScaleDimension(oPC, TRPH_H);
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - fW) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - fH) / 2.0;
+    json jGeom = NuiRect(fCX, fCY, fW, fH);
+
+    // Close button (top-right)
+    json jCloseBtn = NuiButton(JsonString("X"));
+    jCloseBtn = NuiId(jCloseBtn, TRPH_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn,  GetNuiScaleDimension(oPC, 30.0));
+    jCloseBtn = NuiHeight(jCloseBtn, GetNuiScaleDimension(oPC, 30.0));
+
+    json jTopBar = JsonArray();
+    jTopBar = JsonArrayInsert(jTopBar, NuiSpacer());
+    jTopBar = JsonArrayInsert(jTopBar, jCloseBtn);
+
+    // Content: cat list | spacer | detail
+    json jSep = NuiWidth(
+        NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer())),
+        GetNuiScaleDimension(oPC, 8.0));
+
+    json jContent = JsonArray();
+    jContent = JsonArrayInsert(jContent, TrphBuildCatList(oPC));
+    jContent = JsonArrayInsert(jContent, jSep);
+    jContent = JsonArrayInsert(jContent, TrphBuildDetailPanel(oPC));
+
+    json jRoot = JsonArray();
+    jRoot = JsonArrayInsert(jRoot, NuiRow(jTopBar));
+    jRoot = JsonArrayInsert(jRoot, NuiRow(jContent));
+
+    json jWin = NuiWindow(
+        NuiCol(jRoot),
+        JsonString("Sala Trofeów"),
+        NuiBind(TRPH_BIND_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    nToken = NuiCreate(oPC, jWin, TRPH_WINDOW, TRPH_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, TRPH_BIND_GEOM, jGeom);
+
+    SetLocalInt(oPC, TRPH_LVAR_SEL_CAT, TRPH_CAT_UNDEAD);
+    TrphFeedCategories(oPC, nToken);
+    TrphFeedDetail(oPC, nToken, TRPH_CAT_UNDEAD);
+}
+
+// ============================================================
+// Feed — category list
+// ============================================================
+
+void TrphFeedCategories(object oPC, int nToken)
+{
+    int nSel = GetLocalInt(oPC, TRPH_LVAR_SEL_CAT);
+
+    json jLabels = JsonArray();
+    json jEncs   = JsonArray();
+
+    int i;
+    for(i = 0; i < TRPH_CAT_COUNT; i++)
+    {
+        int nAvail  = TrphGetAvailable(oPC, i);
+        int nInInv  = TrphCountInInventory(oPC, i);
+        string sLbl = TrphCatName(i);
+        if(nAvail > 0 || nInInv > 0)
+        {
+            // Show total (deposited available + inventory) so player sees their "wealth"
+            int nTotal = nAvail + nInInv;
+            sLbl = sLbl + "  (" + IntToString(nTotal) + ")";
+        }
+        jLabels = JsonArrayInsert(jLabels, JsonString(sLbl));
+        jEncs   = JsonArrayInsert(jEncs,   JsonBool(i == nSel));
+    }
+
+    NuiSetBind(oPC, nToken, TRPH_BIND_CAT_LABEL, jLabels);
+    NuiSetBind(oPC, nToken, TRPH_BIND_CAT_ENC,   jEncs);
+}
+
+// ============================================================
+// Feed — detail panel for selected category
+// ============================================================
+
+void TrphFeedDetail(object oPC, int nToken, int nCat)
+{
+    int nDeposited = TrphGetDeposited(oPC, nCat);
+    int nAvail     = TrphGetAvailable(oPC, nCat);
+    int nInInv     = TrphCountInInventory(oPC, nCat);
+    int nCrMin     = TrphGetCraftedMinor(oPC, nCat);
+    int nCrMaj     = TrphGetCraftedMajor(oPC, nCat);
+
+    string sTitle  = TrphCatName(nCat) + "  —  " + TrphItemName(nCat);
+    string sFlavor = TrphCatFlavor(nCat);
+
+    string sMyCnt  = "Twoje trofea: " + IntToString(nAvail) + " dostępnych"
+                   + "  |  złożone: " + IntToString(nDeposited)
+                   + "  |  w ekwipunku: " + IntToString(nInInv);
+
+    string sCraft  = "Talizman mały: 5 trofeów (+1 AB)  |  Wielki talizman: 15 trofeów (+2 AB, +1k6 obrażeń)"
+                   + "  |  wykute: " + IntToString(nCrMin) + " / " + IntToString(nCrMaj);
+
+    NuiSetBind(oPC, nToken, TRPH_BIND_DET_TITLE,  JsonString(sTitle));
+    NuiSetBind(oPC, nToken, TRPH_BIND_DET_FLAVOR, JsonString(sFlavor));
+    NuiSetBind(oPC, nToken, TRPH_BIND_MY_COUNT,   JsonString(sMyCnt));
+    NuiSetBind(oPC, nToken, TRPH_BIND_CRAFT_INFO, JsonString(sCraft));
+
+    NuiSetBind(oPC, nToken, TRPH_BIND_DEP_ENA,  JsonBool(nInInv > 0));
+    NuiSetBind(oPC, nToken, TRPH_BIND_FMIN_ENA, JsonBool(nAvail >= TRPH_CRAFT_MINOR));
+    NuiSetBind(oPC, nToken, TRPH_BIND_FMAJ_ENA, JsonBool(nAvail >= TRPH_CRAFT_MAJOR));
+
+    // Leaderboard — pad to TRPH_LB_ROWS
+    json jLb     = TrphGetLeaderboard(nCat);
+    int  nLbLen  = JsonGetLength(jLb);
+
+    json jNames  = JsonArray();
+    json jCounts = JsonArray();
+
+    int i;
+    for(i = 0; i < TRPH_LB_ROWS; i++)
+    {
+        if(i < nLbLen)
+        {
+            json jRow    = JsonArrayGet(jLb, i);
+            string sName = JsonGetString(JsonObjectGet(jRow, "pc_name"));
+            int nDep     = JsonGetInt   (JsonObjectGet(jRow, "deposited"));
+            jNames  = JsonArrayInsert(jNames,  JsonString(IntToString(i + 1) + ".  " + sName));
+            jCounts = JsonArrayInsert(jCounts, JsonString(IntToString(nDep)));
+        }
+        else
+        {
+            jNames  = JsonArrayInsert(jNames,  JsonString("—"));
+            jCounts = JsonArrayInsert(jCounts, JsonString(""));
+        }
+    }
+
+    NuiSetBind(oPC, nToken, TRPH_BIND_LB_NAME,  jNames);
+    NuiSetBind(oPC, nToken, TRPH_BIND_LB_COUNT, jCounts);
+}
+
+// ============================================================
+// Inventory helpers
+// ============================================================
+
+int TrphCountInInventory(object oPC, int nCat)
+{
+    string sTag  = TRPH_ITEM_TAG + IntToString(nCat);
+    int    nCount = 0;
+    object oItem  = GetFirstItemInInventory(oPC);
+    while(GetIsObjectValid(oItem))
+    {
+        if(GetTag(oItem) == sTag)
+            nCount++;
+        oItem = GetNextItemInInventory(oPC);
+    }
+    return nCount;
+}
+
+// Destroys all matching trophy items in PC inventory, records in SQL.
+// Returns number deposited.
+int TrphDepositTrophies(object oPC, int nCat)
+{
+    string sTag  = TRPH_ITEM_TAG + IntToString(nCat);
+    int    nCount = 0;
+    object oItem  = GetFirstItemInInventory(oPC);
+    while(GetIsObjectValid(oItem))
+    {
+        object oNext = GetNextItemInInventory(oPC);
+        if(GetTag(oItem) == sTag)
+        {
+            nCount++;
+            DestroyObject(oItem);
+        }
+        oItem = oNext;
+    }
+    if(nCount > 0)
+        TrphAddDeposit(oPC, nCat, nCount);
+    return nCount;
+}
+
+// ============================================================
+// Crafting — forge talisman
+// ============================================================
+
+void TrphForgeTalisman(object oPC, int nToken, int nCat, int bMajor)
+{
+    int nCost  = bMajor ? TRPH_CRAFT_MAJOR : TRPH_CRAFT_MINOR;
+    int nAvail = TrphGetAvailable(oPC, nCat);
+
+    if(nAvail < nCost)
+    {
+        SendMessageToPC(oPC, "[Trofea] Za mało złożonych trofeów — brakuje " + IntToString(nCost - nAvail) + ".");
+        return;
+    }
+
+    // Try custom resref from HAK first; fall back to generic amulet
+    string sSuffix = bMajor ? "_maj" : "_min";
+    string sResref = TRPH_TALISMAN_RESREF_BASE + IntToString(nCat) + sSuffix;
+    object oItem   = CreateItemOnObject(sResref, oPC);
+
+    if(!GetIsObjectValid(oItem))
+    {
+        // Fallback: generic amulet with dynamic item properties
+        oItem = CreateItemOnObject("nw_it_mneck001", oPC);
+    }
+
+    if(!GetIsObjectValid(oItem))
+    {
+        SendMessageToPC(oPC, "[Trofea] Nie udało się wykuć talizmanu. Skontaktuj się z administratorem.");
+        return;
+    }
+
+    string sTalName = bMajor ? TrphTalismanMajorName(nCat) : TrphTalismanMinorName(nCat);
+    SetName(oItem, sTalName);
+    SetTag(oItem, "trph_talisman_" + IntToString(nCat) + sSuffix);
+
+    int nIPRacial = TrphCatIPRacial(nCat);
+    if(nIPRacial >= 0)
+    {
+        int nABBonus = bMajor ? 2 : 1;
+        AddItemProperty(DURATION_TYPE_PERMANENT,
+            ItemPropertyAttackBonusVsRace(nIPRacial, nABBonus),
+            oItem);
+
+        if(bMajor)
+            AddItemProperty(DURATION_TYPE_PERMANENT,
+                ItemPropertyDamageVsRace(nIPRacial, IP_CONST_DAMAGEBONUS_1d6),
+                oItem);
+    }
+
+    // Flavor description
+    string sDesc = "Talizman wykuty z trofeów: " + TrphCatName(nCat) + ". "
+                 + (bMajor
+                    ? "Potężna magia łowiecka chroni swego właściciela i wzmacnia ciosy."
+                    : "Podstawowa magia łowiecka czyni myśliwego groźniejszym.");
+    SetDescription(oItem, sDesc);
+
+    // Record crafting cost
+    if(bMajor)
+        TrphAddCraftedMajor(oPC, nCat);
+    else
+        TrphAddCraftedMinor(oPC, nCat);
+
+    string sMsg = bMajor
+        ? "Wykuto Wielki Talizman: " + sTalName + "."
+        : "Wykuto Talizman: " + sTalName + ".";
+    SendMessageToPC(oPC, "[Trofea] " + sMsg);
+    FloatingTextStringOnCreature(sTalName + " — gotowe!", oPC, FALSE);
+
+    // Refresh UI
+    TrphFeedCategories(oPC, nToken);
+    TrphFeedDetail(oPC, nToken, nCat);
+}

--- a/Trophy Hall/Scripts/lib_trph_def.nss
+++ b/Trophy Hall/Scripts/lib_trph_def.nss
@@ -1,0 +1,203 @@
+// lib_trph_def.nss — Trophy Hall: constants, category data, NUI bind IDs
+
+#include "lib_nui"
+#include "sql_trph"
+
+// ============================================================
+// Category IDs
+// ============================================================
+
+const int TRPH_CAT_UNDEAD    = 0;
+const int TRPH_CAT_OUTSIDER  = 1;
+const int TRPH_CAT_DRAGON    = 2;
+const int TRPH_CAT_ANIMAL    = 3;
+const int TRPH_CAT_HUMANOID  = 4;
+const int TRPH_CAT_CONSTRUCT = 5;
+const int TRPH_CAT_COUNT     = 6;
+
+// Trophy item tag base: TRPH_ITEM_TAG + IntToString(nCat)
+const string TRPH_ITEM_TAG = "trph_trophy_";
+
+// Custom talisman resref base (HAK): trph_tal_<cat>_min / trph_tal_<cat>_maj
+// Falls back to nw_it_mneck001 (amulet) with dynamic properties if resref missing.
+const string TRPH_TALISMAN_RESREF_BASE = "trph_tal_";
+
+// Crafting thresholds
+const int TRPH_CRAFT_MINOR = 5;
+const int TRPH_CRAFT_MAJOR = 15;
+
+// ============================================================
+// Window / bind / button IDs
+// ============================================================
+
+const string TRPH_WINDOW          = "TRPH_WINDOW";
+const string TRPH_EV_SCRIPT       = "lib_trph_ev";
+
+const string TRPH_BIND_GEOM       = "trph_geom";
+const string TRPH_BIND_CAT_LABEL  = "trph_cat_lbl";
+const string TRPH_BIND_CAT_ENC    = "trph_cat_enc";
+const string TRPH_BIND_DET_TITLE  = "trph_det_title";
+const string TRPH_BIND_DET_FLAVOR = "trph_det_flavor";
+const string TRPH_BIND_MY_COUNT   = "trph_my_count";
+const string TRPH_BIND_CRAFT_INFO = "trph_craft_info";
+const string TRPH_BIND_DEP_ENA    = "trph_dep_ena";
+const string TRPH_BIND_FMIN_ENA   = "trph_fmin_ena";
+const string TRPH_BIND_FMAJ_ENA   = "trph_fmaj_ena";
+const string TRPH_BIND_LB_NAME    = "trph_lb_name";
+const string TRPH_BIND_LB_COUNT   = "trph_lb_count";
+
+const string TRPH_BTN_CLOSE       = "trph_btn_close";
+const string TRPH_BTN_CAT_ROW     = "trph_btn_cat";
+const string TRPH_BTN_DEPOSIT     = "trph_btn_deposit";
+const string TRPH_BTN_FORGE_MINOR = "trph_btn_fmin";
+const string TRPH_BTN_FORGE_MAJOR = "trph_btn_fmaj";
+
+// Local variable on PC: currently selected category index
+const string TRPH_LVAR_SEL_CAT   = "TRPH_SEL_CAT";
+
+// Window dimensions (pre-scale)
+const float TRPH_W  = 700.0;
+const float TRPH_H  = 500.0;
+// Leaderboard rows (always rendered; empty rows show "—")
+const int   TRPH_LB_ROWS = 5;
+
+// ============================================================
+// Category metadata
+// ============================================================
+
+string TrphCatName(int nCat)
+{
+    switch(nCat)
+    {
+        case TRPH_CAT_UNDEAD:    return "Nieumarli";
+        case TRPH_CAT_OUTSIDER:  return "Demony";
+        case TRPH_CAT_DRAGON:    return "Smoki";
+        case TRPH_CAT_ANIMAL:    return "Bestie";
+        case TRPH_CAT_HUMANOID:  return "Humanoidy";
+        case TRPH_CAT_CONSTRUCT: return "Konstrukty";
+    }
+    return "Nieznane";
+}
+
+string TrphCatFlavor(int nCat)
+{
+    switch(nCat)
+    {
+        case TRPH_CAT_UNDEAD:
+            return "Szczątki nieumarłych emanują gnijącą mocą. "
+                 + "Zbiór trofeów hartuje duszę myśliwego przeciw zimnej grozie nieśmierci. "
+                 + "Czaszka licha różni się od czaszki upiora — znawca pozna różnicę.";
+        case TRPH_CAT_OUTSIDER:
+            return "Demony i pozaplanarni najeźdźcy zostawiają po sobie substancje, "
+                 + "które palą zwykłe drewno. Kieł demona, zebrany z wiarą, "
+                 + "staje się pieczęcią chroniącą przed demonicznymi sztuczkami.";
+        case TRPH_CAT_DRAGON:
+            return "Smocze łuski przetrwają wieki po śmierci ich właściciela. "
+                 + "Każda z nich to świadectwo odwagi — lub głupoty — myśliwego. "
+                 + "Najcenniejsi kolekcjonerzy milczą o tym, jak je zdobyli.";
+        case TRPH_CAT_ANIMAL:
+            return "Kły, pazury i skóry dzikich bestii. "
+                 + "Prawo ciemnego lasu jest proste: silniejszy pożera słabszego. "
+                 + "Noszenie zębów pokonanej bestii mówi jej pobratymcom: tu poluje ktoś groźniejszy.";
+        case TRPH_CAT_HUMANOID:
+            return "Skalpy i połamane ostrza wrogich wojowników — mroczny zwyczaj "
+                 + "granicznych rubieży. Nie każdy, kto nosi ludzką twarz, "
+                 + "zasługuje na miłosierdzie. Myśliwy zbiera dowody swoich wyroków.";
+        case TRPH_CAT_CONSTRUCT:
+            return "Odłamki golemów, rdzewiejące tryby mechanizmów, wytłuczone kryształy. "
+                 + "Pamiątki po mądrości magów, którzy tworzyli posłuszne narzędzia śmierci. "
+                 + "Rdzeń golema pulsuje martwą magią — nawet po rozpadzie konstrukcji.";
+    }
+    return "";
+}
+
+string TrphItemName(int nCat)
+{
+    switch(nCat)
+    {
+        case TRPH_CAT_UNDEAD:    return "Czaszka Nieumarłego";
+        case TRPH_CAT_OUTSIDER:  return "Demoniczny Kieł";
+        case TRPH_CAT_DRAGON:    return "Smocza Łuska";
+        case TRPH_CAT_ANIMAL:    return "Kły Bestii";
+        case TRPH_CAT_HUMANOID:  return "Skalp";
+        case TRPH_CAT_CONSTRUCT: return "Rdzeń Golema";
+    }
+    return "Trofeum";
+}
+
+string TrphTalismanMinorName(int nCat)
+{
+    switch(nCat)
+    {
+        case TRPH_CAT_UNDEAD:    return "Amulet Myśliwego Nieumarłych";
+        case TRPH_CAT_OUTSIDER:  return "Pieczęć Pogromcy Demonów";
+        case TRPH_CAT_DRAGON:    return "Łuska Pogromcy Smoków";
+        case TRPH_CAT_ANIMAL:    return "Kieł Łowcy Bestii";
+        case TRPH_CAT_HUMANOID:  return "Pętla Łowcy Skalp";
+        case TRPH_CAT_CONSTRUCT: return "Fragment Magicznego Rdzenia";
+    }
+    return "Talizman Myśliwego";
+}
+
+string TrphTalismanMajorName(int nCat)
+{
+    switch(nCat)
+    {
+        case TRPH_CAT_UNDEAD:    return "Pieczęć Nieustraszonych — Bane Nieumarłych";
+        case TRPH_CAT_OUTSIDER:  return "Znak Pogromcy Piekła";
+        case TRPH_CAT_DRAGON:    return "Serce Smoczego Pogromcy";
+        case TRPH_CAT_ANIMAL:    return "Korona Dzikiego Łowcy";
+        case TRPH_CAT_HUMANOID:  return "Krwawa Pętla Zbrojmistrza";
+        case TRPH_CAT_CONSTRUCT: return "Wielki Rdzeń Golemobójcy";
+    }
+    return "Wielki Talizman Myśliwego";
+}
+
+// Returns RACIAL_TYPE_* constant used to identify creature category on death.
+int TrphCatRacialType(int nCat)
+{
+    switch(nCat)
+    {
+        case TRPH_CAT_UNDEAD:    return RACIAL_TYPE_UNDEAD;
+        case TRPH_CAT_OUTSIDER:  return RACIAL_TYPE_OUTSIDER;
+        case TRPH_CAT_DRAGON:    return RACIAL_TYPE_DRAGON;
+        case TRPH_CAT_ANIMAL:    return RACIAL_TYPE_ANIMAL;
+        case TRPH_CAT_HUMANOID:  return RACIAL_TYPE_HUMANOID_HUMAN;
+        case TRPH_CAT_CONSTRUCT: return RACIAL_TYPE_CONSTRUCT;
+    }
+    return RACIAL_TYPE_INVALID;
+}
+
+// Returns IP_CONST_RACIALTYPE_* for item property "attack bonus vs race".
+// Returns -1 for categories without a clean IP mapping (handled as generic +AB).
+int TrphCatIPRacial(int nCat)
+{
+    switch(nCat)
+    {
+        case TRPH_CAT_UNDEAD:    return IP_CONST_RACIALTYPE_UNDEAD;
+        case TRPH_CAT_OUTSIDER:  return IP_CONST_RACIALTYPE_OUTSIDER;
+        case TRPH_CAT_DRAGON:    return IP_CONST_RACIALTYPE_DRAGON;
+        case TRPH_CAT_ANIMAL:    return IP_CONST_RACIALTYPE_ANIMAL;
+        case TRPH_CAT_HUMANOID:  return IP_CONST_RACIALTYPE_HUMANOID;
+        case TRPH_CAT_CONSTRUCT: return IP_CONST_RACIALTYPE_CONSTRUCT;
+    }
+    return -1;
+}
+
+// Maps GetRacialType() result to TRPH_CAT_*, returns -1 if not tracked.
+int TrphGetCategory(int nRacialType)
+{
+    switch(nRacialType)
+    {
+        case RACIAL_TYPE_UNDEAD:              return TRPH_CAT_UNDEAD;
+        case RACIAL_TYPE_OUTSIDER:            return TRPH_CAT_OUTSIDER;
+        case RACIAL_TYPE_DRAGON:              return TRPH_CAT_DRAGON;
+        case RACIAL_TYPE_ANIMAL:              return TRPH_CAT_ANIMAL;
+        case RACIAL_TYPE_HUMANOID_HUMAN:      return TRPH_CAT_HUMANOID;
+        case RACIAL_TYPE_HUMANOID_ORC:        return TRPH_CAT_HUMANOID;
+        case RACIAL_TYPE_HUMANOID_GOBLINOID:  return TRPH_CAT_HUMANOID;
+        case RACIAL_TYPE_HUMANOID_REPTILIAN:  return TRPH_CAT_HUMANOID;
+        case RACIAL_TYPE_CONSTRUCT:           return TRPH_CAT_CONSTRUCT;
+    }
+    return -1;
+}

--- a/Trophy Hall/Scripts/lib_trph_ev.nss
+++ b/Trophy Hall/Scripts/lib_trph_ev.nss
@@ -1,0 +1,70 @@
+// lib_trph_ev.nss — Trophy Hall: NUI event handler
+// Assigned as NuiCreate's event script for TRPH_WINDOW.
+
+#include "lib_trph"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    if(nToken != NuiFindWindow(oPC, TRPH_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalInt(oPC, TRPH_LVAR_SEL_CAT);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == TRPH_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        if(sElem == TRPH_BTN_DEPOSIT)
+        {
+            int nCat   = GetLocalInt(oPC, TRPH_LVAR_SEL_CAT);
+            int nCount = TrphDepositTrophies(oPC, nCat);
+            if(nCount > 0)
+                SendMessageToPC(oPC,
+                    "[Trofea] Złożono " + IntToString(nCount) + " trofe"
+                    + (nCount == 1 ? "um" : "a")
+                    + " — " + TrphCatName(nCat) + ". "
+                    + "Sala przyjmuje je z mrocznym szacunkiem.");
+            else
+                SendMessageToPC(oPC, "[Trofea] Nie masz trofeów tej kategorii w ekwipunku.");
+            TrphFeedCategories(oPC, nToken);
+            TrphFeedDetail(oPC, nToken, nCat);
+            return;
+        }
+
+        if(sElem == TRPH_BTN_FORGE_MINOR)
+        {
+            int nCat = GetLocalInt(oPC, TRPH_LVAR_SEL_CAT);
+            TrphForgeTalisman(oPC, nToken, nCat, FALSE);
+            return;
+        }
+
+        if(sElem == TRPH_BTN_FORGE_MAJOR)
+        {
+            int nCat = GetLocalInt(oPC, TRPH_LVAR_SEL_CAT);
+            TrphForgeTalisman(oPC, nToken, nCat, TRUE);
+            return;
+        }
+    }
+
+    // Category row click (left column list)
+    if(sEvent == EVENT_TYPE_MOUSEDOWN && sElem == TRPH_BTN_CAT_ROW)
+    {
+        if(nIdx < 0 || nIdx >= TRPH_CAT_COUNT) return;
+        SetLocalInt(oPC, TRPH_LVAR_SEL_CAT, nIdx);
+        TrphFeedCategories(oPC, nToken);
+        TrphFeedDetail(oPC, nToken, nIdx);
+    }
+}

--- a/Trophy Hall/Scripts/sql_trph.nss
+++ b/Trophy Hall/Scripts/sql_trph.nss
@@ -1,0 +1,138 @@
+// sql_trph.nss — Trophy Hall: SQLite schema + queries
+// Campaign DB name: "trph"
+
+void TrphCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("trph",
+        "CREATE TABLE IF NOT EXISTS trph_records ("
+        "  pc_uuid       TEXT NOT NULL,"
+        "  pc_name       TEXT NOT NULL DEFAULT '',"
+        "  cat_id        INTEGER NOT NULL,"
+        "  deposited     INTEGER NOT NULL DEFAULT 0,"
+        "  crafted_minor INTEGER NOT NULL DEFAULT 0,"
+        "  crafted_major INTEGER NOT NULL DEFAULT 0,"
+        "  PRIMARY KEY (pc_uuid, cat_id)"
+        ")");
+    SqlStep(q);
+}
+
+// Inserts a row for each category if it doesn't exist; updates name.
+void TrphRegisterPlayer(object oPC)
+{
+    string sUuid = GetObjectUUID(oPC);
+    string sName = GetName(oPC);
+    int i;
+    for(i = 0; i < 6; i++)
+    {
+        sqlquery qIns = SqlPrepareQueryCampaign("trph",
+            "INSERT OR IGNORE INTO trph_records (pc_uuid, pc_name, cat_id) "
+            "VALUES (@uuid, @name, @cat)");
+        SqlBindString(qIns, "@uuid", sUuid);
+        SqlBindString(qIns, "@name", sName);
+        SqlBindInt   (qIns, "@cat",  i);
+        SqlStep(qIns);
+
+        sqlquery qUpd = SqlPrepareQueryCampaign("trph",
+            "UPDATE trph_records SET pc_name = @name "
+            "WHERE pc_uuid = @uuid AND cat_id = @cat");
+        SqlBindString(qUpd, "@name", sName);
+        SqlBindString(qUpd, "@uuid", sUuid);
+        SqlBindInt   (qUpd, "@cat",  i);
+        SqlStep(qUpd);
+    }
+}
+
+void TrphAddDeposit(object oPC, int nCat, int nAmount)
+{
+    sqlquery q = SqlPrepareQueryCampaign("trph",
+        "UPDATE trph_records SET deposited = deposited + @amt "
+        "WHERE pc_uuid = @uuid AND cat_id = @cat");
+    SqlBindInt   (q, "@amt",  nAmount);
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@cat",  nCat);
+    SqlStep(q);
+}
+
+void TrphAddCraftedMinor(object oPC, int nCat)
+{
+    sqlquery q = SqlPrepareQueryCampaign("trph",
+        "UPDATE trph_records SET crafted_minor = crafted_minor + 1 "
+        "WHERE pc_uuid = @uuid AND cat_id = @cat");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@cat",  nCat);
+    SqlStep(q);
+}
+
+void TrphAddCraftedMajor(object oPC, int nCat)
+{
+    sqlquery q = SqlPrepareQueryCampaign("trph",
+        "UPDATE trph_records SET crafted_major = crafted_major + 1 "
+        "WHERE pc_uuid = @uuid AND cat_id = @cat");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@cat",  nCat);
+    SqlStep(q);
+}
+
+int TrphGetDeposited(object oPC, int nCat)
+{
+    sqlquery q = SqlPrepareQueryCampaign("trph",
+        "SELECT deposited FROM trph_records "
+        "WHERE pc_uuid = @uuid AND cat_id = @cat");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@cat",  nCat);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+int TrphGetCraftedMinor(object oPC, int nCat)
+{
+    sqlquery q = SqlPrepareQueryCampaign("trph",
+        "SELECT crafted_minor FROM trph_records "
+        "WHERE pc_uuid = @uuid AND cat_id = @cat");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@cat",  nCat);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+int TrphGetCraftedMajor(object oPC, int nCat)
+{
+    sqlquery q = SqlPrepareQueryCampaign("trph",
+        "SELECT crafted_major FROM trph_records "
+        "WHERE pc_uuid = @uuid AND cat_id = @cat");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@cat",  nCat);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// Available = deposited - (minor_crafted * 5) - (major_crafted * 15)
+int TrphGetAvailable(object oPC, int nCat)
+{
+    sqlquery q = SqlPrepareQueryCampaign("trph",
+        "SELECT deposited - (crafted_minor * 5) - (crafted_major * 15) "
+        "FROM trph_records WHERE pc_uuid = @uuid AND cat_id = @cat");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@cat",  nCat);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// Returns JsonArray [{pc_name, deposited}], sorted desc, up to 5 rows.
+json TrphGetLeaderboard(int nCat)
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("trph",
+        "SELECT pc_name, deposited FROM trph_records "
+        "WHERE cat_id = @cat AND deposited > 0 "
+        "ORDER BY deposited DESC LIMIT 5");
+    SqlBindInt(q, "@cat", nCat);
+    while(SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "pc_name",   JsonString(SqlGetString(q, 0)));
+        jRow = JsonObjectSet(jRow, "deposited", JsonInt   (SqlGetInt   (q, 1)));
+        jRows = JsonArrayInsert(jRows, jRow);
+    }
+    return jRows;
+}

--- a/Trophy Hall/Scripts/sys_on_death.nss
+++ b/Trophy Hall/Scripts/sys_on_death.nss
@@ -1,0 +1,46 @@
+// sys_on_death.nss — Trophy Hall: trophy loot spawner
+//
+// Assign this as the OnDeath script for every creature type you want to track.
+// Alternatively, if NWNX_Events is loaded, hook NWNX_ON_CREATURE_KILL_AFTER
+// and call ExecuteScript("sys_on_death", oDeadCreature) from there.
+//
+// Trophy drop rate: 40% per kill.  Bosses/named can override with
+// a local int TRPH_FORCE_DROP = 1 on the creature to guarantee a drop.
+
+#include "lib_trph_def"
+
+void main()
+{
+    object oDead = OBJECT_SELF;
+
+    // Never drop from PCs or DM-possessed creatures
+    if(GetIsPC(oDead) || GetIsDMPossessed(oDead)) return;
+
+    int nRacial = GetRacialType(oDead);
+    int nCat    = TrphGetCategory(nRacial);
+    if(nCat < 0) return;
+
+    // Named/boss creatures can force a drop
+    int bForce = GetLocalInt(oDead, "TRPH_FORCE_DROP");
+    if(!bForce && Random(10) >= 4) return;   // 40% base drop rate
+
+    string sTag    = TRPH_ITEM_TAG + IntToString(nCat);
+    string sName   = TrphItemName(nCat);
+    string sDesc   = "Trofeum: " + TrphCatName(nCat)
+                   + ". Złóż w Sali Trofeów, by potwierdzić swoje łowy.";
+
+    // Try the custom HAK resref first
+    object oItem = CreateItemOnObject(sTag, oDead);
+
+    if(!GetIsObjectValid(oItem))
+    {
+        // Fallback: re-use a generic misc item from base game and overwrite its identity
+        oItem = CreateItemOnObject("nw_it_msmlmisc22", oDead);
+    }
+
+    if(!GetIsObjectValid(oItem)) return;
+
+    SetTag        (oItem, sTag);
+    SetName       (oItem, sName);
+    SetDescription(oItem, sDesc);
+}

--- a/Trophy Hall/Scripts/sys_on_enter.nss
+++ b/Trophy Hall/Scripts/sys_on_enter.nss
@@ -1,0 +1,11 @@
+// sys_on_enter.nss — Trophy Hall: register player rows on module enter
+// Hook: OnClientEnter (or append to existing OnClientEnter)
+
+#include "sql_trph"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC) || GetIsDMPossessed(oPC)) return;
+    TrphRegisterPlayer(oPC);
+}

--- a/Trophy Hall/Scripts/sys_on_load.nss
+++ b/Trophy Hall/Scripts/sys_on_load.nss
@@ -1,0 +1,9 @@
+// sys_on_load.nss — Trophy Hall: module init
+// Hook: OnModuleLoad (or add to existing OnModuleLoad via ExecuteScript)
+
+#include "sql_trph"
+
+void main()
+{
+    TrphCreateTables();
+}

--- a/Trophy Hall/Scripts/test_trph.nss
+++ b/Trophy Hall/Scripts/test_trph.nss
@@ -1,0 +1,20 @@
+// test_trph.nss — Trophy Hall: demo script
+//
+// Assign as OnUsed on a Trophy Hall placeable (e.g., a trophy case or bookshelf).
+// When a PC activates the placeable, the Trophy Hall NUI opens.
+//
+// For testing without a placeable: execute from DM's toolbox or
+// call via ExecuteScript("test_trph", oPC).
+
+#include "lib_trph"
+
+void main()
+{
+    object oUser = GetLastUsedBy();
+    if(!GetIsPC(oUser) || GetIsDMPossessed(oUser)) return;
+
+    // Ensure player is registered (idempotent)
+    TrphRegisterPlayer(oUser);
+
+    TrphCreateWindow(oUser);
+}


### PR DESCRIPTION
## Co to robi

Sala Trofeów to system kolekcjonowania i nagradzania za polowanie na konkretne typy stworów. Gracz zbiera trofea (czaszki, kły, łuski…) ze zwłok wrogów, deponuje je w specjalnym miejscu i wymienia na talizmany z bonusami do walki przeciw odpowiedniemu typowi wroga. Okno NUI pokazuje kolekcję, stan konta trofeów i pięcioosobowy ranking myśliwych na serwer.

## Mechanika

- **Loot on death** (`sys_on_death.nss`): 40% szans na drop trofeum z każdej pobitej kreatury należącej do śledzonych kategorii (nieumarli, demony, smoki, bestie, humanoidy, konstrukty). Bossy/named mogą mieć lokalną zmienną `TRPH_FORCE_DROP = 1` gwarantującą drop.
- **Depozyt** (`TrphDepositTrophies`): gracz otwiera Salę Trofeów (placeable z `test_trph.nss` jako OnUsed), wybiera kategorię i składa wszystkie trofea z ekwipunku. Są niszczone, licznik w SQL rośnie.
- **Kucie talizmanów** (`TrphForgeTalisman`): za 5 trofeów — mały talizman (+1 AB vs typ), za 15 — wielki (+2 AB, +1k6 obrażeń vs typ). Talizman to item (custom resref z HAK lub fallback `nw_it_mneck001`) z dynamicznymi `ItemPropertyAttackBonusVsRace` / `ItemPropertyDamageVsRace`.
- **Ranking**: 5 najlepszych myśliwych per kategoria widocznych w NUI, sortowane po liczbie złożonych trofeów.

## Pliki

```
Trophy Hall/
├── Scripts/
│   ├── lib_trph_def.nss   — stałe, kategorie, bindy NUI, metadata (nazwy, flavor PL)
│   ├── sql_trph.nss        — schemat SQLite + wszystkie zapytania (kampania "trph")
│   ├── lib_trph.nss        — budowanie okna NUI, feed functions, deposit, crafting
│   ├── lib_trph_ev.nss     — handler eventów NUI (click, mousedown, close)
│   ├── sys_on_load.nss     — inicjalizacja tabel na starcie modułu
│   ├── sys_on_enter.nss    — rejestracja gracza przy wejściu
│   ├── sys_on_death.nss    — spawn trofeum na zwłokach kreatury
│   ├── test_trph.nss       — OnUsed placeable otwierający Salę Trofeów
│   ├── lib_nui.nss         — shared NUI helpers (kopia z Mailbox)
│   └── lib_nui_utility.nss — shared NUI utilities (kopia z Mailbox)
└── INTEGRATION.md          — instrukcja podpięcia hooków, opcja NWNX_Events, HAK
```

**~908 LOC własnego NWScript** (lib_trph_def + sql_trph + lib_trph + lib_trph_ev + hooki).

## Zależności

- **NWN:EE ≥ 8193.36** — wymaga NUI + `SqlPrepareQueryCampaign` + JSON API
- **NWNX** — opcjonalny; tylko jeśli chcesz hookować wszystkie śmierci stworów przez `NWNX_Events` zamiast przypisywać `sys_on_death` ręcznie do blueprintów kreatur (oba warianty opisane w INTEGRATION.md)
- **HAK** — opcjonalny; bez niego system używa `nw_it_msmlmisc22` (trofea) i `nw_it_mneck001` (talizmany) z bazy gry; z HAK-iem pełne resrefy `trph_trophy_*` i `trph_tal_*`

## Jak włączyć w istniejącym module

1. **OnModuleLoad** → `ExecuteScript("sys_on_load", GetModule())`
2. **OnClientEnter** → `ExecuteScript("sys_on_enter", GetEnteringObject())`
3. **OnDeath kreatur** → przypisać `sys_on_death` do blueprintów (lub wrapper nad istniejącym skryptem), albo użyć NWNX_Events (patrz INTEGRATION.md)
4. **Placeable** → stworzyć w toolsecie, ustawić OnUsed na `test_trph`
5. Opcjonalnie dodać resrefy trofeów i talizmanów do HAK

## Co celowo pominięto

- Brak osobnego magazynu trofeów w NUI — trofea siedzą w ekwipunku jak normalny item, co wymusza interakcję z placem Sali
- Brak limitu „jeden talizman per typ per postać" — można dodać przez SQL check w `TrphForgeTalisman`
- Brak animacji / efektów wizualnych na placeable — decyzja estetyczna serwera
- Brak globalnego komunikatu o pobiciu rekordu rankingowego — punkt rozszerzenia w `TrphAddDeposit`
- Brak `.mod` pliku — środowisko budowania .mod niedostępne w pipeline; INTEGRATION.md zastępuje


---
_Generated by [Claude Code](https://claude.ai/code/session_01FTSfLQfmidnYq327mjaQkk)_