### PR TITLE
feat: Egzorcyzmy (Exorcism)

### DIFF
--- a/Exorcism/INTEGRATION.md
+++ b/Exorcism/INTEGRATION.md
@@ -1,0 +1,99 @@
+# Egzorcyzmy — Instrukcja integracji
+
+## Co to robi
+
+Moduł dodaje pełny system opętania demonami i rytuał egzorcyzmu z mini-grą NUI.
+Postacie mogą zostać opętane przez demony lub duchy na trzech poziomach intensywności.
+Egzorcysta otwiera okno rytuału i musi kliknąć 4 symbole w losowej kolejności w ciągu 35 sekund.
+
+## Poziomy opętania
+
+| Poziom | Nazwa            | Kary                                       |
+|--------|------------------|--------------------------------------------|
+| 0      | Czysta dusza     | brak                                       |
+| 1      | Szepty demonów   | -2 CHA, szeptane komunikaty co ~60s        |
+| 2      | Opanowanie       | -2 CHA, -2 WIS, -15% ruch                 |
+| 3      | Manifestacja     | -2 CHA, -2 WIS, -4 STR, aura wizualna, demon mówi przez postać |
+
+## Hooki do podpięcia
+
+### OnModuleLoad
+Podepnij `sys_on_load` — tworzy tabelę SQLite.
+
+### OnClientEnter
+Podepnij `sys_on_enter` — przywraca efekty opętania po ponownym logowaniu.
+
+### OnModuleHeartbeat
+Podepnij `sys_module_hb` lub dodaj wywołanie jego `main()` do istniejącego HB:
+```nss
+#include "sys_module_hb"
+// w istniejącym OnModuleHeartbeat dodaj na końcu:
+// ExrcDoHeartbeat();  // lub wywołaj script bezpośrednio przez ExecuteScript
+```
+
+## NWNX
+
+Brak wymagań NWNX — moduł korzysta wyłącznie z `SqlPrepareQueryCampaign`.
+
+## Pliki do HAK
+
+Ikony symboli rytuału (TGA 32×32 lub 64×64, bez alpha):
+
+| Stała             | Resref       | Opis                        |
+|-------------------|--------------|-----------------------------|
+| `EXRC_ICON_0`     | `is_blessng` | Symbol Krzyża (Bless)       |
+| `EXRC_ICON_1`     | `is_holywrd` | Symbol Słowa Świętego       |
+| `EXRC_ICON_2`     | `is_divinef` | Symbol Boskiej Tarczy       |
+| `EXRC_ICON_3`     | `is_recallp` | Symbol Cofnięcia            |
+| `EXRC_ICON_4`     | `is_resurr`  | Symbol Zmartwychwstania     |
+| `EXRC_ICON_5`     | `is_death2`  | Symbol Pieczęci Śmierci     |
+
+Stałe te są zdefiniowane w `lib_exrc_def.nss` — zmień resrefy jeśli używasz własnych grafik.
+
+## Przedmiot: Święta Woda
+
+Stwórz item z tagiem `exrc_holy_water` (zdefiniowanym w `EXRC_HOLY_WATER_TAG`).
+Koszt rytuału = poziom opętania celu (1 fiolka dla poziomu 1, 2 dla 2, 3 dla 3).
+
+## Jak zadać opętanie z zewnętrznego skryptu
+
+```nss
+#include "lib_exrc"
+
+// Opęta gracza na poziomie 2
+ExrcInflictPossession(oPC, EXRC_LEVEL_DOMINATED, "Baltazar Wieczny");
+
+// Sprawdź poziom opętania
+int nLevel = ExrcGetLevel(oPC);
+
+// Czyste z poziomu skryptu (np. po śmierci / wskrzeszeniu)
+ExrcSavePossession(oPC, EXRC_LEVEL_CLEAN, "");
+ExrcRemovePossessionEffects(oPC);
+```
+
+## Jak otworzyć okno rytuału
+
+```nss
+#include "lib_exrc"
+
+// Egzorcysta oPC bada cel oTarget
+ExrcOpenDetectWindow(oPC, oTarget);
+
+// Lub bezpośrednio otwiera rytuał:
+ExrcOpenRitualWindow(oPC, oTarget);
+```
+
+## Testowanie
+
+1. Umieść placeable z OnUsed = `test_exrc` w obszarze testowym.
+2. Naciśnij go jako zwykły gracz — postać zostaje opętana (poziom 1).
+3. Naciśnij ponownie — otwiera się okno detekcji z przyciskiem egzorcyzmu.
+4. Naciśnij jako DM — otwiera detekcję na najbliższego gracza.
+5. Upewnij się, że masz `exrc_holy_water` w ekwipunku (1 fiolka dla poziomu 1).
+
+## Co celowo pominięto
+
+- Opętanie NPC (mechanika dotyczy tylko PC).
+- Automatyczne rozprzestrzenianie opętania między graczami (25% szansa przy niepowodzeniu rytuału dotyczy tylko eskalacji poziomu).
+- Odporność na opętanie (można dodać check na spell resistance lub atrybuty WIS).
+- Leczenie przez smierć/zmartwychwstanie (decyzja designerska — można dodać hook OnPlayerDeath).

--- a/Exorcism/Scripts/lib_exrc.nss
+++ b/Exorcism/Scripts/lib_exrc.nss
@@ -1,0 +1,687 @@
+#include "lib_exrc_def"
+
+// ================================================================
+// Possession effects
+// ================================================================
+
+void ExrcRemovePossessionEffects(object oPC)
+{
+    effect eEff = GetFirstEffect(oPC);
+    while(GetIsEffectValid(eEff))
+    {
+        if(GetEffectTag(eEff) == EXRC_EFFECT_TAG)
+            RemoveEffect(oPC, eEff);
+        eEff = GetNextEffect(oPC);
+    }
+}
+
+void ExrcApplyPossessionEffects(object oPC, int nLevel)
+{
+    ExrcRemovePossessionEffects(oPC);
+    if(nLevel == EXRC_LEVEL_CLEAN) return;
+
+    if(nLevel >= EXRC_LEVEL_WHISPERS)
+    {
+        // -2 CHA — głos demona drwi z twojej osobowości
+        effect eCha = EffectAbilityDecrease(ABILITY_CHARISMA, 2);
+        eCha = TagEffect(eCha, EXRC_EFFECT_TAG);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eCha, oPC);
+    }
+
+    if(nLevel >= EXRC_LEVEL_DOMINATED)
+    {
+        // -2 WIS, -10% ruch — demon przejmuje kontrolę nad umysłem
+        effect eWis = EffectAbilityDecrease(ABILITY_WISDOM, 2);
+        eWis = TagEffect(eWis, EXRC_EFFECT_TAG);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eWis, oPC);
+
+        effect eSpd = EffectMovementSpeedDecrease(15);
+        eSpd = TagEffect(eSpd, EXRC_EFFECT_TAG);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eSpd, oPC);
+    }
+
+    if(nLevel >= EXRC_LEVEL_MANIFESTED)
+    {
+        // -4 STR, wizualny efekt (purpurowa aura) — demon jest w pełni obecny
+        effect eStr = EffectAbilityDecrease(ABILITY_STRENGTH, 4);
+        eStr = TagEffect(eStr, EXRC_EFFECT_TAG);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eStr, oPC);
+
+        effect eVfx = EffectVisualEffect(VFX_DUR_AURA_COLD_PROTECTION_10);
+        eVfx = TagEffect(eVfx, EXRC_EFFECT_TAG);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eVfx, oPC);
+    }
+}
+
+void ExrcInflictPossession(object oPC, int nLevel, string sEntity)
+{
+    int nCurrent = ExrcGetLevel(oPC);
+    if(nLevel <= nCurrent) return;    // nie obniżamy poziomu tą funkcją
+
+    ExrcSavePossession(oPC, nLevel, sEntity);
+    ExrcApplyPossessionEffects(oPC, nLevel);
+
+    string sMsg;
+    if(nLevel == EXRC_LEVEL_WHISPERS)
+        sMsg = "[Egzorcyzm] Coś wdziera się w twój umysł... szepty, których nie chcesz słyszeć.";
+    else if(nLevel == EXRC_LEVEL_DOMINATED)
+        sMsg = "[Egzorcyzm] " + sEntity + " zaciska uścisk na twojej woli. Czujesz jak tracisz siebie.";
+    else
+        sMsg = "[Egzorcyzm] " + sEntity + " przebija się przez zasłonę. Twoje ciało nie należy już do ciebie.";
+
+    SendMessageToPC(oPC, sMsg);
+    FloatingTextStringOnCreature(sMsg, oPC, FALSE);
+}
+
+// ================================================================
+// Whisper scheduler (called from heartbeat)
+// ================================================================
+
+const string EXRC_WHISPER_LVAR = "EXRC_WHISPER_IDX";
+
+void ExrcSendWhisper(object oPC)
+{
+    int nLevel = ExrcGetLevel(oPC);
+    if(nLevel == EXRC_LEVEL_CLEAN) return;
+
+    json jRecord = ExrcGetRecord(oPC);
+    string sEntity = JsonGetString(JsonObjectGet(jRecord, "entity_name"));
+    if(sEntity == "") sEntity = "Nieznana Istota";
+
+    int nIdx = GetLocalInt(oPC, EXRC_WHISPER_LVAR);
+
+    string sText;
+    if(nLevel == EXRC_LEVEL_WHISPERS)
+    {
+        // Ciche, niepokojące myśli
+        switch(nIdx % 5)
+        {
+            case 0: sText = "*Szepty* ...oni wszyscy na ciebie patrzą..."; break;
+            case 1: sText = "*Szepty* ...oddaj mi swój gniew..."; break;
+            case 2: sText = "*Szepty* ...jesteś taki zmęczony..."; break;
+            case 3: sText = "*Szepty* ...po co walczyć?..."; break;
+            default: sText = "*Szepty* ...ich krew pachnie słodko..."; break;
+        }
+    }
+    else if(nLevel == EXRC_LEVEL_DOMINATED)
+    {
+        switch(nIdx % 4)
+        {
+            case 0: sText = "[" + sEntity + " mówi przez ciebie] ...moje więzy słabną. Wkrótce będziesz wolny – ode mnie.";  break;
+            case 1: sText = "[" + sEntity + " mówi przez ciebie] ...jak słodki jest twój ból."; break;
+            case 2: sText = "[" + sEntity + " mówi przez ciebie] ...nikt ci nie uwierzy."; break;
+            default: sText = "[" + sEntity + " mówi przez ciebie] ...czuję każdą twoją myśl."; break;
+        }
+    }
+    else
+    {
+        // Manifestacja — demon mówi na głos przez postać
+        SpeakString("[" + sEntity + "] Ja jestem tu teraz. To ciało moje.", TALKVOLUME_TALK);
+        sText = "[Egzorcyzm] Czarna zasłona spada na twoje oczy na chwilę.";
+        ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+            EffectVisualEffect(VFX_DUR_BLUR), oPC, 4.0);
+    }
+
+    if(sText != "")
+        FloatingTextStringOnCreature(sText, oPC, FALSE);
+
+    SetLocalInt(oPC, EXRC_WHISPER_LVAR, nIdx + 1);
+}
+
+// ================================================================
+// NUI — detect window
+// ================================================================
+
+void ExrcOpenDetectWindow(object oPC, object oTarget)
+{
+    if(NuiFindWindow(oPC, EXRC_WIN_DETECT) != 0)
+        NuiDestroy(oPC, NuiFindWindow(oPC, EXRC_WIN_DETECT));
+
+    float fW = GetNuiScaleDimension(oPC, EXRC_DET_W);
+    float fH = GetNuiScaleDimension(oPC, EXRC_DET_H);
+    float fX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - fW) / 2.0;
+    float fY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - fH) / 2.0;
+    float fBtnH = GetNuiScaleDimension(oPC, 30.0);
+    float fRowH = GetNuiScaleDimension(oPC, 24.0);
+
+    // -- Header label --
+    json jName = NuiLabel(NuiBind(EXRC_BIND_DET_NAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jName = NuiHeight(jName, fRowH);
+
+    json jLvl = NuiLabel(NuiBind(EXRC_BIND_DET_LVL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jLvl = NuiHeight(jLvl, fRowH);
+    jLvl = NuiStyleForegroundColor(jLvl, NuiBind(EXRC_BIND_LVL_COL));
+
+    json jEnt = NuiLabel(NuiBind(EXRC_BIND_DET_ENT),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jEnt = NuiHeight(jEnt, fRowH);
+
+    json jAge = NuiLabel(NuiBind(EXRC_BIND_DET_AGE),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jAge = NuiHeight(jAge, fRowH);
+
+    // -- Buttons --
+    json jExrcBtn = NuiButton(JsonString("Przeprowadź egzorcyzm"));
+    jExrcBtn = NuiId(jExrcBtn, EXRC_BTN_EXORCISE);
+    jExrcBtn = NuiEnabled(jExrcBtn, NuiBind(EXRC_BIND_DET_EXNA));
+    jExrcBtn = NuiWidth(jExrcBtn, GetNuiScaleDimension(oPC, 200.0));
+    jExrcBtn = NuiHeight(jExrcBtn, fBtnH);
+
+    json jCloseBtn = NuiButton(JsonString("Zamknij"));
+    jCloseBtn = NuiId(jCloseBtn, EXRC_BTN_DETCLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, GetNuiScaleDimension(oPC, 80.0));
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, jExrcBtn);
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jCloseBtn);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jName);
+    jCol = JsonArrayInsert(jCol, jLvl);
+    jCol = JsonArrayInsert(jCol, jEnt);
+    jCol = JsonArrayInsert(jCol, jAge);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+
+    json jWin = NuiWindow(NuiCol(jCol),
+        JsonString("Badanie duszy"),
+        NuiRect(fX, fY, fW, fH),
+        JsonBool(FALSE), JsonBool(FALSE), JsonBool(TRUE),
+        JsonBool(FALSE), JsonBool(TRUE));
+
+    int nToken = NuiCreate(oPC, jWin, EXRC_WIN_DETECT, EXRC_EV_SCRIPT);
+
+    // -- Feed binds --
+    SetLocalObject(oPC, EXRC_LVAR_TARGET, oTarget);
+    int nLevel     = ExrcGetLevel(oTarget);
+    json jRecord   = ExrcGetRecord(oTarget);
+    string sEntity = "";
+    int nAge       = 0;
+    if(JsonGetType(jRecord) != JSON_TYPE_NULL)
+    {
+        sEntity = JsonGetString(JsonObjectGet(jRecord, "entity_name"));
+        nAge    = ExrcGetPossessionAge(oTarget);
+    }
+
+    NuiSetBind(oPC, nToken, EXRC_BIND_DET_NAME,
+        JsonString("Cel: " + GetName(oTarget)));
+    NuiSetBind(oPC, nToken, EXRC_BIND_DET_LVL,
+        JsonString("Poziom opętania: " + ExrcGetLevelName(nLevel)));
+    NuiSetBind(oPC, nToken, EXRC_BIND_LVL_COL,
+        ExrcGetLevelColor(nLevel));
+    NuiSetBind(oPC, nToken, EXRC_BIND_DET_ENT,
+        JsonString(nLevel > 0 ? "Byt: " + sEntity : ""));
+    NuiSetBind(oPC, nToken, EXRC_BIND_DET_AGE,
+        JsonString(nLevel > 0 ? "Czas opętania: " + IntToString(nAge / 60) + " minut" : ""));
+    NuiSetBind(oPC, nToken, EXRC_BIND_DET_EXNA,
+        JsonBool(nLevel > 0));
+}
+
+// ================================================================
+// NUI — ritual window
+// ================================================================
+
+json ExrcBuildSequenceRow(object oPC)
+{
+    // 4-slot list showing the current sequence as icons
+    float fSlotSz = GetNuiScaleDimension(oPC, 52.0);
+    float fRowH   = GetNuiScaleDimension(oPC, 56.0);
+
+    json jImg = NuiImage(NuiBind(EXRC_BIND_SEQ_IMG),
+        JsonInt(NUI_ASPECT_FIT), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jImg = NuiWidth(jImg, fSlotSz);
+    jImg = NuiHeight(jImg, fSlotSz);
+
+    json jCell = NuiGroup(
+        NuiRow(JsonArrayInsert(JsonArray(), jImg)),
+        TRUE, NUI_SCROLLBARS_NONE);
+    jCell = NuiStyleForegroundColor(jCell, NuiBind(EXRC_BIND_SEQ_COL));
+
+    json jTmpl = JsonArrayInsert(JsonArray(),
+        NuiListTemplateCell(jCell, fSlotSz + 4.0, FALSE));
+
+    json jList = NuiList(jTmpl, NuiBind(EXRC_BIND_SEQ_CNT), fRowH);
+    jList = NuiHeight(jList, fRowH + 2.0);
+    return jList;
+}
+
+json ExrcBuildSymbolRow(object oPC)
+{
+    // 6 clickable symbol buttons
+    float fSz = GetNuiScaleDimension(oPC, 60.0);
+    json jRow = JsonArray();
+    int i;
+    for(i = 0; i < EXRC_SYMBOL_COUNT; i++)
+    {
+        string sId  = EXRC_BTN_SYM + IntToString(i);
+        string sImg = EXRC_BIND_SYMS_IMG + IntToString(i);
+        string sEna = EXRC_BIND_SYMS_ENA + IntToString(i);
+
+        json jBtn = NuiButtonImage(NuiBind(sImg));
+        jBtn = NuiId(jBtn, sId);
+        jBtn = NuiWidth(jBtn, fSz);
+        jBtn = NuiHeight(jBtn, fSz);
+        jBtn = NuiEnabled(jBtn, NuiBind(sEna));
+        jRow = JsonArrayInsert(jRow, jBtn);
+    }
+    return NuiRow(jRow);
+}
+
+void ExrcOpenRitualWindow(object oPC, object oTarget)
+{
+    if(NuiFindWindow(oPC, EXRC_WINDOW) != 0)
+        NuiDestroy(oPC, NuiFindWindow(oPC, EXRC_WINDOW));
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - GetNuiScaleDimension(oPC, EXRC_WIN_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - GetNuiScaleDimension(oPC, EXRC_WIN_H)) / 2.0;
+    json jGeom = NuiRect(fCX, fCY, GetNuiScaleDimension(oPC, EXRC_WIN_W), GetNuiScaleDimension(oPC, EXRC_WIN_H));
+
+    float fBtnH = GetNuiScaleDimension(oPC, 30.0);
+    float fLblH = GetNuiScaleDimension(oPC, 22.0);
+
+    // -- Target info header --
+    json jTName = NuiLabel(NuiBind(EXRC_BIND_TNAME),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jTName = NuiHeight(jTName, fLblH);
+
+    json jLvlLbl = NuiLabel(NuiBind(EXRC_BIND_LVL_TXT),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jLvlLbl = NuiHeight(jLvlLbl, fLblH);
+    jLvlLbl = NuiStyleForegroundColor(jLvlLbl, NuiBind(EXRC_BIND_LVL_COL));
+
+    json jEntLbl = NuiLabel(NuiBind(EXRC_BIND_ENT_TXT),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jEntLbl = NuiHeight(jEntLbl, fLblH);
+
+    json jWaterLbl = NuiLabel(NuiBind(EXRC_BIND_WATER),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jWaterLbl = NuiHeight(jWaterLbl, fLblH);
+
+    // -- Sequence display label --
+    json jSeqLbl = NuiLabel(JsonString("Wymagana kolejność symboli:"),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jSeqLbl = NuiHeight(jSeqLbl, fLblH);
+
+    json jSeqRow = ExrcBuildSequenceRow(oPC);
+
+    // -- Symbol keyboard --
+    json jSymLbl = NuiLabel(JsonString("Aktywne symbole rytuału:"),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jSymLbl = NuiHeight(jSymLbl, fLblH);
+
+    json jSymRow = ExrcBuildSymbolRow(oPC);
+
+    // -- Progress & timer --
+    json jProgLbl = NuiLabel(NuiBind(EXRC_BIND_PROG_TXT),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jProgLbl = NuiHeight(jProgLbl, fLblH);
+
+    json jTimerLbl = NuiLabel(NuiBind(EXRC_BIND_TIMER),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jTimerLbl = NuiHeight(jTimerLbl, fLblH);
+
+    // -- Result message --
+    json jResult = NuiLabel(NuiBind(EXRC_BIND_RESULT),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jResult = NuiHeight(jResult, fLblH);
+    jResult = NuiStyleForegroundColor(jResult, NuiBind(EXRC_BIND_RESULT_COL));
+
+    // -- Bottom bar: Begin + Close --
+    json jBeginBtn = NuiButton(JsonString("Rozpocznij rytuał"));
+    jBeginBtn = NuiId(jBeginBtn, EXRC_BTN_BEGIN);
+    jBeginBtn = NuiEnabled(jBeginBtn, NuiBind(EXRC_BIND_BEGIN_ENA));
+    jBeginBtn = NuiWidth(jBeginBtn, GetNuiScaleDimension(oPC, 160.0));
+    jBeginBtn = NuiHeight(jBeginBtn, fBtnH);
+
+    json jCloseBtn = NuiButton(JsonString("Zamknij"));
+    jCloseBtn = NuiId(jCloseBtn, EXRC_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, GetNuiScaleDimension(oPC, 80.0));
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jBotRow = JsonArray();
+    jBotRow = JsonArrayInsert(jBotRow, jBeginBtn);
+    jBotRow = JsonArrayInsert(jBotRow, NuiSpacer());
+    jBotRow = JsonArrayInsert(jBotRow, jCloseBtn);
+
+    // -- Assemble column --
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jTName);
+    jCol = JsonArrayInsert(jCol, jLvlLbl);
+    jCol = JsonArrayInsert(jCol, jEntLbl);
+    jCol = JsonArrayInsert(jCol, jWaterLbl);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jSeqLbl);
+    jCol = JsonArrayInsert(jCol, jSeqRow);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jSymLbl);
+    jCol = JsonArrayInsert(jCol, jSymRow);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jProgLbl);
+    jCol = JsonArrayInsert(jCol, jTimerLbl);
+    jCol = JsonArrayInsert(jCol, jResult);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBotRow));
+
+    // -- Side spacers for centering --
+    json jSide = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    float fContentW = GetNuiScaleDimension(oPC, EXRC_WIN_W - 40.0);
+    json jMainRow = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiCol(jCol), fContentW));
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+
+    json jWin = NuiWindow(NuiRow(jMainRow),
+        JsonString("Rytuał Egzorcyzmu"),
+        NuiBind(EXRC_WIN_GEOM),
+        JsonBool(FALSE), JsonBool(FALSE), JsonBool(FALSE),
+        JsonBool(TRUE),  JsonBool(FALSE));
+
+    int nToken = NuiCreate(oPC, jWin, EXRC_WINDOW, EXRC_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, EXRC_WIN_GEOM, jGeom);
+
+    SetLocalObject(oPC, EXRC_LVAR_TARGET, oTarget);
+    DeleteLocalInt(oPC, EXRC_LVAR_STARTED);
+    DeleteLocalInt(oPC, EXRC_LVAR_PROGRESS);
+
+    ExrcFeedRitual(oPC, nToken);
+}
+
+// ================================================================
+// Feed / populate ritual window binds
+// ================================================================
+
+void ExrcFeedSymbolButtons(object oPC, int nToken, int bEnabled)
+{
+    int i;
+    for(i = 0; i < EXRC_SYMBOL_COUNT; i++)
+    {
+        NuiSetBind(oPC, nToken,
+            EXRC_BIND_SYMS_IMG + IntToString(i),
+            JsonString(ExrcGetIconByIndex(i)));
+        NuiSetBind(oPC, nToken,
+            EXRC_BIND_SYMS_ENA + IntToString(i),
+            JsonBool(bEnabled));
+    }
+}
+
+void ExrcFeedSequenceDisplay(object oPC, int nToken)
+{
+    json jSeq   = GetLocalJson(oPC, EXRC_LVAR_SEQUENCE);
+    int nProg   = GetLocalInt(oPC, EXRC_LVAR_PROGRESS);
+    int nCount  = JsonGetLength(jSeq);
+
+    json jImgs  = JsonArray();
+    json jCols  = JsonArray();
+    json jGreen = NuiColor( 80, 200,  80);
+    json jWhite = NuiColor(220, 220, 220);
+    json jGray  = NuiColor(100, 100, 100);
+
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        int nSym = JsonGetInt(JsonArrayGet(jSeq, i));
+        jImgs = JsonArrayInsert(jImgs, JsonString(ExrcGetIconByIndex(nSym)));
+        if(i < nProg)
+            jCols = JsonArrayInsert(jCols, jGreen);    // już kliknięty poprawnie
+        else if(i == nProg)
+            jCols = JsonArrayInsert(jCols, jWhite);    // aktualny
+        else
+            jCols = JsonArrayInsert(jCols, jGray);     // przyszłe
+    }
+
+    NuiSetBind(oPC, nToken, EXRC_BIND_SEQ_IMG, jImgs);
+    NuiSetBind(oPC, nToken, EXRC_BIND_SEQ_COL, jCols);
+    NuiSetBind(oPC, nToken, EXRC_BIND_SEQ_CNT, JsonInt(nCount));
+}
+
+void ExrcFeedRitual(object oPC, int nToken)
+{
+    object oTarget = GetLocalObject(oPC, EXRC_LVAR_TARGET);
+    int nLevel     = ExrcGetLevel(oTarget);
+    json jRecord   = ExrcGetRecord(oTarget);
+    string sEntity = "";
+    if(JsonGetType(jRecord) != JSON_TYPE_NULL)
+        sEntity = JsonGetString(JsonObjectGet(jRecord, "entity_name"));
+    if(sEntity == "") sEntity = "Nieznana Istota";
+
+    int nWater     = ExrcCountHolyWater(oPC);
+    int nCost      = ExrcWaterCost(nLevel);
+    int bCanBegin  = (nLevel > 0 && nWater >= nCost);
+
+    NuiSetBind(oPC, nToken, EXRC_BIND_TNAME,
+        JsonString("Cel rytuału: " + GetName(oTarget)));
+    NuiSetBind(oPC, nToken, EXRC_BIND_LVL_TXT,
+        JsonString("Poziom opętania: " + ExrcGetLevelName(nLevel)));
+    NuiSetBind(oPC, nToken, EXRC_BIND_LVL_COL,
+        ExrcGetLevelColor(nLevel));
+    NuiSetBind(oPC, nToken, EXRC_BIND_ENT_TXT,
+        JsonString(nLevel > 0 ? "Byt: " + sEntity : "Dusza czysta — rytuał zbędny."));
+    NuiSetBind(oPC, nToken, EXRC_BIND_WATER,
+        JsonString("Święta Woda: " + IntToString(nWater) + " fiolek (wymagane: " + IntToString(nCost) + ")"));
+    NuiSetBind(oPC, nToken, EXRC_BIND_BEGIN_ENA,
+        JsonBool(bCanBegin && !GetLocalInt(oPC, EXRC_LVAR_STARTED)));
+    NuiSetBind(oPC, nToken, EXRC_BIND_PROG_TXT,  JsonString(""));
+    NuiSetBind(oPC, nToken, EXRC_BIND_TIMER,      JsonString(""));
+    NuiSetBind(oPC, nToken, EXRC_BIND_RESULT,     JsonString(""));
+    NuiSetBind(oPC, nToken, EXRC_BIND_RESULT_COL, NuiColor(220, 220, 220));
+
+    // Sequence — initially empty (shown after Begin is pressed)
+    NuiSetBind(oPC, nToken, EXRC_BIND_SEQ_CNT, JsonInt(0));
+    NuiSetBind(oPC, nToken, EXRC_BIND_SEQ_IMG, JsonArray());
+    NuiSetBind(oPC, nToken, EXRC_BIND_SEQ_COL, JsonArray());
+
+    ExrcFeedSymbolButtons(oPC, nToken, FALSE);
+}
+
+// ================================================================
+// Ritual sequence logic
+// ================================================================
+
+json ExrcGenerateSequence()
+{
+    // Picks EXRC_SEQ_LENGTH symbols from [0..EXRC_SYMBOL_COUNT-1],
+    // repetition allowed to keep it unpredictable.
+    json jSeq = JsonArray();
+    int i;
+    for(i = 0; i < EXRC_SEQ_LENGTH; i++)
+    {
+        int nSym = Random(EXRC_SYMBOL_COUNT);
+        jSeq = JsonArrayInsert(jSeq, JsonInt(nSym));
+    }
+    return jSeq;
+}
+
+void ExrcBeginRitual(object oPC, int nToken)
+{
+    object oTarget = GetLocalObject(oPC, EXRC_LVAR_TARGET);
+    int nLevel     = ExrcGetLevel(oTarget);
+    int nCost      = ExrcWaterCost(nLevel);
+    int nWater     = ExrcCountHolyWater(oPC);
+
+    if(nLevel == EXRC_LEVEL_CLEAN)
+    {
+        NuiSetBind(oPC, nToken, EXRC_BIND_RESULT,
+            JsonString("Dusza celu jest czysta. Rytuał zbędny."));
+        return;
+    }
+    if(nWater < nCost)
+    {
+        NuiSetBind(oPC, nToken, EXRC_BIND_RESULT,
+            JsonString("Niewystarczająca ilość Świętej Wody."));
+        NuiSetBind(oPC, nToken, EXRC_BIND_RESULT_COL, NuiColor(200, 80, 80));
+        return;
+    }
+
+    ExrcConsumeHolyWater(oPC, nCost);
+
+    json jSeq = ExrcGenerateSequence();
+    SetLocalJson(oPC, EXRC_LVAR_SEQUENCE, jSeq);
+    SetLocalInt (oPC, EXRC_LVAR_PROGRESS, 0);
+    SetLocalInt (oPC, EXRC_LVAR_STARTED,  1);
+    SetLocalInt (oPC, EXRC_LVAR_DEADLINE, ExrcNowUnix() + FloatToInt(EXRC_RITUAL_TIMEOUT));
+
+    NuiSetBind(oPC, nToken, EXRC_BIND_BEGIN_ENA, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, EXRC_BIND_RESULT,    JsonString(""));
+    ExrcFeedSymbolButtons(oPC, nToken, TRUE);
+    ExrcFeedSequenceDisplay(oPC, nToken);
+    ExrcTickTimer(oPC);
+
+    // Timeout failsafe via DelayCommand
+    DelayCommand(EXRC_RITUAL_TIMEOUT + 1.0, ExrcHandleTimeout(oPC));
+
+    SendMessageToPC(oPC, "[Egzorcyzm] Rytuał rozpoczęty. Kliknij symbole w podanej kolejności!");
+}
+
+void ExrcHandleTimeout(object oPC)
+{
+    if(!GetLocalInt(oPC, EXRC_LVAR_STARTED)) return;
+
+    int nNow      = ExrcNowUnix();
+    int nDeadline = GetLocalInt(oPC, EXRC_LVAR_DEADLINE);
+    if(nNow <= nDeadline) return;   // already handled successfully
+
+    int nToken = NuiFindWindow(oPC, EXRC_WINDOW);
+    if(nToken == 0)
+    {
+        DeleteLocalInt(oPC, EXRC_LVAR_STARTED);
+        return;
+    }
+
+    DeleteLocalInt(oPC, EXRC_LVAR_STARTED);
+    ExrcFeedSymbolButtons(oPC, nToken, FALSE);
+    // Refresh header to reflect consumed holy water, then overlay failure message
+    ExrcFeedRitual(oPC, nToken);
+    NuiSetBind(oPC, nToken, EXRC_BIND_TIMER,      JsonString("Czas upłynął!"));
+    NuiSetBind(oPC, nToken, EXRC_BIND_RESULT,     JsonString("Rytuał przerwany — demon wzmacnia swój uchwyt."));
+    NuiSetBind(oPC, nToken, EXRC_BIND_RESULT_COL, NuiColor(200, 60, 60));
+
+    // Failure penalty: deal 1d6 divine damage to exorcist; risk level increase
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectDamage(d6(1), DAMAGE_TYPE_DIVINE), oPC);
+    SendMessageToPC(oPC, "[Egzorcyzm] Niepowodzenie! Demon odpycha twoje zaklęcia.");
+
+    // Small chance (25%) the possession level rises on failure
+    if(Random(4) == 0)
+    {
+        object oTarget = GetLocalObject(oPC, EXRC_LVAR_TARGET);
+        int nLevel     = ExrcGetLevel(oTarget);
+        if(nLevel < EXRC_LEVEL_MANIFESTED)
+        {
+            json jRecord = ExrcGetRecord(oTarget);
+            string sEntity = JsonGetString(JsonObjectGet(jRecord, "entity_name"));
+            ExrcInflictPossession(oTarget, nLevel + 1, sEntity);
+            SendMessageToPC(oPC, "[Egzorcyzm] Demon zyskał na sile!");
+        }
+    }
+}
+
+void ExrcTickTimer(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, EXRC_WINDOW);
+    if(nToken == 0 || !GetLocalInt(oPC, EXRC_LVAR_STARTED)) return;
+
+    int nNow      = ExrcNowUnix();
+    int nDeadline = GetLocalInt(oPC, EXRC_LVAR_DEADLINE);
+    int nLeft     = nDeadline - nNow;
+    if(nLeft < 0) nLeft = 0;
+
+    NuiSetBind(oPC, nToken, EXRC_BIND_TIMER,
+        JsonString("Pozostało czasu: " + IntToString(nLeft) + "s"));
+
+    if(nLeft > 0)
+        DelayCommand(1.0, ExrcTickTimer(oPC));
+}
+
+void ExrcHandleSymbolClick(object oPC, int nToken, int nSym)
+{
+    if(!GetLocalInt(oPC, EXRC_LVAR_STARTED)) return;
+
+    int nNow      = ExrcNowUnix();
+    int nDeadline = GetLocalInt(oPC, EXRC_LVAR_DEADLINE);
+    if(nNow > nDeadline)
+    {
+        ExrcHandleTimeout(oPC);
+        return;
+    }
+
+    json jSeq  = GetLocalJson(oPC, EXRC_LVAR_SEQUENCE);
+    int nProg  = GetLocalInt(oPC, EXRC_LVAR_PROGRESS);
+    int nExpected = JsonGetInt(JsonArrayGet(jSeq, nProg));
+
+    if(nSym == nExpected)
+    {
+        nProg++;
+        SetLocalInt(oPC, EXRC_LVAR_PROGRESS, nProg);
+        ExrcFeedSequenceDisplay(oPC, nToken);
+
+        if(nProg >= EXRC_SEQ_LENGTH)
+        {
+            // SUCCESS — persist new level before feeding the window header
+            DeleteLocalInt(oPC, EXRC_LVAR_STARTED);
+
+            object oTarget = GetLocalObject(oPC, EXRC_LVAR_TARGET);
+            int nLevel     = ExrcGetLevel(oTarget);
+            int nNewLevel  = nLevel - 1;
+
+            json jRecord   = ExrcGetRecord(oTarget);
+            string sEntity = JsonGetString(JsonObjectGet(jRecord, "entity_name"));
+            ExrcSavePossession(oTarget, nNewLevel, sEntity);
+            ExrcApplyPossessionEffects(oTarget, nNewLevel);
+
+            // Refresh header (reads new level from DB), then overlay success message
+            ExrcFeedSymbolButtons(oPC, nToken, FALSE);
+            ExrcFeedRitual(oPC, nToken);
+            NuiSetBind(oPC, nToken, EXRC_BIND_RESULT,
+                JsonString("Rytuał zakończony. Demon osłabł!"));
+            NuiSetBind(oPC, nToken, EXRC_BIND_RESULT_COL, NuiColor(80, 200, 80));
+
+            if(nNewLevel == EXRC_LEVEL_CLEAN)
+            {
+                SendMessageToPC(oPC,     "[Egzorcyzm] Demon wypędzony! Dusza celu jest wolna.");
+                SendMessageToPC(oTarget, "[Egzorcyzm] Czujesz jak ciemność opuszcza twój umysł. Jesteś wolny.");
+                FloatingTextStringOnCreature("Opętanie zdjęte!", oTarget, FALSE);
+            }
+            else
+            {
+                string sNewName = ExrcGetLevelName(nNewLevel);
+                SendMessageToPC(oPC,     "[Egzorcyzm] Poziom opętania obniżony do: " + sNewName + ". Kolejny rytuał potrzebny.");
+                SendMessageToPC(oTarget, "[Egzorcyzm] Czujesz chwilową ulgę... ale ciemność wciąż czai się wewnątrz.");
+            }
+        }
+    }
+    else
+    {
+        // WRONG SYMBOL
+        DeleteLocalInt(oPC, EXRC_LVAR_STARTED);
+        ExrcFeedSymbolButtons(oPC, nToken, FALSE);
+        // Refresh header to reflect consumed holy water, then overlay failure message
+        ExrcFeedRitual(oPC, nToken);
+        NuiSetBind(oPC, nToken, EXRC_BIND_TIMER,      JsonString(""));
+        NuiSetBind(oPC, nToken, EXRC_BIND_RESULT,
+            JsonString("Błędny symbol! Rytuał przerwany."));
+        NuiSetBind(oPC, nToken, EXRC_BIND_RESULT_COL, NuiColor(200, 60, 60));
+
+        // Wrong symbol always deals damage
+        ApplyEffectToObject(DURATION_TYPE_INSTANT,
+            EffectDamage(d6(1), DAMAGE_TYPE_DIVINE), oPC);
+        SendMessageToPC(oPC, "[Egzorcyzm] Nieprawidłowa sekwencja! Demon odpycha cię siłą.");
+
+        // 25% chance level rises
+        if(Random(4) == 0)
+        {
+            object oTarget = GetLocalObject(oPC, EXRC_LVAR_TARGET);
+            int nLevel     = ExrcGetLevel(oTarget);
+            if(nLevel < EXRC_LEVEL_MANIFESTED)
+            {
+                json jRecord = ExrcGetRecord(oTarget);
+                string sEntity = JsonGetString(JsonObjectGet(jRecord, "entity_name"));
+                ExrcInflictPossession(oTarget, nLevel + 1, sEntity);
+                SendMessageToPC(oPC, "[Egzorcyzm] Demon zyskał na sile wskutek błędu!");
+            }
+        }
+    }
+}

--- a/Exorcism/Scripts/lib_exrc_def.nss
+++ b/Exorcism/Scripts/lib_exrc_def.nss
@@ -1,0 +1,192 @@
+#include "lib_nui"
+#include "sql_exrc"
+
+void ExrcOpenDetectWindow(object oPC, object oTarget);
+void ExrcOpenRitualWindow(object oPC, object oTarget);
+void ExrcFeedRitual(object oPC, int nToken);
+void ExrcApplyPossessionEffects(object oPC, int nLevel);
+void ExrcRemovePossessionEffects(object oPC);
+void ExrcInflictPossession(object oPC, int nLevel, string sEntity);
+void ExrcTickTimer(object oPC);
+void ExrcHandleTimeout(object oPC);
+void ExrcScheduleWhispers(object oPC);
+
+// ----------------------------------------------------------------
+// Window / script IDs
+// ----------------------------------------------------------------
+
+const string EXRC_WINDOW     = "EXRC_WINDOW";
+const string EXRC_WIN_DETECT = "EXRC_WIN_DETECT";
+const string EXRC_EV_SCRIPT  = "lib_exrc_ev";
+const string EXRC_WIN_GEOM   = "exrc_win_geom";
+const string EXRC_DET_GEOM   = "exrc_det_geom";
+
+// ----------------------------------------------------------------
+// Bind names — ritual window
+// ----------------------------------------------------------------
+
+const string EXRC_BIND_TNAME      = "exrc_tname";
+const string EXRC_BIND_LVL_TXT    = "exrc_lvl_txt";
+const string EXRC_BIND_LVL_COL    = "exrc_lvl_col";
+const string EXRC_BIND_ENT_TXT    = "exrc_ent_txt";
+const string EXRC_BIND_WATER      = "exrc_water";
+const string EXRC_BIND_SEQ_IMG    = "exrc_seq_img";     // list bind — 4 icons
+const string EXRC_BIND_SEQ_CNT    = "exrc_seq_cnt";
+const string EXRC_BIND_SEQ_COL    = "exrc_seq_col";     // per-slot colour (green when hit)
+const string EXRC_BIND_PROG_TXT   = "exrc_prog";
+const string EXRC_BIND_TIMER      = "exrc_timer";
+const string EXRC_BIND_RESULT     = "exrc_result";
+const string EXRC_BIND_RESULT_COL = "exrc_result_col";
+const string EXRC_BIND_BEGIN_ENA  = "exrc_begin_ena";
+const string EXRC_BIND_SYMS_ENA   = "exrc_syms_ena";    // list bind — 6 booleans
+const string EXRC_BIND_SYMS_IMG   = "exrc_syms_img";    // list bind — 6 icons
+
+// ----------------------------------------------------------------
+// Bind names — detect window
+// ----------------------------------------------------------------
+
+const string EXRC_BIND_DET_NAME = "exrc_det_name";
+const string EXRC_BIND_DET_LVL  = "exrc_det_lvl";
+const string EXRC_BIND_DET_ENT  = "exrc_det_ent";
+const string EXRC_BIND_DET_AGE  = "exrc_det_age";
+const string EXRC_BIND_DET_EXNA = "exrc_det_exna";
+
+// ----------------------------------------------------------------
+// Button IDs
+// ----------------------------------------------------------------
+
+const string EXRC_BTN_CLOSE    = "exrc_btn_close";
+const string EXRC_BTN_BEGIN    = "exrc_btn_begin";
+const string EXRC_BTN_SYM      = "exrc_btn_sym";        // + IntToString(i)
+
+const string EXRC_BTN_DETCLOSE = "exrc_btn_detcls";
+const string EXRC_BTN_EXORCISE = "exrc_btn_exrc";
+
+// ----------------------------------------------------------------
+// LVARs on exorcist PC
+// ----------------------------------------------------------------
+
+const string EXRC_LVAR_TARGET   = "EXRC_TARGET";
+const string EXRC_LVAR_SEQUENCE = "EXRC_SEQUENCE";      // JsonArray of 4 ints
+const string EXRC_LVAR_PROGRESS = "EXRC_PROGRESS";
+const string EXRC_LVAR_STARTED  = "EXRC_STARTED";
+const string EXRC_LVAR_DEADLINE = "EXRC_DEADLINE";      // stored as int (unix seconds)
+
+// ----------------------------------------------------------------
+// Possession levels
+// ----------------------------------------------------------------
+
+const int EXRC_LEVEL_CLEAN      = 0;
+const int EXRC_LEVEL_WHISPERS   = 1;    // Szepty demonów
+const int EXRC_LEVEL_DOMINATED  = 2;    // Opanowanie
+const int EXRC_LEVEL_MANIFESTED = 3;    // Manifestacja
+
+// ----------------------------------------------------------------
+// Ritual config
+// ----------------------------------------------------------------
+
+const int   EXRC_SEQ_LENGTH      = 4;
+const int   EXRC_SYMBOL_COUNT    = 6;
+const float EXRC_RITUAL_TIMEOUT  = 35.0;
+const string EXRC_HOLY_WATER_TAG  = "exrc_holy_water";
+const string EXRC_EFFECT_TAG      = "EXRC_EFFECT";
+
+// Icon resrefs for the 6 ritual symbols (TGA files in HAK).
+// Replace with custom artwork or reuse stock NWN spell icons.
+const string EXRC_ICON_0 = "is_blessng";    // Krzyż
+const string EXRC_ICON_1 = "is_holywrd";    // Słowo Święte
+const string EXRC_ICON_2 = "is_divinef";    // Boska Tarcza
+const string EXRC_ICON_3 = "is_recallp";    // Znak Cofnięcia
+const string EXRC_ICON_4 = "is_resurr";     // Zmartwychwstanie
+const string EXRC_ICON_5 = "is_death2";     // Pieczęć Śmierci
+
+// ----------------------------------------------------------------
+// Window layout
+// ----------------------------------------------------------------
+
+const float EXRC_WIN_W = 480.0;
+const float EXRC_WIN_H = 520.0;
+const float EXRC_DET_W = 420.0;
+const float EXRC_DET_H = 280.0;
+
+// ----------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------
+
+string ExrcGetIconByIndex(int nIdx)
+{
+    if(nIdx == 0) return EXRC_ICON_0;
+    if(nIdx == 1) return EXRC_ICON_1;
+    if(nIdx == 2) return EXRC_ICON_2;
+    if(nIdx == 3) return EXRC_ICON_3;
+    if(nIdx == 4) return EXRC_ICON_4;
+    return EXRC_ICON_5;
+}
+
+string ExrcGetLevelName(int nLevel)
+{
+    if(nLevel == EXRC_LEVEL_WHISPERS)   return "Szepty demonów";
+    if(nLevel == EXRC_LEVEL_DOMINATED)  return "Opanowanie";
+    if(nLevel == EXRC_LEVEL_MANIFESTED) return "Manifestacja";
+    return "Czysta dusza";
+}
+
+json ExrcGetLevelColor(int nLevel)
+{
+    if(nLevel == EXRC_LEVEL_WHISPERS)   return NuiColor(220, 200, 50);
+    if(nLevel == EXRC_LEVEL_DOMINATED)  return NuiColor(220, 100, 50);
+    if(nLevel == EXRC_LEVEL_MANIFESTED) return NuiColor(180,  30, 30);
+    return NuiColor(120, 200, 120);
+}
+
+// Returns how many holy water vials the ritual requires for this target's level
+int ExrcWaterCost(int nLevel)
+{
+    return nLevel;   // level 1 = 1 vial, level 2 = 2, level 3 = 3
+}
+
+int ExrcCountHolyWater(object oPC)
+{
+    int nCount = 0;
+    object oItem = GetFirstItemInInventory(oPC);
+    while(GetIsObjectValid(oItem))
+    {
+        if(GetTag(oItem) == EXRC_HOLY_WATER_TAG)
+            nCount += GetItemStackSize(oItem);
+        oItem = GetNextItemInInventory(oPC);
+    }
+    return nCount;
+}
+
+void ExrcConsumeHolyWater(object oPC, int nAmount)
+{
+    int nLeft = nAmount;
+    object oItem = GetFirstItemInInventory(oPC);
+    while(GetIsObjectValid(oItem) && nLeft > 0)
+    {
+        if(GetTag(oItem) == EXRC_HOLY_WATER_TAG)
+        {
+            int nStack = GetItemStackSize(oItem);
+            if(nStack <= nLeft)
+            {
+                nLeft -= nStack;
+                DestroyObject(oItem);
+            }
+            else
+            {
+                SetItemStackSize(oItem, nStack - nLeft);
+                nLeft = 0;
+            }
+        }
+        oItem = GetNextItemInInventory(oPC);
+    }
+}
+
+// Returns the unix time from the campaign DB (portable across NWN versions)
+int ExrcNowUnix()
+{
+    sqlquery q = SqlPrepareQueryCampaign("exorcism",
+        "SELECT CAST(strftime('%s','now') AS INTEGER)");
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}

--- a/Exorcism/Scripts/lib_exrc_ev.nss
+++ b/Exorcism/Scripts/lib_exrc_ev.nss
@@ -1,0 +1,66 @@
+#include "lib_exrc"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+
+    // ---- Detect window ----
+    if(nToken == NuiFindWindow(oPC, EXRC_WIN_DETECT))
+    {
+        if(sEvent == EVENT_TYPE_CLICK)
+        {
+            if(sElem == EXRC_BTN_DETCLOSE)
+            {
+                NuiDestroy(oPC, nToken);
+            }
+            else if(sElem == EXRC_BTN_EXORCISE)
+            {
+                object oTarget = GetLocalObject(oPC, EXRC_LVAR_TARGET);
+                NuiDestroy(oPC, nToken);
+                if(GetIsObjectValid(oTarget))
+                    ExrcOpenRitualWindow(oPC, oTarget);
+            }
+        }
+        return;
+    }
+
+    // ---- Ritual window ----
+    if(nToken != NuiFindWindow(oPC, EXRC_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        // Clean up LVAR state if ritual is still in progress
+        DeleteLocalInt(oPC, EXRC_LVAR_STARTED);
+        DeleteLocalInt(oPC, EXRC_LVAR_PROGRESS);
+        DeleteLocalInt(oPC, EXRC_LVAR_DEADLINE);
+        DeleteLocalJson(oPC, EXRC_LVAR_SEQUENCE);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == EXRC_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        if(sElem == EXRC_BTN_BEGIN)
+        {
+            ExrcBeginRitual(oPC, nToken);
+            return;
+        }
+
+        // Symbol button click: exrc_btn_sym0 .. exrc_btn_sym5
+        if(GetStringLeft(sElem, GetStringLength(EXRC_BTN_SYM)) == EXRC_BTN_SYM)
+        {
+            int nSym = StringToInt(GetStringRight(sElem,
+                GetStringLength(sElem) - GetStringLength(EXRC_BTN_SYM)));
+            ExrcHandleSymbolClick(oPC, nToken, nSym);
+            return;
+        }
+    }
+}

--- a/Exorcism/Scripts/lib_nui.nss
+++ b/Exorcism/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Exorcism/Scripts/lib_nui_utility.nss
+++ b/Exorcism/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Exorcism/Scripts/sql_exrc.nss
+++ b/Exorcism/Scripts/sql_exrc.nss
@@ -1,0 +1,58 @@
+void ExrcCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("exorcism",
+        "CREATE TABLE IF NOT EXISTS exrc_possession ("
+        "uuid TEXT PRIMARY KEY, "
+        "level INTEGER DEFAULT 0, "
+        "entity_name TEXT DEFAULT '', "
+        "possessed_at INTEGER DEFAULT 0)");
+    SqlStep(q);
+}
+
+void ExrcSavePossession(object oPC, int nLevel, string sEntity)
+{
+    sqlquery q = SqlPrepareQueryCampaign("exorcism",
+        "INSERT OR REPLACE INTO exrc_possession (uuid, level, entity_name, possessed_at) "
+        "VALUES (@uuid, @lvl, @ent, "
+        "CASE WHEN @lvl2 > 0 THEN strftime('%s','now') "
+        "ELSE (SELECT possessed_at FROM exrc_possession WHERE uuid = @uuid3) END)");
+    SqlBindString(q, "@uuid",  GetObjectUUID(oPC));
+    SqlBindInt   (q, "@lvl",   nLevel);
+    SqlBindString(q, "@ent",   sEntity);
+    SqlBindInt   (q, "@lvl2",  nLevel);
+    SqlBindString(q, "@uuid3", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+int ExrcGetLevel(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("exorcism",
+        "SELECT level FROM exrc_possession WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+json ExrcGetRecord(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("exorcism",
+        "SELECT level, entity_name, possessed_at FROM exrc_possession WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(!SqlStep(q)) return JsonNull();
+    json j = JsonObject();
+    j = JsonObjectSet(j, "level",        JsonInt   (SqlGetInt   (q, 0)));
+    j = JsonObjectSet(j, "entity_name",  JsonString(SqlGetString(q, 1)));
+    j = JsonObjectSet(j, "possessed_at", JsonInt   (SqlGetInt   (q, 2)));
+    return j;
+}
+
+// Returns seconds since possession, 0 if not possessed
+int ExrcGetPossessionAge(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("exorcism",
+        "SELECT CAST(strftime('%s','now') AS INTEGER) - possessed_at "
+        "FROM exrc_possession WHERE uuid = @uuid AND level > 0");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}

--- a/Exorcism/Scripts/sys_module_hb.nss
+++ b/Exorcism/Scripts/sys_module_hb.nss
@@ -1,0 +1,28 @@
+#include "lib_exrc"
+
+// Wire this into the module's OnModuleHeartbeat script.
+// Whispers fire roughly once per minute per possessed PC (checked each HB,
+// i.e., every 6 seconds, gated by a cooldown LVAR).
+
+const string EXRC_HB_TICK = "EXRC_HB_TICK";
+const int    EXRC_HB_FREQ = 10;    // every ~60 seconds (10 x 6s heartbeats)
+
+void main()
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        int nLevel = ExrcGetLevel(oPC);
+        if(nLevel > EXRC_LEVEL_CLEAN)
+        {
+            int nTick = GetLocalInt(oPC, EXRC_HB_TICK) + 1;
+            SetLocalInt(oPC, EXRC_HB_TICK, nTick);
+            if(nTick >= EXRC_HB_FREQ)
+            {
+                SetLocalInt(oPC, EXRC_HB_TICK, 0);
+                ExrcSendWhisper(oPC);
+            }
+        }
+        oPC = GetNextPC();
+    }
+}

--- a/Exorcism/Scripts/sys_on_enter.nss
+++ b/Exorcism/Scripts/sys_on_enter.nss
@@ -1,0 +1,21 @@
+#include "lib_exrc"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC)) return;
+
+    int nLevel = ExrcGetLevel(oPC);
+    if(nLevel == EXRC_LEVEL_CLEAN) return;
+
+    ExrcApplyPossessionEffects(oPC, nLevel);
+
+    json jRecord = ExrcGetRecord(oPC);
+    string sEntity = JsonGetString(JsonObjectGet(jRecord, "entity_name"));
+    if(sEntity == "") sEntity = "Nieznana Istota";
+
+    string sMsg = "[Egzorcyzm] " + ExrcGetLevelName(nLevel)
+        + " — " + sEntity + " wciąż przebywa w twojej duszy.";
+    DelayCommand(3.0, SendMessageToPC(oPC, sMsg));
+    DelayCommand(3.0, FloatingTextStringOnCreature(sMsg, oPC, FALSE));
+}

--- a/Exorcism/Scripts/sys_on_load.nss
+++ b/Exorcism/Scripts/sys_on_load.nss
@@ -1,0 +1,6 @@
+#include "lib_exrc_def"
+
+void main()
+{
+    ExrcCreateTables();
+}

--- a/Exorcism/Scripts/test_exrc.nss
+++ b/Exorcism/Scripts/test_exrc.nss
@@ -1,0 +1,42 @@
+#include "lib_exrc"
+
+// OnUsed script for a test placeable.
+// Behavior depends on whether the user is already possessed:
+//   - Clean PC: inflicts level 1 possession (test the effects)
+//   - Possessed PC: opens the detect window on self (exorcist mode)
+//   - DM pressing the object: opens detect window targeting nearest PC
+
+void main()
+{
+    object oUser = GetLastUsedBy();
+    if(!GetIsObjectValid(oUser)) return;
+
+    if(GetIsDM(oUser))
+    {
+        // DM: pick nearest PC to inspect/exorcise
+        object oTarget = GetNearestCreature(CREATURE_TYPE_PLAYER_CHAR,
+            PLAYER_CHAR_IS_PC, OBJECT_SELF, 1);
+        if(GetIsObjectValid(oTarget))
+            ExrcOpenDetectWindow(oUser, oTarget);
+        else
+            SendMessageToPC(oUser, "[Egzorcyzm] Brak graczy w zasięgu.");
+        return;
+    }
+
+    if(!GetIsPC(oUser)) return;
+
+    int nLevel = ExrcGetLevel(oUser);
+
+    if(nLevel == EXRC_LEVEL_CLEAN)
+    {
+        // Inflict level 1 possession for testing
+        ExrcInflictPossession(oUser, EXRC_LEVEL_WHISPERS, "Cień Bez Imienia");
+        SendMessageToPC(oUser,
+            "[Test] Ołtarz pulsuje złowrogą energią... coś wślizgnęło się do twojej duszy.");
+    }
+    else
+    {
+        // Open detect window on self so the PC can trigger exorcism
+        ExrcOpenDetectWindow(oUser, oUser);
+    }
+}


### PR DESCRIPTION
## Co to robi

Moduł dodaje pełny system opętania demonami i rytuał egzorcyzmu z mini-grą NUI. Postacie mogą być opętane przez demony lub duchy na trzech poziomach — od szeptów po pełną manifestację z wizualnymi efektami. Egzorcysta przeprowadza rytuał przez okno NUI wymagające kliknięcia 4 świętych symboli w losowej kolejności w ciągu 35 sekund.

## Mechanika

**Poziomy opętania:**
| Poziom | Nazwa            | Kary                                           |
|--------|------------------|------------------------------------------------|
| 0      | Czysta dusza     | brak                                           |
| 1      | Szepty demonów   | −2 CHA, szeptane teksty co ~60 s               |
| 2      | Opanowanie       | −2 CHA, −2 WIS, −15% ruch                     |
| 3      | Manifestacja     | −2 CHA, −2 WIS, −4 STR, aura, demon mówi głośno|

**Rytuał egzorcyzmu (NUI):**
- Okno detekcji: egzorcysta bada cel i widzi poziom/byt/czas opętania.
- Okno rytuału: wyświetla losową sekwencję 4 spośród 6 świętych symboli. Gracz klika przyciski z ikonami w poprawnej kolejności.
- Każdy symbol poprawnie kliknięty podświetla się na zielono.
- Przekroczenie czasu lub błędny symbol: 1d6 obrażeń boskich dla egzorcysty + 25% szansa na eskalację poziomu opętania celu.
- Sukces: poziom opętania celu spada o 1; okno odświeża stan bez zamykania.
- Każda próba zużywa Świętą Wodę (1 fiolka / poziom).

**Heartbeat:**
- Co ~60 s (10 × 6 s HB) — wysyła szept/monolog lub komunikat FloatingText adekwatny do poziomu.
- Na poziomie 3 demon mówi przez postać głośno (`SpeakString`) i aplikuje `VFX_DUR_BLUR`.

**Persystencja:** `SqlPrepareQueryCampaign("exorcism")` — tabela `exrc_possession (uuid, level, entity_name, possessed_at)`.

## Pliki

```
Exorcism/
├── Scripts/
│   ├── sql_exrc.nss          schema SQLite + CRUD
│   ├── lib_exrc_def.nss      stałe, bind IDs, helpery inventory
│   ├── lib_exrc.nss          logika efektów, NUI windows, sekwencja rytuału
│   ├── lib_exrc_ev.nss       handler zdarzeń NUI (void main)
│   ├── lib_nui.nss           współdzielona biblioteka NUI (kopia z projektu)
│   ├── lib_nui_utility.nss   j.w.
│   ├── sys_on_load.nss       CREATE TABLE IF NOT EXISTS
│   ├── sys_on_enter.nss      przywrócenie efektów po logowaniu
│   ├── sys_module_hb.nss     tick whisperów (podepnij do HB modułu)
│   └── test_exrc.nss         placeable OnUsed: inflict / detect / DM-inspect
└── INTEGRATION.md
```

## Zależności (NWNX? SQL?)

Brak NWNX. Wyłącznie `SqlPrepareQueryCampaign` (wbudowane od NWN EE 8193.x).

Wymagane TGA 32×32 w HAK dla ikon symboli (resrefy konfigurowalne jako stałe `EXRC_ICON_0`–`EXRC_ICON_5` w `lib_exrc_def.nss`). Domyślnie podpięte pod istniejące ikony czarów NWN.

Item z tagiem `exrc_holy_water` (konfigurowalny przez stałą `EXRC_HOLY_WATER_TAG`).

## Jak włączyć w istniejącym module

1. `OnModuleLoad` → podepnij `sys_on_load` (lub wywołaj `ExrcCreateTables()`).
2. `OnClientEnter` → podepnij `sys_on_enter` (lub wywołaj jego logikę).
3. `OnModuleHeartbeat` → wywołaj `ExecuteScript("sys_module_hb", GetModule())` lub scal z istniejącym HB.
4. Stwórz item z tagiem `exrc_holy_water` i umieść w handlu.
5. Umieść placeable z OnUsed = `test_exrc` do testów.
6. Opętanie z zewnątrz: `ExrcInflictPossession(oPC, EXRC_LEVEL_WHISPERS, "Nazwa Bytu")`.

## Co celowo pominięto

- Opętanie NPC (tylko gracze mają UUID w DB).
- Odporność na opętanie (można dodać check WIS/spell resistance w `ExrcInflictPossession`).
- Automatyczne rozprzestrzenianie między graczami stojącymi obok siebie.
- Leczenie przez śmierć/wskrzeszenie (wymaga designerskiej decyzji — hook `OnPlayerDeath` wystarczy).
- Plik `.mod` — środowisko CI nie ma toolsetu; patrz `INTEGRATION.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WBU2FScQKvot4gRnhp9kho)_