### PR TITLE
feat: Nałogi (Vices / Addiction System)

### DIFF
--- a/Vices/INTEGRATION.md
+++ b/Vices/INTEGRATION.md
@@ -1,0 +1,111 @@
+# Nałogi (Vices) — Integration Guide
+
+## Hooks wymagane w module
+
+Podepnij skrypty pod zdarzenia modułu (Tool -> Module Properties -> Events):
+
+| Zdarzenie modułu    | Skrypt do podpięcia | Uwagi                             |
+|---------------------|---------------------|-----------------------------------|
+| OnModuleLoad        | `sys_on_load`       | Tworzy tabele SQL                 |
+| OnClientEnter       | `sys_on_enter`      | Przywraca efekty, startuje tick   |
+| OnClientLeave       | `sys_on_leave`      | Zatrzymuje tick, czyści efekty    |
+
+Jeśli moduł ma już skrypty OnClientEnter/Leave, wywołaj z nich bezpośrednio:
+
+```nss
+// W istniejącym OnClientEnter:
+#include "lib_vic"
+// ...
+VicRestoreEffects(GetEnteringObject());
+VicStartTick(GetEnteringObject());
+```
+
+## NWNX
+
+Brak — moduł używa wyłącznie NWScript + NWN EE NUI + `SqlPrepareQueryCampaign`.
+
+## SQL
+
+Baza kampanii: `"vices"` (plik `vices.sqlite3` w folderze modułu lub kampanii).  
+Tabela tworzona automatycznie przy OnModuleLoad (`CREATE TABLE IF NOT EXISTS`).
+
+## Demo placeable
+
+Stwórz dowolny placeable, ustaw skrypt OnUsed na `test_vic`.  
+Gracz kliknie → otworzy panel Nałogów → może spożywać substancje i próbować odwyku.
+
+## Integracja z systemem przedmiotów
+
+Aby wymagać konkretnego przedmiotu do spożycia, w logice sprzedawcy/item:
+
+```nss
+#include "lib_vic"
+
+// W skrypcie OnUsed na przedmiocie (lub OnActivateItem):
+void main()
+{
+    object oPC   = GetItemActivator();      // lub GetLastUsedBy()
+    object oItem = GetItemActivated();      // przedmiot
+
+    // np. sprawdź tag
+    if(GetTag(oItem) == "vic_moonfire_bottle")
+    {
+        DestroyObject(oItem);               // konsumuje przedmiot
+        VicConsumeDose(oPC, VICE_MOONFIRE);
+    }
+}
+```
+
+Sugerowane tagi przedmiotów:
+
+| Substance         | Tag przedmiotu                |
+|-------------------|-------------------------------|
+| Księżycowy Trunek | `vic_moonfire_bottle`         |
+| Proch Snów        | `vic_dreamdust_pouch`         |
+| Krew Demona       | `vic_demon_blood_vial`        |
+| Czarny Korzeń     | `vic_blackroot_extract`       |
+| Mleko Czarownicy  | `vic_witch_milk_flask`        |
+| Pasta Cienia      | `vic_shadow_paste_jar`        |
+
+## Efekty mechaniczne per substancja
+
+### Księżycowy Trunek (VICE_MOONFIRE = 0)
+- **Nasycony:** +STR, +CON, -INT
+- **Odstawienie:** -STR, -DEX; poziom 4+ dodaje VFX_DUR_BLUR
+
+### Proch Snów (VICE_DREAMDUST = 1)
+- **Nasycony:** +WIS, +CHA, -DEX
+- **Odstawienie:** -WIS, -CHA; poziom 3+ dodaje VFX_DUR_MIND_AFFECTING_NEGATIVE
+
+### Krew Demona (VICE_DEMON_BLOOD = 2)
+- **Nasycony:** +STR+1, +AB (misc), -CHA, aura czerwona
+- **Odstawienie:** -STR+1, -CON; poziom 3+ aura pulsująca
+
+### Czarny Korzeń (VICE_BLACKROOT = 3)
+- **Nasycony:** +CON, immunity:fear, -WIS
+- **Odstawienie:** -CON, -WIS; poziom 2+ VFX_DUR_MIND_AFFECTING_FEAR
+
+### Mleko Czarownicy (VICE_WITCH_MILK = 4)
+- **Nasycony:** +CHA, +Persuade, -CON
+- **Odstawienie:** -CHA, -Persuade
+
+### Pasta Cienia (VICE_SHADOW_PASTE = 5)
+- **Nasycony:** +Hide×2, +Move Silently, Ultravision, -Spot
+- **Odstawienie:** -Hide×2, -Move Silently; poziom 3+ -DEX
+
+## Mechanika uzależnienia
+
+- Poziomy 1–5; poziom 0 = czysta postać.
+- Pierwsze spożycie zawsze daje poziom 1.
+- Każde kolejne spożycie: 20% szans na podniesienie poziomu.
+- Odwyk: 30 min bez dawki + szansa sukcesu (80% na poziomie 1, −15% na każdy poziom, min 10%).
+- Nieudany odwyk przy poziomie 3+ może podnieść poziom o 1 (30% szans).
+- Naturalne oczyszczenie: 24h bez dawki, w stanie odstawienia → poziom −1 automatycznie.
+- Tick sprawdza stan co 60 sekund. Przejścia: Nasycony → Pragnienie → Odstawienie.
+
+## Co celowo pominięto
+
+- Brak wizualnych ikon substancji (wymagałoby pliku HAK z grafikami).
+- Brak integracji z systemem walutowym (zakup dawek od sprzedawcy).
+- Brak powiadomień DM o stanie uzależnienia graczy.
+- Brak logowania historii dawek (tabela ma `total_doses` ale bez timestampów per dawkę).

--- a/Vices/Scripts/lib_nui.nss
+++ b/Vices/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Vices/Scripts/lib_nui_utility.nss
+++ b/Vices/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Vices/Scripts/lib_vic.nss
+++ b/Vices/Scripts/lib_vic.nss
@@ -1,0 +1,586 @@
+// lib_vic.nss — Core logic for the Vices (Nałogi) system.
+// Covers: effect management, NUI window builder, FeedViceWindow,
+//         VicConsumeDose, VicAttemptDetox, VicTick, VicRestoreEffects.
+#include "lib_vic_def"
+
+// ============================================================
+// State derivation
+// ============================================================
+
+// Derives the current runtime state from SQL data + current time.
+int VicGetCurrentState(int nLevel, int nLastDose, int nNow)
+{
+    if(nLevel <= 0) return VICE_STATE_SOBER;
+    int nElapsed = nNow - nLastDose;
+    if(nElapsed < VicCravingOnset(nLevel))    return VICE_STATE_SATISFIED;
+    if(nElapsed < VicWithdrawalOnset(nLevel)) return VICE_STATE_CRAVING;
+    return VICE_STATE_WITHDRAWAL;
+}
+
+// ============================================================
+// Effect management
+// ============================================================
+
+void VicRemoveEffects(object oPC, int nSubstance)
+{
+    string sBuffTag  = VIC_ETAG_BUFF   + IntToString(nSubstance);
+    string sWithTag  = VIC_ETAG_WITHDR + IntToString(nSubstance);
+    effect eEff = GetFirstEffect(oPC);
+    while(GetIsEffectValid(eEff))
+    {
+        string sTag = GetEffectTag(eEff);
+        if(sTag == sBuffTag || sTag == sWithTag)
+            RemoveEffect(oPC, eEff);
+        eEff = GetNextEffect(oPC);
+    }
+}
+
+void VicApplyEffects(object oPC, int nSubstance, int nState, int nLevel)
+{
+    VicRemoveEffects(oPC, nSubstance);
+    if(nState == VICE_STATE_SOBER) return;
+
+    int bBuff   = (nState == VICE_STATE_SATISFIED);
+    string sTag = bBuff ? (VIC_ETAG_BUFF + IntToString(nSubstance))
+                        : (VIC_ETAG_WITHDR + IntToString(nSubstance));
+    int nMag    = VicBuffMagnitude(nLevel);   // 1, 2 or 3
+    int nWMag   = nLevel;                     // withdrawal scales harder
+
+    effect eLink;
+
+    switch(nSubstance)
+    {
+        case VICE_MOONFIRE:
+            if(bBuff)
+            {
+                eLink = TagEffect(EffectAbilityIncrease(ABILITY_STRENGTH, nMag), sTag);
+                eLink = EffectLinkEffects(eLink,
+                    TagEffect(EffectAbilityIncrease(ABILITY_CONSTITUTION, 1), sTag));
+                eLink = EffectLinkEffects(eLink,
+                    TagEffect(EffectAbilityDecrease(ABILITY_INTELLIGENCE, 1), sTag));
+            }
+            else
+            {
+                eLink = TagEffect(EffectAbilityDecrease(ABILITY_STRENGTH, nWMag), sTag);
+                eLink = EffectLinkEffects(eLink,
+                    TagEffect(EffectAbilityDecrease(ABILITY_DEXTERITY, 1), sTag));
+                if(nLevel >= 4)
+                    eLink = EffectLinkEffects(eLink,
+                        TagEffect(EffectVisualEffect(VFX_DUR_BLUR), sTag));
+            }
+            break;
+
+        case VICE_DREAMDUST:
+            if(bBuff)
+            {
+                eLink = TagEffect(EffectAbilityIncrease(ABILITY_WISDOM, nMag), sTag);
+                eLink = EffectLinkEffects(eLink,
+                    TagEffect(EffectAbilityIncrease(ABILITY_CHARISMA, 1), sTag));
+                eLink = EffectLinkEffects(eLink,
+                    TagEffect(EffectAbilityDecrease(ABILITY_DEXTERITY, 1), sTag));
+            }
+            else
+            {
+                eLink = TagEffect(EffectAbilityDecrease(ABILITY_WISDOM, nWMag), sTag);
+                eLink = EffectLinkEffects(eLink,
+                    TagEffect(EffectAbilityDecrease(ABILITY_CHARISMA, 1), sTag));
+                if(nLevel >= 3)
+                    eLink = EffectLinkEffects(eLink,
+                        TagEffect(EffectVisualEffect(VFX_DUR_MIND_AFFECTING_NEGATIVE), sTag));
+            }
+            break;
+
+        case VICE_DEMON_BLOOD:
+            if(bBuff)
+            {
+                eLink = TagEffect(EffectAbilityIncrease(ABILITY_STRENGTH, nMag + 1), sTag);
+                eLink = EffectLinkEffects(eLink,
+                    TagEffect(EffectAttackIncrease(1), sTag));
+                eLink = EffectLinkEffects(eLink,
+                    TagEffect(EffectAbilityDecrease(ABILITY_CHARISMA, nMag), sTag));
+                eLink = EffectLinkEffects(eLink,
+                    TagEffect(EffectVisualEffect(VFX_DUR_AURA_RED), sTag));
+            }
+            else
+            {
+                eLink = TagEffect(EffectAbilityDecrease(ABILITY_STRENGTH, nWMag + 1), sTag);
+                eLink = EffectLinkEffects(eLink,
+                    TagEffect(EffectAbilityDecrease(ABILITY_CONSTITUTION, 1), sTag));
+                if(nLevel >= 3)
+                    eLink = EffectLinkEffects(eLink,
+                        TagEffect(EffectVisualEffect(VFX_DUR_AURA_PULSE_RED), sTag));
+            }
+            break;
+
+        case VICE_BLACKROOT:
+            if(bBuff)
+            {
+                eLink = TagEffect(EffectAbilityIncrease(ABILITY_CONSTITUTION, nMag), sTag);
+                eLink = EffectLinkEffects(eLink,
+                    TagEffect(EffectImmunity(IMMUNITY_TYPE_FEAR), sTag));
+                eLink = EffectLinkEffects(eLink,
+                    TagEffect(EffectAbilityDecrease(ABILITY_WISDOM, 1), sTag));
+            }
+            else
+            {
+                eLink = TagEffect(EffectAbilityDecrease(ABILITY_CONSTITUTION, nWMag), sTag);
+                eLink = EffectLinkEffects(eLink,
+                    TagEffect(EffectAbilityDecrease(ABILITY_WISDOM, 1), sTag));
+                if(nLevel >= 2)
+                    eLink = EffectLinkEffects(eLink,
+                        TagEffect(EffectVisualEffect(VFX_DUR_MIND_AFFECTING_FEAR), sTag));
+            }
+            break;
+
+        case VICE_WITCH_MILK:
+            if(bBuff)
+            {
+                eLink = TagEffect(EffectAbilityIncrease(ABILITY_CHARISMA, nMag), sTag);
+                eLink = EffectLinkEffects(eLink,
+                    TagEffect(EffectSkillIncrease(SKILL_PERSUADE, nMag), sTag));
+                eLink = EffectLinkEffects(eLink,
+                    TagEffect(EffectAbilityDecrease(ABILITY_CONSTITUTION, 1), sTag));
+            }
+            else
+            {
+                eLink = TagEffect(EffectAbilityDecrease(ABILITY_CHARISMA, nWMag), sTag);
+                eLink = EffectLinkEffects(eLink,
+                    TagEffect(EffectSkillDecrease(SKILL_PERSUADE, nWMag), sTag));
+            }
+            break;
+
+        case VICE_SHADOW_PASTE:
+            if(bBuff)
+            {
+                eLink = TagEffect(EffectSkillIncrease(SKILL_HIDE, nMag * 2), sTag);
+                eLink = EffectLinkEffects(eLink,
+                    TagEffect(EffectSkillIncrease(SKILL_MOVE_SILENTLY, nMag), sTag));
+                eLink = EffectLinkEffects(eLink,
+                    TagEffect(EffectUltravision(), sTag));
+                eLink = EffectLinkEffects(eLink,
+                    TagEffect(EffectSkillDecrease(SKILL_SPOT, 1), sTag));
+            }
+            else
+            {
+                eLink = TagEffect(EffectSkillDecrease(SKILL_HIDE, nWMag * 2), sTag);
+                eLink = EffectLinkEffects(eLink,
+                    TagEffect(EffectSkillDecrease(SKILL_MOVE_SILENTLY, nWMag), sTag));
+                if(nLevel >= 3)
+                    eLink = EffectLinkEffects(eLink,
+                        TagEffect(EffectAbilityDecrease(ABILITY_DEXTERITY, 1), sTag));
+            }
+            break;
+
+        default: return;
+    }
+
+    ApplyEffectToObject(DURATION_TYPE_PERMANENT, eLink, oPC);
+}
+
+// ============================================================
+// NUI — window layout
+// ============================================================
+
+json VicBuildSubstanceRow(object oPC, int nSub)
+{
+    float fH    = GetNuiScaleDimension(oPC, 36.0);
+    float fNameW = GetNuiScaleDimension(oPC, 160.0);
+    float fStW   = GetNuiScaleDimension(oPC, 90.0);
+    float fLvW   = GetNuiScaleDimension(oPC, 80.0);
+    float fBtnW  = GetNuiScaleDimension(oPC, 90.0);
+
+    string sS = IntToString(nSub);
+
+    json jName = NuiLabel(NuiBind(VIC_BIND_NAME + sS),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jName = NuiWidth(jName, fNameW);
+    jName = NuiStyleForegroundColor(jName, NuiBind(VIC_BIND_COLOR + sS));
+
+    json jState = NuiLabel(NuiBind(VIC_BIND_STATE + sS),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jState = NuiWidth(jState, fStW);
+    jState = NuiStyleForegroundColor(jState, NuiBind(VIC_BIND_COLOR + sS));
+
+    json jLevel = NuiLabel(NuiBind(VIC_BIND_LEVEL + sS),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jLevel = NuiWidth(jLevel, fLvW);
+
+    json jConsume = NuiButton(JsonString("Spożyj"));
+    jConsume = NuiId(jConsume, VIC_BTN_CONSUME + sS);
+    jConsume = NuiEnabled(jConsume, NuiBind(VIC_BIND_BTENA + sS));
+    jConsume = NuiWidth(jConsume, fBtnW);
+    jConsume = NuiHeight(jConsume, fH);
+
+    json jBreak = NuiButton(JsonString("Odwyk"));
+    jBreak = NuiId(jBreak, VIC_BTN_BREAK + sS);
+    jBreak = NuiEnabled(jBreak, NuiBind(VIC_BIND_CLEAN + sS));
+    jBreak = NuiWidth(jBreak, fBtnW);
+    jBreak = NuiHeight(jBreak, fH);
+
+    json jCells = JsonArray();
+    jCells = JsonArrayInsert(jCells, jName);
+    jCells = JsonArrayInsert(jCells, jState);
+    jCells = JsonArrayInsert(jCells, jLevel);
+    jCells = JsonArrayInsert(jCells, jConsume);
+    jCells = JsonArrayInsert(jCells, jBreak);
+
+    json jRow = NuiRow(jCells);
+    return NuiHeight(jRow, fH);
+}
+
+void VicOpenWindow(object oPC)
+{
+    int nExisting = NuiFindWindow(oPC, VIC_WINDOW);
+    if(nExisting != 0)
+    {
+        FeedViceWindow(oPC, nExisting);
+        return;
+    }
+
+    float fW = 540.0;
+    float fH = 460.0;
+
+    float fNameW = GetNuiScaleDimension(oPC, 160.0);
+    float fStW   = GetNuiScaleDimension(oPC, 90.0);
+    float fLvW   = GetNuiScaleDimension(oPC, 80.0);
+    float fBtnW  = GetNuiScaleDimension(oPC, 90.0);
+    float fHdrH  = GetNuiScaleDimension(oPC, 22.0);
+
+    // Header row
+    json jHName  = NuiWidth(NuiLabel(JsonString("Substancja"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)), fNameW);
+    json jHState = NuiWidth(NuiLabel(JsonString("Stan"),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE)), fStW);
+    json jHLevel = NuiWidth(NuiLabel(JsonString("Uzależnienie"),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE)), fLvW);
+    json jHCons  = NuiWidth(NuiLabel(JsonString(""),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE)), fBtnW);
+    json jHBreak = NuiWidth(NuiLabel(JsonString(""),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE)), fBtnW);
+
+    json jHdrCells = JsonArray();
+    jHdrCells = JsonArrayInsert(jHdrCells, jHName);
+    jHdrCells = JsonArrayInsert(jHdrCells, jHState);
+    jHdrCells = JsonArrayInsert(jHdrCells, jHLevel);
+    jHdrCells = JsonArrayInsert(jHdrCells, jHCons);
+    jHdrCells = JsonArrayInsert(jHdrCells, jHBreak);
+    json jHdrRow = NuiHeight(NuiRow(jHdrCells), fHdrH);
+
+    // Separator
+    json jSep = NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, 2.0));
+
+    // Substance rows
+    json jSubRows = JsonArray();
+    int i;
+    for(i = 0; i < VICE_COUNT; i++)
+        jSubRows = JsonArrayInsert(jSubRows, VicBuildSubstanceRow(oPC, i));
+
+    // Flavor text area
+    json jFlavor = NuiLabel(NuiBind(VIC_BIND_FLAVOR),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jFlavor = NuiHeight(jFlavor, GetNuiScaleDimension(oPC, 52.0));
+
+    // Warning line
+    json jWarning = NuiLabel(NuiBind(VIC_BIND_WARNING),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jWarning = NuiStyleForegroundColor(jWarning, NuiColor(220, 50, 50, 255));
+    jWarning = NuiHeight(jWarning, GetNuiScaleDimension(oPC, 24.0));
+
+    // Build root column
+    json jCols = JsonArray();
+    jCols = JsonArrayInsert(jCols, jHdrRow);
+    jCols = JsonArrayInsert(jCols, jSep);
+    for(i = 0; i < VICE_COUNT; i++)
+        jCols = JsonArrayInsert(jCols, JsonArrayGet(jSubRows, i));
+    jCols = JsonArrayInsert(jCols, NuiSpacer());
+    jCols = JsonArrayInsert(jCols, jFlavor);
+    jCols = JsonArrayInsert(jCols, jWarning);
+
+    json jRoot = NuiCol(jCols);
+
+    json jWin = NuiWindow(jRoot,
+        JsonString("Nałogi"),
+        NuiBind(VIC_WIN_GEOM),
+        JsonBool(FALSE),    // not resizable
+        JsonBool(FALSE),    // not collapsed
+        JsonBool(TRUE),     // closable
+        JsonBool(FALSE),    // not transparent
+        JsonBool(TRUE));    // border
+
+    int nToken = NuiCreate(oPC, jWin, VIC_WINDOW, VIC_EV_SCRIPT);
+    if(nToken == 0) return;
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))
+                 - GetNuiScaleDimension(oPC, fW)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT))
+                 - GetNuiScaleDimension(oPC, fH)) / 2.0;
+    NuiSetBind(oPC, nToken, VIC_WIN_GEOM,
+        NuiRect(fCX, fCY, GetNuiScaleDimension(oPC, fW), GetNuiScaleDimension(oPC, fH)));
+
+    FeedViceWindow(oPC, nToken);
+}
+
+void FeedViceWindow(object oPC, int nToken)
+{
+    int nNow          = VicGetNow();
+    string sFlavor    = "";
+    int nInWithdrawal = 0;
+    int i;
+
+    for(i = 0; i < VICE_COUNT; i++)
+    {
+        string sS    = IntToString(i);
+        json jRec    = VicGetAddict(oPC, i);
+        int nLevel   = 0;
+        int nLastDose = 0;
+        if(JsonGetType(jRec) != JSON_TYPE_NULL)
+        {
+            nLevel    = JsonGetInt(JsonObjectGet(jRec, "level"));
+            nLastDose = JsonGetInt(JsonObjectGet(jRec, "last_dose"));
+        }
+
+        int nState = VicGetCurrentState(nLevel, nLastDose, nNow);
+
+        NuiSetBind(oPC, nToken, VIC_BIND_NAME  + sS, JsonString(VicSubstanceName(i)));
+        NuiSetBind(oPC, nToken, VIC_BIND_STATE + sS, JsonString(VicStateName(nState)));
+        NuiSetBind(oPC, nToken, VIC_BIND_COLOR + sS, VicStateColor(nState));
+
+        string sLvl = (nLevel > 0) ? ("Stopień " + IntToString(nLevel)) : "Brak";
+        NuiSetBind(oPC, nToken, VIC_BIND_LEVEL + sS, JsonString(sLvl));
+
+        NuiSetBind(oPC, nToken, VIC_BIND_BTENA + sS, JsonBool(TRUE));
+        NuiSetBind(oPC, nToken, VIC_BIND_CLEAN + sS, JsonBool(nLevel > 0));
+
+        if(nState == VICE_STATE_WITHDRAWAL) nInWithdrawal++;
+
+        // Most severe active substance gets the flavor text slot.
+        if(nState == VICE_STATE_WITHDRAWAL && sFlavor == "")
+            sFlavor = VicFlavorText(i, nState, nLevel);
+        else if(nState == VICE_STATE_CRAVING && sFlavor == "")
+            sFlavor = VicFlavorText(i, nState, nLevel);
+        else if(nState == VICE_STATE_SATISFIED && sFlavor == "")
+            sFlavor = VicFlavorText(i, nState, nLevel);
+    }
+
+    if(sFlavor == "")
+        sFlavor = "Czysty jak woda ze strumienia... na razie.";
+    NuiSetBind(oPC, nToken, VIC_BIND_FLAVOR, JsonString(sFlavor));
+
+    string sWarn = "";
+    if(nInWithdrawal == 1)
+        sWarn = "UWAGA: Odstawienie aktywne. Szukaj dawki lub wytrzymaj.";
+    else if(nInWithdrawal > 1)
+        sWarn = "UWAGA: Odstawienie aktywne (" + IntToString(nInWithdrawal) + " substancje). Pilnie szukaj dawek.";
+    NuiSetBind(oPC, nToken, VIC_BIND_WARNING, JsonString(sWarn));
+}
+
+// ============================================================
+// Consume dose
+// ============================================================
+
+void VicConsumeDose(object oPC, int nSubstance)
+{
+    if(nSubstance < 0 || nSubstance >= VICE_COUNT) return;
+
+    json jRec  = VicGetAddict(oPC, nSubstance);
+    int nLevel = 0;
+    if(JsonGetType(jRec) != JSON_TYPE_NULL)
+        nLevel = JsonGetInt(JsonObjectGet(jRec, "level"));
+
+    int nNow      = VicGetNow();
+    int nNewLevel = nLevel;
+
+    if(nLevel == 0)
+    {
+        // First exposure — creates level 1 addiction.
+        nNewLevel = 1;
+        string sMsg = "Coś się zmieniło po " + VicSubstanceName(nSubstance) + ". Ciało to zapamięta.";
+        SendMessageToPC(oPC, "[Nałogi] " + sMsg);
+        FloatingTextStringOnCreature(sMsg, oPC, FALSE);
+    }
+    else if(nLevel < 5 && d100(1) <= 20)
+    {
+        // 20% chance to escalate per dose when already addicted.
+        nNewLevel = nLevel + 1;
+        string sMsg = "Uzależnienie od " + VicSubstanceName(nSubstance)
+                    + " wzrosło do stopnia " + IntToString(nNewLevel) + ".";
+        SendMessageToPC(oPC, "[Nałogi] " + sMsg);
+        FloatingTextStringOnCreature(sMsg, oPC, FALSE);
+    }
+
+    VicUpsertDose(oPC, nSubstance, nNewLevel, nNow);
+    SetLocalInt(oPC, VIC_LVAR_STATE_PFX + IntToString(nSubstance), VICE_STATE_SATISFIED);
+    VicApplyEffects(oPC, nSubstance, VICE_STATE_SATISFIED, nNewLevel);
+
+    string sFlavor = VicFlavorText(nSubstance, VICE_STATE_SATISFIED, nNewLevel);
+    FloatingTextStringOnCreature(sFlavor, oPC, FALSE);
+    SendMessageToPC(oPC, "[Nałogi] " + sFlavor);
+
+    int nToken = NuiFindWindow(oPC, VIC_WINDOW);
+    if(nToken != 0) FeedViceWindow(oPC, nToken);
+}
+
+// ============================================================
+// Detox attempt
+// ============================================================
+
+void VicAttemptDetox(object oPC, int nSubstance)
+{
+    if(nSubstance < 0 || nSubstance >= VICE_COUNT) return;
+
+    json jRec = VicGetAddict(oPC, nSubstance);
+    if(JsonGetType(jRec) == JSON_TYPE_NULL) return;
+    int nLevel    = JsonGetInt(JsonObjectGet(jRec, "level"));
+    int nLastDose = JsonGetInt(JsonObjectGet(jRec, "last_dose"));
+    if(nLevel <= 0) return;
+
+    int nNow = VicGetNow();
+    if(nNow - nLastDose < VIC_DETOX_MIN_WAIT)
+    {
+        SendMessageToPC(oPC, "[Nałogi] Nie minęło wystarczająco dużo czasu od ostatniej dawki.");
+        return;
+    }
+
+    // Success chance: 80% at level 1, drops 15% per level (floor 10%).
+    int nChance = 80 - (nLevel - 1) * 15;
+    if(nChance < 10) nChance = 10;
+
+    if(d100(1) <= nChance)
+    {
+        int nNew = nLevel - 1;
+        VicSetLevel(oPC, nSubstance, nNew);
+        if(nNew == 0)
+        {
+            SetLocalInt(oPC, VIC_LVAR_STATE_PFX + IntToString(nSubstance), VICE_STATE_SOBER);
+            VicRemoveEffects(oPC, nSubstance);
+            string sMsg = "Pokonałeś nałóg: " + VicSubstanceName(nSubstance) + ". Ciało krzyczy, ale rozum wygrywa.";
+            SendMessageToPC(oPC, "[Nałogi] " + sMsg);
+            FloatingTextStringOnCreature(sMsg, oPC, FALSE);
+        }
+        else
+        {
+            string sMsg = "Uzależnienie od " + VicSubstanceName(nSubstance)
+                        + " zmniejszyło się do stopnia " + IntToString(nNew) + ".";
+            SendMessageToPC(oPC, "[Nałogi] " + sMsg);
+        }
+    }
+    else
+    {
+        SendMessageToPC(oPC, "[Nałogi] Ciało odmówiło. Odwyk się nie powiódł.");
+        FloatingTextStringOnCreature("Ciało odmówiło posłuszeństwa!", oPC, FALSE);
+        // Failed detox at high addiction may worsen it.
+        if(nLevel >= 3 && d100(1) <= 30)
+        {
+            VicSetLevel(oPC, nSubstance, nLevel + 1 <= 5 ? nLevel + 1 : 5);
+            SendMessageToPC(oPC, "[Nałogi] Przy próbie odwyku uzależnienie wzrosło — ciało odrzuciło wysiłek.");
+        }
+    }
+
+    int nToken = NuiFindWindow(oPC, VIC_WINDOW);
+    if(nToken != 0) FeedViceWindow(oPC, nToken);
+}
+
+// ============================================================
+// Tick — runs every VIC_TICK_INTERVAL seconds per logged-in PC.
+// Checks for state transitions and applies/removes effects accordingly.
+// Also handles natural recovery: 24h clean lowers level by 1.
+// ============================================================
+
+void VicTick(object oPC)
+{
+    if(!GetIsObjectValid(oPC) || !GetIsPC(oPC)) return;
+    if(!GetLocalInt(oPC, VIC_LVAR_TICK)) return;
+
+    int nNow = VicGetNow();
+    int i;
+    for(i = 0; i < VICE_COUNT; i++)
+    {
+        json jRec = VicGetAddict(oPC, i);
+        if(JsonGetType(jRec) == JSON_TYPE_NULL) continue;
+        int nLevel    = JsonGetInt(JsonObjectGet(jRec, "level"));
+        int nLastDose = JsonGetInt(JsonObjectGet(jRec, "last_dose"));
+        if(nLevel <= 0) continue;
+
+        int nState     = VicGetCurrentState(nLevel, nLastDose, nNow);
+        string sKey    = VIC_LVAR_STATE_PFX + IntToString(i);
+        int nLastState = GetLocalInt(oPC, sKey);
+
+        if(nState != nLastState)
+        {
+            SetLocalInt(oPC, sKey, nState);
+            VicApplyEffects(oPC, i, nState, nLevel);
+
+            if(nState == VICE_STATE_CRAVING)
+            {
+                string sMsg = "Pragnienie " + VicSubstanceName(i) + " narasta powoli…";
+                FloatingTextStringOnCreature(sMsg, oPC, FALSE);
+                SendMessageToPC(oPC, "[Nałogi] " + sMsg);
+            }
+            else if(nState == VICE_STATE_WITHDRAWAL)
+            {
+                string sMsg = VicFlavorText(i, VICE_STATE_WITHDRAWAL, nLevel);
+                FloatingTextStringOnCreature(sMsg, oPC, FALSE);
+                SendMessageToPC(oPC, "[Nałogi] " + sMsg);
+            }
+        }
+
+        // Natural recovery: 24h completely clean drops level by 1.
+        if(nState == VICE_STATE_WITHDRAWAL && (nNow - nLastDose) >= 86400)
+        {
+            int nNew = nLevel - 1;
+            if(nNew < 0) nNew = 0;
+            VicSetLevel(oPC, i, nNew);
+            if(nNew == 0)
+            {
+                SetLocalInt(oPC, sKey, VICE_STATE_SOBER);
+                VicRemoveEffects(oPC, i);
+                string sMsg = "Ciało przeszło przez piekło i wyszło czyste z nałogu: "
+                            + VicSubstanceName(i) + ".";
+                FloatingTextStringOnCreature(sMsg, oPC, FALSE);
+                SendMessageToPC(oPC, "[Nałogi] " + sMsg);
+            }
+        }
+    }
+
+    int nToken = NuiFindWindow(oPC, VIC_WINDOW);
+    if(nToken != 0) FeedViceWindow(oPC, nToken);
+
+    DelayCommand(VIC_TICK_INTERVAL, VicTick(oPC));
+}
+
+void VicStartTick(object oPC)
+{
+    if(GetLocalInt(oPC, VIC_LVAR_TICK)) return;
+    SetLocalInt(oPC, VIC_LVAR_TICK, 1);
+    DelayCommand(VIC_TICK_INTERVAL, VicTick(oPC));
+}
+
+void VicStopTick(object oPC)
+{
+    DeleteLocalInt(oPC, VIC_LVAR_TICK);
+}
+
+// Reapplies persisted effects after login.
+void VicRestoreEffects(object oPC)
+{
+    int nNow = VicGetNow();
+    int i;
+    for(i = 0; i < VICE_COUNT; i++)
+    {
+        json jRec = VicGetAddict(oPC, i);
+        if(JsonGetType(jRec) == JSON_TYPE_NULL) continue;
+        int nLevel    = JsonGetInt(JsonObjectGet(jRec, "level"));
+        int nLastDose = JsonGetInt(JsonObjectGet(jRec, "last_dose"));
+        if(nLevel <= 0) continue;
+
+        int nState = VicGetCurrentState(nLevel, nLastDose, nNow);
+        SetLocalInt(oPC, VIC_LVAR_STATE_PFX + IntToString(i), nState);
+        VicApplyEffects(oPC, i, nState, nLevel);
+
+        if(nState == VICE_STATE_WITHDRAWAL)
+        {
+            string sMsg = "[Nałogi] Odstawienie aktywne: " + VicSubstanceName(i) + ".";
+            SendMessageToPC(oPC, sMsg);
+        }
+    }
+}

--- a/Vices/Scripts/lib_vic_def.nss
+++ b/Vices/Scripts/lib_vic_def.nss
@@ -1,0 +1,205 @@
+// lib_vic_def.nss — Constants, NUI bind/button IDs, substance metadata, and
+// timing helpers for the Vices (Nałogi) system.
+#include "lib_nui"
+#include "sql_vic"
+
+// ============================================================
+// Forward declarations (bodies in lib_vic.nss)
+// ============================================================
+void FeedViceWindow(object oPC, int nToken);
+void VicApplyEffects(object oPC, int nSubstance, int nState, int nLevel);
+void VicRemoveEffects(object oPC, int nSubstance);
+void VicTick(object oPC);
+
+// ============================================================
+// Substance IDs
+// ============================================================
+const int VICE_MOONFIRE     = 0;   // Księżycowy Trunek — destylat rosy i korzenia silvari
+const int VICE_DREAMDUST    = 1;   // Proch Snów — proch z Czarnego Lotosu
+const int VICE_DEMON_BLOOD  = 2;   // Krew Demona — skrzepnięta krew z niższych warstw
+const int VICE_BLACKROOT    = 3;   // Czarny Korzeń — ekstrakt z krypt
+const int VICE_WITCH_MILK   = 4;   // Mleko Czarownicy — białawy płyn z Drzewa Wiedźmy
+const int VICE_SHADOW_PASTE = 5;   // Pasta Cienia — czarna maź Zakonu Cienia
+const int VICE_COUNT        = 6;
+
+// ============================================================
+// Runtime addiction states (not persisted — derived each tick)
+// ============================================================
+const int VICE_STATE_SOBER      = 0;
+const int VICE_STATE_SATISFIED  = 1;
+const int VICE_STATE_CRAVING    = 2;
+const int VICE_STATE_WITHDRAWAL = 3;
+
+// ============================================================
+// Window / script IDs
+// ============================================================
+const string VIC_WINDOW    = "VIC_WINDOW";
+const string VIC_EV_SCRIPT = "lib_vic_ev";
+const string VIC_WIN_GEOM  = "vic_win_geom";
+
+// ============================================================
+// Bind names  (suffix = IntToString(substanceId) for per-row binds)
+// ============================================================
+const string VIC_BIND_NAME    = "vic_name_";    // + substId
+const string VIC_BIND_STATE   = "vic_state_";   // + substId
+const string VIC_BIND_LEVEL   = "vic_level_";   // + substId
+const string VIC_BIND_COLOR   = "vic_color_";   // + substId
+const string VIC_BIND_BTENA   = "vic_btena_";   // consume btn enabled + substId
+const string VIC_BIND_CLEAN   = "vic_clean_";   // detox btn enabled + substId
+const string VIC_BIND_FLAVOR  = "vic_flavor";
+const string VIC_BIND_WARNING = "vic_warning";
+
+// ============================================================
+// Button IDs
+// ============================================================
+const string VIC_BTN_CONSUME  = "vic_consume_";  // + substId
+const string VIC_BTN_BREAK    = "vic_break_";    // + substId
+
+// ============================================================
+// LVARs on PC
+// ============================================================
+const string VIC_LVAR_TICK      = "VIC_TICK";
+const string VIC_LVAR_STATE_PFX = "VIC_LAST_";  // + substId → last known state int
+
+// Effect tags — used with TagEffect() to locate effects for removal.
+const string VIC_ETAG_BUFF   = "VIC_B_";   // + substId
+const string VIC_ETAG_WITHDR = "VIC_W_";   // + substId
+
+// Tick interval (seconds)
+const float VIC_TICK_INTERVAL = 60.0;
+
+// Detox minimum wait without dosing before attempting (30 min real-time).
+const int VIC_DETOX_MIN_WAIT = 1800;
+
+// ============================================================
+// Timing helpers
+// ============================================================
+
+// Seconds after last dose before craving onset.
+int VicCravingOnset(int nLevel)
+{
+    switch(nLevel)
+    {
+        case 1: return 1800;  // 30 min
+        case 2: return 1500;  // 25 min
+        case 3: return 1200;  // 20 min
+        case 4: return  900;  // 15 min
+        case 5: return  420;  //  7 min
+    }
+    return 99999;
+}
+
+// Seconds after last dose before full withdrawal onset.
+int VicWithdrawalOnset(int nLevel)
+{
+    switch(nLevel)
+    {
+        case 1: return 3600;  // 60 min
+        case 2: return 2400;  // 40 min
+        case 3: return 1800;  // 30 min
+        case 4: return 1200;  // 20 min
+        case 5: return  600;  // 10 min
+    }
+    return 99999;
+}
+
+// Effect magnitude (buff bonus) scales with addiction level.
+int VicBuffMagnitude(int nLevel)
+{
+    if(nLevel <= 2) return 1;
+    if(nLevel <= 4) return 2;
+    return 3;
+}
+
+// ============================================================
+// Display helpers
+// ============================================================
+
+string VicSubstanceName(int nSub)
+{
+    switch(nSub)
+    {
+        case VICE_MOONFIRE:     return "Księżycowy Trunek";
+        case VICE_DREAMDUST:    return "Proch Snów";
+        case VICE_DEMON_BLOOD:  return "Krew Demona";
+        case VICE_BLACKROOT:    return "Czarny Korzeń";
+        case VICE_WITCH_MILK:   return "Mleko Czarownicy";
+        case VICE_SHADOW_PASTE: return "Pasta Cienia";
+    }
+    return "Nieznana Substancja";
+}
+
+string VicStateName(int nState)
+{
+    switch(nState)
+    {
+        case VICE_STATE_SOBER:      return "Trzeźwy";
+        case VICE_STATE_SATISFIED:  return "Nasycony";
+        case VICE_STATE_CRAVING:    return "Pragnie";
+        case VICE_STATE_WITHDRAWAL: return "Odstawienie";
+    }
+    return "";
+}
+
+json VicStateColor(int nState)
+{
+    switch(nState)
+    {
+        case VICE_STATE_SOBER:      return NuiColor(170, 170, 170, 255);
+        case VICE_STATE_SATISFIED:  return NuiColor(90,  210, 90,  255);
+        case VICE_STATE_CRAVING:    return NuiColor(220, 180, 60,  255);
+        case VICE_STATE_WITHDRAWAL: return NuiColor(220, 50,  50,  255);
+    }
+    return NuiColor(255, 255, 255, 255);
+}
+
+string VicFlavorText(int nSub, int nState, int nLevel)
+{
+    if(nState == VICE_STATE_SATISFIED)
+    {
+        switch(nSub)
+        {
+            case VICE_MOONFIRE:     return "Ciepło rozlewa się po ciele jak roztopiony bursztyn. Mięśnie nie znają zmęczenia.";
+            case VICE_DREAMDUST:    return "Zmysły wyostrzają się. Świat mówi przez ukryte wzory i szepty pod powierzchnią.";
+            case VICE_DEMON_BLOOD:  return "Krew się gotuje, gniew i siła stają się jednym. Pieczęć na skórze pulsuje czerwienią.";
+            case VICE_BLACKROOT:    return "Strach milknie jak zdmuchnięta świeca. Zostaje tylko zimna, krystaliczna determinacja.";
+            case VICE_WITCH_MILK:   return "Słowa płyną jak jedwab przez palce. Inni słuchają — i wierzą każdemu słowu.";
+            case VICE_SHADOW_PASTE: return "Cień staje się twoim sojusznikiem. Kroki cichną bez wysiłku, wzrok ostrzy się w mroku.";
+        }
+    }
+    else if(nState == VICE_STATE_CRAVING)
+    {
+        switch(nSub)
+        {
+            case VICE_MOONFIRE:     return "Usta wysychają. Głowa pulsuje bolesnym rytmem. Jeden łyk… jeden tylko łyk.";
+            case VICE_DREAMDUST:    return "Rzeczywistość jest zbyt głośna, zbyt ostra. Musisz uśmierzyć ten hałas.";
+            case VICE_DEMON_BLOOD:  return "Ciało żąda więcej mocy. Ten głód to nie pragnienie — to rozkaz z wnętrzności.";
+            case VICE_BLACKROOT:    return "Stary strach pełza z powrotem jak mgła z krypty. Korzeń by go zagnał.";
+            case VICE_WITCH_MILK:   return "Słowa plączą się na języku. Czujesz się błahym, zwykłym, nudnym.";
+            case VICE_SHADOW_PASTE: return "Cienie wokół wydają się wrogie. Czujesz się obnażony i zbyt widoczny.";
+        }
+    }
+    else if(nState == VICE_STATE_WITHDRAWAL)
+    {
+        switch(nSub)
+        {
+            case VICE_MOONFIRE:     return "Trzęsą ci się ręce. Każda kość boli jakby ktoś wbijał w nią gwoździe. Karczma zbawia.";
+            case VICE_DREAMDUST:    return "Bez prochu świat to agonalne błoto. Myśli rwą się jak spróchniała lina nad przepaścią.";
+            case VICE_DEMON_BLOOD:  return "Ciało buntuje się gwałtownie. Mięśnie kurczą się. Pieczęć pali jak rozgrzany metal.";
+            case VICE_BLACKROOT:    return "Strach powrócił w pełnej chwale. Każdy cień to wróg. Każdy krok to pułapka.";
+            case VICE_WITCH_MILK:   return "Mdłości. Drżenie rąk. Jesteś niczym — pustym workiem na kości — bez mleka.";
+            case VICE_SHADOW_PASTE: return "Czujesz się śmiertelnie obnażony. Pasta to nie luksus — to jedyna rzecz, która ma sens.";
+        }
+    }
+    // SOBER — first time description
+    switch(nSub)
+    {
+        case VICE_MOONFIRE:     return "Destylat ze zmrożonej rosy i korzenia silvari. Wędrowcy mówią, że rozgrzewa krew przed bitwą.";
+        case VICE_DREAMDUST:    return "Proszek mielony z suszonego kwiatu Czarnego Lotosu. Wróżbiarze cenią go nad złoto.";
+        case VICE_DEMON_BLOOD:  return "Skrzepnięta krew z głębokich warstw. Smakuje metalicznie i niesie obietnicę potęgi.";
+        case VICE_BLACKROOT:    return "Ekstrakt z korzenia rosnącego tylko w mroku krypt. Medycy używają go jako środka przeciwbólowego.";
+        case VICE_WITCH_MILK:   return "Biały płyn z drzewa Czarownicy. Przyciąga wzrok i przykuwa języki. Ceniony przez dyplomatów.";
+        case VICE_SHADOW_PASTE: return "Czarna maź wyrabiana przez złodziei Zakonu Cienia i wcierana w skórę przed pracą.";
+    }
+    return "";
+}

--- a/Vices/Scripts/lib_vic_ev.nss
+++ b/Vices/Scripts/lib_vic_ev.nss
@@ -1,0 +1,35 @@
+// lib_vic_ev.nss — NUI event handler for the Vices (Nałogi) window.
+// Registered as the event script in NuiCreate.
+#include "lib_vic"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+
+    if(nToken != NuiFindWindow(oPC, VIC_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE) return;
+
+    if(sEvent != EVENT_TYPE_CLICK) return;
+
+    // Consume button: VIC_BTN_CONSUME + substanceId
+    int nConsumeLen = GetStringLength(VIC_BTN_CONSUME);
+    if(GetStringLeft(sElem, nConsumeLen) == VIC_BTN_CONSUME)
+    {
+        int nSub = StringToInt(GetStringRight(sElem, GetStringLength(sElem) - nConsumeLen));
+        VicConsumeDose(oPC, nSub);
+        return;
+    }
+
+    // Detox button: VIC_BTN_BREAK + substanceId
+    int nBreakLen = GetStringLength(VIC_BTN_BREAK);
+    if(GetStringLeft(sElem, nBreakLen) == VIC_BTN_BREAK)
+    {
+        int nSub = StringToInt(GetStringRight(sElem, GetStringLength(sElem) - nBreakLen));
+        VicAttemptDetox(oPC, nSub);
+        return;
+    }
+}

--- a/Vices/Scripts/sql_vic.nss
+++ b/Vices/Scripts/sql_vic.nss
@@ -1,0 +1,90 @@
+// sql_vic.nss — SQLite schema and queries for the Vices (Addiction) system.
+// Campaign DB name: "vices"
+// Table: vic_addiction (uuid, substance_id, level, last_dose, total_doses)
+
+void VicCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("vices",
+        "CREATE TABLE IF NOT EXISTS vic_addiction ("
+        " uuid          TEXT    NOT NULL,"
+        " substance_id  INTEGER NOT NULL,"
+        " level         INTEGER DEFAULT 1,"
+        " last_dose     INTEGER DEFAULT 0,"
+        " total_doses   INTEGER DEFAULT 0,"
+        " PRIMARY KEY(uuid, substance_id))");
+    SqlStep(q);
+}
+
+// Returns {level, last_dose, total_doses} or JsonNull() when no record exists.
+json VicGetAddict(object oPC, int nSubstance)
+{
+    sqlquery q = SqlPrepareQueryCampaign("vices",
+        "SELECT level, last_dose, total_doses"
+        " FROM vic_addiction"
+        " WHERE uuid = @uuid AND substance_id = @sid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt(q,    "@sid",  nSubstance);
+    if(!SqlStep(q)) return JsonNull();
+    json j = JsonObject();
+    j = JsonObjectSet(j, "level",       JsonInt(SqlGetInt(q, 0)));
+    j = JsonObjectSet(j, "last_dose",   JsonInt(SqlGetInt(q, 1)));
+    j = JsonObjectSet(j, "total_doses", JsonInt(SqlGetInt(q, 2)));
+    return j;
+}
+
+// Upsert: sets level and last_dose, increments total_doses.
+void VicUpsertDose(object oPC, int nSubstance, int nNewLevel, int nNow)
+{
+    sqlquery q = SqlPrepareQueryCampaign("vices",
+        "INSERT INTO vic_addiction (uuid, substance_id, level, last_dose, total_doses)"
+        " VALUES (@uuid, @sid, @lvl, @now, 1)"
+        " ON CONFLICT(uuid, substance_id) DO UPDATE SET"
+        "  level = @lvl, last_dose = @now, total_doses = total_doses + 1");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt(q,    "@sid",  nSubstance);
+    SqlBindInt(q,    "@lvl",  nNewLevel);
+    SqlBindInt(q,    "@now",  nNow);
+    SqlStep(q);
+}
+
+// Update only the addiction level (used by detox and natural recovery).
+void VicSetLevel(object oPC, int nSubstance, int nLevel)
+{
+    sqlquery q = SqlPrepareQueryCampaign("vices",
+        "UPDATE vic_addiction SET level = @lvl"
+        " WHERE uuid = @uuid AND substance_id = @sid");
+    SqlBindInt(q,    "@lvl",  nLevel);
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt(q,    "@sid",  nSubstance);
+    SqlStep(q);
+}
+
+// Returns current Unix timestamp via SQLite.
+int VicGetNow()
+{
+    sqlquery q = SqlPrepareQueryCampaign("vices",
+        "SELECT CAST(strftime('%s','now') AS INTEGER)");
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// Returns all addictions for a PC as a JsonArray of {substance_id, level, last_dose}.
+json VicGetAllAddictions(object oPC)
+{
+    json jArr = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("vices",
+        "SELECT substance_id, level, last_dose"
+        " FROM vic_addiction"
+        " WHERE uuid = @uuid AND level > 0"
+        " ORDER BY substance_id");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    while(SqlStep(q))
+    {
+        json j = JsonObject();
+        j = JsonObjectSet(j, "substance_id", JsonInt(SqlGetInt(q, 0)));
+        j = JsonObjectSet(j, "level",        JsonInt(SqlGetInt(q, 1)));
+        j = JsonObjectSet(j, "last_dose",    JsonInt(SqlGetInt(q, 2)));
+        jArr = JsonArrayInsert(jArr, j);
+    }
+    return jArr;
+}

--- a/Vices/Scripts/sys_on_enter.nss
+++ b/Vices/Scripts/sys_on_enter.nss
@@ -1,0 +1,12 @@
+// sys_on_enter.nss — OnClientEnter hook for Vices.
+// Restores effects and starts the per-PC addiction tick.
+#include "lib_vic"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC) || GetIsDMPossessed(oPC)) return;
+
+    VicRestoreEffects(oPC);
+    VicStartTick(oPC);
+}

--- a/Vices/Scripts/sys_on_leave.nss
+++ b/Vices/Scripts/sys_on_leave.nss
@@ -1,0 +1,15 @@
+// sys_on_leave.nss — OnClientLeave hook for Vices.
+// Stops the tick and strips engine effects (they will be reapplied on next login).
+#include "lib_vic"
+
+void main()
+{
+    object oPC = GetExitingObject();
+    if(!GetIsPC(oPC)) return;
+
+    VicStopTick(oPC);
+
+    int i;
+    for(i = 0; i < VICE_COUNT; i++)
+        VicRemoveEffects(oPC, i);
+}

--- a/Vices/Scripts/sys_on_load.nss
+++ b/Vices/Scripts/sys_on_load.nss
@@ -1,0 +1,8 @@
+// sys_on_load.nss — OnModuleLoad hook for Vices.
+// Creates the campaign DB tables on module start.
+#include "lib_vic_def"
+
+void main()
+{
+    VicCreateTables();
+}

--- a/Vices/Scripts/test_vic.nss
+++ b/Vices/Scripts/test_vic.nss
@@ -1,0 +1,12 @@
+// test_vic.nss — OnUsed script for a demo placeable.
+// Place a placeable with this script on OnUsed to open the Vices panel.
+// The "Spożyj" buttons consume doses directly (no item requirement in demo mode).
+#include "lib_vic"
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    VicOpenWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

System uzależnień od mrocznych substancji. Postać może spożywać 6 różnych substancji (Księżycowy Trunek, Proch Snów, Krew Demona, Czarny Korzeń, Mleko Czarownicy, Pasta Cienia), stopniowo uzależniając się (poziomy 1–5). Każda substancja daje unikalne bonusy mechaniczne gdy nasycona, a rosnące kary gdy organizm jej żąda.

## Mechanika

- **6 substancji** z różnymi profilami efektów (STR/WIS/CHA/CON/Hide/Persuade ± VFX)
- **4 stany** per substancja: Trzeźwy → Nasycony → Pragnienie → Odstawienie; przejścia wyznaczone przez czas od ostatniej dawki (craving onset: 30→7 min, withdrawal: 60→10 min, zależnie od poziomu uzależnienia)
- **Uzależnienie 1–5:** 20% szans na eskalację przy każdej dawce; im wyższy poziom tym silniejszy efekt buffa (nMag = 1/2/3) i cięższe kary odstawienia (nWMag = poziom)
- **Odwyk:** wymaga 30 min bez dawki; szansa sukcesu 80%→10% malejąca z poziomem; nieudany odwyk przy poz. 3+ może podnieść poziom (30%)
- **Naturalne oczyszczenie:** 24h w stanie odstawienia → poziom −1 automatycznie (tick)
- **Tick 60s** per zalogowanego gracza przez `DelayCommand`; przejścia stanów → `VicApplyEffects` + FloatingText + SendMessage
- **Efekty trwałe** tagowane przez `TagEffect(VIC_ETAG_BUFF_N / VIC_ETAG_WITHDR_N)`, wyszukiwane i usuwane przez pętlę `GetFirstEffect/GetNextEffect`
- **Reaplikacja po logowaniu** przez `VicRestoreEffects` na `OnClientEnter`
- **NUI** z 6 wierszami (substancja / stan / uzależnienie / Spożyj / Odwyk), kolorowanie stanu (szary/zielony/żółty/czerwony), pole flavour text, wiersz ostrzeżenia przy aktywnym odstawieniu

## Pliki

```
Vices/
├── Scripts/
│   ├── sql_vic.nss          — schemat SQLite + CRUD (VicGetAddict, VicUpsertDose, VicSetLevel, VicGetNow)
│   ├── lib_vic_def.nss      — stałe (substance IDs, state, bind/btn IDs), helpery czasu, metadane substancji, flavor text PL
│   ├── lib_vic.nss          — logika efektów, builder NUI, FeedViceWindow, VicConsumeDose, VicAttemptDetox, VicTick, VicRestoreEffects
│   ├── lib_vic_ev.nss       — handler eventów NUI (click → consume / detox)
│   ├── sys_on_load.nss      — OnModuleLoad: tworzy tabele
│   ├── sys_on_enter.nss     — OnClientEnter: reaplikacja efektów + start ticka
│   ├── sys_on_leave.nss     — OnClientLeave: stop ticka + czyszczenie efektów
│   ├── test_vic.nss         — OnUsed placeable → VicOpenWindow
│   ├── lib_nui.nss          — kopia współdzielonego helpera NUI
│   └── lib_nui_utility.nss  — kopia współdzielonego helpera NUI
└── INTEGRATION.md           — instrukcja integracji, tabela efektów, snippet item-on-use
```

## Zależności

- **NWNX:** brak — wyłącznie NWScript + NWN EE NUI + `SqlPrepareQueryCampaign`
- **SQL:** baza kampanii `"vices"` (`vices.sqlite3`), tabela `vic_addiction` tworzona przy starcie modułu

## Jak włączyć w istniejącym module

1. Dodaj skrypty do HAK lub folderu `Override` modułu
2. W **OnModuleLoad** wywołaj `VicCreateTables()` (lub podepnij `sys_on_load` bezpośrednio)
3. W **OnClientEnter** wywołaj `VicRestoreEffects(oPC)` + `VicStartTick(oPC)`
4. W **OnClientLeave** wywołaj `VicStopTick(oPC)` + pętlę `VicRemoveEffects`
5. Stwórz placeable z OnUsed = `test_vic` do demonstracji
6. Opcjonalnie: w OnActivateItem dla substancji wywołaj `VicConsumeDose(oPC, VICE_*)` i zniszcz przedmiot

## Co celowo pominięto

- Brak grafik/ikon substancji (wymagałyby pliku HAK; moduł jest demo-ready bez nich)
- Brak sklepu / handlarza substancjami (to domena systemu handlu)
- Brak powiadomień DM o stanie uzależnienia graczy
- Brak per-dawka timestampów w historii (tylko total_doses)
- Brak integracji ze złotem (zakup dawek od NPC)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FK3cSvbz8hDupRqV3hXHtJ)_