### PR TITLE
feat: Lichwiarz (System Długu u Lichwiarza)

### DIFF
--- a/Lichwiarz/INTEGRATION.md
+++ b/Lichwiarz/INTEGRATION.md
@@ -1,0 +1,52 @@
+# Lichwiarz — Integracja z modułem
+
+## Zależności
+- **NWNX**: nie wymagane
+- **NWN:EE**: wersja 1.87+ (wymagane `TagEffect` / `RemoveTaggedEffects`)
+- **Kampania SQLite**: automatycznie tworzona jako `lichwiarz` w folderze kampanii
+
+## Hooki do podpięcia
+
+| Zdarzenie modułu      | Skrypt              | Uwagi                                          |
+|-----------------------|---------------------|------------------------------------------------|
+| OnModuleLoad          | `sys_on_load`       | Tworzy tabele SQLite (`CREATE TABLE IF NOT EXISTS`) |
+| OnClientEnter         | `sys_on_enter`      | Nalicza brakujące ticki i przywraca kary       |
+| Placeable → OnUsed    | `test_lch`          | Otwiera UI lichwiarza; podepnij pod dowolny NPC/placeable |
+
+> Jeśli moduł ma już skrypty OnModuleLoad / OnClientEnter, wywołaj odpowiednie funkcje z istniejących skryptów:
+> ```nss
+> #include "lib_lch_def"
+> // ...
+> LchCreateTables();          // w OnLoad
+> LchCheckAndApplyPenalties(GetEnteringObject());  // w OnClientEnter
+> ```
+
+## Tworzenie Egzekutora
+Poziom kary 3 (dług ≥ 300% pożyczonej kwoty) spawnuje kreaturę o resref `lch_enforcer`.
+Dodaj do haka kreaturę z tym resrefem — sugerowany blueprint: silny wojownik (CR 10+), uzbrojony, wrogie alignment. Jeśli brak resrefa, spawn jest pomijany (bez błędu).
+
+## Uruchamianie testu
+1. Załaduj moduł w Toolsecie (lub użyj istniejącego).
+2. Umieść placeable (np. "Altar"), ustaw jego `OnUsed → test_lch`.
+3. Uruchom moduł, najedź na placeable — otwiera się okno "LICHWIARZ — Dług i Fatum".
+4. Pożycz złoto, odczekaj (lub ustaw `LCH_TICK_SECONDS = 60` dla szybkich testów), otwórz okno ponownie — dług wzrośnie.
+
+## Pliki skryptów
+```
+Lichwiarz/scripts/
+  sql_lch.nss          SQLite: schema + CRUD
+  lib_lch_def.nss      Stałe, helpery gry (efekty, kary)
+  lib_lch.nss          Budowa NUI, logika pożyczania/spłaty
+  lib_lch_ev.nss       Handler zdarzeń NUI (main())
+  sys_on_load.nss      OnModuleLoad: inicjalizacja tabeli
+  sys_on_enter.nss     OnClientEnter: ticki i kary
+  test_lch.nss         OnUsed: otwiera okno
+  lib_nui.nss          Wspólna biblioteka NUI (kopia)
+  lib_nui_utility.nss  Wspólna biblioteka NUI utils (kopia)
+```
+
+## Celowo pominięto
+- GUI historii transakcji (logowanie spłat w osobnej tabeli)
+- Możliwość ustawienia własnej stopy procentowej per-pożyczka przez DM
+- Powiadomienie DM o aktywnych egzekutorach
+- Timer heartbeat (ticki są lazy — naliczane przy otwarciu okna lub logowaniu)

--- a/Lichwiarz/scripts/lib_lch.nss
+++ b/Lichwiarz/scripts/lib_lch.nss
@@ -1,0 +1,463 @@
+// lib_lch.nss — NUI layout builders, window management, and game-action API
+
+#include "lib_lch_def"
+
+// ----------------------------------------------------------------
+// Main window layout
+// ----------------------------------------------------------------
+
+json BuildLchMainLayout(object oPC)
+{
+    float fBtnH = GetNuiScaleDimension(oPC, 30.0);
+    float fRowH = GetNuiScaleDimension(oPC, 26.0);
+    float fLblW = GetNuiScaleDimension(oPC, 165.0);
+
+    json jCol = JsonArray();
+
+    // --- Dług ---
+    json jDebtKey = NuiLabel(JsonString("Aktualny dług:"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jDebtKey = NuiWidth(jDebtKey, fLblW);
+    jDebtKey = NuiHeight(jDebtKey, fRowH);
+    json jDebtVal = NuiLabel(NuiBind(LCH_BIND_DEBT_LBL), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jDebtVal = NuiHeight(jDebtVal, fRowH);
+    json jDebtRow = JsonArray();
+    jDebtRow = JsonArrayInsert(jDebtRow, jDebtKey);
+    jDebtRow = JsonArrayInsert(jDebtRow, jDebtVal);
+    jCol = JsonArrayInsert(jCol, NuiRow(jDebtRow));
+
+    // --- Pożyczono łącznie ---
+    json jPrincKey = NuiLabel(JsonString("Pożyczono łącznie:"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jPrincKey = NuiWidth(jPrincKey, fLblW);
+    jPrincKey = NuiHeight(jPrincKey, fRowH);
+    json jPrincVal = NuiLabel(NuiBind(LCH_BIND_PRINCIPAL_LBL), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jPrincVal = NuiHeight(jPrincVal, fRowH);
+    json jPrincRow = JsonArray();
+    jPrincRow = JsonArrayInsert(jPrincRow, jPrincKey);
+    jPrincRow = JsonArrayInsert(jPrincRow, jPrincVal);
+    jCol = JsonArrayInsert(jCol, NuiRow(jPrincRow));
+
+    // --- Spłacono łącznie ---
+    json jRepKey = NuiLabel(JsonString("Spłacono łącznie:"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRepKey = NuiWidth(jRepKey, fLblW);
+    jRepKey = NuiHeight(jRepKey, fRowH);
+    json jRepVal = NuiLabel(NuiBind(LCH_BIND_REPAID_LBL), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRepVal = NuiHeight(jRepVal, fRowH);
+    json jRepRow = JsonArray();
+    jRepRow = JsonArrayInsert(jRepRow, jRepKey);
+    jRepRow = JsonArrayInsert(jRepRow, jRepVal);
+    jCol = JsonArrayInsert(jCol, NuiRow(jRepRow));
+
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 10.0));
+
+    // --- Oprocentowanie ---
+    json jRateKey = NuiLabel(JsonString("Oprocentowanie:"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRateKey = NuiWidth(jRateKey, fLblW);
+    jRateKey = NuiHeight(jRateKey, fRowH);
+    json jRateVal = NuiLabel(NuiBind(LCH_BIND_RATE_LBL), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRateVal = NuiHeight(jRateVal, fRowH);
+    json jRateRow = JsonArray();
+    jRateRow = JsonArrayInsert(jRateRow, jRateKey);
+    jRateRow = JsonArrayInsert(jRateRow, jRateVal);
+    jCol = JsonArrayInsert(jCol, NuiRow(jRateRow));
+
+    // --- Następne naliczenie ---
+    json jTickKey = NuiLabel(JsonString("Następne naliczenie:"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTickKey = NuiWidth(jTickKey, fLblW);
+    jTickKey = NuiHeight(jTickKey, fRowH);
+    json jTickVal = NuiLabel(NuiBind(LCH_BIND_TICK_LBL), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTickVal = NuiHeight(jTickVal, fRowH);
+    json jTickRow = JsonArray();
+    jTickRow = JsonArrayInsert(jTickRow, jTickKey);
+    jTickRow = JsonArrayInsert(jTickRow, jTickVal);
+    jCol = JsonArrayInsert(jCol, NuiRow(jTickRow));
+
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 10.0));
+
+    // --- Kara (colored) ---
+    json jPenKey = NuiLabel(JsonString("Kara:"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jPenKey = NuiWidth(jPenKey, fLblW);
+    jPenKey = NuiHeight(jPenKey, fRowH);
+    json jPenVal = NuiLabel(NuiBind(LCH_BIND_PENALTY_LBL), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jPenVal = NuiStyleForegroundColor(jPenVal, NuiBind(LCH_BIND_PENALTY_COL));
+    jPenVal = NuiHeight(jPenVal, fRowH);
+    json jPenRow = JsonArray();
+    jPenRow = JsonArrayInsert(jPenRow, jPenKey);
+    jPenRow = JsonArrayInsert(jPenRow, jPenVal);
+    jCol = JsonArrayInsert(jCol, NuiRow(jPenRow));
+
+    // --- Spacer pushes buttons to bottom ---
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+
+    // --- Flavor text ---
+    json jFlavorLbl = NuiLabel(
+        JsonString("„Złoto jest cierpliwe. Lichwiarz też — ale nie na zawsze.""),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jFlavorLbl = NuiHeight(jFlavorLbl, GetNuiScaleDimension(oPC, 22.0));
+    jFlavorLbl = NuiStyleForegroundColor(jFlavorLbl, NuiColor(160, 130, 80));
+    jCol = JsonArrayInsert(jCol, jFlavorLbl);
+
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+
+    // --- Buttons ---
+    json jBorrowBtn = NuiButton(JsonString("Pożycz złoto"));
+    jBorrowBtn = NuiId(jBorrowBtn, LCH_BTN_BORROW);
+    jBorrowBtn = NuiEnabled(jBorrowBtn, NuiBind(LCH_BIND_BORROW_ENA));
+    jBorrowBtn = NuiWidth(jBorrowBtn, GetNuiScaleDimension(oPC, 160.0));
+    jBorrowBtn = NuiHeight(jBorrowBtn, fBtnH);
+
+    json jRepayBtn = NuiButton(JsonString("Spłać dług"));
+    jRepayBtn = NuiId(jRepayBtn, LCH_BTN_REPAY);
+    jRepayBtn = NuiEnabled(jRepayBtn, NuiBind(LCH_BIND_REPAY_ENA));
+    jRepayBtn = NuiWidth(jRepayBtn, GetNuiScaleDimension(oPC, 160.0));
+    jRepayBtn = NuiHeight(jRepayBtn, fBtnH);
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, jBorrowBtn);
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jRepayBtn);
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+
+    // Side spacers for horizontal centering (following Mailbox pattern)
+    float fContentW = GetNuiScaleDimension(oPC, 440.0);
+    json jSide = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    json jMainRow = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiCol(jCol), fContentW));
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    return NuiRow(jMainRow);
+}
+
+// ----------------------------------------------------------------
+// Open / refresh main window
+// ----------------------------------------------------------------
+
+void LchOpenWindow(object oPC)
+{
+    LchCheckAndApplyPenalties(oPC);
+
+    int nExisting = NuiFindWindow(oPC, LCH_WINDOW);
+    if(nExisting != 0)
+    {
+        FeedLchMain(oPC, nExisting);
+        return;
+    }
+
+    float fScreenW = IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH));
+    float fScreenH = IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT));
+    float fWinW    = GetNuiScaleDimension(oPC, LCH_W);
+    float fWinH    = GetNuiScaleDimension(oPC, LCH_H);
+    float fCX      = (fScreenW - fWinW) / 2.0;
+    float fCY      = (fScreenH - fWinH) / 2.0;
+
+    json jWin = NuiWindow(
+        BuildLchMainLayout(oPC),
+        JsonString("LICHWIARZ — Dług i Fatum"),
+        NuiBind(LCH_BIND_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    int nToken = NuiCreate(oPC, jWin, LCH_WINDOW, LCH_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, LCH_BIND_WIN_GEOM, NuiRect(fCX, fCY, fWinW, fWinH));
+    FeedLchMain(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Feed main window binds
+// ----------------------------------------------------------------
+
+void FeedLchMain(object oPC, int nToken)
+{
+    json jLoan = LchGetLoan(oPC);
+    int  nNow  = LchNow();
+
+    if(JsonGetType(jLoan) == JSON_TYPE_NULL)
+    {
+        NuiSetBind(oPC, nToken, LCH_BIND_DEBT_LBL,      JsonString("0 sz."));
+        NuiSetBind(oPC, nToken, LCH_BIND_PRINCIPAL_LBL, JsonString("0 sz."));
+        NuiSetBind(oPC, nToken, LCH_BIND_REPAID_LBL,    JsonString("0 sz."));
+        NuiSetBind(oPC, nToken, LCH_BIND_RATE_LBL,      JsonString("5% / godz."));
+        NuiSetBind(oPC, nToken, LCH_BIND_TICK_LBL,      JsonString("—"));
+        NuiSetBind(oPC, nToken, LCH_BIND_PENALTY_LBL,   JsonString("Brak"));
+        NuiSetBind(oPC, nToken, LCH_BIND_PENALTY_COL,   LchPenaltyColor(0));
+        NuiSetBind(oPC, nToken, LCH_BIND_BORROW_ENA,    JsonBool(TRUE));
+        NuiSetBind(oPC, nToken, LCH_BIND_REPAY_ENA,     JsonBool(FALSE));
+        return;
+    }
+
+    int   nDebt      = JsonGetInt  (JsonObjectGet(jLoan, "current_debt"));
+    int   nPrincipal = JsonGetInt  (JsonObjectGet(jLoan, "principal"));
+    int   nRepaid    = JsonGetInt  (JsonObjectGet(jLoan, "total_repaid"));
+    float fRate      = JsonGetFloat(JsonObjectGet(jLoan, "interest_rate"));
+    int   nPenalty   = JsonGetInt  (JsonObjectGet(jLoan, "penalty_level"));
+    int   nLastTick  = JsonGetInt  (JsonObjectGet(jLoan, "last_tick"));
+
+    int nElapsed     = nNow - nLastTick;
+    int nSecondsLeft = (nElapsed < LCH_TICK_SECONDS) ? (LCH_TICK_SECONDS - nElapsed) : 0;
+
+    NuiSetBind(oPC, nToken, LCH_BIND_DEBT_LBL,      JsonString(IntToString(nDebt) + " sz."));
+    NuiSetBind(oPC, nToken, LCH_BIND_PRINCIPAL_LBL, JsonString(IntToString(nPrincipal) + " sz."));
+    NuiSetBind(oPC, nToken, LCH_BIND_REPAID_LBL,    JsonString(IntToString(nRepaid) + " sz."));
+    NuiSetBind(oPC, nToken, LCH_BIND_RATE_LBL,      JsonString(IntToString(FloatToInt(fRate * 100.0)) + "% / godz."));
+    NuiSetBind(oPC, nToken, LCH_BIND_TICK_LBL,      JsonString(nSecondsLeft > 0 ? "za " + LchFormatTime(nSecondsLeft) : "teraz"));
+    NuiSetBind(oPC, nToken, LCH_BIND_PENALTY_LBL,   JsonString(LchPenaltyName(nPenalty)));
+    NuiSetBind(oPC, nToken, LCH_BIND_PENALTY_COL,   LchPenaltyColor(nPenalty));
+    NuiSetBind(oPC, nToken, LCH_BIND_BORROW_ENA,    JsonBool(nDebt < LCH_MAX_LOAN));
+    NuiSetBind(oPC, nToken, LCH_BIND_REPAY_ENA,     JsonBool(nDebt > 0));
+}
+
+// ----------------------------------------------------------------
+// Borrow popup
+// ----------------------------------------------------------------
+
+void LchCreateBorrowPopup(object oPC)
+{
+    if(NuiFindWindow(oPC, LCH_WIN_BORROW) != 0)
+        NuiDestroy(oPC, NuiFindWindow(oPC, LCH_WIN_BORROW));
+
+    float fBtnH = GetNuiScaleDimension(oPC, 30.0);
+    float fRowH = GetNuiScaleDimension(oPC, 22.0);
+    float fW    = GetNuiScaleDimension(oPC, LCH_POPUP_W);
+    float fH    = GetNuiScaleDimension(oPC, LCH_POPUP_H);
+    float fX    = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - fW) / 2.0;
+    float fY    = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - fH) / 2.0;
+
+    json jRangeLbl = NuiLabel(
+        JsonString("Kwota (min. " + IntToString(LCH_MIN_LOAN) + " — max. " + IntToString(LCH_MAX_LOAN) + " sz.):"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRangeLbl = NuiHeight(jRangeLbl, fRowH);
+
+    json jAmtField = NuiTextEdit(JsonString(""), NuiBind(LCH_BIND_BORROW_AMT), 6, FALSE);
+    jAmtField = NuiHeight(jAmtField, fBtnH);
+
+    json jRateLbl = NuiLabel(
+        JsonString("Oprocentowanie: 5% / godz. Dług rośnie z każdą godziną braku spłaty."),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRateLbl = NuiHeight(jRateLbl, GetNuiScaleDimension(oPC, 40.0));
+    jRateLbl = NuiStyleForegroundColor(jRateLbl, NuiColor(200, 160, 60));
+
+    json jFlavorLbl = NuiLabel(
+        JsonString("„Złoto mam — pytań nie zadaję.\nSpłacisz, bo wszyscy spłacają… w końcu.""),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jFlavorLbl = NuiHeight(jFlavorLbl, GetNuiScaleDimension(oPC, 44.0));
+    jFlavorLbl = NuiStyleForegroundColor(jFlavorLbl, NuiColor(160, 130, 80));
+
+    json jConfirmBtn = NuiButton(JsonString("Bierz złoto"));
+    jConfirmBtn = NuiId(jConfirmBtn, LCH_BTN_BORROW_OK);
+    jConfirmBtn = NuiEnabled(jConfirmBtn, NuiBind(LCH_BIND_CONFIRM_ENA));
+    jConfirmBtn = NuiWidth(jConfirmBtn, GetNuiScaleDimension(oPC, 150.0));
+    jConfirmBtn = NuiHeight(jConfirmBtn, fBtnH);
+
+    json jCancelBtn = NuiButton(JsonString("Anuluj"));
+    jCancelBtn = NuiId(jCancelBtn, LCH_BTN_BORROW_X);
+    jCancelBtn = NuiWidth(jCancelBtn, GetNuiScaleDimension(oPC, 100.0));
+    jCancelBtn = NuiHeight(jCancelBtn, fBtnH);
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, jConfirmBtn);
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jCancelBtn);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jRangeLbl);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, jAmtField);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jRateLbl);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, jFlavorLbl);
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+
+    json jWin = NuiWindow(NuiCol(jCol),
+        JsonString("Pożyczka u Lichwiarza"),
+        NuiRect(fX, fY, fW, fH),
+        JsonBool(FALSE), JsonBool(FALSE), JsonBool(TRUE),
+        JsonBool(FALSE), JsonBool(TRUE));
+
+    int nToken = NuiCreate(oPC, jWin, LCH_WIN_BORROW, LCH_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, LCH_BIND_BORROW_AMT,  JsonString(""));
+    NuiSetBind(oPC, nToken, LCH_BIND_CONFIRM_ENA, JsonBool(FALSE));
+    NuiSetBindWatch(oPC, nToken, LCH_BIND_BORROW_AMT, TRUE);
+}
+
+// ----------------------------------------------------------------
+// Repay popup
+// ----------------------------------------------------------------
+
+void LchCreateRepayPopup(object oPC)
+{
+    if(NuiFindWindow(oPC, LCH_WIN_REPAY) != 0)
+        NuiDestroy(oPC, NuiFindWindow(oPC, LCH_WIN_REPAY));
+
+    json jLoan = LchGetLoan(oPC);
+    if(JsonGetType(jLoan) == JSON_TYPE_NULL) return;
+
+    int nDebt = JsonGetInt(JsonObjectGet(jLoan, "current_debt"));
+    int nGold = GetGold(oPC);
+
+    float fBtnH = GetNuiScaleDimension(oPC, 30.0);
+    float fRowH = GetNuiScaleDimension(oPC, 22.0);
+    float fW    = GetNuiScaleDimension(oPC, LCH_POPUP_W);
+    float fH    = GetNuiScaleDimension(oPC, LCH_POPUP_H);
+    float fX    = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - fW) / 2.0;
+    float fY    = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - fH) / 2.0;
+
+    json jDebtLbl = NuiLabel(NuiBind(LCH_BIND_REPAY_DEBT), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jDebtLbl = NuiHeight(jDebtLbl, fRowH);
+
+    json jGoldLbl = NuiLabel(NuiBind(LCH_BIND_REPAY_GOLD), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jGoldLbl = NuiHeight(jGoldLbl, fRowH);
+
+    json jPromptLbl = NuiLabel(JsonString("Kwota spłaty:"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jPromptLbl = NuiHeight(jPromptLbl, fRowH);
+
+    json jAmtField = NuiTextEdit(JsonString(""), NuiBind(LCH_BIND_REPAY_AMT), 8, FALSE);
+    jAmtField = NuiHeight(jAmtField, fBtnH);
+
+    json jDoBtn = NuiButton(JsonString("Spłać podaną kwotę"));
+    jDoBtn = NuiId(jDoBtn, LCH_BTN_REPAY_DO);
+    jDoBtn = NuiEnabled(jDoBtn, NuiBind(LCH_BIND_DO_REPAY_ENA));
+    jDoBtn = NuiHeight(jDoBtn, fBtnH);
+
+    json jFullBtn = NuiButton(NuiBind(LCH_BIND_FULL_LBL));
+    jFullBtn = NuiId(jFullBtn, LCH_BTN_REPAY_FULL);
+    jFullBtn = NuiEnabled(jFullBtn, NuiBind(LCH_BIND_FULL_ENA));
+    jFullBtn = NuiHeight(jFullBtn, fBtnH);
+
+    json jCancelBtn = NuiButton(JsonString("Anuluj"));
+    jCancelBtn = NuiId(jCancelBtn, LCH_BTN_REPAY_X);
+    jCancelBtn = NuiWidth(jCancelBtn, GetNuiScaleDimension(oPC, 100.0));
+    jCancelBtn = NuiHeight(jCancelBtn, fBtnH);
+
+    json jBotRow = JsonArray();
+    jBotRow = JsonArrayInsert(jBotRow, NuiSpacer());
+    jBotRow = JsonArrayInsert(jBotRow, jCancelBtn);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jDebtLbl);
+    jCol = JsonArrayInsert(jCol, jGoldLbl);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, jPromptLbl);
+    jCol = JsonArrayInsert(jCol, jAmtField);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jDoBtn);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, jFullBtn);
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+    jCol = JsonArrayInsert(jCol, NuiRow(jBotRow));
+
+    json jWin = NuiWindow(NuiCol(jCol),
+        JsonString("Spłata długu"),
+        NuiRect(fX, fY, fW, fH),
+        JsonBool(FALSE), JsonBool(FALSE), JsonBool(TRUE),
+        JsonBool(FALSE), JsonBool(TRUE));
+
+    int nToken = NuiCreate(oPC, jWin, LCH_WIN_REPAY, LCH_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, LCH_BIND_REPAY_DEBT,   JsonString("Aktualny dług: " + IntToString(nDebt) + " sz."));
+    NuiSetBind(oPC, nToken, LCH_BIND_REPAY_GOLD,   JsonString("Twoje złoto: "   + IntToString(nGold) + " sz."));
+    NuiSetBind(oPC, nToken, LCH_BIND_REPAY_AMT,    JsonString(""));
+    NuiSetBind(oPC, nToken, LCH_BIND_DO_REPAY_ENA, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, LCH_BIND_FULL_LBL,     JsonString("Spłać całość (" + IntToString(nDebt) + " sz.)"));
+    NuiSetBind(oPC, nToken, LCH_BIND_FULL_ENA,     JsonBool(nGold >= nDebt && nDebt > 0));
+    NuiSetBindWatch(oPC, nToken, LCH_BIND_REPAY_AMT, TRUE);
+}
+
+// ----------------------------------------------------------------
+// Game actions: borrow and repay
+// ----------------------------------------------------------------
+
+void LchHandleBorrow(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, LCH_WIN_BORROW);
+    if(nToken == 0) return;
+
+    string sAmt = JsonGetString(NuiGetBind(oPC, nToken, LCH_BIND_BORROW_AMT));
+    int    nAmt = StringToInt(sAmt);
+
+    if(nAmt < LCH_MIN_LOAN || nAmt > LCH_MAX_LOAN)
+    {
+        SendMessageToPC(oPC, "[Lichwiarz] Kwota musi wynosić od " +
+            IntToString(LCH_MIN_LOAN) + " do " + IntToString(LCH_MAX_LOAN) + " sz.");
+        return;
+    }
+
+    json jLoan       = LchGetLoan(oPC);
+    int  nCurrentDebt = (JsonGetType(jLoan) != JSON_TYPE_NULL)
+                        ? JsonGetInt(JsonObjectGet(jLoan, "current_debt")) : 0;
+
+    if(nCurrentDebt + nAmt > LCH_MAX_LOAN)
+    {
+        SendMessageToPC(oPC, "[Lichwiarz] Łączny dług przekroczyłby limit " + IntToString(LCH_MAX_LOAN) + " sz.");
+        return;
+    }
+
+    LchBorrow(oPC, nAmt);
+    GiveGoldToCreature(oPC, nAmt);
+    NuiDestroy(oPC, nToken);
+
+    int nMain = NuiFindWindow(oPC, LCH_WINDOW);
+    if(nMain != 0) FeedLchMain(oPC, nMain);
+
+    SendMessageToPC(oPC, "[Lichwiarz] Otrzymałeś " + IntToString(nAmt) + " sz. Pamiętaj — dług rośnie każdą godziną.");
+    FloatingTextStringOnCreature("Pożyczka: " + IntToString(nAmt) + " sz.", oPC, FALSE);
+}
+
+void LchHandleRepay(object oPC, int bFull)
+{
+    int nToken = NuiFindWindow(oPC, LCH_WIN_REPAY);
+    if(nToken == 0) return;
+
+    json jLoan = LchGetLoan(oPC);
+    if(JsonGetType(jLoan) == JSON_TYPE_NULL)
+    {
+        NuiDestroy(oPC, nToken);
+        return;
+    }
+
+    int nDebt = JsonGetInt(JsonObjectGet(jLoan, "current_debt"));
+    int nGold = GetGold(oPC);
+    int nAmt;
+
+    if(bFull)
+    {
+        nAmt = nDebt;
+    }
+    else
+    {
+        string sAmt = JsonGetString(NuiGetBind(oPC, nToken, LCH_BIND_REPAY_AMT));
+        nAmt = StringToInt(sAmt);
+    }
+
+    if(nAmt <= 0)
+    {
+        SendMessageToPC(oPC, "[Lichwiarz] Podaj kwotę większą od zera.");
+        return;
+    }
+    if(nAmt > nGold)
+    {
+        SendMessageToPC(oPC, "[Lichwiarz] Nie masz tyle złota.");
+        return;
+    }
+    if(nAmt > nDebt) nAmt = nDebt;
+
+    TakeGoldFromCreature(nAmt, oPC, TRUE);
+    int nRemaining = LchRepay(oPC, nAmt);
+    NuiDestroy(oPC, nToken);
+
+    if(nRemaining == 0)
+    {
+        LchOnDebtCleared(oPC);
+    }
+    else
+    {
+        LchCheckAndApplyPenalties(oPC);
+        SendMessageToPC(oPC, "[Lichwiarz] Spłaciłeś " + IntToString(nAmt) +
+            " sz. Pozostały dług: " + IntToString(nRemaining) + " sz.");
+    }
+
+    int nMain = NuiFindWindow(oPC, LCH_WINDOW);
+    if(nMain != 0) FeedLchMain(oPC, nMain);
+}

--- a/Lichwiarz/scripts/lib_lch_def.nss
+++ b/Lichwiarz/scripts/lib_lch_def.nss
@@ -1,0 +1,223 @@
+// lib_lch_def.nss — constants, forward declarations, and non-UI helpers for Lichwiarz
+
+#include "lib_nui"
+#include "sql_lch"
+
+// --- Forward declarations from lib_lch.nss ---
+void LchOpenWindow(object oPC);
+void FeedLchMain(object oPC, int nToken);
+void LchCreateBorrowPopup(object oPC);
+void LchCreateRepayPopup(object oPC);
+void LchHandleBorrow(object oPC);
+void LchHandleRepay(object oPC, int bFull);
+
+// --- Window identifiers ---
+const string LCH_WINDOW        = "LCH_WINDOW";
+const string LCH_WIN_BORROW    = "LCH_WIN_BORROW";
+const string LCH_WIN_REPAY     = "LCH_WIN_REPAY";
+const string LCH_EV_SCRIPT     = "lib_lch_ev";
+
+// --- Dimensions ---
+const float  LCH_W             = 480.0;
+const float  LCH_H             = 360.0;
+const float  LCH_POPUP_W       = 400.0;
+const float  LCH_POPUP_H       = 290.0;
+
+// --- Main window binds ---
+const string LCH_BIND_WIN_GEOM      = "lch_win_geom";
+const string LCH_BIND_DEBT_LBL      = "lch_debt_lbl";
+const string LCH_BIND_PRINCIPAL_LBL = "lch_principal_lbl";
+const string LCH_BIND_REPAID_LBL    = "lch_repaid_lbl";
+const string LCH_BIND_RATE_LBL      = "lch_rate_lbl";
+const string LCH_BIND_TICK_LBL      = "lch_tick_lbl";
+const string LCH_BIND_PENALTY_LBL   = "lch_penalty_lbl";
+const string LCH_BIND_PENALTY_COL   = "lch_penalty_col";
+const string LCH_BIND_BORROW_ENA    = "lch_borrow_ena";
+const string LCH_BIND_REPAY_ENA     = "lch_repay_ena";
+
+// --- Borrow popup binds ---
+const string LCH_BIND_BORROW_AMT    = "lch_borrow_amt";
+const string LCH_BIND_CONFIRM_ENA   = "lch_confirm_ena";
+
+// --- Repay popup binds ---
+const string LCH_BIND_REPAY_AMT     = "lch_repay_amt";
+const string LCH_BIND_REPAY_DEBT    = "lch_repay_debt_lbl";
+const string LCH_BIND_REPAY_GOLD    = "lch_repay_gold_lbl";
+const string LCH_BIND_DO_REPAY_ENA  = "lch_do_repay_ena";
+const string LCH_BIND_FULL_LBL      = "lch_full_lbl";
+const string LCH_BIND_FULL_ENA      = "lch_full_ena";
+
+// --- Buttons ---
+const string LCH_BTN_CLOSE          = "lch_btn_close";
+const string LCH_BTN_BORROW         = "lch_btn_borrow";
+const string LCH_BTN_REPAY          = "lch_btn_repay";
+const string LCH_BTN_BORROW_OK      = "lch_btn_borrow_ok";
+const string LCH_BTN_BORROW_X       = "lch_btn_borrow_x";
+const string LCH_BTN_REPAY_DO       = "lch_btn_repay_do";
+const string LCH_BTN_REPAY_FULL     = "lch_btn_repay_full";
+const string LCH_BTN_REPAY_X        = "lch_btn_repay_x";
+
+// --- LVARs on PC object ---
+const string LCH_LVAR_PENALTY       = "LCH_PENALTY_LEVEL";
+
+// --- Loan limits ---
+const int    LCH_MAX_LOAN           = 50000;
+const int    LCH_MIN_LOAN           = 100;
+
+// Debt-to-principal thresholds (%) that trigger each penalty level
+const int    LCH_PENALTY_1_PCT      = 150;   // 150 % → Klątwa
+const int    LCH_PENALTY_2_PCT      = 200;   // 200 % → Piętno
+const int    LCH_PENALTY_3_PCT      = 300;   // 300 % → Egzekutor
+
+// Resref of the enforcer creature (must exist in hak or module palette)
+const string LCH_ENFORCER_RESREF    = "lch_enforcer";
+
+// Tag applied to all managed effects so they can be batch-removed
+const string LCH_EFFECT_TAG         = "LCH_DEBT_EFFECT";
+
+// ----------------------------------------------------------------
+// Display helpers
+// ----------------------------------------------------------------
+
+string LchFormatTime(int nSeconds)
+{
+    if(nSeconds <= 0)    return "teraz";
+    if(nSeconds < 60)    return IntToString(nSeconds) + " sek.";
+    if(nSeconds < 3600)  return IntToString(nSeconds / 60) + " min.";
+    int nH = nSeconds / 3600;
+    int nM = (nSeconds / 60) - nH * 60;
+    return IntToString(nH) + " godz. " + IntToString(nM) + " min.";
+}
+
+string LchPenaltyName(int nLevel)
+{
+    if(nLevel <= 0) return "Brak";
+    if(nLevel == 1) return "Klątwa Niespłaconego";
+    if(nLevel == 2) return "Piętno Dłużnika";
+    return "Egzekutor";
+}
+
+json LchPenaltyColor(int nLevel)
+{
+    if(nLevel <= 0) return NuiColor(150, 200, 150);
+    if(nLevel == 1) return NuiColor(220, 190, 60);
+    if(nLevel == 2) return NuiColor(220, 100, 30);
+    return NuiColor(200, 30, 30);
+}
+
+// ----------------------------------------------------------------
+// Effect management
+// ----------------------------------------------------------------
+
+void LchRemovePenaltyEffects(object oPC)
+{
+    RemoveTaggedEffects(oPC, LCH_EFFECT_TAG);
+    DeleteLocalInt(oPC, LCH_LVAR_PENALTY);
+}
+
+void LchApplyPenalties(object oPC, int nPenaltyLevel)
+{
+    int nCurrent = GetLocalInt(oPC, LCH_LVAR_PENALTY);
+    if(nCurrent == nPenaltyLevel) return;
+
+    LchRemovePenaltyEffects(oPC);
+    SetLocalInt(oPC, LCH_LVAR_PENALTY, nPenaltyLevel);
+
+    if(nPenaltyLevel == 0) return;
+
+    effect eCurse;
+    effect eVFX;
+    effect eLink;
+
+    if(nPenaltyLevel == 1)
+    {
+        // Klątwa Niespłaconego — lekki debuff na wszystkie statystyki
+        eCurse = EffectCurse(1, 1, 1, 0, 1, 0);
+        eCurse = TagEffect(eCurse, LCH_EFFECT_TAG);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eCurse, oPC);
+        SendMessageToPC(oPC, "[Lichwiarz] Pieczęć długu pulsuje słabo na twojej skórze… „Płać lub cierp."");
+    }
+    else if(nPenaltyLevel == 2)
+    {
+        // Piętno Dłużnika — silny debuff + mroczna aura
+        eCurse = EffectCurse(2, 2, 2, 1, 2, 2);
+        eVFX   = EffectVisualEffect(VFX_DUR_PROT_EVIL_10);
+        eLink  = EffectLinkEffects(eCurse, eVFX);
+        eLink  = TagEffect(eLink, LCH_EFFECT_TAG);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eLink, oPC);
+        SendMessageToPC(oPC, "[Lichwiarz] Piętno dłużnika znaczy twoje oblicze. Każdy widzi twój wstyd.");
+        FloatingTextStringOnCreature("Piętno Dłużnika!", oPC, FALSE);
+    }
+    else
+    {
+        // Egzekutor — silny debuff, mroczna aura, spawn wrogiego ścigającego
+        eCurse = EffectCurse(3, 3, 3, 2, 3, 3);
+        eVFX   = EffectVisualEffect(VFX_DUR_PROT_EVIL_10);
+        eLink  = EffectLinkEffects(eCurse, eVFX);
+        eLink  = TagEffect(eLink, LCH_EFFECT_TAG);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eLink, oPC);
+
+        // Spawns once; unique tag per PC prevents duplicates
+        string sEnfTag = "LCH_ENF_" + GetObjectUUID(oPC);
+        object oEnf = GetObjectByTag(sEnfTag);
+        if(!GetIsObjectValid(oEnf))
+        {
+            oEnf = CreateObject(OBJECT_TYPE_CREATURE, LCH_ENFORCER_RESREF, GetLocation(oPC), FALSE, sEnfTag);
+            if(GetIsObjectValid(oEnf))
+                AssignCommand(oEnf, ActionAttackObject(oPC));
+        }
+        SendMessageToPC(oPC, "[Lichwiarz] „Nie chciałeś płacić słowami. Zapłacisz krwią." Egzekutor wyłania się z cienia.");
+        FloatingTextStringOnCreature("Egzekutor!", oPC, FALSE);
+    }
+}
+
+// ----------------------------------------------------------------
+// Debt lifecycle — call on login and when the window opens
+// ----------------------------------------------------------------
+
+void LchCheckAndApplyPenalties(object oPC)
+{
+    LchTickInterest(oPC);
+
+    json jLoan = LchGetLoan(oPC);
+    if(JsonGetType(jLoan) == JSON_TYPE_NULL)
+    {
+        LchRemovePenaltyEffects(oPC);
+        return;
+    }
+
+    int nDebt      = JsonGetInt(JsonObjectGet(jLoan, "current_debt"));
+    int nPrincipal = JsonGetInt(JsonObjectGet(jLoan, "principal"));
+
+    if(nPrincipal <= 0)
+    {
+        LchRemovePenaltyEffects(oPC);
+        return;
+    }
+
+    int nPct     = (nDebt * 100) / nPrincipal;
+    int nNewLevel = 0;
+    if     (nPct >= LCH_PENALTY_3_PCT) nNewLevel = 3;
+    else if(nPct >= LCH_PENALTY_2_PCT) nNewLevel = 2;
+    else if(nPct >= LCH_PENALTY_1_PCT) nNewLevel = 1;
+
+    if(nNewLevel != JsonGetInt(JsonObjectGet(jLoan, "penalty_level")))
+        LchSetPenaltyLevel(oPC, nNewLevel);
+
+    LchApplyPenalties(oPC, nNewLevel);
+}
+
+// Called when debt reaches zero
+void LchOnDebtCleared(object oPC)
+{
+    LchRemovePenaltyEffects(oPC);
+
+    // Destroy any live enforcer assigned to this PC
+    string sEnfTag = "LCH_ENF_" + GetObjectUUID(oPC);
+    object oEnf = GetObjectByTag(sEnfTag);
+    if(GetIsObjectValid(oEnf))
+        DestroyObject(oEnf);
+
+    SendMessageToPC(oPC, "[Lichwiarz] Dług spłacony w całości. Ciemność cofa się od twojej duszy… na razie.");
+    FloatingTextStringOnCreature("Dług spłacony!", oPC, FALSE);
+}

--- a/Lichwiarz/scripts/lib_lch_ev.nss
+++ b/Lichwiarz/scripts/lib_lch_ev.nss
@@ -1,0 +1,76 @@
+// lib_lch_ev.nss — NUI event handler for Lichwiarz (Usurer system)
+
+#include "lib_lch"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+
+    // ---- Borrow popup ----
+    if(nToken == NuiFindWindow(oPC, LCH_WIN_BORROW))
+    {
+        if(sEvent == EVENT_TYPE_WATCH && sElem == LCH_BIND_BORROW_AMT)
+        {
+            string sVal       = JsonGetString(NuiGetBind(oPC, nToken, LCH_BIND_BORROW_AMT));
+            int    nVal       = StringToInt(sVal);
+            json   jLoan      = LchGetLoan(oPC);
+            int    nCurrDebt  = (JsonGetType(jLoan) != JSON_TYPE_NULL)
+                                ? JsonGetInt(JsonObjectGet(jLoan, "current_debt")) : 0;
+            int bValid = (sVal != "" && nVal >= LCH_MIN_LOAN && nVal <= LCH_MAX_LOAN
+                          && (nCurrDebt + nVal) <= LCH_MAX_LOAN);
+            NuiSetBind(oPC, nToken, LCH_BIND_CONFIRM_ENA, JsonBool(bValid));
+            return;
+        }
+        if(sEvent == EVENT_TYPE_CLICK)
+        {
+            if(sElem == LCH_BTN_BORROW_OK) { LchHandleBorrow(oPC);        return; }
+            if(sElem == LCH_BTN_BORROW_X)  { NuiDestroy(oPC, nToken);     return; }
+        }
+        return;
+    }
+
+    // ---- Repay popup ----
+    if(nToken == NuiFindWindow(oPC, LCH_WIN_REPAY))
+    {
+        if(sEvent == EVENT_TYPE_WATCH && sElem == LCH_BIND_REPAY_AMT)
+        {
+            string sVal  = JsonGetString(NuiGetBind(oPC, nToken, LCH_BIND_REPAY_AMT));
+            int    nVal  = StringToInt(sVal);
+            int    nGold = GetGold(oPC);
+            json   jLoan = LchGetLoan(oPC);
+            int    nDebt = (JsonGetType(jLoan) != JSON_TYPE_NULL)
+                           ? JsonGetInt(JsonObjectGet(jLoan, "current_debt")) : 0;
+            int bValid = (sVal != "" && nVal > 0 && nVal <= nGold && nVal <= nDebt);
+            NuiSetBind(oPC, nToken, LCH_BIND_DO_REPAY_ENA, JsonBool(bValid));
+            return;
+        }
+        if(sEvent == EVENT_TYPE_CLICK)
+        {
+            if(sElem == LCH_BTN_REPAY_DO)   { LchHandleRepay(oPC, FALSE); return; }
+            if(sElem == LCH_BTN_REPAY_FULL) { LchHandleRepay(oPC, TRUE);  return; }
+            if(sElem == LCH_BTN_REPAY_X)    { NuiDestroy(oPC, nToken);    return; }
+        }
+        return;
+    }
+
+    // ---- Main window ----
+    if(nToken != NuiFindWindow(oPC, LCH_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        int nBorrow = NuiFindWindow(oPC, LCH_WIN_BORROW);
+        int nRepay  = NuiFindWindow(oPC, LCH_WIN_REPAY);
+        if(nBorrow != 0) NuiDestroy(oPC, nBorrow);
+        if(nRepay  != 0) NuiDestroy(oPC, nRepay);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == LCH_BTN_BORROW) { LchCreateBorrowPopup(oPC); return; }
+        if(sElem == LCH_BTN_REPAY)  { LchCreateRepayPopup(oPC);  return; }
+    }
+}

--- a/Lichwiarz/scripts/lib_nui.nss
+++ b/Lichwiarz/scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Lichwiarz/scripts/lib_nui_utility.nss
+++ b/Lichwiarz/scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Lichwiarz/scripts/sql_lch.nss
+++ b/Lichwiarz/scripts/sql_lch.nss
@@ -1,0 +1,151 @@
+// sql_lch.nss — SQLite schema and query layer for Lichwiarz (Usurer system)
+
+const int   LCH_TICK_SECONDS = 3600;   // interest tick: every real hour
+const float LCH_BASE_RATE    = 0.05;   // 5% per tick
+
+void LchCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("lichwiarz",
+        "CREATE TABLE IF NOT EXISTS lch_loans (uuid TEXT PRIMARY KEY, char_name TEXT NOT NULL DEFAULT '', principal INTEGER NOT NULL DEFAULT 0, current_debt INTEGER NOT NULL DEFAULT 0, interest_rate REAL NOT NULL DEFAULT 0.05, last_tick INTEGER NOT NULL DEFAULT 0, borrowed_at INTEGER NOT NULL DEFAULT 0, penalty_level INTEGER NOT NULL DEFAULT 0, total_repaid INTEGER NOT NULL DEFAULT 0)");
+    SqlStep(q);
+}
+
+// Returns current UTC unix timestamp via SQLite
+int LchNow()
+{
+    sqlquery q = SqlPrepareQueryCampaign("lichwiarz",
+        "SELECT CAST(strftime('%s','now') AS INTEGER)");
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// Returns loan row for oPC, or JsonNull() if no debt
+json LchGetLoan(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("lichwiarz",
+        "SELECT char_name, principal, current_debt, interest_rate, last_tick, borrowed_at, penalty_level, total_repaid FROM lch_loans WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(!SqlStep(q)) return JsonNull();
+
+    json j = JsonObject();
+    j = JsonObjectSet(j, "char_name",     JsonString(SqlGetString(q, 0)));
+    j = JsonObjectSet(j, "principal",     JsonInt   (SqlGetInt   (q, 1)));
+    j = JsonObjectSet(j, "current_debt",  JsonInt   (SqlGetInt   (q, 2)));
+    j = JsonObjectSet(j, "interest_rate", JsonFloat (SqlGetFloat (q, 3)));
+    j = JsonObjectSet(j, "last_tick",     JsonInt   (SqlGetInt   (q, 4)));
+    j = JsonObjectSet(j, "borrowed_at",   JsonInt   (SqlGetInt   (q, 5)));
+    j = JsonObjectSet(j, "penalty_level", JsonInt   (SqlGetInt   (q, 6)));
+    j = JsonObjectSet(j, "total_repaid",  JsonInt   (SqlGetInt   (q, 7)));
+    return j;
+}
+
+// Calculates and applies all elapsed hourly ticks; returns updated debt (0 = no loan)
+int LchTickInterest(object oPC)
+{
+    json jLoan = LchGetLoan(oPC);
+    if(JsonGetType(jLoan) == JSON_TYPE_NULL) return 0;
+
+    int   nDebt     = JsonGetInt  (JsonObjectGet(jLoan, "current_debt"));
+    float fRate     = JsonGetFloat(JsonObjectGet(jLoan, "interest_rate"));
+    int   nLastTick = JsonGetInt  (JsonObjectGet(jLoan, "last_tick"));
+    int   nNow      = LchNow();
+    int   nElapsed  = nNow - nLastTick;
+
+    if(nElapsed < LCH_TICK_SECONDS) return nDebt;
+
+    int nTicks   = nElapsed / LCH_TICK_SECONDS;
+    int nNewTick = nLastTick + nTicks * LCH_TICK_SECONDS;
+    int i;
+    for(i = 0; i < nTicks; i++)
+        nDebt = FloatToInt(IntToFloat(nDebt) * (1.0 + fRate));
+
+    sqlquery q = SqlPrepareQueryCampaign("lichwiarz",
+        "UPDATE lch_loans SET current_debt = @debt, last_tick = @tick WHERE uuid = @uuid");
+    SqlBindInt   (q, "@debt", nDebt);
+    SqlBindInt   (q, "@tick", nNewTick);
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+    return nDebt;
+}
+
+// Creates or extends a loan for oPC by nAmount
+void LchBorrow(object oPC, int nAmount)
+{
+    int  nNow  = LchNow();
+    json jLoan = LchGetLoan(oPC);
+
+    if(JsonGetType(jLoan) == JSON_TYPE_NULL)
+    {
+        sqlquery q = SqlPrepareQueryCampaign("lichwiarz",
+            "INSERT INTO lch_loans (uuid, char_name, principal, current_debt, interest_rate, last_tick, borrowed_at, penalty_level, total_repaid) VALUES (@uuid, @name, @amt, @amt, @rate, @now, @now, 0, 0)");
+        SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+        SqlBindString(q, "@name", GetName(oPC));
+        SqlBindInt   (q, "@amt",  nAmount);
+        SqlBindFloat (q, "@rate", LCH_BASE_RATE);
+        SqlBindInt   (q, "@now",  nNow);
+        SqlStep(q);
+    }
+    else
+    {
+        int nPrincipal = JsonGetInt(JsonObjectGet(jLoan, "principal"));
+        int nDebt      = JsonGetInt(JsonObjectGet(jLoan, "current_debt"));
+        sqlquery q = SqlPrepareQueryCampaign("lichwiarz",
+            "UPDATE lch_loans SET principal = @p, current_debt = @d, last_tick = @now, char_name = @name WHERE uuid = @uuid");
+        SqlBindInt   (q, "@p",    nPrincipal + nAmount);
+        SqlBindInt   (q, "@d",    nDebt + nAmount);
+        SqlBindInt   (q, "@now",  nNow);
+        SqlBindString(q, "@name", GetName(oPC));
+        SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+        SqlStep(q);
+    }
+}
+
+// Applies a partial payment; deletes record when fully repaid.
+// Returns remaining debt (0 = loan cleared).
+int LchRepay(object oPC, int nAmount)
+{
+    json jLoan = LchGetLoan(oPC);
+    if(JsonGetType(jLoan) == JSON_TYPE_NULL) return 0;
+
+    int nDebt   = JsonGetInt(JsonObjectGet(jLoan, "current_debt"));
+    int nRepaid = JsonGetInt(JsonObjectGet(jLoan, "total_repaid"));
+
+    if(nAmount >= nDebt)
+    {
+        sqlquery q = SqlPrepareQueryCampaign("lichwiarz",
+            "DELETE FROM lch_loans WHERE uuid = @uuid");
+        SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+        SqlStep(q);
+        return 0;
+    }
+
+    int nNewDebt = nDebt - nAmount;
+    sqlquery q = SqlPrepareQueryCampaign("lichwiarz",
+        "UPDATE lch_loans SET current_debt = @debt, total_repaid = @repaid, penalty_level = 0 WHERE uuid = @uuid");
+    SqlBindInt   (q, "@debt",   nNewDebt);
+    SqlBindInt   (q, "@repaid", nRepaid + nAmount);
+    SqlBindString(q, "@uuid",   GetObjectUUID(oPC));
+    SqlStep(q);
+    return nNewDebt;
+}
+
+void LchSetPenaltyLevel(object oPC, int nLevel)
+{
+    sqlquery q = SqlPrepareQueryCampaign("lichwiarz",
+        "UPDATE lch_loans SET penalty_level = @level WHERE uuid = @uuid");
+    SqlBindInt   (q, "@level", nLevel);
+    SqlBindString(q, "@uuid",  GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+// Seconds remaining until next interest tick (0 if overdue)
+int LchSecondsUntilNextTick(object oPC)
+{
+    json jLoan = LchGetLoan(oPC);
+    if(JsonGetType(jLoan) == JSON_TYPE_NULL) return 0;
+    int nLastTick = JsonGetInt(JsonObjectGet(jLoan, "last_tick"));
+    int nNow      = LchNow();
+    int nElapsed  = nNow - nLastTick;
+    if(nElapsed >= LCH_TICK_SECONDS) return 0;
+    return LCH_TICK_SECONDS - nElapsed;
+}

--- a/Lichwiarz/scripts/sys_on_enter.nss
+++ b/Lichwiarz/scripts/sys_on_enter.nss
@@ -1,0 +1,28 @@
+// sys_on_enter.nss — module OnClientEnter: tick interest and enforce debt penalties on login
+#include "lib_lch"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC)) return;
+
+    json jLoan = LchGetLoan(oPC);
+    if(JsonGetType(jLoan) == JSON_TYPE_NULL) return;
+
+    // Accumulate any missed ticks and (re-)apply penalty effects
+    LchCheckAndApplyPenalties(oPC);
+
+    // Reload after tick so values reflect interest accrued while offline
+    jLoan = LchGetLoan(oPC);
+    if(JsonGetType(jLoan) == JSON_TYPE_NULL) return;
+
+    int nDebt    = JsonGetInt(JsonObjectGet(jLoan, "current_debt"));
+    int nPenalty = JsonGetInt(JsonObjectGet(jLoan, "penalty_level"));
+
+    string sMsg = "[Lichwiarz] Twój aktualny dług wynosi " + IntToString(nDebt) + " sz.";
+    if(nPenalty > 0)
+        sMsg = sMsg + " Aktywna kara: " + LchPenaltyName(nPenalty) + ".";
+
+    DelayCommand(3.0, SendMessageToPC(oPC, sMsg));
+    DelayCommand(3.0, FloatingTextStringOnCreature("Dług: " + IntToString(nDebt) + " sz.", oPC, FALSE));
+}

--- a/Lichwiarz/scripts/sys_on_load.nss
+++ b/Lichwiarz/scripts/sys_on_load.nss
@@ -1,0 +1,7 @@
+// sys_on_load.nss — module OnModuleLoad: initialise Lichwiarz tables
+#include "lib_lch_def"
+
+void main()
+{
+    LchCreateTables();
+}

--- a/Lichwiarz/scripts/test_lch.nss
+++ b/Lichwiarz/scripts/test_lch.nss
@@ -1,0 +1,10 @@
+// test_lch.nss — placeable OnUsed: opens the Lichwiarz (Usurer) window
+// Place any placeable in the module, set its OnUsed script to test_lch.
+#include "lib_lch"
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+    LchOpenWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

Lichwiarz to persystentny system długu oparty na czasie rzeczywistym. Gracz może pożyczyć złoto u mrocznego lichwiarza; dług narasta 5% za każdą rzeczywistą godzinę i jest przechowywany w SQLite między sesjami. Panel NUI pokazuje aktualny stan finansowy, oprocentowanie, czas do następnego naliczenia oraz poziom aktywnej kary. Gracz może spłacać dług w dowolnych ratach lub jednorazowo.

## Mechanika

**Pożyczka:** Gracz otwiera okno i klika „Pożycz złoto". Pojawia się popup z walidowanym polem kwoty (min. 100, max. 50 000 sz.); po potwierdzeniu złoto trafia natychmiast do ekwipunku a dług do bazy danych.

**Odsetki (lazy tick):** Przy każdym logowaniu i otwarciu okna system oblicza liczbę pełnych godzin od ostatniego naliczenia i podnosi dług o 5% za każdą (pętla `for` w `LchTickInterest`). Nie wymaga heartbeatu.

**Kary — eskalacja trzech poziomów:**

| Poziom | Próg (dług / pożyczka) | Efekt                                                    |
|--------|------------------------|----------------------------------------------------------|
| 1 — Klątwa Niespłaconego | ≥ 150 % | `EffectCurse(1,1,1,0,1,0)` — lekki debuff wszystkich statystyk |
| 2 — Piętno Dłużnika     | ≥ 200 % | `EffectCurse(2,2,2,1,2,2)` + `VFX_DUR_PROT_EVIL_10` (mroczna aura widoczna dla innych) |
| 3 — Egzekutor           | ≥ 300 % | Jak poziom 2 + spawn kreatury `lch_enforcer` atakującej gracza |

Efekty są zarządzane tagami (`TagEffect` / `RemoveTaggedEffects`) — znikają natychmiast po spłacie.

**Spłata:** Popup repayment wyświetla aktualny dług i stan złota gracza. Gracz może wpisać dowolną kwotę lub kliknąć „Spłać całość". Przycisk pełnej spłaty jest aktywny tylko gdy gracz ma wystarczająco złota.

## Pliki

```
Lichwiarz/
  scripts/
    sql_lch.nss          SQLite: CREATE TABLE, CRUD, LchTickInterest()
    lib_lch_def.nss      Stałe, helpery efektów, LchCheckAndApplyPenalties()
    lib_lch.nss          NUI: BuildLchMainLayout(), popupy, LchHandleBorrow/Repay()
    lib_lch_ev.nss       main() — handler zdarzeń NUI z watch na polach kwoty
    sys_on_load.nss      OnModuleLoad: LchCreateTables()
    sys_on_enter.nss     OnClientEnter: tick + kary + powiadomienie o długu
    test_lch.nss         Placeable OnUsed: LchOpenWindow()
    lib_nui.nss          Kopia wspólnej biblioteki NUI
    lib_nui_utility.nss  Kopia wspólnych utils NUI
  INTEGRATION.md
```

## Zależności

- **NWNX:** nie wymagane
- **NWN:EE 1.87+:** wymagane dla `TagEffect()` / `RemoveTaggedEffects()`
- **SQLite:** kampania `lichwiarz` tworzona automatycznie przez `LchCreateTables()`

## Jak włączyć w istniejącym module

1. Skopiuj folder `Lichwiarz/scripts/` do katalogu skryptów modułu.
2. W skrypcie **OnModuleLoad** wywołaj: `LchCreateTables()`
3. W skrypcie **OnClientEnter** wywołaj: `LchCheckAndApplyPenalties(GetEnteringObject())`
4. Umieść placeable z `OnUsed → test_lch` (lub wywołaj `LchOpenWindow(oPC)` z własnego NPC-dialogu).
5. *(Opcjonalnie)* Dodaj do haka kreaturę o resref `lch_enforcer` dla poziomu 3 kar.

## Co celowo pominięto

- **Historia transakcji** (osobna tabela `lch_history`) — upraszcza schemat, można dodać jako rozszerzenie
- **Konfigurowalna stopa procentowa per-gracz przez DM** — 5%/godz. jest wystarczające dla testów balansowania
- **Heartbeat-timer** — ticki są lazy (naliczane przy logowaniu/otwarciu okna), co eliminuje zależność od skryptu OnHeartbeat
- **Wielowalutowość** — system operuje wyłącznie na standardowym złocie NWN


---
_Generated by [Claude Code](https://claude.ai/code/session_015qJU88NNjc6SHTVzJWH5h9)_