### PR TITLE
feat: Blizny (Wounds & Scars)

### DIFF
--- a/Scars/INTEGRATION.md
+++ b/Scars/INTEGRATION.md
@@ -1,0 +1,37 @@
+# Blizny (Wounds & Scars) — Integration Guide
+
+## Wymagania
+
+- NWN:EE 8193.37+ (wymagane `TagEffect` / `GetEffectTag` — natywne w EE)
+- Brak NWNX
+- Campaign DB `scar` tworzony automatycznie
+
+## Podpięcie hooków
+
+Wywołaj odpowiednie funkcje z istniejących handlerów modułu:
+
+| Zdarzenie modułu | Plik | Wywołanie |
+|---|---|---|
+| OnModuleLoad | `sys_on_load.nss` | `ScarCreateTables()` |
+| OnClientEnter | `sys_on_enter.nss` | Całość lub `ScarRefreshHealed(oPC); ScarApplyEffects(oPC);` |
+| OnPlayerRespawn | `sys_on_respawn.nss` | Całość lub `ScarGainWound(oPC);` z 75% szansą |
+
+Jeśli moduł ma jeden skrypt na zdarzenie, możesz użyć pliku bezpośrednio.
+
+## Placeable "Stół Medyczny"
+
+1. Dodaj placeable do modułu, nazwij go dowolnie.
+2. Ustaw `OnUsed` → `test_scar`.
+3. W środowisku produkcyjnym zamień `test_scar` na dedykowany skrypt bez symulowania ran.
+
+## Skrypty do włączenia w HAK / Override
+
+Brak — moduł nie wymaga zasobów graficznych.
+
+## Co celowo pominięto
+
+- **Animacje leczenia** — wymagałyby assetów w hak
+- **Chirurg NPC z dialogiem** — integrator podpina własny NPC przez `ScarOpenWindow(oPC)` w ConversationAction
+- **Maksymalna liczba blizn** — blizny (status 2) nie są kasowane; nagromadzone trofea bitewne
+- **Dodatkowe typy ran z broni** — rozszerzalne przez `ScarDbAddWound(oPC, nType, nLoc)` bezpośrednio
+- **Wizualna zmiana appearance** — celowo rozdzielona od systemu Corruption/Appearance

--- a/Scars/Scripts/lib_nui.nss
+++ b/Scars/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Scars/Scripts/lib_nui_utility.nss
+++ b/Scars/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Scars/Scripts/lib_scar.nss
+++ b/Scars/Scripts/lib_scar.nss
@@ -1,0 +1,406 @@
+#include "lib_scar_def"
+
+const float SCAR_W = 640.0;
+const float SCAR_H = 530.0;
+
+// ── NUI construction ──────────────────────────────────────────────
+
+json BuildScarListRow(object oPC)
+{
+    float fLocW = GetNuiScaleDimension(oPC, 115.0);
+    float fTypW = GetNuiScaleDimension(oPC, 115.0);
+    float fStaW = GetNuiScaleDimension(oPC, 90.0);
+    float fEffW = GetNuiScaleDimension(oPC, 150.0);
+
+    json jLoc = NuiLabel(NuiBind(SCAR_BIND_ROW_LOC), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jLoc = NuiWidth(jLoc, fLocW);
+    jLoc = NuiStyleForegroundColor(jLoc, NuiBind(SCAR_BIND_ROW_COLOR));
+
+    json jTyp = NuiLabel(NuiBind(SCAR_BIND_ROW_TYPE), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTyp = NuiWidth(jTyp, fTypW);
+    jTyp = NuiStyleForegroundColor(jTyp, NuiBind(SCAR_BIND_ROW_COLOR));
+
+    json jSta = NuiLabel(NuiBind(SCAR_BIND_ROW_STATUS), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jSta = NuiWidth(jSta, fStaW);
+    jSta = NuiStyleForegroundColor(jSta, NuiBind(SCAR_BIND_ROW_COLOR));
+
+    json jEff = NuiLabel(NuiBind(SCAR_BIND_ROW_EFF), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jEff = NuiWidth(jEff, fEffW);
+    jEff = NuiStyleForegroundColor(jEff, NuiBind(SCAR_BIND_ROW_COLOR));
+
+    json jInner = JsonArray();
+    jInner = JsonArrayInsert(jInner, jLoc);
+    jInner = JsonArrayInsert(jInner, jTyp);
+    jInner = JsonArrayInsert(jInner, jSta);
+    jInner = JsonArrayInsert(jInner, jEff);
+
+    json jCell = NuiGroup(NuiRow(jInner), TRUE, NUI_SCROLLBARS_NONE);
+    jCell = NuiId(jCell, SCAR_BTN_ROW);
+    jCell = NuiEncouraged(jCell, NuiBind(SCAR_BIND_ROW_ENC));
+    return jCell;
+}
+
+json BuildScarWindow(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 30.0);
+    float fRowH  = GetNuiScaleDimension(oPC, 28.0);
+    float fListH = GetNuiScaleDimension(oPC, 200.0);
+    float fFlvH  = GetNuiScaleDimension(oPC, 115.0);
+
+    // Column header row (static labels, not bound)
+    float fLocW = GetNuiScaleDimension(oPC, 115.0);
+    float fTypW = GetNuiScaleDimension(oPC, 115.0);
+    float fStaW = GetNuiScaleDimension(oPC, 90.0);
+
+    json jHLoc = NuiWidth(NuiLabel(JsonString("Lokalizacja"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)), fLocW);
+    json jHTyp = NuiWidth(NuiLabel(JsonString("Rodzaj"),       JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)), fTypW);
+    json jHSta = NuiWidth(NuiLabel(JsonString("Stan"),         JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE)), fStaW);
+    json jHEff = NuiLabel(JsonString("Efekt"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+
+    json jHdrRow = JsonArray();
+    jHdrRow = JsonArrayInsert(jHdrRow, jHLoc);
+    jHdrRow = JsonArrayInsert(jHdrRow, jHTyp);
+    jHdrRow = JsonArrayInsert(jHdrRow, jHSta);
+    jHdrRow = JsonArrayInsert(jHdrRow, jHEff);
+
+    // List
+    json jTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(BuildScarListRow(oPC), 0.0, TRUE));
+    json jList = NuiList(jTmpl, NuiBind(SCAR_BIND_ROW_COUNT), fRowH);
+    jList = NuiHeight(jList, fListH);
+
+    // Detail panel
+    json jDetHdr = NuiLabel(NuiBind(SCAR_BIND_DET_HEADER), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jDetHdr = NuiHeight(jDetHdr, fBtnH);
+
+    json jDetFlv = NuiGroup(NuiText(NuiBind(SCAR_BIND_DET_FLAVOR), FALSE), TRUE, NUI_SCROLLBARS_NONE);
+    jDetFlv = NuiHeight(jDetFlv, fFlvH);
+
+    // Treatment button
+    json jTreatBtn = NuiButton(NuiBind(SCAR_BIND_TREAT_LBL));
+    jTreatBtn = NuiId(jTreatBtn, SCAR_BTN_TREAT);
+    jTreatBtn = NuiEnabled(jTreatBtn, NuiBind(SCAR_BIND_TREAT_ENA));
+    jTreatBtn = NuiWidth(jTreatBtn, GetNuiScaleDimension(oPC, 240.0));
+    jTreatBtn = NuiHeight(jTreatBtn, fBtnH);
+
+    json jBotRow = JsonArray();
+    jBotRow = JsonArrayInsert(jBotRow, NuiSpacer());
+    jBotRow = JsonArrayInsert(jBotRow, jTreatBtn);
+
+    // Close button in top-right corner
+    json jClose = NuiButton(JsonString("X"));
+    jClose = NuiId(jClose, SCAR_BTN_CLOSE);
+    jClose = NuiWidth(jClose, GetNuiScaleDimension(oPC, 30.0));
+    jClose = NuiHeight(jClose, fBtnH);
+
+    json jTopBar = JsonArray();
+    jTopBar = JsonArrayInsert(jTopBar, NuiSpacer());
+    jTopBar = JsonArrayInsert(jTopBar, jClose);
+
+    // Assemble column
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(jTopBar));
+    jCol = JsonArrayInsert(jCol, NuiRow(jHdrRow));
+    jCol = JsonArrayInsert(jCol, jList);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, jDetHdr);
+    jCol = JsonArrayInsert(jCol, jDetFlv);
+    jCol = JsonArrayInsert(jCol, NuiRow(jBotRow));
+
+    json jSide = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    float fCW  = GetNuiScaleDimension(oPC, SCAR_W - 40.0);
+
+    json jMain = JsonArray();
+    jMain = JsonArrayInsert(jMain, jSide);
+    jMain = JsonArrayInsert(jMain, NuiWidth(NuiCol(jCol), fCW));
+    jMain = JsonArrayInsert(jMain, jSide);
+    return NuiRow(jMain);
+}
+
+// ── Window management ─────────────────────────────────────────────
+
+void ScarOpenWindow(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, SCAR_WINDOW);
+    if(nToken != 0)
+    {
+        FeedScarList(oPC, nToken);
+        return;
+    }
+
+    float fX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))
+                - GetNuiScaleDimension(oPC, SCAR_W)) / 2.0;
+    float fY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT))
+                - GetNuiScaleDimension(oPC, SCAR_H)) / 2.0;
+    json jGeom = NuiRect(fX, fY, GetNuiScaleDimension(oPC, SCAR_W), GetNuiScaleDimension(oPC, SCAR_H));
+
+    json jWin = NuiWindow(BuildScarWindow(oPC),
+        JsonString("Rany i Blizny"),
+        NuiBind(SCAR_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    nToken = NuiCreate(oPC, jWin, SCAR_WINDOW, SCAR_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, SCAR_WIN_GEOM, jGeom);
+    FeedScarList(oPC, nToken);
+}
+
+// ── Feed functions ────────────────────────────────────────────────
+
+void FeedScarDetail(object oPC, int nToken, int nWoundId)
+{
+    json jWounds = ScarDbGetWounds(oPC);
+    int  nCount  = JsonGetLength(jWounds);
+    json jTarget = JsonNull();
+    int  i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jRow = JsonArrayGet(jWounds, i);
+        if(JsonGetInt(JsonObjectGet(jRow, "id")) == nWoundId)
+        {
+            jTarget = jRow;
+            break;
+        }
+    }
+
+    if(JsonGetType(jTarget) == JSON_TYPE_NULL)
+    {
+        SetLocalInt(oPC, SCAR_LVAR_SEL_ID, 0);
+        return;
+    }
+
+    int    nType  = JsonGetInt(JsonObjectGet(jTarget, "wound_type"));
+    int    nLoc   = JsonGetInt(JsonObjectGet(jTarget, "location"));
+    int    nStat  = JsonGetInt(JsonObjectGet(jTarget, "status"));
+    string sFlavor = (nStat == SCAR_STATUS_SCARRED)
+                   ? ScarFlavorScar(nType, nLoc)
+                   : ScarFlavorOpen(nType, nLoc);
+    string sHeader = ScarLocName(nLoc) + " — " + ScarTypeName(nType) + " [" + ScarStatusName(nStat) + "]";
+
+    int bCanTreat = (nStat == SCAR_STATUS_OPEN);
+    string sTreatLbl;
+    if(bCanTreat)
+        sTreatLbl = "Lecz ranę (" + IntToString(SCAR_TREAT_COST) + " sz.)";
+    else if(nStat == SCAR_STATUS_HEALING)
+        sTreatLbl = "Gojenie w toku... (powróć za " + IntToString(SCAR_HEAL_HOURS) + "h)";
+    else
+        sTreatLbl = "Blizna — trwały ślad bitwy";
+
+    NuiSetBind(oPC, nToken, SCAR_BIND_DET_HEADER, JsonString(sHeader));
+    NuiSetBind(oPC, nToken, SCAR_BIND_DET_FLAVOR, JsonString(sFlavor));
+    NuiSetBind(oPC, nToken, SCAR_BIND_TREAT_ENA,  JsonBool(bCanTreat));
+    NuiSetBind(oPC, nToken, SCAR_BIND_TREAT_LBL,  JsonString(sTreatLbl));
+}
+
+void FeedScarList(object oPC, int nToken)
+{
+    ScarRefreshHealed(oPC);
+
+    json jWounds = ScarDbGetWounds(oPC);
+    int  nCount  = JsonGetLength(jWounds);
+    int  nSelId  = GetLocalInt(oPC, SCAR_LVAR_SEL_ID);
+
+    json jLocs    = JsonArray();
+    json jTypes   = JsonArray();
+    json jStats   = JsonArray();
+    json jEffects = JsonArray();
+    json jColors  = JsonArray();
+    json jEncs    = JsonArray();
+
+    json jColOpen  = NuiColor(220, 70, 70);
+    json jColHeal  = NuiColor(220, 200, 60);
+    json jColScar  = NuiColor(150, 150, 150);
+
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jRow  = JsonArrayGet(jWounds, i);
+        int  nId   = JsonGetInt(JsonObjectGet(jRow, "id"));
+        int  nType = JsonGetInt(JsonObjectGet(jRow, "wound_type"));
+        int  nLoc  = JsonGetInt(JsonObjectGet(jRow, "location"));
+        int  nStat = JsonGetInt(JsonObjectGet(jRow, "status"));
+
+        json jColor;
+        switch(nStat)
+        {
+            case SCAR_STATUS_OPEN:    jColor = jColOpen;  break;
+            case SCAR_STATUS_HEALING: jColor = jColHeal;  break;
+            default:                  jColor = jColScar;  break;
+        }
+
+        jLocs    = JsonArrayInsert(jLocs,    JsonString(ScarLocName(nLoc)));
+        jTypes   = JsonArrayInsert(jTypes,   JsonString(ScarTypeName(nType)));
+        jStats   = JsonArrayInsert(jStats,   JsonString(ScarStatusName(nStat)));
+        jEffects = JsonArrayInsert(jEffects, JsonString(ScarEffectLabel(nType, nStat)));
+        jColors  = JsonArrayInsert(jColors,  jColor);
+        jEncs    = JsonArrayInsert(jEncs,    JsonBool(nSelId > 0 && nId == nSelId));
+    }
+
+    NuiSetBind(oPC, nToken, SCAR_BIND_ROW_LOC,    jLocs);
+    NuiSetBind(oPC, nToken, SCAR_BIND_ROW_TYPE,   jTypes);
+    NuiSetBind(oPC, nToken, SCAR_BIND_ROW_STATUS, jStats);
+    NuiSetBind(oPC, nToken, SCAR_BIND_ROW_EFF,    jEffects);
+    NuiSetBind(oPC, nToken, SCAR_BIND_ROW_COLOR,  jColors);
+    NuiSetBind(oPC, nToken, SCAR_BIND_ROW_ENC,    jEncs);
+    NuiSetBind(oPC, nToken, SCAR_BIND_ROW_COUNT,  JsonInt(nCount));
+
+    if(nSelId > 0)
+        FeedScarDetail(oPC, nToken, nSelId);
+    else
+    {
+        NuiSetBind(oPC, nToken, SCAR_BIND_DET_HEADER, JsonString("Kliknij ranę, aby zobaczyć szczegóły."));
+        NuiSetBind(oPC, nToken, SCAR_BIND_DET_FLAVOR, JsonString(""));
+        NuiSetBind(oPC, nToken, SCAR_BIND_TREAT_ENA,  JsonBool(FALSE));
+        NuiSetBind(oPC, nToken, SCAR_BIND_TREAT_LBL,  JsonString("Lecz ranę"));
+    }
+}
+
+// ── Effect management ─────────────────────────────────────────────
+
+void ScarRemoveEffects(object oPC)
+{
+    effect eEff = GetFirstEffect(oPC);
+    while(GetIsEffectValid(eEff))
+    {
+        if(GetEffectTag(eEff) == SCAR_EFFECT_TAG)
+            RemoveEffect(oPC, eEff);
+        eEff = GetNextEffect(oPC);
+    }
+}
+
+void ScarApplyEffects(object oPC)
+{
+    ScarRemoveEffects(oPC);
+
+    json jWounds = ScarDbGetWounds(oPC);
+    int  nCount  = JsonGetLength(jWounds);
+    int  i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jRow  = JsonArrayGet(jWounds, i);
+        int  nType = JsonGetInt(JsonObjectGet(jRow, "wound_type"));
+        int  nStat = JsonGetInt(JsonObjectGet(jRow, "status"));
+
+        effect eEff;
+        int bValid = TRUE;
+
+        if(nStat == SCAR_STATUS_OPEN)
+        {
+            switch(nType)
+            {
+                case SCAR_TYPE_CUT:    eEff = EffectAbilityDecrease(ABILITY_DEXTERITY,    1); break;
+                case SCAR_TYPE_BURN:   eEff = EffectAbilityDecrease(ABILITY_CHARISMA,     1); break;
+                case SCAR_TYPE_PIERCE: eEff = EffectAbilityDecrease(ABILITY_CONSTITUTION, 1); break;
+                case SCAR_TYPE_BREAK:  eEff = EffectAbilityDecrease(ABILITY_STRENGTH,     1); break;
+                case SCAR_TYPE_NERVE:  eEff = EffectAbilityDecrease(ABILITY_INTELLIGENCE, 1); break;
+                default: bValid = FALSE; break;
+            }
+        }
+        else if(nStat == SCAR_STATUS_SCARRED)
+        {
+            switch(nType)
+            {
+                case SCAR_TYPE_CUT:
+                    eEff = EffectSkillIncrease(SKILL_INTIMIDATE, 1);
+                    break;
+                case SCAR_TYPE_BURN:
+                    eEff = EffectDamageResistance(DAMAGE_TYPE_FIRE, 5, 0);
+                    break;
+                case SCAR_TYPE_PIERCE:
+                    eEff = EffectSavingThrowIncrease(SAVING_THROW_FORT, 1, SAVING_THROW_TYPE_ALL);
+                    break;
+                case SCAR_TYPE_BREAK:
+                    eEff = EffectSavingThrowIncrease(SAVING_THROW_FORT, 1, SAVING_THROW_TYPE_ALL);
+                    break;
+                case SCAR_TYPE_NERVE:
+                    // Chronic pain from nerve damage: slower thought, heightened hearing
+                    eEff = EffectLinkEffects(
+                        EffectSkillDecrease(SKILL_CONCENTRATION, 1),
+                        EffectSkillIncrease(SKILL_LISTEN, 1));
+                    break;
+                default: bValid = FALSE; break;
+            }
+        }
+        else
+        {
+            bValid = FALSE; // HEALING status: no active effect
+        }
+
+        if(bValid)
+        {
+            eEff = TagEffect(eEff, SCAR_EFFECT_TAG);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, eEff, oPC);
+        }
+    }
+}
+
+// ── Wound lifecycle ───────────────────────────────────────────────
+
+void ScarRefreshHealed(object oPC)
+{
+    ScarDbFinalizeHealed(oPC, SCAR_HEAL_HOURS * 3600);
+}
+
+void ScarGainWound(object oPC)
+{
+    if(ScarDbCountAll(oPC) >= SCAR_MAX_WOUNDS) return;
+
+    int nType = Random(5);
+    int nLoc  = Random(6);
+
+    ScarDbAddWound(oPC, nType, nLoc);
+    ScarApplyEffects(oPC);
+
+    string sMsg = "[Rana] Doznałeś poważnych obrażeń: "
+                + ScarTypeName(nType) + " — " + ScarLocName(nLoc) + ". "
+                + "Znajdź chirurga i lecz ranę, zanim się pogorszy.";
+    SendMessageToPC(oPC, sMsg);
+    FloatingTextStringOnCreature(
+        "Nowa rana: " + ScarTypeName(nType) + " (" + ScarLocName(nLoc) + ")!",
+        oPC, FALSE);
+}
+
+void ScarTreatWound(object oPC, int nWoundId, int nToken)
+{
+    if(GetGold(oPC) < SCAR_TREAT_COST)
+    {
+        SendMessageToPC(oPC, "[Rana] Brak złota. Opatrunek kosztuje "
+            + IntToString(SCAR_TREAT_COST) + " sz.");
+        return;
+    }
+
+    // Confirm wound belongs to this PC and is open (guard against stale UI state)
+    json jWounds = ScarDbGetWounds(oPC);
+    int  nCount  = JsonGetLength(jWounds);
+    int  bFound  = FALSE;
+    int  i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jRow  = JsonArrayGet(jWounds, i);
+        if(JsonGetInt(JsonObjectGet(jRow, "id"))     == nWoundId &&
+           JsonGetInt(JsonObjectGet(jRow, "status")) == SCAR_STATUS_OPEN)
+        {
+            bFound = TRUE;
+            break;
+        }
+    }
+
+    if(!bFound)
+    {
+        SendMessageToPC(oPC, "[Rana] Nie można leczyć tej rany.");
+        return;
+    }
+
+    AssignCommand(oPC, TakeGoldFromCreature(SCAR_TREAT_COST, oPC, TRUE));
+    ScarDbTreatWound(nWoundId);
+    ScarApplyEffects(oPC);
+
+    // Clear selection so the list refreshes cleanly
+    SetLocalInt(oPC, SCAR_LVAR_SEL_ID, 0);
+    FeedScarList(oPC, nToken);
+
+    SendMessageToPC(oPC, "[Rana] Rana została opatrzona. Za "
+        + IntToString(SCAR_HEAL_HOURS) + " godzin przemieni się w bliznę.");
+}

--- a/Scars/Scripts/lib_scar_def.nss
+++ b/Scars/Scripts/lib_scar_def.nss
@@ -1,0 +1,206 @@
+#include "lib_nui"
+#include "sql_scar"
+
+void ScarOpenWindow(object oPC);
+void ScarApplyEffects(object oPC);
+void ScarRemoveEffects(object oPC);
+void ScarGainWound(object oPC);
+void ScarRefreshHealed(object oPC);
+void ScarTreatWound(object oPC, int nWoundId, int nToken);
+void FeedScarList(object oPC, int nToken);
+void FeedScarDetail(object oPC, int nToken, int nWoundId);
+
+// ── Window IDs ────────────────────────────────────────────────────
+const string SCAR_WINDOW     = "SCAR_WINDOW";
+const string SCAR_EV_SCRIPT  = "lib_scar_ev";
+const string SCAR_WIN_GEOM   = "scar_win_geom";
+
+// List (NuiList) binds
+const string SCAR_BIND_ROW_LOC    = "scar_row_loc";
+const string SCAR_BIND_ROW_TYPE   = "scar_row_type";
+const string SCAR_BIND_ROW_STATUS = "scar_row_sta";
+const string SCAR_BIND_ROW_EFF    = "scar_row_eff";
+const string SCAR_BIND_ROW_COLOR  = "scar_row_col";
+const string SCAR_BIND_ROW_ENC    = "scar_row_enc";
+const string SCAR_BIND_ROW_COUNT  = "scar_rowcount";
+
+// Detail panel binds
+const string SCAR_BIND_DET_HEADER = "scar_det_hdr";
+const string SCAR_BIND_DET_FLAVOR = "scar_det_flav";
+const string SCAR_BIND_TREAT_ENA  = "scar_treat_ena";
+const string SCAR_BIND_TREAT_LBL  = "scar_treat_lbl";
+
+// Button IDs
+const string SCAR_BTN_CLOSE = "scar_btn_close";
+const string SCAR_BTN_ROW   = "scar_btn_row";
+const string SCAR_BTN_TREAT = "scar_btn_treat";
+
+// PC local variable — selected wound id in UI
+const string SCAR_LVAR_SEL_ID = "SCAR_SEL_ID";
+
+// Tag written on every effect applied by this system so we can isolate them.
+// Requires NWN:EE 8193.37+ for TagEffect / GetEffectTag.
+const string SCAR_EFFECT_TAG = "SCAR_SYS";
+
+// ── Wound types ───────────────────────────────────────────────────
+const int SCAR_TYPE_CUT    = 0;
+const int SCAR_TYPE_BURN   = 1;
+const int SCAR_TYPE_PIERCE = 2;
+const int SCAR_TYPE_BREAK  = 3;
+const int SCAR_TYPE_NERVE  = 4;
+
+// ── Body locations ────────────────────────────────────────────────
+const int SCAR_LOC_HEAD  = 0;
+const int SCAR_LOC_CHEST = 1;
+const int SCAR_LOC_ARM_L = 2;
+const int SCAR_LOC_ARM_R = 3;
+const int SCAR_LOC_LEG_L = 4;
+const int SCAR_LOC_LEG_R = 5;
+
+// ── Wound status ──────────────────────────────────────────────────
+const int SCAR_STATUS_OPEN    = 0; // untreated; stat penalty active
+const int SCAR_STATUS_HEALING = 1; // treated; penalty removed, awaiting scar
+const int SCAR_STATUS_SCARRED = 2; // fully healed; scar effect active
+
+// ── Tunable config ────────────────────────────────────────────────
+const int SCAR_TREAT_COST = 75;   // gold cost per treatment
+const int SCAR_HEAL_HOURS = 24;   // real-time hours before wound becomes scar
+const int SCAR_MAX_WOUNDS = 8;    // cap: new wounds are ignored above this
+
+// ── String helpers (player-visible text in Polish) ─────────────────
+
+string ScarTypeName(int nType)
+{
+    switch(nType)
+    {
+        case SCAR_TYPE_CUT:    return "Cięcie";
+        case SCAR_TYPE_BURN:   return "Oparzenie";
+        case SCAR_TYPE_PIERCE: return "Przebicie";
+        case SCAR_TYPE_BREAK:  return "Złamanie";
+        case SCAR_TYPE_NERVE:  return "Nerwy";
+    }
+    return "Rana";
+}
+
+string ScarLocName(int nLoc)
+{
+    switch(nLoc)
+    {
+        case SCAR_LOC_HEAD:  return "Głowa";
+        case SCAR_LOC_CHEST: return "Tors";
+        case SCAR_LOC_ARM_L: return "Lewe ramię";
+        case SCAR_LOC_ARM_R: return "Prawe ramię";
+        case SCAR_LOC_LEG_L: return "Lewa noga";
+        case SCAR_LOC_LEG_R: return "Prawa noga";
+    }
+    return "Nieznane";
+}
+
+string ScarStatusName(int nStatus)
+{
+    switch(nStatus)
+    {
+        case SCAR_STATUS_OPEN:    return "Otwarta";
+        case SCAR_STATUS_HEALING: return "Goi się";
+        case SCAR_STATUS_SCARRED: return "Blizna";
+    }
+    return "";
+}
+
+// Short effect label shown in the list column
+string ScarEffectLabel(int nType, int nStatus)
+{
+    if(nStatus == SCAR_STATUS_OPEN)
+    {
+        switch(nType)
+        {
+            case SCAR_TYPE_CUT:    return "-1 ZZR";
+            case SCAR_TYPE_BURN:   return "-1 CHA";
+            case SCAR_TYPE_PIERCE: return "-1 KON";
+            case SCAR_TYPE_BREAK:  return "-1 SIŁ";
+            case SCAR_TYPE_NERVE:  return "-1 INT";
+        }
+    }
+    else if(nStatus == SCAR_STATUS_SCARRED)
+    {
+        switch(nType)
+        {
+            case SCAR_TYPE_CUT:    return "+1 Zastraszanie";
+            case SCAR_TYPE_BURN:   return "Odp. ogień 5";
+            case SCAR_TYPE_PIERCE: return "+1 Wytrwałość";
+            case SCAR_TYPE_BREAK:  return "+1 Wytrwałość";
+            case SCAR_TYPE_NERVE:  return "-1 Konc / +1 Nas.";
+        }
+    }
+    return "—";
+}
+
+// Flavor text for an open / healing wound
+string ScarFlavorOpen(int nType, int nLoc)
+{
+    string sLoc;
+    switch(nLoc)
+    {
+        case SCAR_LOC_HEAD:  sLoc = "Na głowie"; break;
+        case SCAR_LOC_CHEST: sLoc = "Na torsi"; break;
+        case SCAR_LOC_ARM_L: sLoc = "Na lewym ramieniu"; break;
+        case SCAR_LOC_ARM_R: sLoc = "Na prawym ramieniu"; break;
+        case SCAR_LOC_LEG_L: sLoc = "Na lewej nodze"; break;
+        case SCAR_LOC_LEG_R: sLoc = "Na prawej nodze"; break;
+        default: sLoc = "Gdzieś"; break;
+    }
+    switch(nType)
+    {
+        case SCAR_TYPE_CUT:
+            return sLoc + " widzisz głębokie cięcie, które wciąż sączy krew pod bandażem. "
+                + "Każdy ruch rozrywa strupki. Chirurg mógłby zszyć ranę i zapobiec zakażeniu.";
+        case SCAR_TYPE_BURN:
+            return sLoc + " skóra jest zgrubiała i pokryta pęcherzami. Zapach przypalenia nie odpuszcza. "
+                + "Zimny balsam ograniczyłby zniszczenia, lecz ślad pozostanie na zawsze.";
+        case SCAR_TYPE_PIERCE:
+            return sLoc + " tkwi wąska, lecz głęboka rana po klindze lub bełcie. "
+                + "Wewnątrz może wciąż tkwić odłamek metalu. Lekarz powinien zbadać ranę przed gojeniem.";
+        case SCAR_TYPE_BREAK:
+            return sLoc + " kość trzeszczała podczas walki jak sucha gałąź. "
+                + "Każdy chwyt wywołuje przeszywający ból. Bez szyn i odpoczynku gojenie idzie krzywo.";
+        case SCAR_TYPE_NERVE:
+            return sLoc + " palce lub mięśnie są częściowo odrętwiali po trafieniu błyskawicą "
+                + "lub ciosie w splot nerwów. Myśli rozpraszają się. Ból jest tępy i ciągły.";
+    }
+    return "Rana wymaga opieki medycznej.";
+}
+
+// Flavor text for a fully healed scar
+string ScarFlavorScar(int nType, int nLoc)
+{
+    string sLoc;
+    switch(nLoc)
+    {
+        case SCAR_LOC_HEAD:  sLoc = "Na głowie"; break;
+        case SCAR_LOC_CHEST: sLoc = "Na torsi"; break;
+        case SCAR_LOC_ARM_L: sLoc = "Na lewym ramieniu"; break;
+        case SCAR_LOC_ARM_R: sLoc = "Na prawym ramieniu"; break;
+        case SCAR_LOC_LEG_L: sLoc = "Na lewej nodze"; break;
+        case SCAR_LOC_LEG_R: sLoc = "Na prawej nodze"; break;
+        default: sLoc = "Gdzieś"; break;
+    }
+    switch(nType)
+    {
+        case SCAR_TYPE_CUT:
+            return sLoc + " biegnie blada nitka blizny po cięciu. "
+                + "Niejedna negocjacja skończyła się ugodą, gdy rozmówca zauważył ten ślad po raz pierwszy.";
+        case SCAR_TYPE_BURN:
+            return sLoc + " skóra jest zgrubiała i błyszcząca niczym wyprawa na starym bucie. "
+                + "Blizna po oparzeniu zahartowała ciało na żar — lecz dawna uroda odeszła bezpowrotnie.";
+        case SCAR_TYPE_PIERCE:
+            return sLoc + " okrągła blizna po przebiciu wgłębia się jak odcisk monety. "
+                + "Tors zapamiętał każde wbicie ostrza — i wytrzymuje teraz nieco więcej.";
+        case SCAR_TYPE_BREAK:
+            return sLoc + " kość zrosła się grubsza niż wcześniej. "
+                + "Mówią, że złamana kość jest mocniejsza po zrośnięciu. I coś jest w tej mądrości.";
+        case SCAR_TYPE_NERVE:
+            return sLoc + " drobne mrowienie przypomina o przeszłości przy każdej zmianie pogody. "
+                + "Umysł, choć wolniejszy podczas skupienia, wyostrzył słuch w poszukiwaniu zagrożeń.";
+    }
+    return "Blizna zagoiła się, lecz jej historia pozostaje wyryта na ciele.";
+}

--- a/Scars/Scripts/lib_scar_ev.nss
+++ b/Scars/Scripts/lib_scar_ev.nss
@@ -1,0 +1,56 @@
+#include "lib_scar"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    if(nToken != NuiFindWindow(oPC, SCAR_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalInt(oPC, SCAR_LVAR_SEL_ID);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == SCAR_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        if(sElem == SCAR_BTN_TREAT)
+        {
+            int nId = GetLocalInt(oPC, SCAR_LVAR_SEL_ID);
+            if(nId > 0)
+                ScarTreatWound(oPC, nId, nToken);
+            return;
+        }
+    }
+
+    if(sEvent == EVENT_TYPE_MOUSEDOWN && sElem == SCAR_BTN_ROW)
+    {
+        json jWounds = ScarDbGetWounds(oPC);
+        int  nCount  = JsonGetLength(jWounds);
+        if(nIdx < 0 || nIdx >= nCount) return;
+
+        json jRow = JsonArrayGet(jWounds, nIdx);
+        int  nId  = JsonGetInt(JsonObjectGet(jRow, "id"));
+
+        SetLocalInt(oPC, SCAR_LVAR_SEL_ID, nId);
+
+        json jEncs = JsonArray();
+        int i;
+        for(i = 0; i < nCount; i++)
+            jEncs = JsonArrayInsert(jEncs, JsonBool(i == nIdx));
+        NuiSetBind(oPC, nToken, SCAR_BIND_ROW_ENC, jEncs);
+
+        FeedScarDetail(oPC, nToken, nId);
+        return;
+    }
+}

--- a/Scars/Scripts/sql_scar.nss
+++ b/Scars/Scripts/sql_scar.nss
@@ -1,0 +1,91 @@
+void ScarCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("scar",
+        "CREATE TABLE IF NOT EXISTS scar_wounds ("
+        " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        " pc_uuid TEXT NOT NULL,"
+        " wound_type INTEGER NOT NULL DEFAULT 0,"
+        " location INTEGER NOT NULL DEFAULT 0,"
+        " status INTEGER NOT NULL DEFAULT 0,"
+        " gained_at INTEGER NOT NULL DEFAULT (strftime('%s','now')),"
+        " healed_at INTEGER DEFAULT NULL"
+        ")");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("scar",
+        "CREATE INDEX IF NOT EXISTS idx_scar_pc ON scar_wounds (pc_uuid)");
+    SqlStep(q);
+}
+
+json ScarDbGetWounds(object oPC)
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("scar",
+        "SELECT id, wound_type, location, status, gained_at, healed_at "
+        "FROM scar_wounds WHERE pc_uuid = @uuid ORDER BY gained_at DESC");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    while(SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "id",         JsonInt(SqlGetInt(q, 0)));
+        jRow = JsonObjectSet(jRow, "wound_type", JsonInt(SqlGetInt(q, 1)));
+        jRow = JsonObjectSet(jRow, "location",   JsonInt(SqlGetInt(q, 2)));
+        jRow = JsonObjectSet(jRow, "status",     JsonInt(SqlGetInt(q, 3)));
+        jRow = JsonObjectSet(jRow, "gained_at",  JsonInt(SqlGetInt(q, 4)));
+        jRow = JsonObjectSet(jRow, "healed_at",  JsonInt(SqlGetInt(q, 5)));
+        jRows = JsonArrayInsert(jRows, jRow);
+    }
+    return jRows;
+}
+
+int ScarDbAddWound(object oPC, int nType, int nLoc)
+{
+    sqlquery q = SqlPrepareQueryCampaign("scar",
+        "INSERT INTO scar_wounds (pc_uuid, wound_type, location, status) VALUES (@uuid, @type, @loc, 0)");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt(q, "@type", nType);
+    SqlBindInt(q, "@loc",  nLoc);
+    SqlStep(q);
+    sqlquery qId = SqlPrepareQueryCampaign("scar", "SELECT last_insert_rowid()");
+    if(SqlStep(qId)) return SqlGetInt(qId, 0);
+    return -1;
+}
+
+void ScarDbTreatWound(int nId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("scar",
+        "UPDATE scar_wounds SET status = 1, healed_at = strftime('%s','now') WHERE id = @id AND status = 0");
+    SqlBindInt(q, "@id", nId);
+    SqlStep(q);
+}
+
+// Promotes HEALING wounds to SCARRED once the heal window has elapsed
+void ScarDbFinalizeHealed(object oPC, int nHealSeconds)
+{
+    sqlquery q = SqlPrepareQueryCampaign("scar",
+        "UPDATE scar_wounds SET status = 2 "
+        "WHERE pc_uuid = @uuid AND status = 1 "
+        "AND healed_at IS NOT NULL "
+        "AND healed_at + @secs <= strftime('%s','now')");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt(q, "@secs", nHealSeconds);
+    SqlStep(q);
+}
+
+int ScarDbCountOpen(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("scar",
+        "SELECT COUNT(*) FROM scar_wounds WHERE pc_uuid = @uuid AND status = 0");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+int ScarDbCountAll(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("scar",
+        "SELECT COUNT(*) FROM scar_wounds WHERE pc_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}

--- a/Scars/Scripts/sys_on_enter.nss
+++ b/Scars/Scripts/sys_on_enter.nss
@@ -1,0 +1,21 @@
+#include "lib_scar"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC) || GetIsDMPossessed(oPC)) return;
+
+    // Advance any wounds that finished healing while the player was offline
+    ScarRefreshHealed(oPC);
+    ScarApplyEffects(oPC);
+
+    int nOpen = ScarDbCountOpen(oPC);
+    if(nOpen > 0)
+    {
+        string sMsg = "[Rana] Masz " + IntToString(nOpen)
+            + " niezaopatrzoną ranę. Kary do statystyk są aktywne. "
+            + "Odwiedź chirurga lub użyj placeable \"Stół Medyczny\".";
+        DelayCommand(3.0, SendMessageToPC(oPC, sMsg));
+        DelayCommand(3.5, FloatingTextStringOnCreature(sMsg, oPC, FALSE));
+    }
+}

--- a/Scars/Scripts/sys_on_load.nss
+++ b/Scars/Scripts/sys_on_load.nss
@@ -1,0 +1,6 @@
+#include "lib_scar_def"
+
+void main()
+{
+    ScarCreateTables();
+}

--- a/Scars/Scripts/sys_on_respawn.nss
+++ b/Scars/Scripts/sys_on_respawn.nss
@@ -1,0 +1,11 @@
+#include "lib_scar"
+
+void main()
+{
+    object oPC = GetLastRespawnButtonPresser();
+    if(!GetIsPC(oPC)) return;
+
+    // 75% chance per respawn; only one wound per death to avoid instant cap
+    if(Random(4) < 3)
+        ScarGainWound(oPC);
+}

--- a/Scars/Scripts/test_scar.nss
+++ b/Scars/Scripts/test_scar.nss
@@ -1,0 +1,17 @@
+#include "lib_scar"
+
+// OnUsed handler for a placeable named "Stół Medyczny" (Medical Table).
+// Simulates a near-death wound if none exist, then opens the wound UI.
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    if(ScarDbCountAll(oPC) == 0)
+    {
+        ScarGainWound(oPC);
+        SendMessageToPC(oPC, "[Test] Przyznano testową ranę. Otwieranie dziennika...");
+    }
+
+    ScarOpenWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

Dodaje moduł **Blizny** — system trwałych ran i blizn bojowych dla postaci gracza. Każda śmierć w walce może zostawić ślad na ciele, który rzutuje na statystyki i przypomina o ciężkich bitwach.

## Mechanika

- **Rana (OPEN)**: Przyznawana przy respawnie z 75% szansą. Losowy typ (Cięcie / Oparzenie / Przebicie / Złamanie / Nerwy) i lokalizacja ciała (6 miejsc). Nakłada karę -1 do odpowiedniej statystyki (DEX/CHA/CON/STR/INT) jako `DURATION_TYPE_PERMANENT` effect tagowany `SCAR_SYS`.
- **Leczenie (HEALING)**: Koszt 75 sz. przez placeable lub NPC. Kara znika natychmiast. Po 24 godzinach (czas rzeczywisty, sprawdzany przy loginie) rana przechodzi w bliznę.
- **Blizna (SCARRED)**: Trwały ślad z pasywnym bonusem (+1 Zastraszanie / Odp. ogień 5 / +1 Wytrwałość / -1 Konc +1 Nasłuch zależnie od typu). Blizny się nie kasują — gromadzą się jako kronika bitewna.

**NUI „Rany i Blizny"**: lista z kodowaniem kolorów (czerwony=otwarta, żółty=gojąca, szary=blizna), panel szczegółów z flavor tekstem po polsku, przycisk leczenia z kosztem.

## Pliki

```
Scars/
├── Scripts/
│   ├── sql_scar.nss          — schemat scar_wounds + zapytania SQLite
│   ├── lib_scar_def.nss      — stałe, ID bindów, helpery stringów (PL)
│   ├── lib_scar.nss          — NUI, FeedScarList, ScarApplyEffects, ScarTreatWound
│   ├── lib_scar_ev.nss       — handler NUI eventów
│   ├── sys_on_load.nss       — CREATE TABLE IF NOT EXISTS
│   ├── sys_on_enter.nss      — refresh + re-apply efektów przy loginie
│   ├── sys_on_respawn.nss    — gain wound po śmierci (75% szansa)
│   ├── test_scar.nss         — OnUsed placeable: symuluje ranę i otwiera UI
│   ├── lib_nui.nss           — lokalna kopia shared NUI utility
│   └── lib_nui_utility.nss   — j.w.
└── INTEGRATION.md
```

## Zależności

- **Brak NWNX** — wszystko natywny NWN:EE
- **NWN:EE 8193.37+** wymagane dla `TagEffect()` / `GetEffectTag()` (używane do izolowania efektów systemu bez ryzyka konfliktu z innymi modułami)
- Campaign DB: `scar` (tworzona automatycznie przez `ScarCreateTables()`)

## Jak włączyć w istniejącym module

1. Skopiuj `Scars/Scripts/*.nss` do hak lub override modułu.
2. Z `OnModuleLoad` wywołaj `ScarCreateTables()`.
3. Z `OnClientEnter` wywołaj `ScarRefreshHealed(oPC); ScarApplyEffects(oPC);` oraz powiadomienie o ranach.
4. Z `OnPlayerRespawn` wywołaj `if(Random(4) < 3) ScarGainWound(oPC);`.
5. Dodaj placeable z `OnUsed = test_scar` (lub własny skrypt wywołujący `ScarOpenWindow(oPC)`).
6. (Opcjonalnie) Podepnij `ScarOpenWindow(oPC)` do dialogu chirurga NPC.

## Co celowo pominięto

- **Animacje leczenia / wizualne opatrunki** — wymagałyby assetów w hak
- **Chirurg NPC z pełnym dialogiem** — integrator podpina własnego NPC
- **Zmiana wyglądu postaci per blizna** — osobny moduł (Appearance już istnieje)
- **Cap na blizny** — blizny gromadzą się bez limitu jako kronika bitewna; tylko rany otwarte mają limit `SCAR_MAX_WOUNDS = 8`
- **Integracja z Plague/Corruption** — celowo izolowane; można dodać callbacki przy `ScarGainWound`


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rmc6eon8PcDNNGoPd4Hhw3)_