### PR TITLE
feat: Sacred Oaths (Przysięgi Świętości)

### DIFF
--- a/Sacred Oaths/INTEGRATION.md
+++ b/Sacred Oaths/INTEGRATION.md
@@ -1,0 +1,51 @@
+# Sacred Oaths — Instrukcja integracji
+
+## Wymagania
+
+- NWN: Enhanced Edition (minimum 8193.34)
+- NWNX: **nie wymagane** — moduł używa wyłącznie standardowego API NWScript + NUI + SQLite Campaign DB.
+- Campaign DB: `oaths` (tworzona automatycznie przez `sys_on_load.nss`)
+
+## Hooki modułowe do podpięcia
+
+| Zdarzenie modułu      | Skrypt             | Uwagi                                                              |
+|-----------------------|--------------------|--------------------------------------------------------------------|
+| OnModuleLoad          | `sys_on_load`      | Tworzy tabelę `oaths` w Campaign DB.                              |
+| OnClientEnter         | `sys_on_enter`     | Przywraca efekty przysięgi i klątwę po zalogowaniu.              |
+| OnHeartbeat           | `sys_on_hb`        | Sprawdza naruszenia co ~60 s (co 10 taktów HB × 6 s = 60 s).    |
+| OnNuiEvent            | *(auto — NuiCreate ustawia `lib_oath_ev`)* | Brak dodatkowego hookowania.     |
+
+Jeśli moduł ma już własny `OnHeartbeat`, wywołaj `ExecuteScript("sys_on_hb", GetModule())` wewnątrz istniejącego skryptu lub użyj systemu haków (np. NWNX Hooks / lista skryptów w SetEventScript).
+
+## Kaplica — placeable
+
+1. Umieść dowolny placeable (np. ołtarz, kapliczka, posąg) na mapie.
+2. Ustaw jego skrypt `OnUsed` na `test_oath`.
+3. Upewnij się, że placeable ma włączone `Usable = TRUE`.
+
+## Jak gracz korzysta z systemu
+
+1. Gracz używa Kaplicy Przysiąg → otwiera się panel NUI.
+2. Wybiera przysięgę z lewej listy → widzi szczegóły (premie, ograniczenie, lore, koszt).
+3. Klika **Złóż Przysięgę** → pojawia się popup potwierdzenia.
+4. Po potwierdzeniu gracz traci złoto (jeśli wymagane) i otrzymuje trwałe efekty.
+5. Naruszenia są wykrywane automatycznie w heartbeat (dla Ubóstwa i Żelaza).
+6. Po 3 naruszeniach lub dobrodynamicznym wyrzeczeniu się — klątwa (-2 do wszystkich atrybutów).
+7. Odkupienie kosztuje 500 sz.z. i zdejmuje klątwę.
+
+## Dostępne przysięgi
+
+| ID | Nazwa                 | Premie                                              | Ograniczenie                                | Koszt   |
+|----|-----------------------|-----------------------------------------------------|---------------------------------------------|---------|
+| 1  | Przysięga Ubóstwa     | +2 WIS, +2 CHA, +1 do wszystkich rzutów obronnych  | Maks. 500 sz.z. (HB check)                  | 200 sz.z |
+| 2  | Przysięga Żelaza      | +4 naturalna KP, +2 CON                             | Brak zbroi z bazową KP > 0 (HB check)       | 150 sz.z |
+| 3  | Przysięga Zemsty      | +4 testy ataku, +2k6 obrażeń magicznych             | Nie uciekaj z walki (kodeks honorowy)        | 300 sz.z |
+| 4  | Przysięga Krwi        | Odporność na strach i efekty mentalne, +3 STR       | Drenaż 5% maks. PŻ co ~60 s                  | Brak    |
+| 5  | Przysięga Milczenia   | +5 Ukrywanie, +5 Cichy krok, +2 DEX                | Brak zaklęć werbalnych (kodeks honorowy)     | 150 sz.z |
+
+## Co celowo pominięto
+
+- **Cel zemsty** dla Przysięgi Zemsty: wybór konkretnej rasy/stworzenia wymagałby NWNX:Creature do podpięcia OnHit i checkowania rasy. Obecna implementacja daje flat +4 AB bez per-race filtrowania — wystarczy na start, można rozszerzyć.
+- **Sprawdzanie rzucania zaklęć** dla Przysięgi Milczenia: brak standardowego hooka w NWScript dla „przed rzuceniem czaru". Wymagałby NWNX:Events `NWNX_ON_CAST_SPELL_BEFORE`. Implementacja pozostaje kodeksem honorowym.
+- **Zapisywanie geometrii okna**: okno otwiera się wyśrodkowane; zapis pozycji okna (NuiBind geometry) nie jest trwały między sesjami bez NWNX:Persistencia.
+- **DM Panel**: brak interfejsu DM do ręcznego resetowania przysiąg. Można to zrobić przez `OathDbClear(oPC)` z konsoli DM.

--- a/Sacred Oaths/scripts/lib_nui.nss
+++ b/Sacred Oaths/scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Sacred Oaths/scripts/lib_nui_utility.nss
+++ b/Sacred Oaths/scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Sacred Oaths/scripts/lib_oath.nss
+++ b/Sacred Oaths/scripts/lib_oath.nss
@@ -1,0 +1,742 @@
+// lib_oath.nss — NUI layout, effect logic and violation checking for Sacred Oaths
+
+#include "lib_oath_def"
+
+// ================================================================
+// Text helpers
+// ================================================================
+
+string OathGetName(int nId)
+{
+    switch(nId)
+    {
+        case OATH_POVERTY:   return "Przysięga Ubóstwa";
+        case OATH_IRON:      return "Przysięga Żelaza";
+        case OATH_VENGEANCE: return "Przysięga Zemsty";
+        case OATH_BLOOD:     return "Przysięga Krwi";
+        case OATH_SILENCE:   return "Przysięga Milczenia";
+    }
+    return "Nieznana Przysięga";
+}
+
+string OathGetBonusText(int nId)
+{
+    switch(nId)
+    {
+        case OATH_POVERTY:
+            return "+2 Mądrości, +2 Charyzmy, +1 do wszystkich rzutów obronnych";
+        case OATH_IRON:
+            return "+4 do naturalnej klasy pancerza, +2 Kondycji";
+        case OATH_VENGEANCE:
+            return "+4 do testów ataku, +2k6 obrażeń magicznych przy każdym trafieniu";
+        case OATH_BLOOD:
+            return "Odporność na Strach i efekty mentalne, +3 Siły";
+        case OATH_SILENCE:
+            return "+5 do Ukrywania się, +5 do Cichego poruszania, +2 Zręczności";
+    }
+    return "";
+}
+
+string OathGetRestrText(int nId)
+{
+    switch(nId)
+    {
+        case OATH_POVERTY:
+            return "Nie możesz posiadać więcej niż " + IntToString(OATH_POVERTY_CAP)
+                 + " sz.z. — nadmiar zostanie wykryty i policzy się jako naruszenie.";
+        case OATH_IRON:
+            return "Nie możesz nosić zbroi (bazowa KP > 0). "
+                 + "Każde wykrycie zbroi liczy się jako naruszenie.";
+        case OATH_VENGEANCE:
+            return "Nie możesz uciekać z walki z wrogiem, gdy masz więcej niż 25% HP. "
+                 + "Kodeks honorowy — system nie egzekwuje automatycznie.";
+        case OATH_BLOOD:
+            return "Co ~60 sekund tracisz " + IntToString(OATH_BLOOD_DRAIN_PCT)
+                 + "% maksymalnych PŻ. Krew jest ceną potęgi.";
+        case OATH_SILENCE:
+            return "Nie możesz rzucać zaklęć werbalnych ani używać głosu w walce. "
+                 + "Kodeks honorowy — system nie egzekwuje automatycznie.";
+    }
+    return "";
+}
+
+string OathGetLoreText(int nId)
+{
+    switch(nId)
+    {
+        case OATH_POVERTY:
+            return "„Bogactwo jest łańcuchem duszy. Kto wyrzeka się złota, "
+                 + "otwiera serce na moc wyższą niż metal i ziemia."";
+        case OATH_IRON:
+            return "„Twoje ciało jest tarczą. Każda blizna to lekcja przeżyta. "
+                 + "Stal na plecach to słabość umysłu — prawdziwy wojownik jej nie potrzebuje."";
+        case OATH_VENGEANCE:
+            return "„Krew za krew. Śmierć za śmierć. Kto raz obrał cel, "
+                 + "nie spocznie, nie ucieknie, nie wyrzeknie się — aż wyrок zostanie spełniony."";
+        case OATH_BLOOD:
+            return "„Potęga drzemie w każdej kropli. Przelej swoją — "
+                 + "a staniesz się niezłomny. Lub zgniły. Bogowie nie rozróżniają."";
+        case OATH_SILENCE:
+            return "„Słowa są bronią głupców i modlitwą tchórzy. "
+                 + "Prawdziwa siła milczy, obserwuje i uderza raz — nieomylnie."";
+    }
+    return "";
+}
+
+int OathGetCost(int nId)
+{
+    switch(nId)
+    {
+        case OATH_POVERTY:   return OATH_COST_POVERTY;
+        case OATH_IRON:      return OATH_COST_IRON;
+        case OATH_VENGEANCE: return OATH_COST_VENGEANCE;
+        case OATH_BLOOD:     return OATH_COST_BLOOD;
+        case OATH_SILENCE:   return OATH_COST_SILENCE;
+    }
+    return 0;
+}
+
+// ================================================================
+// Effect management
+// ================================================================
+
+effect OathTag(effect e)
+{
+    return TagEffect(e, OATH_EFFECT_TAG);
+}
+
+void OathRemoveEffects(object oPC)
+{
+    effect e = GetFirstEffect(oPC);
+    while(GetIsEffectValid(e))
+    {
+        effect eNext = GetNextEffect(oPC);
+        if(GetEffectTag(e) == OATH_EFFECT_TAG)
+            RemoveEffect(oPC, e);
+        e = eNext;
+    }
+}
+
+void OathRemoveCurse(object oPC)
+{
+    effect e = GetFirstEffect(oPC);
+    while(GetIsEffectValid(e))
+    {
+        effect eNext = GetNextEffect(oPC);
+        if(GetEffectTag(e) == OATH_CURSE_TAG)
+            RemoveEffect(oPC, e);
+        e = eNext;
+    }
+}
+
+void OathApplyCurse(object oPC)
+{
+    // -2 to all six ability scores; skill penalties follow automatically via ability mods
+    effect eCurse = TagEffect(EffectCurse(2, 2, 2, 2, 2, 2), OATH_CURSE_TAG);
+    ApplyEffectToObject(DURATION_TYPE_PERMANENT, eCurse, oPC);
+}
+
+void OathApplyEffects(object oPC, int nOathId)
+{
+    OathRemoveEffects(oPC);
+    if(nOathId <= 0) return;
+
+    switch(nOathId)
+    {
+        case OATH_POVERTY:
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                OathTag(EffectAbilityIncrease(ABILITY_WISDOM, 2)), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                OathTag(EffectAbilityIncrease(ABILITY_CHARISMA, 2)), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                OathTag(EffectSavingThrowIncrease(SAVING_THROW_ALL, 1, SAVING_THROW_TYPE_ALL)), oPC);
+            break;
+
+        case OATH_IRON:
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                OathTag(EffectACIncrease(4, AC_NATURAL_BONUS)), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                OathTag(EffectAbilityIncrease(ABILITY_CONSTITUTION, 2)), oPC);
+            break;
+
+        case OATH_VENGEANCE:
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                OathTag(EffectAttackIncrease(4)), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                OathTag(EffectDamageIncrease(DAMAGE_BONUS_2d6, DAMAGE_TYPE_MAGICAL)), oPC);
+            break;
+
+        case OATH_BLOOD:
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                OathTag(EffectImmunity(IMMUNITY_TYPE_FEAR)), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                OathTag(EffectImmunity(IMMUNITY_TYPE_MIND_SPELLS)), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                OathTag(EffectAbilityIncrease(ABILITY_STRENGTH, 3)), oPC);
+            break;
+
+        case OATH_SILENCE:
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                OathTag(EffectSkillIncrease(SKILL_HIDE, 5)), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                OathTag(EffectSkillIncrease(SKILL_MOVE_SILENTLY, 5)), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                OathTag(EffectAbilityIncrease(ABILITY_DEXTERITY, 2)), oPC);
+            break;
+    }
+}
+
+// ================================================================
+// Oath break
+// ================================================================
+
+void OathBreak(object oPC, string sReason)
+{
+    int nOathId = OathGetActive(oPC);
+    if(nOathId <= 0) return;
+
+    OathRemoveEffects(oPC);
+    OathDbMarkBroken(oPC);
+
+    OathApplyCurse(oPC);
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectVisualEffect(VFX_IMP_DOOM), oPC);
+
+    FloatingTextStringOnCreature(
+        "Pieczęć pęka — " + OathGetName(nOathId) + " zerwana! " + sReason
+        + " Bogowie odwracają oblicza.", oPC, FALSE);
+
+    SendMessageToPC(oPC, "[Przysięgi] Przysięga zerwana. Nosisz piętno krzywoprzysięzcy "
+        "(-2 do wszystkich atrybutów). Odkup się za "
+        + IntToString(OATH_COST_ATONE) + " sz.z. w Kaplicy.");
+
+    int nToken = NuiFindWindow(oPC, OATH_WINDOW);
+    if(nToken != 0)
+    {
+        FeedOathStatus(oPC, nToken);
+        FeedOathDetail(oPC, nToken, GetLocalInt(oPC, OATH_LVAR_SEL));
+    }
+}
+
+// ================================================================
+// Violation checking (called from module heartbeat)
+// ================================================================
+
+void OathCheckViolations(object oPC)
+{
+    int nOathId = OathGetActive(oPC);
+    if(nOathId <= 0) return;
+
+    int bViolated = FALSE;
+    string sReason = "";
+
+    switch(nOathId)
+    {
+        case OATH_POVERTY:
+        {
+            int nGold = GetGold(oPC);
+            if(nGold > OATH_POVERTY_CAP)
+            {
+                bViolated = TRUE;
+                sReason = "Posiadasz " + IntToString(nGold) + " sz.z. (limit: "
+                        + IntToString(OATH_POVERTY_CAP) + ").";
+            }
+            break;
+        }
+        case OATH_IRON:
+        {
+            object oChest = GetItemInSlot(INVENTORY_SLOT_CHEST, oPC);
+            if(GetIsObjectValid(oChest) && GetBaseAC(oChest) > 0)
+            {
+                bViolated = TRUE;
+                sReason = "Nosisz zbroję — ciało powinno być jedyną tarczą.";
+            }
+            break;
+        }
+        case OATH_BLOOD:
+        {
+            int nMaxHP  = GetMaxHitPoints(oPC);
+            int nDrain  = max(1, nMaxHP * OATH_BLOOD_DRAIN_PCT / 100);
+            if(GetCurrentHitPoints(oPC) > nDrain + 5)
+            {
+                ApplyEffectToObject(DURATION_TYPE_INSTANT,
+                    EffectDamage(nDrain, DAMAGE_TYPE_MAGICAL, DAMAGE_POWER_NORMAL), oPC);
+                ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                    EffectVisualEffect(VFX_DUR_BLUR), oPC, 1.5);
+            }
+            // Blood drain is a cost, not a violation — oath never breaks from it
+            return;
+        }
+        // OATH_VENGEANCE and OATH_SILENCE are honour-system only
+    }
+
+    if(bViolated)
+    {
+        OathDbViolation(oPC);
+        int nViol = OathGetViolations(oPC);
+
+        if(nViol >= OATH_MAX_VIOLATIONS)
+        {
+            OathBreak(oPC, sReason);
+        }
+        else
+        {
+            FloatingTextStringOnCreature(
+                "Ostrzeżenie przysięgi: " + sReason
+                + " [Naruszenia: " + IntToString(nViol) + "/"
+                + IntToString(OATH_MAX_VIOLATIONS) + "]", oPC, FALSE);
+        }
+    }
+}
+
+// ================================================================
+// Login restore
+// ================================================================
+
+void OathRestoreOnLogin(object oPC)
+{
+    int nOathId = OathGetActive(oPC);
+    if(nOathId > 0)
+    {
+        OathApplyEffects(oPC, nOathId);
+        SendMessageToPC(oPC, "[Przysięgi] Aktywna przysięga: " + OathGetName(nOathId)
+            + ". Niechaj bogowie będą świadkami.");
+        return;
+    }
+    if(OathIsBroken(oPC))
+    {
+        OathApplyCurse(oPC);
+        SendMessageToPC(oPC, "[Przysięgi] Nosisz piętno krzywoprzysięzcy. "
+            "Odkup się za " + IntToString(OATH_COST_ATONE) + " sz.z. u kapłana.");
+    }
+}
+
+// ================================================================
+// NUI: feed functions
+// ================================================================
+
+void FeedOathStatus(object oPC, int nToken)
+{
+    int nActive = OathGetActive(oPC);
+    int nBroken = OathIsBroken(oPC);
+    string sText;
+    json jColor;
+
+    if(nBroken)
+    {
+        sText  = "PIĘTNO KRZYWOPRZYSIĘZCY — odkup się za " + IntToString(OATH_COST_ATONE) + " sz.z.";
+        jColor = NuiColor(210, 50, 50);
+    }
+    else if(nActive > 0)
+    {
+        int nViol  = OathGetViolations(oPC);
+        int nSworn = OathGetSwornAt(oPC);
+        sText = OathGetName(nActive) + "  ·  przysięga od: " + OathDaysSince(nSworn) + " dni";
+        if(nViol > 0)
+            sText = sText + "  ·  naruszenia: " + IntToString(nViol) + "/" + IntToString(OATH_MAX_VIOLATIONS);
+        jColor = NuiColor(110, 210, 90);
+    }
+    else
+    {
+        sText  = "Brak aktywnej przysięgi";
+        jColor = NuiColor(155, 155, 155);
+    }
+
+    NuiSetBind(oPC, nToken, OATH_BIND_ACTIVE_LBL, JsonString(sText));
+    NuiSetBind(oPC, nToken, OATH_BIND_ACTIVE_COL, jColor);
+}
+
+void FeedOathDetail(object oPC, int nToken, int nOathId)
+{
+    if(nOathId <= 0)
+    {
+        NuiSetBind(oPC, nToken, OATH_BIND_DET_NAME,  JsonString(""));
+        NuiSetBind(oPC, nToken, OATH_BIND_DET_BONUS,  JsonString(""));
+        NuiSetBind(oPC, nToken, OATH_BIND_DET_RESTR,  JsonString(""));
+        NuiSetBind(oPC, nToken, OATH_BIND_DET_LORE,
+            JsonString("Wybierz przysięgę z listy, aby poznać jej moc i cenę."));
+        NuiSetBind(oPC, nToken, OATH_BIND_DET_COST,  JsonString(""));
+        NuiSetBind(oPC, nToken, OATH_BIND_SWEAR_ENA, JsonBool(FALSE));
+        NuiSetBind(oPC, nToken, OATH_BIND_SWEAR_LBL, JsonString("Złóż Przysięgę"));
+        NuiSetBind(oPC, nToken, OATH_BIND_REN_ENA,   JsonBool(FALSE));
+        return;
+    }
+
+    int nActive  = OathGetActive(oPC);
+    int nBroken  = OathIsBroken(oPC);
+    int nCost    = OathGetCost(nOathId);
+    int bIsActive = (nActive == nOathId);
+
+    NuiSetBind(oPC, nToken, OATH_BIND_DET_NAME,  JsonString(OathGetName(nOathId)));
+    NuiSetBind(oPC, nToken, OATH_BIND_DET_BONUS,  JsonString("Premie:  " + OathGetBonusText(nOathId)));
+    NuiSetBind(oPC, nToken, OATH_BIND_DET_RESTR,  JsonString("Ograniczenie:  " + OathGetRestrText(nOathId)));
+    NuiSetBind(oPC, nToken, OATH_BIND_DET_LORE,   JsonString(OathGetLoreText(nOathId)));
+
+    string sCostLine = (nCost > 0)
+        ? "Koszt złożenia: " + IntToString(nCost) + " sz.z."
+        : "Koszt złożenia: brak złota — tylko krew.";
+    NuiSetBind(oPC, nToken, OATH_BIND_DET_COST, JsonString(sCostLine));
+
+    int bCanSwear = (nActive == 0) && !nBroken && (GetGold(oPC) >= nCost);
+
+    NuiSetBind(oPC, nToken, OATH_BIND_SWEAR_ENA, JsonBool(bCanSwear));
+    NuiSetBind(oPC, nToken, OATH_BIND_SWEAR_LBL,
+        JsonString(bIsActive ? "▶  Aktywna przysięga" : "Złóż Przysięgę"));
+    NuiSetBind(oPC, nToken, OATH_BIND_REN_ENA, JsonBool(bIsActive));
+}
+
+void FeedOathRows(object oPC, int nToken, int nSelectedId)
+{
+    int i;
+    for(i = 1; i <= OATH_COUNT; i++)
+        NuiSetBind(oPC, nToken, OATH_BIND_ROW_ENC + IntToString(i), JsonBool(i == nSelectedId));
+}
+
+// ================================================================
+// NUI: layout builders
+// ================================================================
+
+json BuildOathLeftPanel(object oPC)
+{
+    float fRowH  = GetNuiScaleDimension(oPC, 42.0);
+    float fPanW  = GetNuiScaleDimension(oPC, 220.0);
+    float fHdrH  = GetNuiScaleDimension(oPC, 26.0);
+
+    json jCol = JsonArray();
+
+    json jHdr = NuiLabel(JsonString("Dostępne przysięgi"),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jHdr = NuiHeight(jHdr, fHdrH);
+    jHdr = NuiStyleForegroundColor(jHdr, GetNuiColorNwnGold());
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jHdr)));
+
+    int i;
+    for(i = 1; i <= OATH_COUNT; i++)
+    {
+        json jLbl = NuiLabel(JsonString(OathGetName(i)),
+            JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+
+        json jCells = JsonArray();
+        jCells = JsonArrayInsert(jCells, NuiSpacer());
+        jCells = JsonArrayInsert(jCells, jLbl);
+
+        json jGroup = NuiGroup(NuiRow(jCells), FALSE, NUI_SCROLLBARS_NONE);
+        jGroup = NuiId(jGroup, OATH_BTN_ROW + IntToString(i));
+        jGroup = NuiHeight(jGroup, fRowH);
+        jGroup = NuiEncouraged(jGroup, NuiBind(OATH_BIND_ROW_ENC + IntToString(i)));
+
+        jCol = JsonArrayInsert(jCol, jGroup);
+    }
+
+    json jPanel = NuiGroup(NuiCol(jCol), TRUE, NUI_SCROLLBARS_NONE);
+    jPanel = NuiWidth(jPanel, fPanW);
+    return jPanel;
+}
+
+json BuildOathRightPanel(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 30.0);
+    float fNameH = GetNuiScaleDimension(oPC, 30.0);
+    float fLoreH = GetNuiScaleDimension(oPC, 64.0);
+    float fBonH  = GetNuiScaleDimension(oPC, 52.0);
+    float fResH  = GetNuiScaleDimension(oPC, 60.0);
+    float fCostH = GetNuiScaleDimension(oPC, 24.0);
+
+    json jCol = JsonArray();
+
+    // Oath name
+    json jName = NuiLabel(NuiBind(OATH_BIND_DET_NAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jName = NuiHeight(jName, fNameH);
+    jName = NuiStyleForegroundColor(jName, GetNuiColorNwnGold());
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jName)));
+
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+
+    // Lore quote
+    json jLore = NuiLabel(NuiBind(OATH_BIND_DET_LORE),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_TOP));
+    jLore = NuiHeight(jLore, fLoreH);
+    jLore = NuiStyleForegroundColor(jLore, NuiColor(190, 180, 155));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jLore)));
+
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+
+    // Bonus description
+    json jBonus = NuiLabel(NuiBind(OATH_BIND_DET_BONUS),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_TOP));
+    jBonus = NuiHeight(jBonus, fBonH);
+    jBonus = NuiStyleForegroundColor(jBonus, NuiColor(90, 215, 90));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jBonus)));
+
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+
+    // Restriction description
+    json jRestr = NuiLabel(NuiBind(OATH_BIND_DET_RESTR),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_TOP));
+    jRestr = NuiHeight(jRestr, fResH);
+    jRestr = NuiStyleForegroundColor(jRestr, NuiColor(215, 90, 90));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jRestr)));
+
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+
+    // Cost line
+    json jCost = NuiLabel(NuiBind(OATH_BIND_DET_COST),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jCost = NuiHeight(jCost, fCostH);
+    jCost = NuiStyleForegroundColor(jCost, NuiColor(200, 165, 75));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jCost)));
+
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 10.0));
+
+    // Button row: [Złóż Przysięgę]  spacer  [Wyrzeknij się]
+    json jSwear = NuiButton(NuiBind(OATH_BIND_SWEAR_LBL));
+    jSwear = NuiId(jSwear, OATH_BTN_SWEAR);
+    jSwear = NuiEnabled(jSwear, NuiBind(OATH_BIND_SWEAR_ENA));
+    jSwear = NuiHeight(jSwear, fBtnH);
+
+    json jRenounce = NuiButton(JsonString("Wyrzeknij się"));
+    jRenounce = NuiId(jRenounce, OATH_BTN_RENOUNCE);
+    jRenounce = NuiEnabled(jRenounce, NuiBind(OATH_BIND_REN_ENA));
+    jRenounce = NuiHeight(jRenounce, fBtnH);
+    jRenounce = NuiWidth(jRenounce, GetNuiScaleDimension(oPC, 130.0));
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, jSwear);
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jRenounce);
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+
+    return NuiGroup(NuiCol(jCol), FALSE, NUI_SCROLLBARS_NONE);
+}
+
+// ================================================================
+// NUI: open window
+// ================================================================
+
+void OathOpenWindow(object oPC)
+{
+    int nExist = NuiFindWindow(oPC, OATH_WINDOW);
+    if(nExist != 0)
+    {
+        NuiDestroy(oPC, nExist);
+    }
+
+    float fGuiW = IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH));
+    float fGuiH = IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT));
+    float fW    = GetNuiScaleDimension(oPC, OATH_W);
+    float fH    = GetNuiScaleDimension(oPC, OATH_H);
+    float fCX   = (fGuiW - fW) / 2.0;
+    float fCY   = (fGuiH - fH) / 2.0;
+
+    // ---- Status bar row ----
+    json jStatusLbl = NuiLabel(NuiBind(OATH_BIND_ACTIVE_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jStatusLbl = NuiStyleForegroundColor(jStatusLbl, NuiBind(OATH_BIND_ACTIVE_COL));
+    jStatusLbl = NuiHeight(jStatusLbl, GetNuiScaleDimension(oPC, 24.0));
+
+    json jAtone = NuiButton(JsonString("Odkup się"));
+    jAtone = NuiId(jAtone, OATH_BTN_ATONE);
+    jAtone = NuiWidth(jAtone, GetNuiScaleDimension(oPC, 110.0));
+    jAtone = NuiHeight(jAtone, GetNuiScaleDimension(oPC, 24.0));
+
+    json jClose = NuiButton(JsonString("✕"));
+    jClose = NuiId(jClose, OATH_BTN_CLOSE);
+    jClose = NuiWidth(jClose, GetNuiScaleDimension(oPC, 28.0));
+    jClose = NuiHeight(jClose, GetNuiScaleDimension(oPC, 24.0));
+
+    json jTopRow = JsonArray();
+    jTopRow = JsonArrayInsert(jTopRow, jStatusLbl);
+    jTopRow = JsonArrayInsert(jTopRow, jAtone);
+    jTopRow = JsonArrayInsert(jTopRow, jClose);
+
+    // ---- Main content ----
+    json jContent = JsonArray();
+    jContent = JsonArrayInsert(jContent, BuildOathLeftPanel(oPC));
+    jContent = JsonArrayInsert(jContent, BuildOathRightPanel(oPC));
+
+    // ---- Root layout ----
+    json jRoot = JsonArray();
+    jRoot = JsonArrayInsert(jRoot, NuiRow(jTopRow));
+    jRoot = JsonArrayInsert(jRoot, CreateEmptyRow(oPC, 4.0));
+    jRoot = JsonArrayInsert(jRoot, NuiRow(jContent));
+
+    json jWin = NuiWindow(
+        NuiCol(jRoot),
+        JsonString("Kaplica Przysiąg"),
+        NuiRect(fCX, fCY, fW, fH),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE),
+        JsonBool(TRUE));
+
+    int nToken = NuiCreate(oPC, jWin, OATH_WINDOW, OATH_EV_SCRIPT);
+    if(nToken == 0) return;
+
+    SetLocalInt(oPC, OATH_LVAR_SEL, 0);
+    FeedOathStatus(oPC, nToken);
+    FeedOathRows(oPC, nToken, 0);
+    FeedOathDetail(oPC, nToken, 0);
+}
+
+// ================================================================
+// NUI: confirm popup
+// ================================================================
+
+void OathCreateConfirmPopup(object oPC, int nOathId, string sType)
+{
+    int nExist = NuiFindWindow(oPC, OATH_WIN_CONFIRM);
+    if(nExist != 0) NuiDestroy(oPC, nExist);
+
+    SetLocalString(oPC, OATH_LVAR_CONFIRM, sType);
+
+    string sMsg;
+    if(sType == "swear")
+    {
+        int nCost = OathGetCost(nOathId);
+        sMsg = "Złożyć " + OathGetName(nOathId) + "?\n"
+             + (nCost > 0 ? "Koszt: " + IntToString(nCost) + " sz.z.\n" : "Koszt: krew.\n")
+             + "Bogowie będą świadkami. Nie ma odwrotu bez piętna.";
+    }
+    else if(sType == "renounce")
+    {
+        sMsg = "Wyrzec się " + OathGetName(nOathId) + "?\n"
+             + "Złamanie przysięgi sprowadzi klątwę i piętno krzywoprzysięzcy.\n"
+             + "Jesteś pewien?";
+    }
+    else
+    {
+        sMsg = "Odkupić winę krzywoprzysięzcy za " + IntToString(OATH_COST_ATONE) + " sz.z.?\n"
+             + "Piętno zostanie zdjęte i będziesz mógł złożyć nową przysięgę.";
+    }
+
+    float fPW = GetNuiScaleDimension(oPC, 370.0);
+    float fPH = GetNuiScaleDimension(oPC, 180.0);
+    float fBH = GetNuiScaleDimension(oPC, 32.0);
+
+    json jMsg = NuiLabel(NuiBind(OATH_BIND_CONF_MSG),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jMsg = NuiHeight(jMsg, GetNuiScaleDimension(oPC, 90.0));
+
+    json jYes = NuiButton(JsonString("Tak, potwierdzam"));
+    jYes = NuiId(jYes, OATH_BTN_YES);
+    jYes = NuiHeight(jYes, fBH);
+
+    json jNo = NuiButton(JsonString("Nie, rezygnuję"));
+    jNo = NuiId(jNo, OATH_BTN_NO);
+    jNo = NuiHeight(jNo, fBH);
+
+    json jBtns = JsonArray();
+    jBtns = JsonArrayInsert(jBtns, jYes);
+    jBtns = JsonArrayInsert(jBtns, jNo);
+
+    json jLayout = JsonArray();
+    jLayout = JsonArrayInsert(jLayout, NuiRow(JsonArrayInsert(JsonArray(), jMsg)));
+    jLayout = JsonArrayInsert(jLayout, NuiRow(jBtns));
+
+    float fGuiW = IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH));
+    float fGuiH = IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT));
+
+    json jWin = NuiWindow(
+        NuiCol(jLayout),
+        JsonString("Potwierdzenie"),
+        NuiRect((fGuiW - fPW) / 2.0, (fGuiH - fPH) / 2.0, fPW, fPH),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE));
+
+    int nToken = NuiCreate(oPC, jWin, OATH_WIN_CONFIRM, OATH_EV_SCRIPT);
+    if(nToken != 0)
+        NuiSetBind(oPC, nToken, OATH_BIND_CONF_MSG, JsonString(sMsg));
+}
+
+// ================================================================
+// Swear / Renounce / Atone
+// ================================================================
+
+void OathDoSwear(object oPC, int nOathId)
+{
+    int nCost = OathGetCost(nOathId);
+
+    if(GetGold(oPC) < nCost)
+    {
+        SendMessageToPC(oPC, "[Przysięgi] Potrzebujesz " + IntToString(nCost)
+            + " sz.z., by złożyć tę przysięgę.");
+        return;
+    }
+    if(OathGetActive(oPC) > 0)
+    {
+        SendMessageToPC(oPC, "[Przysięgi] Możesz złożyć tylko jedną przysięgę naraz.");
+        return;
+    }
+    if(OathIsBroken(oPC))
+    {
+        SendMessageToPC(oPC, "[Przysięgi] Piętno krzywoprzysięzcy blokuje nowe przysięgi. Najpierw się odkup.");
+        return;
+    }
+
+    if(nCost > 0)
+        AssignCommand(oPC, TakeGoldFromCreature(nCost, oPC, TRUE));
+
+    OathDbSwear(oPC, nOathId);
+    OathApplyEffects(oPC, nOathId);
+
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectVisualEffect(VFX_FNF_HOLY_BURST), oPC);
+
+    FloatingTextStringOnCreature(
+        OathGetName(nOathId) + " złożona. Bogowie przyjmują świadectwo.", oPC, FALSE);
+
+    SendMessageToPC(oPC, "[Przysięgi] Złożono " + OathGetName(nOathId) + ". Moc jest twoja.");
+
+    int nToken = NuiFindWindow(oPC, OATH_WINDOW);
+    if(nToken != 0)
+    {
+        SetLocalInt(oPC, OATH_LVAR_SEL, nOathId);
+        FeedOathStatus(oPC, nToken);
+        FeedOathDetail(oPC, nToken, nOathId);
+        FeedOathRows(oPC, nToken, nOathId);
+    }
+}
+
+void OathDoRenounce(object oPC)
+{
+    OathBreak(oPC, "Dobrowolne wyrzeczenie się przysięgi.");
+}
+
+void OathDoAtone(object oPC)
+{
+    if(!OathIsBroken(oPC))
+    {
+        SendMessageToPC(oPC, "[Przysięgi] Nie nosisz piętna krzywoprzysięzcy.");
+        return;
+    }
+    if(GetGold(oPC) < OATH_COST_ATONE)
+    {
+        SendMessageToPC(oPC, "[Przysięgi] Odkupienie kosztuje " + IntToString(OATH_COST_ATONE)
+            + " sz.z. Nie masz wystarczająco złota.");
+        return;
+    }
+
+    AssignCommand(oPC, TakeGoldFromCreature(OATH_COST_ATONE, oPC, TRUE));
+    OathRemoveCurse(oPC);
+    OathDbClear(oPC);
+
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectVisualEffect(VFX_IMP_HOLY_AID), oPC);
+
+    FloatingTextStringOnCreature(
+        "Bogowie przyjmują ofiarę. Piętno opada jak popiół.", oPC, FALSE);
+
+    SendMessageToPC(oPC, "[Przysięgi] Piętno krzywoprzysięzcy zdjęte. Możesz złożyć nową przysięgę.");
+
+    int nToken = NuiFindWindow(oPC, OATH_WINDOW);
+    if(nToken != 0)
+    {
+        FeedOathStatus(oPC, nToken);
+        FeedOathDetail(oPC, nToken, GetLocalInt(oPC, OATH_LVAR_SEL));
+    }
+}

--- a/Sacred Oaths/scripts/lib_oath_def.nss
+++ b/Sacred Oaths/scripts/lib_oath_def.nss
@@ -1,0 +1,87 @@
+// lib_oath_def.nss — constants, bind IDs and forward declarations for Sacred Oaths
+
+#include "lib_nui"
+#include "sql_oath"
+
+// ---- Forward declarations ----
+void OathOpenWindow(object oPC);
+void OathApplyEffects(object oPC, int nOathId);
+void OathRemoveEffects(object oPC);
+void OathBreak(object oPC, string sReason);
+void OathCheckViolations(object oPC);
+void OathRestoreOnLogin(object oPC);
+void FeedOathDetail(object oPC, int nToken, int nOathId);
+void FeedOathStatus(object oPC, int nToken);
+void FeedOathRows(object oPC, int nToken, int nSelectedId);
+void OathCreateConfirmPopup(object oPC, int nOathId, string sType);
+void OathDoSwear(object oPC, int nOathId);
+void OathDoRenounce(object oPC);
+string OathGetName(int nId);
+string OathGetBonusText(int nId);
+string OathGetRestrText(int nId);
+string OathGetLoreText(int nId);
+int    OathGetCost(int nId);
+
+// ---- Window IDs ----
+const string OATH_WINDOW       = "OATH_WINDOW";
+const string OATH_EV_SCRIPT    = "lib_oath_ev";
+const string OATH_WIN_CONFIRM  = "OATH_WIN_CONFIRM";
+
+// ---- Bind IDs ----
+const string OATH_BIND_ACTIVE_LBL  = "oath_active_lbl";
+const string OATH_BIND_ACTIVE_COL  = "oath_active_col";
+const string OATH_BIND_DET_NAME    = "oath_det_name";
+const string OATH_BIND_DET_BONUS   = "oath_det_bonus";
+const string OATH_BIND_DET_RESTR   = "oath_det_restr";
+const string OATH_BIND_DET_LORE    = "oath_det_lore";
+const string OATH_BIND_DET_COST    = "oath_det_cost";
+const string OATH_BIND_SWEAR_ENA   = "oath_swear_ena";
+const string OATH_BIND_SWEAR_LBL   = "oath_swear_lbl";
+const string OATH_BIND_REN_ENA     = "oath_ren_ena";
+const string OATH_BIND_CONF_MSG    = "oath_conf_msg";
+
+// Per-row binds: append IntToString(oath_id) to get the specific bind
+const string OATH_BIND_ROW_ENC     = "oath_row_enc";  // + "1".."5"
+
+// ---- Button IDs ----
+const string OATH_BTN_CLOSE        = "oath_btn_close";
+const string OATH_BTN_ROW          = "oath_btn_row";  // + "1".."5"
+const string OATH_BTN_SWEAR        = "oath_btn_swear";
+const string OATH_BTN_RENOUNCE     = "oath_btn_renounce";
+const string OATH_BTN_YES          = "oath_btn_yes";
+const string OATH_BTN_NO           = "oath_btn_no";
+const string OATH_BTN_ATONE        = "oath_btn_atone";
+
+// ---- LVARs on PC ----
+const string OATH_LVAR_SEL         = "OATH_SEL";
+const string OATH_LVAR_CONFIRM     = "OATH_CONFIRM";  // "swear" | "renounce" | "atone"
+const string OATH_LVAR_HB_CNT      = "OATH_HB_CNT";
+
+// ---- Layout ----
+const float  OATH_W                = 680.0;
+const float  OATH_H                = 480.0;
+
+// ---- Oath IDs ----
+const int    OATH_COUNT            = 5;
+const int    OATH_POVERTY          = 1;
+const int    OATH_IRON             = 2;
+const int    OATH_VENGEANCE        = 3;
+const int    OATH_BLOOD            = 4;
+const int    OATH_SILENCE          = 5;
+
+// ---- Oath costs (gold) ----
+const int    OATH_COST_POVERTY     = 200;
+const int    OATH_COST_IRON        = 150;
+const int    OATH_COST_VENGEANCE   = 300;
+const int    OATH_COST_BLOOD       = 0;
+const int    OATH_COST_SILENCE     = 150;
+const int    OATH_COST_ATONE       = 500;  // gold to lift the Oathbreaker curse
+
+// ---- Mechanic parameters ----
+const int    OATH_POVERTY_CAP      = 500;   // max gold for Poverty oath
+const int    OATH_BLOOD_DRAIN_PCT  = 5;     // % max HP drained per violation check
+const int    OATH_MAX_VIOLATIONS   = 3;     // violations before oath shatters
+const int    OATH_HB_TICKS         = 10;    // module heartbeats between violation checks (~60 s)
+
+const string OATH_EFFECT_TAG       = "SACRED_OATH";
+const string OATH_CURSE_TAG        = "OATH_BREAKER";

--- a/Sacred Oaths/scripts/lib_oath_ev.nss
+++ b/Sacred Oaths/scripts/lib_oath_ev.nss
@@ -1,0 +1,121 @@
+// lib_oath_ev.nss — NUI event handler for Sacred Oaths
+
+#include "lib_oath"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+
+    // ----------------------------------------------------------------
+    // Confirm popup
+    // ----------------------------------------------------------------
+    if(nToken == NuiFindWindow(oPC, OATH_WIN_CONFIRM))
+    {
+        if(sEvent == EVENT_TYPE_CLICK)
+        {
+            if(sElem == OATH_BTN_YES)
+            {
+                string sType   = GetLocalString(oPC, OATH_LVAR_CONFIRM);
+                int    nOathId = GetLocalInt(oPC, OATH_LVAR_SEL);
+
+                NuiDestroy(oPC, nToken);
+
+                if(sType == "swear")
+                    OathDoSwear(oPC, nOathId);
+                else if(sType == "renounce")
+                    OathDoRenounce(oPC);
+                else if(sType == "atone")
+                    OathDoAtone(oPC);
+            }
+            else if(sElem == OATH_BTN_NO)
+            {
+                NuiDestroy(oPC, nToken);
+            }
+        }
+        return;
+    }
+
+    // ----------------------------------------------------------------
+    // Main window
+    // ----------------------------------------------------------------
+    if(nToken != NuiFindWindow(oPC, OATH_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalInt(oPC, OATH_LVAR_SEL);
+        DeleteLocalString(oPC, OATH_LVAR_CONFIRM);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == OATH_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        if(sElem == OATH_BTN_SWEAR)
+        {
+            int nSel = GetLocalInt(oPC, OATH_LVAR_SEL);
+            if(nSel <= 0)
+            {
+                SendMessageToPC(oPC, "[Przysięgi] Wybierz przysięgę z listy.");
+                return;
+            }
+            OathCreateConfirmPopup(oPC, nSel, "swear");
+            return;
+        }
+
+        if(sElem == OATH_BTN_RENOUNCE)
+        {
+            int nActive = OathGetActive(oPC);
+            if(nActive <= 0) return;
+            OathCreateConfirmPopup(oPC, nActive, "renounce");
+            return;
+        }
+
+        if(sElem == OATH_BTN_ATONE)
+        {
+            if(!OathIsBroken(oPC))
+            {
+                SendMessageToPC(oPC, "[Przysięgi] Nie nosisz piętna — odkupienie nie jest potrzebne.");
+                return;
+            }
+            OathCreateConfirmPopup(oPC, 0, "atone");
+            return;
+        }
+
+        // Oath row clicks (oath_btn_row1 .. oath_btn_row5)
+        int i;
+        for(i = 1; i <= OATH_COUNT; i++)
+        {
+            if(sElem == OATH_BTN_ROW + IntToString(i))
+            {
+                SetLocalInt(oPC, OATH_LVAR_SEL, i);
+                FeedOathRows(oPC, nToken, i);
+                FeedOathDetail(oPC, nToken, i);
+                return;
+            }
+        }
+    }
+
+    if(sEvent == EVENT_TYPE_MOUSEDOWN)
+    {
+        // Row clicks also fire mousedown — handle same as click for groups
+        int i;
+        for(i = 1; i <= OATH_COUNT; i++)
+        {
+            if(sElem == OATH_BTN_ROW + IntToString(i))
+            {
+                SetLocalInt(oPC, OATH_LVAR_SEL, i);
+                FeedOathRows(oPC, nToken, i);
+                FeedOathDetail(oPC, nToken, i);
+                return;
+            }
+        }
+    }
+}

--- a/Sacred Oaths/scripts/sql_oath.nss
+++ b/Sacred Oaths/scripts/sql_oath.nss
@@ -1,0 +1,96 @@
+// sql_oath.nss — DB schema and queries for Sacred Oaths
+
+void OathCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("oaths",
+        "CREATE TABLE IF NOT EXISTS oaths ("
+        "uuid TEXT PRIMARY KEY, "
+        "oath_id INTEGER DEFAULT 0, "
+        "sworn_at INTEGER DEFAULT 0, "
+        "violations INTEGER DEFAULT 0, "
+        "is_broken INTEGER DEFAULT 0)");
+    SqlStep(q);
+}
+
+int OathGetActive(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("oaths",
+        "SELECT oath_id FROM oaths WHERE uuid=@u AND is_broken=0 AND oath_id>0");
+    SqlBindString(q, "@u", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+int OathIsBroken(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("oaths",
+        "SELECT is_broken FROM oaths WHERE uuid=@u");
+    SqlBindString(q, "@u", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+int OathGetViolations(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("oaths",
+        "SELECT violations FROM oaths WHERE uuid=@u");
+    SqlBindString(q, "@u", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+int OathGetSwornAt(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("oaths",
+        "SELECT sworn_at FROM oaths WHERE uuid=@u");
+    SqlBindString(q, "@u", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+void OathDbSwear(object oPC, int nOathId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("oaths",
+        "INSERT OR REPLACE INTO oaths "
+        "(uuid, oath_id, sworn_at, violations, is_broken) "
+        "VALUES (@u, @id, strftime('%s','now'), 0, 0)");
+    SqlBindString(q, "@u",  GetObjectUUID(oPC));
+    SqlBindInt   (q, "@id", nOathId);
+    SqlStep(q);
+}
+
+void OathDbViolation(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("oaths",
+        "UPDATE oaths SET violations=violations+1 WHERE uuid=@u");
+    SqlBindString(q, "@u", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+void OathDbMarkBroken(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("oaths",
+        "UPDATE oaths SET is_broken=1 WHERE uuid=@u");
+    SqlBindString(q, "@u", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+// Clears the broken record so PC can take a new oath after atonement
+void OathDbClear(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("oaths",
+        "DELETE FROM oaths WHERE uuid=@u");
+    SqlBindString(q, "@u", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+// Returns elapsed days as a string (SQLite handles the arithmetic)
+string OathDaysSince(int nUnix)
+{
+    if(nUnix <= 0) return "0";
+    sqlquery q = SqlPrepareQueryCampaign("oaths",
+        "SELECT CAST((strftime('%s','now') - @ts) / 86400 AS INTEGER)");
+    SqlBindInt(q, "@ts", nUnix);
+    if(SqlStep(q)) return SqlGetString(q, 0);
+    return "0";
+}

--- a/Sacred Oaths/scripts/sys_on_enter.nss
+++ b/Sacred Oaths/scripts/sys_on_enter.nss
@@ -1,0 +1,11 @@
+// sys_on_enter.nss — module OnClientEnter: restore oath effects after login
+
+#include "lib_oath"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC) || GetIsDMPossessed(oPC)) return;
+
+    OathRestoreOnLogin(oPC);
+}

--- a/Sacred Oaths/scripts/sys_on_hb.nss
+++ b/Sacred Oaths/scripts/sys_on_hb.nss
@@ -1,0 +1,24 @@
+// sys_on_hb.nss — module OnHeartbeat: check oath violations every ~60 s
+// Hook this script to the module OnHeartbeat event (alongside any existing HB script).
+
+#include "lib_oath"
+
+void main()
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        if(GetIsPC(oPC) && !GetIsDMPossessed(oPC))
+        {
+            int nCnt = GetLocalInt(oPC, OATH_LVAR_HB_CNT) + 1;
+            SetLocalInt(oPC, OATH_LVAR_HB_CNT, nCnt);
+
+            if(nCnt >= OATH_HB_TICKS)
+            {
+                DeleteLocalInt(oPC, OATH_LVAR_HB_CNT);
+                OathCheckViolations(oPC);
+            }
+        }
+        oPC = GetNextPC();
+    }
+}

--- a/Sacred Oaths/scripts/sys_on_load.nss
+++ b/Sacred Oaths/scripts/sys_on_load.nss
@@ -1,0 +1,8 @@
+// sys_on_load.nss — module OnModuleLoad: initialise Sacred Oaths DB
+
+#include "lib_oath_def"
+
+void main()
+{
+    OathCreateTables();
+}

--- a/Sacred Oaths/scripts/test_oath.nss
+++ b/Sacred Oaths/scripts/test_oath.nss
@@ -1,0 +1,12 @@
+// test_oath.nss — OnUsed for the Oath Shrine placeable
+// Place a shrine in-world, set its OnUsed script to "test_oath".
+
+#include "lib_oath"
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    OathOpenWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

Moduł **Sacred Oaths** umożliwia graczom składanie jednej z pięciu świętych przysiąg w Kaplicy Przysiąg. Każda przysięga daje trwałe premie mechaniczne (atrybuty, KP, AB, odporności, umiejętności) w zamian za ograniczenie egzekwowane automatycznie lub jako kodeks honorowy. Złamanie przysięgi trzy razy (lub dobrowolne jej zerwanie) prowadzi do piętna krzywoprzysięzcy, które można zdjąć za 500 sz.z. w tej samej kaplicy.

## Mechanika

**Pięć przysiąg:**

| # | Nazwa | Premie | Ograniczenie | Koszt |
|---|-------|--------|--------------|-------|
| 1 | Przysięga Ubóstwa | +2 WIS, +2 CHA, +1 do rzutów obronnych | Max 500 sz.z. (sprawdzane co ~60 s) | 200 sz.z. |
| 2 | Przysięga Żelaza | +4 naturalna KP, +2 CON | Brak zbroi z bazową KP > 0 (sprawdzane co ~60 s) | 150 sz.z. |
| 3 | Przysięga Zemsty | +4 testy ataku, +2k6 obrażeń magicznych | Nie uciekaj z walki (kodeks honorowy) | 300 sz.z. |
| 4 | Przysięga Krwi | Odporność na strach i efekty mentalne, +3 STR | Drenaż 5% max PŻ co ~60 s | Brak |
| 5 | Przysięga Milczenia | +5 Ukrywanie, +5 Cichy krok, +2 DEX | Brak zaklęć werbalnych (kodeks honorowy) | 150 sz.z. |

**Przepływ:**
1. Gracz używa placeable'a Kaplicy → otwiera się panel NUI (680×480).
2. Lewy panel: 5 przycisków wierszy z podświetleniem wybranej przysięgi.
3. Prawy panel: cytat klimatyczny, premie (zielony), ograniczenie (czerwony), koszt (złoty), przyciski [Złóż] / [Wyrzeknij się].
4. Potwierdzenie w osobnym popupie (bez możliwości cofnięcia bez konsekwencji).
5. Efekty trwałe (DURATION_TYPE_PERMANENT) z tagiem `SACRED_OATH` — usuwalne przez `OathRemoveEffects`.
6. Po 3 naruszeniach lub dobrowolnym wyrzeczeniu: efekty zdejmowane, klątwa `EffectCurse(-2,x6)` z tagiem `OATH_BREAKER`.
7. Odkupienie (500 sz.z.) czyści DB i zdejmuje klątwę — postać może złożyć nową przysięgę.

**Persystencja:** SQLite Campaign DB `oaths`, tabela `oaths` (uuid PK, oath_id, sworn_at, violations, is_broken). Efekty przywracane przy logowaniu przez `sys_on_enter`.

## Pliki

```
Sacred Oaths/
├── scripts/
│   ├── sql_oath.nss       — schemat DB + zapytania (OathDbSwear, OathDbViolation, …)
│   ├── lib_oath_def.nss   — stałe, ID bindów, ID przycisków, forward decl
│   ├── lib_oath.nss       — rdzeń: tekst oath, efekty, naruszenia, NUI (745 LOC)
│   ├── lib_oath_ev.nss    — handler NUI event: switch po elemencie i typie (121 LOC)
│   ├── sys_on_load.nss    — OathCreateTables() przy starcie modułu
│   ├── sys_on_enter.nss   — OathRestoreOnLogin() przy logowaniu
│   ├── sys_on_hb.nss      — OathCheckViolations() co ~60 s (10 × 6 s HB)
│   ├── test_oath.nss      — OnUsed kaplicy, otwiera okno
│   ├── lib_nui.nss        — kopia współdzielonego helpera NUI
│   └── lib_nui_utility.nss
└── INTEGRATION.md         — tabela hooków, opis przysiąg, znane ograniczenia
```

**Łącznie custom LOC: ~1104** (bez lib_nui / lib_nui_utility).

## Zależności (NWNX? SQL?)

- **NWNX: nie wymagany.** Moduł używa wyłącznie standardowego NWScript + NUI + SQLite Campaign DB.
- **SQLite Campaign DB** `oaths` — tworzona idempotentnie przez `CREATE TABLE IF NOT EXISTS` w `sys_on_load`.

## Jak włączyć w istniejącym module

1. Skopiuj folder `Sacred Oaths/scripts/` do HAK lub do folderu skryptów modułu.
2. W **Module Properties → Events**:
   - `OnModuleLoad` → wywołaj `sys_on_load` (lub `ExecuteScript("sys_on_load", GetModule())` z istniejącego)
   - `OnClientEnter` → wywołaj `sys_on_enter`
   - `OnHeartbeat` → wywołaj `sys_on_hb`
3. Umieść dowolny placeable (ołtarz/kapliczka) na mapie, `OnUsed` = `test_oath`, `Usable = TRUE`.

Jeśli moduł ma już własne skrypty dla tych zdarzeń, dodaj `ExecuteScript("sys_on_*", OBJECT_SELF/GetModule())` na końcu każdego z nich.

## Co celowo pominięto

- **Per-race targeting dla Przysięgi Zemsty** — wymagałby NWNX:Events `ON_HIT_CAST_SPELL` do filtrowania wg rasy; obecna implementacja daje flat +4 AB bez podziału na typy wroga.
- **Blokada zaklęć werbalnych** dla Przysięgi Milczenia — brak standardowego NWScript hooka `before cast`; wymaga NWNX:Events `NWNX_ON_CAST_SPELL_BEFORE`.
- **Zapis pozycji okna** między sesjami — wymagałby NWNX:Player GetBicFile lub zewnętrznej persystencji; okno otwiera się zawsze wyśrodkowane.
- **DM Panel** do ręcznego resetowania przysiąg — można to zrobić przez `OathDbClear(oPC)` z konsoli DM lub jako osobny moduł.


---
_Generated by [Claude Code](https://claude.ai/code/session_016HNX7fS2ERFvcq2m6Agza9)_