### PR TITLE
feat: Pilgrim's Curse

### DIFF
--- a/Pilgrim's Curse/INTEGRATION.md
+++ b/Pilgrim's Curse/INTEGRATION.md
@@ -1,0 +1,95 @@
+# Pilgrim's Curse — Instrukcja integracji
+
+## Co to robi
+
+Gracze nawiedzają rozsiane po module **ciemne sanktuaria** (placeables). Każde odwiedzenie
+dodaje punkty **Brzemienia** jednego z czterech typów (Cień / Krew / Śmierć / Chaos).
+Kumulujące się brzemię odblokowuje coraz silniejsze efekty pasywne (bonusy do STR/CON,
+odporności, widzenie w ciemności). Na najwyższym progu pojawia się kara −4 do CHA —
+twarz pielgrzyma budzi odrazę. Ołtarz Pokuty (`plg_catharsis`) pozwala oczyścić brzemię
+za złoto, ale zostawia tymczasowy debuff. NUI (3 zakładki) pokazuje progress bary brzemienia,
+lore sanktuariów i ranking 10 najbardziej przeklętych postaci.
+
+## Hooki modułu
+
+| Zdarzenie              | Skrypt do podpięcia  |
+|------------------------|----------------------|
+| Module OnLoad          | `sys_on_load`        |
+| Module OnClientEnter   | `sys_on_enter`       |
+
+## Placeables
+
+Każde sanktuarium to zwykły placeable z odpowiednim tagiem i skryptem `test_plg` w polu
+*OnUsed*. Nie trzeba żadnych zmiennych lokalnych — tag wystarczy.
+
+### Tagi wbudowane (seed w sys_on_load.nss)
+
+| Tag                      | Typ    | Brzemię |
+|--------------------------|--------|---------|
+| `plg_shrine_shadow_01`   | Cień   | 1       |
+| `plg_shrine_shadow_02`   | Cień   | 2       |
+| `plg_shrine_blood_01`    | Krew   | 1       |
+| `plg_shrine_blood_02`    | Krew   | 2       |
+| `plg_shrine_death_01`    | Śmierć | 1       |
+| `plg_shrine_death_02`    | Śmierć | 2       |
+| `plg_shrine_chaos_01`    | Chaos  | 1       |
+| `plg_shrine_chaos_02`    | Chaos  | 2       |
+| `plg_catharsis`          | —      | (oczyszczenie) |
+
+Otworzenie okna statusu: dowolny placeable z `test_plg` w OnUsed, tag inny niż powyższe.
+
+### Rejestracja własnych sanktuariów
+
+Wywołaj `PlgRegisterShrine(tag, nazwa, lore, typ, wartość)` z `sys_on_load.nss`
+(lub z dowolnego skryptu DM). Typy: `"shadow"`, `"blood"`, `"death"`, `"chaos"`.
+
+```nss
+PlgRegisterShrine("moje_sanktuarium", "Ołtarz Bólu", "Ból jest jedyną prawdą.", "blood", 3);
+```
+
+## Progi brzemienia i efekty
+
+| Łączne brzemię | Tier                  | Efekty                                              |
+|----------------|-----------------------|-----------------------------------------------------|
+| < 3            | Nieoznaczony          | brak                                                |
+| 3–5            | Lekkie Brzemię        | STR +1                                              |
+| 6–9            | Umiarkowane Brzemię   | STR +2, odporność na strach, widzenie w ciemności   |
+| 10–14          | Ciężkie Brzemię       | + CON +2, odporność na chorobę                      |
+| ≥ 15           | Piętno Potępionego    | + CON +3, odporności na truciznę i paraliż, CHA −4  |
+
+Katharsis: koszt = brzemię × 500 zł; kara: STR −2, CON −2 przez 3600 sekund.
+
+## Baza danych
+
+Campaign DB o nazwie `plg` (plik `plg.sqlite` w folderze servervault/databases):
+
+- `plg_shrines`  — definicje sanktuariów
+- `plg_pilgrims` — stan brzemienia per postać (klucz: UUID)
+- `plg_visits`   — log wizyt per postać per sanktuarium (reset po ukończeniu obiegu)
+
+Nie wymaga NWNX. Wszystkie zapytania przez `SqlPrepareQueryCampaign`.
+
+## Zależności
+
+- **NWN:EE** — wymagane NUI API (`NuiCreate`, `NuiBind`, …) i `TagEffect` / `SupernaturalEffect`
+- Brak wymagań NWNX
+
+## Test manualny
+
+1. Podepnij `sys_on_load` do Module OnLoad i załaduj moduł.
+2. Umieść placeable z tagiem `plg_shrine_shadow_01` i `test_plg` w OnUsed.
+3. Umieść placeable z tagiem `plg_catharsis` i `test_plg` w OnUsed.
+4. Umieść placeable z dowolnym tagiem (np. `plg_status_book`) i `test_plg` w OnUsed — to otwiera okno statusu.
+5. Wejdź jako gracz, kliknij sanktuarium, sprawdź pop-up i efekty.
+6. Kliknij status-book, przejrzyj 3 zakładki NUI.
+7. Zbierz brzemię ≥ 3, sprawdź efekty pasywne na postaci.
+8. Podejdź do ołtarza pokuty i kliknij "Katharsis" w oknie statusu.
+
+## Co celowo pominięto
+
+- **Wariant pielgrzymki świetlnej** — dedykowane sanktuaria "białe" z buff-only efektami;
+  można dodać jako kolejny `burden_type = "light"` bez zmiany architektury.
+- **Notyfikacja DM** o ukończeniu obiegu — brak hooków DM w tym projekcie.
+- **Animacje / dźwięki sanktuariów** — wymagałyby niestandardowych zasobów w HAK.
+- **Limit sanktuariów per circuit** — aktualnie zlicza wszystkie zarejestrowane;
+  dodanie wybranej ścieżki (np. tylko 4 z 8) wymaga pola `path_id` w schemacie.

--- a/Pilgrim's Curse/Scripts/lib_nui.nss
+++ b/Pilgrim's Curse/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Pilgrim's Curse/Scripts/lib_nui_utility.nss
+++ b/Pilgrim's Curse/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Pilgrim's Curse/Scripts/lib_plg.nss
+++ b/Pilgrim's Curse/Scripts/lib_plg.nss
@@ -1,0 +1,758 @@
+#include "lib_plg_def"
+
+// ----------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------
+
+string PlgBurdenTypeLabel(string sType)
+{
+    if(sType == "shadow") return "Cień";
+    if(sType == "blood")  return "Krew";
+    if(sType == "death")  return "Śmierć";
+    if(sType == "chaos")  return "Chaos";
+    return sType;
+}
+
+string PlgGetTierName(int nTotal)
+{
+    if(nTotal >= PLG_TIER_4) return "Piętno Potępionego";
+    if(nTotal >= PLG_TIER_3) return "Ciężkie Brzemię";
+    if(nTotal >= PLG_TIER_2) return "Umiarkowane Brzemię";
+    if(nTotal >= PLG_TIER_1) return "Lekkie Brzemię";
+    return "Nieoznaczony";
+}
+
+string PlgGetEffectSummary(int nTotal)
+{
+    if(nTotal == 0)
+        return "Brak efektów. Nieskażony jeszcze ciemnością.";
+
+    string s = "";
+    if(nTotal >= PLG_TIER_1)
+        s = s + "+ Siła +1\n";
+    if(nTotal >= PLG_TIER_2)
+        s = s + "+ Siła +2, Odporność na Strach, Widzenie w Ciemności\n";
+    if(nTotal >= PLG_TIER_3)
+        s = s + "+ Budowa +2, Odporność na Chorobę\n";
+    if(nTotal >= PLG_TIER_4)
+        s = s + "+ Budowa +3, Odporność na Truciznę i Paraliż\n"
+              + "— Charyzma -4 (oblicze wzbudza odrazę)\n";
+    return s;
+}
+
+int PlgGetCatharsisCost(int nTotal)
+{
+    return nTotal * 500;
+}
+
+// ----------------------------------------------------------------
+// Burden effect management
+// ----------------------------------------------------------------
+
+void PlgRemoveBurdenEffects(object oPC)
+{
+    effect eEff = GetFirstEffect(oPC);
+    while(GetIsEffectValid(eEff))
+    {
+        if(GetEffectTag(eEff) == PLG_FX_TAG)
+            RemoveEffect(oPC, eEff);
+        eEff = GetNextEffect(oPC);
+    }
+}
+
+void PlgApplyBurdenEffects(object oPC)
+{
+    PlgRemoveBurdenEffects(oPC);
+
+    json jP = PlgGetPilgrim(oPC);
+    if(JsonGetType(jP) == JSON_TYPE_NULL) return;
+
+    int nTotal = JsonGetInt(JsonObjectGet(jP, "burden_shadow"))
+               + JsonGetInt(JsonObjectGet(jP, "burden_blood"))
+               + JsonGetInt(JsonObjectGet(jP, "burden_death"))
+               + JsonGetInt(JsonObjectGet(jP, "burden_chaos"));
+
+    if(nTotal < PLG_TIER_1) return;
+
+    // Tier 1: STR +1
+    effect eS1 = TagEffect(SupernaturalEffect(EffectAbilityIncrease(ABILITY_STRENGTH, 1)), PLG_FX_TAG);
+    ApplyEffectToCreature(oPC, eS1, DURATION_TYPE_PERMANENT, 0.0);
+
+    if(nTotal >= PLG_TIER_2)
+    {
+        // Extra STR +1 (cumulative → +2 total), fear immunity, ultravision
+        effect eS2 = TagEffect(SupernaturalEffect(EffectAbilityIncrease(ABILITY_STRENGTH, 1)), PLG_FX_TAG);
+        ApplyEffectToCreature(oPC, eS2, DURATION_TYPE_PERMANENT, 0.0);
+
+        effect eFear = TagEffect(SupernaturalEffect(EffectImmunity(IMMUNITY_TYPE_FEAR)), PLG_FX_TAG);
+        ApplyEffectToCreature(oPC, eFear, DURATION_TYPE_PERMANENT, 0.0);
+
+        effect eUV = TagEffect(SupernaturalEffect(EffectUltravision()), PLG_FX_TAG);
+        ApplyEffectToCreature(oPC, eUV, DURATION_TYPE_PERMANENT, 0.0);
+    }
+
+    if(nTotal >= PLG_TIER_3)
+    {
+        effect eCon = TagEffect(SupernaturalEffect(EffectAbilityIncrease(ABILITY_CONSTITUTION, 2)), PLG_FX_TAG);
+        ApplyEffectToCreature(oPC, eCon, DURATION_TYPE_PERMANENT, 0.0);
+
+        effect eDis = TagEffect(SupernaturalEffect(EffectImmunity(IMMUNITY_TYPE_DISEASE)), PLG_FX_TAG);
+        ApplyEffectToCreature(oPC, eDis, DURATION_TYPE_PERMANENT, 0.0);
+    }
+
+    if(nTotal >= PLG_TIER_4)
+    {
+        // CON +1 more (→ +3 total), poison + paralysis immunity, CHA -4
+        effect eCon2 = TagEffect(SupernaturalEffect(EffectAbilityIncrease(ABILITY_CONSTITUTION, 1)), PLG_FX_TAG);
+        ApplyEffectToCreature(oPC, eCon2, DURATION_TYPE_PERMANENT, 0.0);
+
+        effect ePoison = TagEffect(SupernaturalEffect(EffectImmunity(IMMUNITY_TYPE_POISON)), PLG_FX_TAG);
+        ApplyEffectToCreature(oPC, ePoison, DURATION_TYPE_PERMANENT, 0.0);
+
+        effect ePar = TagEffect(SupernaturalEffect(EffectImmunity(IMMUNITY_TYPE_PARALYSIS)), PLG_FX_TAG);
+        ApplyEffectToCreature(oPC, ePar, DURATION_TYPE_PERMANENT, 0.0);
+
+        // The price of the Damned's visage.
+        effect eCha = TagEffect(SupernaturalEffect(EffectAbilityDecrease(ABILITY_CHARISMA, 4)), PLG_FX_TAG);
+        ApplyEffectToCreature(oPC, eCha, DURATION_TYPE_PERMANENT, 0.0);
+    }
+}
+
+// ----------------------------------------------------------------
+// Shrine interaction logic
+// ----------------------------------------------------------------
+
+void PlgHandleShrine(object oPC, object oShrine)
+{
+    string sTag = GetTag(oShrine);
+
+    // ---- Catharsis altar ----
+    if(sTag == PLG_CATHARSIS_TAG)
+    {
+        json jP = PlgGetPilgrim(oPC);
+        if(JsonGetType(jP) == JSON_TYPE_NULL)
+        {
+            SendMessageToPC(oPC, "[Pielgrzymka] Nie jesteś zapisany — wejdź do modułu ponownie.");
+            return;
+        }
+        int nShadow = JsonGetInt(JsonObjectGet(jP, "burden_shadow"));
+        int nBlood  = JsonGetInt(JsonObjectGet(jP, "burden_blood"));
+        int nDeath  = JsonGetInt(JsonObjectGet(jP, "burden_death"));
+        int nChaos  = JsonGetInt(JsonObjectGet(jP, "burden_chaos"));
+        int nTotal  = nShadow + nBlood + nDeath + nChaos;
+
+        if(nTotal <= 0)
+        {
+            SendMessageToPC(oPC, "[Pielgrzymka] Nie nosisz żadnego brzemienia — Katharsis zbędna.");
+            return;
+        }
+        int nCost = PlgGetCatharsisCost(nTotal);
+        if(GetGold(oPC) < nCost)
+        {
+            SendMessageToPC(oPC, "[Pielgrzymka] Katharsis kosztuje " + IntToString(nCost)
+                + " złota. Nie stać cię na oczyszczenie.");
+            return;
+        }
+
+        TakeGoldFromCreature(nCost, oPC, TRUE);
+        PlgPerformCatharsis(oPC);
+        PlgRemoveBurdenEffects(oPC);
+
+        // Penance: body pays after spirit is cleansed.
+        effect ePen1 = EffectAbilityDecrease(ABILITY_STRENGTH, 2);
+        effect ePen2 = EffectAbilityDecrease(ABILITY_CONSTITUTION, 2);
+        ApplyEffectToCreature(oPC, ePen1, DURATION_TYPE_TEMPORARY, 3600.0);
+        ApplyEffectToCreature(oPC, ePen2, DURATION_TYPE_TEMPORARY, 3600.0);
+
+        FloatingTextStringOnCreature(
+            "Brzemię spłynęło z twoich ramion... lecz ciało płaci cenę.", oPC, FALSE);
+        SendMessageToPC(oPC, "[Pielgrzymka] Katharsis dokonana. Zapłacono "
+            + IntToString(nCost) + " złota. Kara ciała potrwa godzinę.");
+
+        // Refresh UI if open.
+        int nToken = NuiFindWindow(oPC, PLG_WINDOW);
+        if(nToken != 0) PlgFeedStatus(oPC, nToken);
+        return;
+    }
+
+    // ---- Regular shrine ----
+    int nShrineId = PlgGetShrineId(sTag);
+    if(nShrineId < 0)
+    {
+        SendMessageToPC(oPC, "[Pielgrzymka] To sanktuarium nie jest zarejestrowane w systemie.");
+        return;
+    }
+
+    json jShrine = PlgGetShrine(nShrineId);
+    string sType = JsonGetString(JsonObjectGet(jShrine, "burden_type"));
+    int nVal     = JsonGetInt(JsonObjectGet(jShrine, "burden_val"));
+
+    int bAlreadyVisited = PlgHasVisited(oPC, nShrineId);
+
+    if(!bAlreadyVisited)
+    {
+        PlgRecordVisit(oPC, nShrineId, sType, nVal);
+        PlgApplyBurdenEffects(oPC);
+
+        if(PlgCheckCircuitCompletion(oPC))
+        {
+            PlgIncrementCircuits(oPC);
+            PlgResetVisits(oPC);
+            FloatingTextStringOnCreature(
+                "Krąg pielgrzymki zamknięty. Brzemię twoich grzechów rośnie niepomiernie.", oPC, FALSE);
+            SendMessageToPC(oPC, "[Pielgrzymka] Wszystkie sanktuaria odwiedzone. Obieg zamknięty.");
+        }
+        else
+        {
+            FloatingTextStringOnCreature(
+                "Sanktuarium przyjmuje twą ofiarę... brzemię ciężeje.", oPC, FALSE);
+        }
+    }
+    else
+    {
+        SendMessageToPC(oPC, "[Pielgrzymka] Już oddałeś hołd temu sanktuarium w tym obiegu.");
+    }
+
+    PlgShowShrinePopup(oPC, nShrineId, bAlreadyVisited);
+}
+
+// ----------------------------------------------------------------
+// Shrine info popup
+// ----------------------------------------------------------------
+
+void PlgShowShrinePopup(object oPC, int nShrineId, int bAlreadyVisited)
+{
+    if(NuiFindWindow(oPC, PLG_WIN_SHRINE_INFO) != 0)
+        NuiDestroy(oPC, NuiFindWindow(oPC, PLG_WIN_SHRINE_INFO));
+
+    json jShrine = PlgGetShrine(nShrineId);
+    if(JsonGetType(jShrine) == JSON_TYPE_NULL) return;
+
+    string sName = JsonGetString(JsonObjectGet(jShrine, "name"));
+    string sLore = JsonGetString(JsonObjectGet(jShrine, "lore"));
+    string sType = JsonGetString(JsonObjectGet(jShrine, "burden_type"));
+
+    float fW = GetNuiScaleDimension(oPC, 460.0);
+    float fH = GetNuiScaleDimension(oPC, 290.0);
+    float fX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - fW) / 2.0;
+    float fY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - fH) / 2.0;
+
+    float fBtnH = GetNuiScaleDimension(oPC, 28.0);
+
+    // Title
+    json jName = NuiLabel(NuiBind(PLG_BIND_SINFO_NAME),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jName = NuiHeight(jName, GetNuiScaleDimension(oPC, 30.0));
+
+    // Type badge
+    json jType = NuiLabel(NuiBind(PLG_BIND_SINFO_TYPE),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jType = NuiHeight(jType, GetNuiScaleDimension(oPC, 22.0));
+
+    // Lore text area
+    json jLore = NuiText(NuiBind(PLG_BIND_SINFO_LORE), FALSE);
+    jLore = NuiHeight(jLore, GetNuiScaleDimension(oPC, 130.0));
+
+    // Visit status
+    json jStat = NuiLabel(NuiBind(PLG_BIND_SINFO_STAT),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jStat = NuiHeight(jStat, GetNuiScaleDimension(oPC, 22.0));
+
+    // Close button
+    json jClose = NuiButton(JsonString("Zamknij"));
+    jClose = NuiId(jClose, PLG_BTN_SINFO_CLOSE);
+    jClose = NuiWidth(jClose, GetNuiScaleDimension(oPC, 100.0));
+    jClose = NuiHeight(jClose, fBtnH);
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jClose);
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jName);
+    jCol = JsonArrayInsert(jCol, jType);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jLore);
+    jCol = JsonArrayInsert(jCol, jStat);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+
+    json jWin = NuiWindow(NuiCol(jCol),
+        JsonBool(FALSE),
+        NuiBind(PLG_BIND_SINFO_GEOM),
+        JsonBool(FALSE), JsonBool(FALSE), JsonBool(TRUE),
+        JsonBool(FALSE), JsonBool(TRUE));
+
+    int nToken = NuiCreate(oPC, jWin, PLG_WIN_SHRINE_INFO, PLG_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, PLG_BIND_SINFO_GEOM, NuiRect(fX, fY, fW, fH));
+    NuiSetBind(oPC, nToken, PLG_BIND_SINFO_NAME, JsonString(sName));
+    NuiSetBind(oPC, nToken, PLG_BIND_SINFO_TYPE,
+        JsonString("[ " + PlgBurdenTypeLabel(sType) + " ]"));
+    NuiSetBind(oPC, nToken, PLG_BIND_SINFO_LORE, JsonString(sLore));
+
+    string sStat = bAlreadyVisited
+        ? "Odwiedzone w tym obiegu."
+        : "Sanktuarium przyjęło twą hołd po raz pierwszy.";
+    NuiSetBind(oPC, nToken, PLG_BIND_SINFO_STAT, JsonString(sStat));
+}
+
+// ----------------------------------------------------------------
+// NUI layout builders
+// ----------------------------------------------------------------
+
+json PlgBuildTabBar(object oPC)
+{
+    float fBtnH = GetNuiScaleDimension(oPC, 28.0);
+    float fBtnW = GetNuiScaleDimension(oPC, 140.0);
+
+    json jS = NuiButton(JsonString("Piętno"));
+    jS = NuiId(jS, PLG_BTN_TAB_STATUS);
+    jS = NuiWidth(jS, fBtnW);
+    jS = NuiHeight(jS, fBtnH);
+
+    json jSh = NuiButton(JsonString("Sanktuaria"));
+    jSh = NuiId(jSh, PLG_BTN_TAB_SHRINES);
+    jSh = NuiWidth(jSh, fBtnW);
+    jSh = NuiHeight(jSh, fBtnH);
+
+    json jB = NuiButton(JsonString("Potępieni"));
+    jB = NuiId(jB, PLG_BTN_TAB_BOARD);
+    jB = NuiWidth(jB, fBtnW);
+    jB = NuiHeight(jB, fBtnH);
+
+    json jClose = NuiButton(JsonString("X"));
+    jClose = NuiId(jClose, PLG_BTN_CLOSE);
+    jClose = NuiWidth(jClose, GetNuiScaleDimension(oPC, 30.0));
+    jClose = NuiHeight(jClose, fBtnH);
+
+    json jRow = JsonArray();
+    jRow = JsonArrayInsert(jRow, jS);
+    jRow = JsonArrayInsert(jRow, jSh);
+    jRow = JsonArrayInsert(jRow, jB);
+    jRow = JsonArrayInsert(jRow, NuiSpacer());
+    jRow = JsonArrayInsert(jRow, jClose);
+    return NuiRow(jRow);
+}
+
+// ---- Status tab ----
+
+json PlgBuildStatusTab(object oPC)
+{
+    float fRowH  = GetNuiScaleDimension(oPC, 26.0);
+    float fBtnH  = GetNuiScaleDimension(oPC, 30.0);
+    float fLblW  = GetNuiScaleDimension(oPC, 100.0);
+    float fValW  = GetNuiScaleDimension(oPC, 36.0);
+
+    // Helper: one burden bar row [label | progress | value]
+    // Repeats 4 times; uses separate binds per type.
+    json jShadowLbl = NuiLabel(JsonString("Cień:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jShadowLbl = NuiWidth(jShadowLbl, fLblW);
+
+    json jBloodLbl = NuiLabel(JsonString("Krew:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jBloodLbl = NuiWidth(jBloodLbl, fLblW);
+
+    json jDeathLbl = NuiLabel(JsonString("Śmierć:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jDeathLbl = NuiWidth(jDeathLbl, fLblW);
+
+    json jChaosLbl = NuiLabel(JsonString("Chaos:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jChaosLbl = NuiWidth(jChaosLbl, fLblW);
+
+    json jShadowPrg = NuiProgress(NuiBind(PLG_BIND_SHADOW_PRG));
+    json jBloodPrg  = NuiProgress(NuiBind(PLG_BIND_BLOOD_PRG));
+    json jDeathPrg  = NuiProgress(NuiBind(PLG_BIND_DEATH_PRG));
+    json jChaosPrg  = NuiProgress(NuiBind(PLG_BIND_CHAOS_PRG));
+
+    json jShadowVal = NuiLabel(NuiBind(PLG_BIND_SHADOW_VAL),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jShadowVal = NuiWidth(jShadowVal, fValW);
+
+    json jBloodVal = NuiLabel(NuiBind(PLG_BIND_BLOOD_VAL),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jBloodVal = NuiWidth(jBloodVal, fValW);
+
+    json jDeathVal = NuiLabel(NuiBind(PLG_BIND_DEATH_VAL),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jDeathVal = NuiWidth(jDeathVal, fValW);
+
+    json jChaosVal = NuiLabel(NuiBind(PLG_BIND_CHAOS_VAL),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jChaosVal = NuiWidth(jChaosVal, fValW);
+
+    // Row builder macro (inline via json arrays)
+    json jSRow = JsonArray();
+    jSRow = JsonArrayInsert(jSRow, jShadowLbl);
+    jSRow = JsonArrayInsert(jSRow, jShadowPrg);
+    jSRow = JsonArrayInsert(jSRow, jShadowVal);
+
+    json jBRow = JsonArray();
+    jBRow = JsonArrayInsert(jBRow, jBloodLbl);
+    jBRow = JsonArrayInsert(jBRow, jBloodPrg);
+    jBRow = JsonArrayInsert(jBRow, jBloodVal);
+
+    json jDRow = JsonArray();
+    jDRow = JsonArrayInsert(jDRow, jDeathLbl);
+    jDRow = JsonArrayInsert(jDRow, jDeathPrg);
+    jDRow = JsonArrayInsert(jDRow, jDeathVal);
+
+    json jCRow = JsonArray();
+    jCRow = JsonArrayInsert(jCRow, jChaosLbl);
+    jCRow = JsonArrayInsert(jCRow, jChaosPrg);
+    jCRow = JsonArrayInsert(jCRow, jChaosVal);
+
+    // Summary labels
+    json jTotal = NuiLabel(NuiBind(PLG_BIND_TOTAL_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTotal = NuiHeight(jTotal, fRowH);
+
+    json jTier = NuiLabel(NuiBind(PLG_BIND_TIER_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTier = NuiHeight(jTier, fRowH);
+
+    json jVisits = NuiLabel(NuiBind(PLG_BIND_VISITS_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jVisits = NuiHeight(jVisits, fRowH);
+
+    json jCircuits = NuiLabel(NuiBind(PLG_BIND_CIRCUITS_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jCircuits = NuiHeight(jCircuits, fRowH);
+
+    // Active effects text area
+    json jFxLbl = NuiLabel(JsonString("Aktywne efekty:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jFxLbl = NuiHeight(jFxLbl, fRowH);
+
+    json jFxArea = NuiText(NuiBind(PLG_BIND_FX_LBL), FALSE);
+    jFxArea = NuiHeight(jFxArea, GetNuiScaleDimension(oPC, 100.0));
+
+    // Catharsis button
+    json jKathBtn = NuiButton(NuiBind(PLG_BIND_KATH_LBL));
+    jKathBtn = NuiId(jKathBtn, PLG_BTN_CATHARSIS);
+    jKathBtn = NuiEnabled(jKathBtn, NuiBind(PLG_BIND_KATH_ENA));
+    jKathBtn = NuiTooltip(jKathBtn, NuiBind(PLG_BIND_KATH_TIP));
+    jKathBtn = NuiHeight(jKathBtn, fBtnH);
+
+    json jKathRow = JsonArray();
+    jKathRow = JsonArrayInsert(jKathRow, NuiSpacer());
+    jKathRow = JsonArrayInsert(jKathRow, jKathBtn);
+    jKathRow = JsonArrayInsert(jKathRow, NuiSpacer());
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, NuiHeight(NuiRow(jSRow), fRowH));
+    jCol = JsonArrayInsert(jCol, NuiHeight(NuiRow(jBRow), fRowH));
+    jCol = JsonArrayInsert(jCol, NuiHeight(NuiRow(jDRow), fRowH));
+    jCol = JsonArrayInsert(jCol, NuiHeight(NuiRow(jCRow), fRowH));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, jTotal);
+    jCol = JsonArrayInsert(jCol, jTier);
+    jCol = JsonArrayInsert(jCol, jVisits);
+    jCol = JsonArrayInsert(jCol, jCircuits);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jFxLbl);
+    jCol = JsonArrayInsert(jCol, jFxArea);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jKathRow));
+
+    return NuiCol(jCol);
+}
+
+// ---- Shrines tab ----
+
+json PlgBuildShrinesTab(object oPC)
+{
+    float fRowH = GetNuiScaleDimension(oPC, 26.0);
+    float fListH = GetNuiScaleDimension(oPC, 390.0);
+    float fTypeW  = GetNuiScaleDimension(oPC, 80.0);
+    float fVisW   = GetNuiScaleDimension(oPC, 60.0);
+
+    json jNameLbl = NuiLabel(NuiBind(PLG_BIND_SHRINE_NAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+
+    json jTypeLbl = NuiLabel(NuiBind(PLG_BIND_SHRINE_TYPE),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jTypeLbl = NuiWidth(jTypeLbl, fTypeW);
+
+    json jVisLbl = NuiLabel(NuiBind(PLG_BIND_SHRINE_VIS),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jVisLbl = NuiWidth(jVisLbl, fVisW);
+
+    json jCellRow = JsonArray();
+    jCellRow = JsonArrayInsert(jCellRow, jNameLbl);
+    jCellRow = JsonArrayInsert(jCellRow, jTypeLbl);
+    jCellRow = JsonArrayInsert(jCellRow, jVisLbl);
+
+    json jCell = NuiGroup(NuiRow(jCellRow), TRUE, NUI_SCROLLBARS_NONE);
+    jCell = NuiId(jCell, PLG_BTN_SHRINE_ROW);
+    jCell = NuiEncouraged(jCell, NuiBind(PLG_BIND_SHRINE_ENC));
+
+    json jTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jCell, 0.0, TRUE));
+
+    json jList = NuiList(jTmpl, NuiBind(PLG_BIND_SHRINE_CNT), fRowH);
+    jList = NuiHeight(jList, fListH);
+
+    // Header row
+    json jHName = NuiLabel(JsonString("Sanktuarium"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    json jHType = NuiLabel(JsonString("Typ"),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jHType = NuiWidth(jHType, fTypeW);
+    json jHVis = NuiLabel(JsonString("Status"),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jHVis = NuiWidth(jHVis, fVisW);
+
+    json jHRow = JsonArray();
+    jHRow = JsonArrayInsert(jHRow, jHName);
+    jHRow = JsonArrayInsert(jHRow, jHType);
+    jHRow = JsonArrayInsert(jHRow, jHVis);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, NuiHeight(NuiRow(jHRow), GetNuiScaleDimension(oPC, 22.0)));
+    jCol = JsonArrayInsert(jCol, jList);
+
+    return NuiCol(jCol);
+}
+
+// ---- Leaderboard tab ----
+
+json PlgBuildLeaderboardTab(object oPC)
+{
+    float fRowH  = GetNuiScaleDimension(oPC, 26.0);
+    float fListH = GetNuiScaleDimension(oPC, 380.0);
+    float fNumW  = GetNuiScaleDimension(oPC, 55.0);
+
+    json jNameLbl = NuiLabel(NuiBind(PLG_BIND_BOARD_NAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+
+    json jTotalLbl = NuiLabel(NuiBind(PLG_BIND_BOARD_TOTAL),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jTotalLbl = NuiWidth(jTotalLbl, fNumW);
+
+    json jCircLbl = NuiLabel(NuiBind(PLG_BIND_BOARD_CIRCUITS),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jCircLbl = NuiWidth(jCircLbl, fNumW);
+
+    json jCellRow = JsonArray();
+    jCellRow = JsonArrayInsert(jCellRow, jNameLbl);
+    jCellRow = JsonArrayInsert(jCellRow, jTotalLbl);
+    jCellRow = JsonArrayInsert(jCellRow, jCircLbl);
+
+    json jCell = NuiGroup(NuiRow(jCellRow), TRUE, NUI_SCROLLBARS_NONE);
+
+    json jTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jCell, 0.0, TRUE));
+
+    json jList = NuiList(jTmpl, NuiBind(PLG_BIND_BOARD_CNT), fRowH);
+    jList = NuiHeight(jList, fListH);
+
+    // Header
+    json jHName = NuiLabel(JsonString("Imię"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    json jHTotal = NuiLabel(JsonString("Brzemię"),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jHTotal = NuiWidth(jHTotal, fNumW);
+    json jHCirc = NuiLabel(JsonString("Obiegi"),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jHCirc = NuiWidth(jHCirc, fNumW);
+
+    json jHRow = JsonArray();
+    jHRow = JsonArrayInsert(jHRow, jHName);
+    jHRow = JsonArrayInsert(jHRow, jHTotal);
+    jHRow = JsonArrayInsert(jHRow, jHCirc);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, NuiHeight(NuiRow(jHRow), GetNuiScaleDimension(oPC, 22.0)));
+    jCol = JsonArrayInsert(jCol, jList);
+
+    return NuiCol(jCol);
+}
+
+// ---- Main window ----
+
+json PlgBuildMainLayout(object oPC)
+{
+    json jSwapGrp = NuiGroup(PlgBuildStatusTab(oPC), FALSE, NUI_SCROLLBARS_NONE);
+    jSwapGrp = NuiId(jSwapGrp, PLG_GRP_SWAP);
+
+    json jRootCol = JsonArray();
+    jRootCol = JsonArrayInsert(jRootCol, PlgBuildTabBar(oPC));
+    jRootCol = JsonArrayInsert(jRootCol, jSwapGrp);
+
+    return NuiCol(jRootCol);
+}
+
+// ----------------------------------------------------------------
+// Window open / tab swap
+// ----------------------------------------------------------------
+
+void PlgOpenWindow(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, PLG_WINDOW);
+    if(nToken != 0)
+    {
+        PlgSwapTab(oPC, nToken, GetLocalInt(oPC, PLG_LVAR_TAB));
+        return;
+    }
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))
+                  - GetNuiScaleDimension(oPC, PLG_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT))
+                  - GetNuiScaleDimension(oPC, PLG_H)) / 2.0;
+
+    json jGeom = NuiRect(fCX, fCY, GetNuiScaleDimension(oPC, PLG_W), GetNuiScaleDimension(oPC, PLG_H));
+
+    json jWin = NuiWindow(PlgBuildMainLayout(oPC),
+        JsonBool(FALSE),
+        NuiBind(PLG_WIN_GEOM),
+        JsonBool(FALSE), JsonBool(FALSE), JsonBool(FALSE),
+        JsonBool(TRUE),  JsonBool(FALSE));
+
+    nToken = NuiCreate(oPC, jWin, PLG_WINDOW, PLG_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, PLG_WIN_GEOM, jGeom);
+
+    SetLocalInt(oPC, PLG_LVAR_TAB, 0);
+    PlgFeedStatus(oPC, nToken);
+}
+
+void PlgSwapTab(object oPC, int nToken, int nTab)
+{
+    SetLocalInt(oPC, PLG_LVAR_TAB, nTab);
+    if(nTab == 0)
+    {
+        NuiSetGroupLayout(oPC, nToken, PLG_GRP_SWAP, PlgBuildStatusTab(oPC));
+        PlgFeedStatus(oPC, nToken);
+    }
+    else if(nTab == 1)
+    {
+        NuiSetGroupLayout(oPC, nToken, PLG_GRP_SWAP, PlgBuildShrinesTab(oPC));
+        PlgFeedShrines(oPC, nToken);
+    }
+    else
+    {
+        NuiSetGroupLayout(oPC, nToken, PLG_GRP_SWAP, PlgBuildLeaderboardTab(oPC));
+        PlgFeedLeaderboard(oPC, nToken);
+    }
+}
+
+// ----------------------------------------------------------------
+// Data feeding
+// ----------------------------------------------------------------
+
+void PlgFeedStatus(object oPC, int nToken)
+{
+    json jP = PlgGetPilgrim(oPC);
+    int nShadow = 0;
+    int nBlood  = 0;
+    int nDeath  = 0;
+    int nChaos  = 0;
+    int nVisits = 0;
+    int nCircs  = 0;
+
+    if(JsonGetType(jP) != JSON_TYPE_NULL)
+    {
+        nShadow = JsonGetInt(JsonObjectGet(jP, "burden_shadow"));
+        nBlood  = JsonGetInt(JsonObjectGet(jP, "burden_blood"));
+        nDeath  = JsonGetInt(JsonObjectGet(jP, "burden_death"));
+        nChaos  = JsonGetInt(JsonObjectGet(jP, "burden_chaos"));
+        nVisits = JsonGetInt(JsonObjectGet(jP, "total_visits"));
+        nCircs  = JsonGetInt(JsonObjectGet(jP, "circuits_done"));
+    }
+    int nTotal = nShadow + nBlood + nDeath + nChaos;
+
+    // Progress bars (0.0–1.0)
+    float fMax = IntToFloat(PLG_BAR_MAX);
+    float fSh = IntToFloat(nShadow) / fMax; if(fSh > 1.0) fSh = 1.0;
+    float fBl = IntToFloat(nBlood)  / fMax; if(fBl > 1.0) fBl = 1.0;
+    float fDe = IntToFloat(nDeath)  / fMax; if(fDe > 1.0) fDe = 1.0;
+    float fCh = IntToFloat(nChaos)  / fMax; if(fCh > 1.0) fCh = 1.0;
+    NuiSetBind(oPC, nToken, PLG_BIND_SHADOW_PRG, JsonFloat(fSh));
+    NuiSetBind(oPC, nToken, PLG_BIND_BLOOD_PRG,  JsonFloat(fBl));
+    NuiSetBind(oPC, nToken, PLG_BIND_DEATH_PRG,  JsonFloat(fDe));
+    NuiSetBind(oPC, nToken, PLG_BIND_CHAOS_PRG,  JsonFloat(fCh));
+
+    NuiSetBind(oPC, nToken, PLG_BIND_SHADOW_VAL, JsonString(IntToString(nShadow)));
+    NuiSetBind(oPC, nToken, PLG_BIND_BLOOD_VAL,  JsonString(IntToString(nBlood)));
+    NuiSetBind(oPC, nToken, PLG_BIND_DEATH_VAL,  JsonString(IntToString(nDeath)));
+    NuiSetBind(oPC, nToken, PLG_BIND_CHAOS_VAL,  JsonString(IntToString(nChaos)));
+
+    NuiSetBind(oPC, nToken, PLG_BIND_TOTAL_LBL,
+        JsonString("Łączne brzemię: " + IntToString(nTotal)));
+    NuiSetBind(oPC, nToken, PLG_BIND_TIER_LBL,
+        JsonString("Poziom: " + PlgGetTierName(nTotal)));
+    NuiSetBind(oPC, nToken, PLG_BIND_VISITS_LBL,
+        JsonString("Wizyty w sanktuariach: " + IntToString(nVisits)));
+    NuiSetBind(oPC, nToken, PLG_BIND_CIRCUITS_LBL,
+        JsonString("Ukończone obiegi: " + IntToString(nCircs)));
+
+    NuiSetBind(oPC, nToken, PLG_BIND_FX_LBL, JsonString(PlgGetEffectSummary(nTotal)));
+
+    // Catharsis button
+    int nCost = PlgGetCatharsisCost(nTotal);
+    int bHasBurden = nTotal > 0;
+    NuiSetBind(oPC, nToken, PLG_BIND_KATH_ENA, JsonBool(bHasBurden));
+    NuiSetBind(oPC, nToken, PLG_BIND_KATH_LBL,
+        JsonString("Katharsis (" + IntToString(nCost) + " zł)"));
+    NuiSetBind(oPC, nToken, PLG_BIND_KATH_TIP,
+        JsonString("Oczyść brzemię w pobliskim ołtarzu pokuty za "
+            + IntToString(nCost) + " złota.\nPrzez godzinę Siła i Budowa będą obniżone o 2."));
+}
+
+void PlgFeedShrines(object oPC, int nToken)
+{
+    json jShrines = PlgGetAllShrines(oPC);
+    int nCount    = JsonGetLength(jShrines);
+
+    json jNames = JsonArray();
+    json jTypes = JsonArray();
+    json jVis   = JsonArray();
+    json jEncs  = JsonArray();
+
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jS      = JsonArrayGet(jShrines, i);
+        string sName = JsonGetString(JsonObjectGet(jS, "name"));
+        string sType = JsonGetString(JsonObjectGet(jS, "burden_type"));
+        int nVisited = JsonGetInt(JsonObjectGet(jS, "visited"));
+
+        jNames = JsonArrayInsert(jNames, JsonString(sName));
+        jTypes = JsonArrayInsert(jTypes, JsonString(PlgBurdenTypeLabel(sType)));
+        jVis   = JsonArrayInsert(jVis,   JsonString(nVisited ? "Tak" : "—"));
+        jEncs  = JsonArrayInsert(jEncs,  JsonBool(FALSE));
+    }
+
+    NuiSetBind(oPC, nToken, PLG_BIND_SHRINE_NAME, jNames);
+    NuiSetBind(oPC, nToken, PLG_BIND_SHRINE_TYPE, jTypes);
+    NuiSetBind(oPC, nToken, PLG_BIND_SHRINE_VIS,  jVis);
+    NuiSetBind(oPC, nToken, PLG_BIND_SHRINE_ENC,  jEncs);
+    NuiSetBind(oPC, nToken, PLG_BIND_SHRINE_CNT,  JsonInt(nCount));
+}
+
+void PlgFeedLeaderboard(object oPC, int nToken)
+{
+    json jBoard = PlgGetLeaderboard();
+    int nCount  = JsonGetLength(jBoard);
+
+    json jNames  = JsonArray();
+    json jTotals = JsonArray();
+    json jCircs  = JsonArray();
+
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jRow = JsonArrayGet(jBoard, i);
+        jNames  = JsonArrayInsert(jNames,  JsonString(JsonGetString(JsonObjectGet(jRow, "char_name"))));
+        jTotals = JsonArrayInsert(jTotals, JsonString(IntToString(JsonGetInt(JsonObjectGet(jRow, "total")))));
+        jCircs  = JsonArrayInsert(jCircs,  JsonString(IntToString(JsonGetInt(JsonObjectGet(jRow, "circuits_done")))));
+    }
+
+    NuiSetBind(oPC, nToken, PLG_BIND_BOARD_NAME,     jNames);
+    NuiSetBind(oPC, nToken, PLG_BIND_BOARD_TOTAL,    jTotals);
+    NuiSetBind(oPC, nToken, PLG_BIND_BOARD_CIRCUITS, jCircs);
+    NuiSetBind(oPC, nToken, PLG_BIND_BOARD_CNT,      JsonInt(nCount));
+}

--- a/Pilgrim's Curse/Scripts/lib_plg_def.nss
+++ b/Pilgrim's Curse/Scripts/lib_plg_def.nss
@@ -1,0 +1,118 @@
+#include "lib_nui"
+#include "sql_plg"
+
+// Forward declarations — defined in lib_plg.nss
+void PlgOpenWindow(object oPC);
+void PlgApplyBurdenEffects(object oPC);
+void PlgRemoveBurdenEffects(object oPC);
+void PlgHandleShrine(object oPC, object oShrine);
+void PlgFeedStatus(object oPC, int nToken);
+void PlgFeedShrines(object oPC, int nToken);
+void PlgFeedLeaderboard(object oPC, int nToken);
+void PlgSwapTab(object oPC, int nToken, int nTab);
+void PlgShowShrinePopup(object oPC, int nShrineId, int bAlreadyVisited);
+json PlgBuildStatusTab(object oPC);
+json PlgBuildShrinesTab(object oPC);
+json PlgBuildLeaderboardTab(object oPC);
+
+// ----------------------------------------------------------------
+// Window identifiers
+// ----------------------------------------------------------------
+
+const string PLG_WINDOW           = "PLG_WINDOW";
+const string PLG_EV_SCRIPT        = "lib_plg_ev";
+const string PLG_GRP_SWAP         = "PLG_GRP_SWAP";
+const string PLG_WIN_GEOM         = "plg_win_geom";
+const string PLG_WIN_SHRINE_INFO  = "PLG_WIN_SINFO";
+
+// ----------------------------------------------------------------
+// Button IDs
+// ----------------------------------------------------------------
+
+const string PLG_BTN_CLOSE        = "plg_btn_close";
+const string PLG_BTN_TAB_STATUS   = "plg_btn_tab0";
+const string PLG_BTN_TAB_SHRINES  = "plg_btn_tab1";
+const string PLG_BTN_TAB_BOARD    = "plg_btn_tab2";
+const string PLG_BTN_CATHARSIS    = "plg_btn_kath";
+const string PLG_BTN_SHRINE_ROW   = "plg_btn_srow";
+const string PLG_BTN_SINFO_CLOSE  = "plg_btn_sinfc";
+
+// ----------------------------------------------------------------
+// Status tab bind keys
+// ----------------------------------------------------------------
+
+const string PLG_BIND_SHADOW_VAL  = "plg_sv";
+const string PLG_BIND_BLOOD_VAL   = "plg_bv";
+const string PLG_BIND_DEATH_VAL   = "plg_dv";
+const string PLG_BIND_CHAOS_VAL   = "plg_cv";
+const string PLG_BIND_SHADOW_PRG  = "plg_sp";
+const string PLG_BIND_BLOOD_PRG   = "plg_bp";
+const string PLG_BIND_DEATH_PRG   = "plg_dp";
+const string PLG_BIND_CHAOS_PRG   = "plg_cp";
+const string PLG_BIND_TOTAL_LBL   = "plg_total";
+const string PLG_BIND_TIER_LBL    = "plg_tier";
+const string PLG_BIND_FX_LBL      = "plg_fxlbl";
+const string PLG_BIND_VISITS_LBL  = "plg_visits";
+const string PLG_BIND_CIRCUITS_LBL = "plg_circuits";
+const string PLG_BIND_KATH_ENA    = "plg_kath_ena";
+const string PLG_BIND_KATH_LBL    = "plg_kath_lbl";
+const string PLG_BIND_KATH_TIP    = "plg_kath_tip";
+
+// ----------------------------------------------------------------
+// Shrines tab bind keys
+// ----------------------------------------------------------------
+
+const string PLG_BIND_SHRINE_NAME = "plg_sname";
+const string PLG_BIND_SHRINE_TYPE = "plg_stype";
+const string PLG_BIND_SHRINE_VIS  = "plg_svis";
+const string PLG_BIND_SHRINE_ENC  = "plg_senc";
+const string PLG_BIND_SHRINE_CNT  = "plg_scnt";
+
+// ----------------------------------------------------------------
+// Shrine info popup bind keys
+// ----------------------------------------------------------------
+
+const string PLG_BIND_SINFO_NAME  = "plg_si_name";
+const string PLG_BIND_SINFO_TYPE  = "plg_si_type";
+const string PLG_BIND_SINFO_LORE  = "plg_si_lore";
+const string PLG_BIND_SINFO_STAT  = "plg_si_stat";
+const string PLG_BIND_SINFO_GEOM  = "plg_si_geom";
+
+// ----------------------------------------------------------------
+// Leaderboard bind keys
+// ----------------------------------------------------------------
+
+const string PLG_BIND_BOARD_NAME     = "plg_bname";
+const string PLG_BIND_BOARD_TOTAL    = "plg_btotal";
+const string PLG_BIND_BOARD_CIRCUITS = "plg_bcirc";
+const string PLG_BIND_BOARD_CNT      = "plg_bcnt";
+
+// ----------------------------------------------------------------
+// Local variables stored on the PC object
+// ----------------------------------------------------------------
+
+const string PLG_LVAR_TAB         = "PLG_TAB";       // 0=status 1=shrines 2=leaderboard
+const string PLG_LVAR_SEL_SHRINE  = "PLG_SEL_SH";    // shrine id last selected in list
+
+// ----------------------------------------------------------------
+// Game design constants
+// ----------------------------------------------------------------
+
+// TagEffect tag — lets us find and remove burden effects later.
+const string PLG_FX_TAG           = "PLG_BURDEN";
+
+// Placeable tag for the catharsis altar.
+const string PLG_CATHARSIS_TAG    = "plg_catharsis";
+
+// Window dimensions
+const float PLG_W                 = 640.0;
+const float PLG_H                 = 530.0;
+
+// Burden thresholds that unlock tier effects.
+const int PLG_TIER_1              = 3;   // Minor blessing begins
+const int PLG_TIER_2              = 6;   // Fear immunity, ultravision
+const int PLG_TIER_3              = 10;  // Constitution buff, disease immunity
+const int PLG_TIER_4              = 15;  // Poison+paralysis immunity, CHA penalty
+
+// Upper bound for the progress-bar display (clamped to 1.0 above this).
+const int PLG_BAR_MAX             = 20;

--- a/Pilgrim's Curse/Scripts/lib_plg_ev.nss
+++ b/Pilgrim's Curse/Scripts/lib_plg_ev.nss
@@ -1,0 +1,93 @@
+#include "lib_plg"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    // ---- Shrine info popup ----
+    if(nToken == NuiFindWindow(oPC, PLG_WIN_SHRINE_INFO))
+    {
+        if(sEvent == EVENT_TYPE_CLICK && sElem == PLG_BTN_SINFO_CLOSE)
+            NuiDestroy(oPC, nToken);
+        return;
+    }
+
+    // ---- Main window ----
+    if(nToken != NuiFindWindow(oPC, PLG_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalInt(oPC, PLG_LVAR_TAB);
+        DeleteLocalInt(oPC, PLG_LVAR_SEL_SHRINE);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == PLG_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        if(sElem == PLG_BTN_TAB_STATUS)
+        {
+            PlgSwapTab(oPC, nToken, 0);
+            return;
+        }
+
+        if(sElem == PLG_BTN_TAB_SHRINES)
+        {
+            PlgSwapTab(oPC, nToken, 1);
+            return;
+        }
+
+        if(sElem == PLG_BTN_TAB_BOARD)
+        {
+            PlgSwapTab(oPC, nToken, 2);
+            return;
+        }
+
+        // Catharsis button — requires being near the catharsis placeable.
+        if(sElem == PLG_BTN_CATHARSIS)
+        {
+            object oAltar = GetNearestObjectByTag(PLG_CATHARSIS_TAG, oPC);
+            if(!GetIsObjectValid(oAltar) || GetDistanceBetween(oPC, oAltar) > 5.0)
+            {
+                SendMessageToPC(oPC, "[Pielgrzymka] Musisz stać przy Ołtarzu Pokuty, "
+                    "by dokonać Katharsis.");
+                return;
+            }
+            PlgHandleShrine(oPC, oAltar);
+            return;
+        }
+    }
+
+    // Shrine row click — show info popup for the clicked shrine.
+    if(sEvent == EVENT_TYPE_MOUSEDOWN && sElem == PLG_BTN_SHRINE_ROW)
+    {
+        json jShrines = PlgGetAllShrines(oPC);
+        if(nIdx < 0 || nIdx >= JsonGetLength(jShrines)) return;
+
+        json jS      = JsonArrayGet(jShrines, nIdx);
+        int nId      = JsonGetInt(JsonObjectGet(jS, "id"));
+        int nVisited = JsonGetInt(JsonObjectGet(jS, "visited"));
+
+        SetLocalInt(oPC, PLG_LVAR_SEL_SHRINE, nId);
+
+        // Highlight selected row.
+        int nCount = JsonGetLength(jShrines);
+        json jEncs = JsonArray();
+        int i;
+        for(i = 0; i < nCount; i++)
+            jEncs = JsonArrayInsert(jEncs, JsonBool(i == nIdx));
+        NuiSetBind(oPC, nToken, PLG_BIND_SHRINE_ENC, jEncs);
+
+        PlgShowShrinePopup(oPC, nId, nVisited);
+        return;
+    }
+}

--- a/Pilgrim's Curse/Scripts/sql_plg.nss
+++ b/Pilgrim's Curse/Scripts/sql_plg.nss
@@ -1,0 +1,258 @@
+// Persistent storage for Pilgrim's Curse.
+// All queries target campaign DB "plg".
+
+const string PLG_DB = "plg";
+
+void PlgCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign(PLG_DB,
+        "CREATE TABLE IF NOT EXISTS plg_shrines ("
+        "  id           INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "  tag          TEXT NOT NULL UNIQUE,"
+        "  name         TEXT DEFAULT '',"
+        "  lore         TEXT DEFAULT '',"
+        "  burden_type  TEXT DEFAULT 'shadow',"
+        "  burden_val   INTEGER DEFAULT 1)");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign(PLG_DB,
+        "CREATE TABLE IF NOT EXISTS plg_pilgrims ("
+        "  uuid          TEXT PRIMARY KEY,"
+        "  char_name     TEXT DEFAULT '',"
+        "  burden_shadow INTEGER DEFAULT 0,"
+        "  burden_blood  INTEGER DEFAULT 0,"
+        "  burden_death  INTEGER DEFAULT 0,"
+        "  burden_chaos  INTEGER DEFAULT 0,"
+        "  total_visits  INTEGER DEFAULT 0,"
+        "  circuits_done INTEGER DEFAULT 0)");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign(PLG_DB,
+        "CREATE TABLE IF NOT EXISTS plg_visits ("
+        "  uuid       TEXT NOT NULL,"
+        "  shrine_id  INTEGER NOT NULL,"
+        "  visited_at INTEGER DEFAULT 0,"
+        "  PRIMARY KEY (uuid, shrine_id))");
+    SqlStep(q);
+}
+
+// Idempotent — uses INSERT OR IGNORE so re-running on_load is safe.
+void PlgRegisterShrine(string sTag, string sName, string sLore, string sType, int nVal)
+{
+    sqlquery q = SqlPrepareQueryCampaign(PLG_DB,
+        "INSERT OR IGNORE INTO plg_shrines (tag, name, lore, burden_type, burden_val) "
+        "VALUES (@tag, @name, @lore, @type, @val)");
+    SqlBindString(q, "@tag",  sTag);
+    SqlBindString(q, "@name", sName);
+    SqlBindString(q, "@lore", sLore);
+    SqlBindString(q, "@type", sType);
+    SqlBindInt   (q, "@val",  nVal);
+    SqlStep(q);
+}
+
+void PlgRegisterPlayer(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign(PLG_DB,
+        "INSERT OR IGNORE INTO plg_pilgrims (uuid, char_name) VALUES (@uuid, @name)");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindString(q, "@name", GetName(oPC));
+    SqlStep(q);
+
+    // Refresh display name on each login.
+    q = SqlPrepareQueryCampaign(PLG_DB,
+        "UPDATE plg_pilgrims SET char_name = @name WHERE uuid = @uuid");
+    SqlBindString(q, "@name", GetName(oPC));
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+// Returns JsonNull if the player has never been registered.
+json PlgGetPilgrim(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign(PLG_DB,
+        "SELECT uuid, char_name, burden_shadow, burden_blood, burden_death, burden_chaos, "
+        "       total_visits, circuits_done "
+        "FROM plg_pilgrims WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(!SqlStep(q)) return JsonNull();
+    json j = JsonObject();
+    j = JsonObjectSet(j, "uuid",          JsonString(SqlGetString(q, 0)));
+    j = JsonObjectSet(j, "char_name",     JsonString(SqlGetString(q, 1)));
+    j = JsonObjectSet(j, "burden_shadow", JsonInt   (SqlGetInt   (q, 2)));
+    j = JsonObjectSet(j, "burden_blood",  JsonInt   (SqlGetInt   (q, 3)));
+    j = JsonObjectSet(j, "burden_death",  JsonInt   (SqlGetInt   (q, 4)));
+    j = JsonObjectSet(j, "burden_chaos",  JsonInt   (SqlGetInt   (q, 5)));
+    j = JsonObjectSet(j, "total_visits",  JsonInt   (SqlGetInt   (q, 6)));
+    j = JsonObjectSet(j, "circuits_done", JsonInt   (SqlGetInt   (q, 7)));
+    return j;
+}
+
+// Returns -1 when tag is unknown.
+int PlgGetShrineId(string sTag)
+{
+    sqlquery q = SqlPrepareQueryCampaign(PLG_DB,
+        "SELECT id FROM plg_shrines WHERE tag = @tag");
+    SqlBindString(q, "@tag", sTag);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return -1;
+}
+
+json PlgGetShrine(int nId)
+{
+    sqlquery q = SqlPrepareQueryCampaign(PLG_DB,
+        "SELECT id, tag, name, lore, burden_type, burden_val "
+        "FROM plg_shrines WHERE id = @id");
+    SqlBindInt(q, "@id", nId);
+    if(!SqlStep(q)) return JsonNull();
+    json j = JsonObject();
+    j = JsonObjectSet(j, "id",          JsonInt   (SqlGetInt   (q, 0)));
+    j = JsonObjectSet(j, "tag",         JsonString(SqlGetString(q, 1)));
+    j = JsonObjectSet(j, "name",        JsonString(SqlGetString(q, 2)));
+    j = JsonObjectSet(j, "lore",        JsonString(SqlGetString(q, 3)));
+    j = JsonObjectSet(j, "burden_type", JsonString(SqlGetString(q, 4)));
+    j = JsonObjectSet(j, "burden_val",  JsonInt   (SqlGetInt   (q, 5)));
+    return j;
+}
+
+int PlgHasVisited(object oPC, int nShrineId)
+{
+    sqlquery q = SqlPrepareQueryCampaign(PLG_DB,
+        "SELECT COUNT(*) FROM plg_visits WHERE uuid = @uuid AND shrine_id = @id");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@id",   nShrineId);
+    if(SqlStep(q)) return SqlGetInt(q, 0) > 0;
+    return 0;
+}
+
+// Returns JsonArray of {id, name, lore, burden_type, burden_val, visited} for all shrines.
+json PlgGetAllShrines(object oPC)
+{
+    json jResult = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign(PLG_DB,
+        "SELECT s.id, s.name, s.lore, s.burden_type, s.burden_val,"
+        "  CASE WHEN v.uuid IS NOT NULL THEN 1 ELSE 0 END AS visited "
+        "FROM plg_shrines s "
+        "LEFT JOIN plg_visits v ON v.shrine_id = s.id AND v.uuid = @uuid "
+        "ORDER BY s.burden_type, s.name");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    while(SqlStep(q))
+    {
+        json j = JsonObject();
+        j = JsonObjectSet(j, "id",          JsonInt   (SqlGetInt   (q, 0)));
+        j = JsonObjectSet(j, "name",        JsonString(SqlGetString(q, 1)));
+        j = JsonObjectSet(j, "lore",        JsonString(SqlGetString(q, 2)));
+        j = JsonObjectSet(j, "burden_type", JsonString(SqlGetString(q, 3)));
+        j = JsonObjectSet(j, "burden_val",  JsonInt   (SqlGetInt   (q, 4)));
+        j = JsonObjectSet(j, "visited",     JsonInt   (SqlGetInt   (q, 5)));
+        jResult = JsonArrayInsert(jResult, j);
+    }
+    return jResult;
+}
+
+// Marks the visit and adds burden points.  NWScript can't bind column names so
+// we branch on sType to build the correct UPDATE statement.
+void PlgRecordVisit(object oPC, int nShrineId, string sType, int nVal)
+{
+    sqlquery q = SqlPrepareQueryCampaign(PLG_DB,
+        "INSERT OR IGNORE INTO plg_visits (uuid, shrine_id, visited_at) "
+        "VALUES (@uuid, @id, strftime('%s','now'))");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@id",   nShrineId);
+    SqlStep(q);
+
+    string sSql = "";
+    if(sType == "shadow")
+        sSql = "UPDATE plg_pilgrims SET burden_shadow = burden_shadow + @val,"
+               " total_visits = total_visits + 1 WHERE uuid = @uuid";
+    else if(sType == "blood")
+        sSql = "UPDATE plg_pilgrims SET burden_blood = burden_blood + @val,"
+               " total_visits = total_visits + 1 WHERE uuid = @uuid";
+    else if(sType == "death")
+        sSql = "UPDATE plg_pilgrims SET burden_death = burden_death + @val,"
+               " total_visits = total_visits + 1 WHERE uuid = @uuid";
+    else
+        sSql = "UPDATE plg_pilgrims SET burden_chaos = burden_chaos + @val,"
+               " total_visits = total_visits + 1 WHERE uuid = @uuid";
+
+    q = SqlPrepareQueryCampaign(PLG_DB, sSql);
+    SqlBindInt   (q, "@val",  nVal);
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+int PlgGetShrineCount()
+{
+    sqlquery q = SqlPrepareQueryCampaign(PLG_DB, "SELECT COUNT(*) FROM plg_shrines");
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+int PlgGetVisitCount(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign(PLG_DB,
+        "SELECT COUNT(*) FROM plg_visits WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+int PlgCheckCircuitCompletion(object oPC)
+{
+    int nTotal = PlgGetShrineCount();
+    if(nTotal == 0) return 0;
+    return PlgGetVisitCount(oPC) >= nTotal;
+}
+
+void PlgIncrementCircuits(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign(PLG_DB,
+        "UPDATE plg_pilgrims SET circuits_done = circuits_done + 1 WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+// Clears the visit log so the player can walk the circuit again.
+void PlgResetVisits(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign(PLG_DB,
+        "DELETE FROM plg_visits WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+// Catharsis zeroes ALL burden but preserves visit history / circuits.
+void PlgPerformCatharsis(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign(PLG_DB,
+        "UPDATE plg_pilgrims"
+        " SET burden_shadow = 0, burden_blood = 0, burden_death = 0, burden_chaos = 0"
+        " WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+// Top-10 by total burden for the leaderboard tab.
+json PlgGetLeaderboard()
+{
+    json jResult = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign(PLG_DB,
+        "SELECT char_name, burden_shadow, burden_blood, burden_death, burden_chaos,"
+        "  circuits_done,"
+        "  (burden_shadow + burden_blood + burden_death + burden_chaos) AS total "
+        "FROM plg_pilgrims "
+        "WHERE (burden_shadow + burden_blood + burden_death + burden_chaos) > 0 "
+        "ORDER BY total DESC LIMIT 10");
+    while(SqlStep(q))
+    {
+        json j = JsonObject();
+        j = JsonObjectSet(j, "char_name",     JsonString(SqlGetString(q, 0)));
+        j = JsonObjectSet(j, "burden_shadow", JsonInt   (SqlGetInt   (q, 1)));
+        j = JsonObjectSet(j, "burden_blood",  JsonInt   (SqlGetInt   (q, 2)));
+        j = JsonObjectSet(j, "burden_death",  JsonInt   (SqlGetInt   (q, 3)));
+        j = JsonObjectSet(j, "burden_chaos",  JsonInt   (SqlGetInt   (q, 4)));
+        j = JsonObjectSet(j, "circuits_done", JsonInt   (SqlGetInt   (q, 5)));
+        j = JsonObjectSet(j, "total",         JsonInt   (SqlGetInt   (q, 6)));
+        jResult = JsonArrayInsert(jResult, j);
+    }
+    return jResult;
+}

--- a/Pilgrim's Curse/Scripts/sys_on_enter.nss
+++ b/Pilgrim's Curse/Scripts/sys_on_enter.nss
@@ -1,0 +1,10 @@
+#include "lib_plg"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC) || GetIsDMPossessed(oPC)) return;
+
+    PlgRegisterPlayer(oPC);
+    PlgApplyBurdenEffects(oPC);
+}

--- a/Pilgrim's Curse/Scripts/sys_on_load.nss
+++ b/Pilgrim's Curse/Scripts/sys_on_load.nss
@@ -1,0 +1,76 @@
+#include "lib_plg_def"
+
+// Seed eight sample shrines.  Tags must match placeable tags in the area.
+// Lore strings are visible to players — keep them dark-fantasy flavoured.
+void SeedShrines()
+{
+    PlgRegisterShrine(
+        "plg_shrine_shadow_01",
+        "Kamienny Krąg Cieni",
+        "Osiem kamieni ustawionych w milczący okrąg. "
+        "Każdy z nich nosi wyryte imię boga, który już dawno o sobie zapomniał. "
+        "Powietrze jest gęste od nieobecności.",
+        "shadow", 1);
+
+    PlgRegisterShrine(
+        "plg_shrine_shadow_02",
+        "Ołtarz Zapomnianego",
+        "Ktoś przyniósł tu kwiaty — zgniłe, wyschnięte. "
+        "Napis na postumencie głosi: »Kto mnie zna, ten mnie traci«. "
+        "Dotknięcie kamienia zostawia na palcach siny ślad.",
+        "shadow", 2);
+
+    PlgRegisterShrine(
+        "plg_shrine_blood_01",
+        "Kaplica Krwawej Ofiary",
+        "Rynnę pod ołtarzem wypełnia coś czarnego i gęstego. "
+        "Modlitewnik leżący w kącie jest zapisany od środka — "
+        "ludzką krwią, starannym pismem.",
+        "blood", 1);
+
+    PlgRegisterShrine(
+        "plg_shrine_blood_02",
+        "Studnia Czerwonej Mgły",
+        "Cembrowina bez dna, z której od czasu do czasu "
+        "unosi się ciepła para o zapachu miedzi. "
+        "Legendy mówią, że wrzucona moneta nigdy nie brzęka.",
+        "blood", 2);
+
+    PlgRegisterShrine(
+        "plg_shrine_death_01",
+        "Grobowiec Pierwszego Upadłego",
+        "Epitafium wyryto w języku, którego nikt już nie czyta. "
+        "Tłumaczenie wykute obok głosi jedynie: »Pierwszy z nas«. "
+        "W kącie stoi butelka wina — nietkniętego od wieków.",
+        "death", 1);
+
+    PlgRegisterShrine(
+        "plg_shrine_death_02",
+        "Katakumby Wiecznego Snu",
+        "Sto jeden wnęk, sto jeden czaszek. Setna pierwsza jest pusta. "
+        "Lokalni mieszkańcy przysięgają, że od dziesięciu lat wnęka czeka. "
+        "Nie mówią na kogo.",
+        "death", 2);
+
+    PlgRegisterShrine(
+        "plg_shrine_chaos_01",
+        "Wir Szaleństwa",
+        "Wzory wypalione w ziemi nie mają symetrii ani powtórzeń. "
+        "Patrząc na nie zbyt długo czuje się, "
+        "że własne myśli zaczynają przeskakiwać bez powodu.",
+        "chaos", 1);
+
+    PlgRegisterShrine(
+        "plg_shrine_chaos_02",
+        "Kolumna Przekleństwa",
+        "Czterdzieści stop monolitu pokrywają wyryte twarze "
+        "— różne, lecz wszystkie z tym samym wyrazem. "
+        "Pieczęć u podstawy pulsuje słabo, jak serce w agonii.",
+        "chaos", 2);
+}
+
+void main()
+{
+    PlgCreateTables();
+    SeedShrines();
+}

--- a/Pilgrim's Curse/Scripts/test_plg.nss
+++ b/Pilgrim's Curse/Scripts/test_plg.nss
@@ -1,0 +1,22 @@
+#include "lib_plg"
+
+// OnUsed script for both shrine placeables and the status-book placeable.
+// Attach to:
+//   • placeables with tag "plg_shrine_*"  → shrine interaction
+//   • placeable with tag "plg_catharsis"  → catharsis altar
+//   • any other placeable                 → opens status window
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    string sTag = GetTag(OBJECT_SELF);
+
+    if(GetStringLeft(sTag, 11) == "plg_shrine_" || sTag == PLG_CATHARSIS_TAG)
+    {
+        PlgHandleShrine(oPC, OBJECT_SELF);
+        return;
+    }
+
+    PlgOpenWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

System mrocznej pielgrzymki, w którym gracze nawiedzają **ciemne sanktuaria** (placeables)
rozsiane po świecie i gromadzą **Brzemię** (Burden) czterech typów:
Cień / Krew / Śmierć / Chaos.  Skumulowane brzemię odblokowuje coraz silniejsze efekty
pasywne trwałe (*SupernaturalEffect + TagEffect*).  Ołtarz Pokuty (`plg_catharsis`)
pozwala oczyścić całość za złoto, ale zostawia godzinny debuff STR/CON.

## Mechanika

**Progi brzemienia i efekty:**

| Łączne brzemię | Tier                  | Efekty                                              |
|----------------|-----------------------|-----------------------------------------------------|
| < 3            | Nieoznaczony          | brak                                                |
| 3–5            | Lekkie Brzemię        | STR +1                                              |
| 6–9            | Umiarkowane Brzemię   | STR +2, odporność na strach, widzenie w ciemności   |
| 10–14          | Ciężkie Brzemię       | + CON +2, odporność na chorobę                      |
| ≥ 15           | Piętno Potępionego    | + CON +3, odporności na truciznę i paraliż, CHA −4  |

**Obieg sanktuariów:** Odwiedzenie wszystkich zarejestrowanych sanktuariów zamyka krąg,
licznik `circuits_done` rośnie, log wizyt się resetuje — gracz może zacząć od nowa
za kolejny ładunek brzemienia.

**NUI (3 zakładki):**
- *Piętno* — progress bary per typ brzemienia, podsumowanie, opis aktywnych efektów, przycisk Katharsis
- *Sanktuaria* — scrollowana lista wszystkich sanktuariów z typem i statusem wizyty;
  kliknięcie otwiera pop-up z nazwą i lore tekstem
- *Potępieni* — globalny ranking top-10 po łącznym bremieniu + liczba ukończonych obiegów

**Katharsis:** koszt = brzemię × 500 zł; dostępna tylko przy ołtarzu pokuty (dystans ≤ 5j).

## Pliki

```
Pilgrim's Curse/
├── Scripts/
│   ├── sql_plg.nss         — schemat DB + wszystkie zapytania SQLite
│   ├── lib_plg_def.nss     — stałe, ID bindów, progi, forward decls
│   ├── lib_plg.nss         — logika (efekty, shrines, NUI builders, feed)
│   ├── lib_plg_ev.nss      — handler NUI eventów
│   ├── sys_on_load.nss     — init tabel + seed 8 sanktuariów
│   ├── sys_on_enter.nss    — rejestracja gracza, rehydracja efektów
│   ├── test_plg.nss        — OnUsed dla placeables (shrine + status book)
│   ├── lib_nui.nss         — (wspólny helper, kopia z Mailbox)
│   └── lib_nui_utility.nss — (wspólny helper, kopia z Mailbox)
└── INTEGRATION.md          — pełna instrukcja integracji
```

~1335 LOC kodu modułu-specific.

## Zależności

- **NWN:EE** — wymagane NUI API, `TagEffect`, `SupernaturalEffect`, `EffectUltravision`
- **SQLite** — campaign DB `plg` (przez `SqlPrepareQueryCampaign`)
- Brak NWNX

## Jak włączyć w istniejącym module

1. Dodaj wszystkie pliki do HAK/skryptów modułu
2. Module **OnLoad** → `sys_on_load`
3. Module **OnClientEnter** → `sys_on_enter`
4. Na każdym sanktuarium (placeable): **OnUsed** → `test_plg`, tag wg tabeli w INTEGRATION.md
5. Ołtarz pokuty: **OnUsed** → `test_plg`, tag `plg_catharsis`
6. Status-book (otwiera okno): **OnUsed** → `test_plg`, dowolny inny tag

Szczegóły + tabela tagów + instrukcja dodawania własnych sanktuariów w `INTEGRATION.md`.

## Co celowo pominięto

- Wariant pielgrzymki świetlnej (typ `"light"` z efektami buffs-only) — architektura gotowa, wystarczy dokonfigurować
- Animacje/dźwięki sanktuariów — wymagają zasobów w HAK
- Notyfikacja DM o ukończeniu obiegu
- Ograniczenie do wybranej ścieżki (np. tylko 4 z 8 sanktuariów) — wymaga pola `path_id` w schemacie


---
_Generated by [Claude Code](https://claude.ai/code/session_011Es2W6QTQUvC4nik9KJCL6)_