### PR TITLE
feat: Arena Gladiatorów

### DIFF
--- a/Arena Gladiatorow/INTEGRATION.md
+++ b/Arena Gladiatorow/INTEGRATION.md
@@ -1,0 +1,79 @@
+# Arena Gladiatorów — Integracja
+
+## Opis
+
+System areny gladiatorów z trójligowym systemem walk (Rekrut / Wojownik / Mistrz),
+trwałą tabelą wyników (SQL), tytułami za próg zwycięstw i interfejsem NUI.
+
+## Wymagania
+
+- NWN EE 8193.36 lub nowszy (NUI, SqlPrepareQueryCampaign, JsonObject)
+- Brak wymagań NWNX
+
+## Podpinanie hooków
+
+| Skrypt               | Zdarzenie modułu       |
+|----------------------|------------------------|
+| `sys_on_load.nss`    | OnModuleLoad           |
+| `sys_on_enter.nss`   | OnClientEnter          |
+| `lib_gla_ev.nss`     | NUI Event Script (podawany przez ArenaOpenWindow) |
+
+## Baza danych
+
+Kampania SQLite o nazwie `arena` tworzona automatycznie przy OnModuleLoad.
+Tabela `arena_fighters` — jedno pole na gracza, idempotentna migracja.
+
+## Placeable — tablica areny
+
+1. Utwórz placeable z dowolnym wyglądem (np. `plc_pedestal`).
+2. Ustaw skrypt OnUsed: `test_gla`.
+3. Umieść go w obszarze, gdzie gracze mogą walczyć (otwarta przestrzeń
+   o promieniu ~8m, by potwory mogły się swobodnie spawować).
+
+## Skrypty HAK
+
+Dodaj do haka (lub skopiuj do folderu scripts modułu):
+
+```
+lib_gla_def.nss
+lib_gla.nss
+lib_gla_ev.nss
+sql_gla.nss
+lib_nui.nss
+lib_nui_utility.nss
+sys_on_load.nss
+sys_on_enter.nss
+sys_on_enter.nss
+test_gla.nss
+```
+
+## Flow walki
+
+1. Gracz używa tablicy → otwiera się okno NUI.
+2. Zakładka **Tabela Chwały**: top-10 graczy według infamii.
+3. Zakładka **Moje Walki**: statystyki, wybór ligi, przycisk „WALCZ!".
+4. Po kliknięciu „WALCZ!" system spawnuje 2–4 potwory w pobliżu gracza
+   w 3 falach rosnącej trudności.
+5. Co 5 s skrypt sprawdza stan walki (SmierćPC / śmierć wszystkich wrogów / timeout 180 s).
+6. Wygrana → zapis do SQL, aktualizacja tabeli, opcjonalny efekt wizualny i nowy tytuł.
+7. Przegrana → odliczenie kary infamii.
+
+## Resrefy potworów
+
+Moduł korzysta ze standardowych blueprintów NWN:
+- Liga 1 (Rekrut):  `nw_goblin001`, `nw_goblina`, `nw_bandit001`, `nw_bandita`, `nw_kobold001`
+- Liga 2 (Wojownik): `nw_orc001`, `nw_orca`, `nw_gnoll001`, `nw_gnollarcher`, `nw_bugbear001`
+- Liga 3 (Mistrz):   `nw_ogre001`, `nw_ogrehalf001`, `nw_troll001`, `nw_gianthill001`
+
+Jeśli blueprinty nie istnieją w module, stworzenie potwora nie powiedzie się cicho
+— system odnotuje 0 wrogów i fala zostanie pominięta.
+
+## Co celowo pominięto
+
+- **Zakłady** — gracze nie mogą zakładać się na wynik walki (rozszerzenie przyszłości).
+- **Obserwatorzy (spectators)** — brak NUI dla widzów śledzących walkę w czasie rzeczywistym.
+- **Nagrody przedmiotowe** — wygrana przyznaje tylko infamię i tytuł; magistrat modułu
+  może rozszerzyć `ArenaHandleWin` o przyznanie konkretnych itemów.
+- **Walki PvP** — mechanika opiera się wyłącznie na PvE (PC vs. NPC).
+- **Dedykowany obszar areny** — system działa w dowolnym miejscu; nie wymaga
+  specjalnie przygotowanego terenu, co upraszcza setup kosztem immersji.

--- a/Arena Gladiatorow/scripts/lib_gla.nss
+++ b/Arena Gladiatorow/scripts/lib_gla.nss
@@ -1,0 +1,577 @@
+#include "lib_gla_def"
+
+// ----------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------
+
+string ArenaLeagueName(int nLeague)
+{
+    switch(nLeague)
+    {
+        case ARENA_LEAGUE_RECRUIT:  return "Rekrut";
+        case ARENA_LEAGUE_WARRIOR:  return "Wojownik";
+        case ARENA_LEAGUE_CHAMPION: return "Mistrz";
+    }
+    return "Rekrut";
+}
+
+int ArenaLeagueInfamy(int nLeague)
+{
+    switch(nLeague)
+    {
+        case ARENA_LEAGUE_RECRUIT:  return ARENA_INF_WIN_L1;
+        case ARENA_LEAGUE_WARRIOR:  return ARENA_INF_WIN_L2;
+        case ARENA_LEAGUE_CHAMPION: return ARENA_INF_WIN_L3;
+    }
+    return ARENA_INF_WIN_L1;
+}
+
+string ArenaTitleFromWins(int nTotalWins)
+{
+    if(nTotalWins >= ARENA_WINS_LEGEND)  return "Legenda Krwi";
+    if(nTotalWins >= ARENA_WINS_VETERAN) return "Weteran Areny";
+    if(nTotalWins >= ARENA_WINS_FIGHTER) return "Gladiator";
+    return "Nowicjusz";
+}
+
+// Number of creatures spawned per wave, scales with league.
+int ArenaWaveSize(int nLeague)
+{
+    switch(nLeague)
+    {
+        case ARENA_LEAGUE_RECRUIT:  return 2;
+        case ARENA_LEAGUE_WARRIOR:  return 3;
+        case ARENA_LEAGUE_CHAMPION: return 4;
+    }
+    return 2;
+}
+
+// Returns the creature blueprint resref for a given league, wave index (0-2), and slot (0-3).
+// Wave index drives escalating toughness within a fight session.
+string ArenaCreatureResRef(int nLeague, int nWave, int nSlot)
+{
+    if(nLeague == ARENA_LEAGUE_RECRUIT)
+    {
+        if(nWave == 0) return (nSlot == 0 ? "nw_goblin001" : "nw_goblina");
+        if(nWave == 1) return (nSlot < 2   ? "nw_bandit001" : "nw_bandita");
+        return (nSlot == 0 ? "nw_bandit001" : "nw_kobold001");
+    }
+    if(nLeague == ARENA_LEAGUE_WARRIOR)
+    {
+        if(nWave == 0) return (nSlot < 2 ? "nw_orc001"      : "nw_orca");
+        if(nWave == 1) return (nSlot < 2 ? "nw_gnoll001"    : "nw_gnollarcher");
+        return (nSlot < 2 ? "nw_bugbear001" : "nw_gnoll001");
+    }
+    // ARENA_LEAGUE_CHAMPION
+    if(nWave == 0) return (nSlot < 2 ? "nw_ogre001"      : "nw_ogrehalf001");
+    if(nWave == 1) return (nSlot < 2 ? "nw_troll001"     : "nw_ogre001");
+    return (nSlot < 3 ? "nw_gianthill001" : "nw_troll001");
+}
+
+// ----------------------------------------------------------------
+// Fight: spawn / clear / check
+// ----------------------------------------------------------------
+
+void ArenaClearSpawns(object oPC)
+{
+    int nCount = GetLocalInt(oPC, ARENA_LVAR_SPAWN_N);
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        object oC = GetLocalObject(oPC, "ARENA_C_" + IntToString(i));
+        if(GetIsObjectValid(oC) && !GetIsDead(oC))
+            DestroyObject(oC, 0.0);
+    }
+    SetLocalInt(oPC, ARENA_LVAR_SPAWN_N, 0);
+}
+
+void ArenaSpawnWave(object oPC, int nWave)
+{
+    int nLeague = GetLocalInt(oPC, ARENA_LVAR_FT_LG);
+    int nSize   = ArenaWaveSize(nLeague);
+
+    int i;
+    for(i = 0; i < nSize; i++)
+    {
+        string sRes  = ArenaCreatureResRef(nLeague, nWave, i);
+        // Spread spawns in a ring of radius 5 at equal angles so they don't stack.
+        float fAngle = (360.0 / IntToFloat(nSize)) * IntToFloat(i);
+        location lSpawn = GenerateNewLocation(oPC, 5.0, fAngle, fAngle + 180.0);
+        object oC = CreateObject(OBJECT_TYPE_CREATURE, sRes, lSpawn);
+        if(GetIsObjectValid(oC))
+        {
+            SetLocalObject(oPC, "ARENA_C_" + IntToString(i), oC);
+            ChangeToStandardFaction(oC, STANDARD_FACTION_HOSTILE);
+            // Short delay before attack command so the creature spawns fully
+            DelayCommand(0.5, AssignCommand(oC, ActionAttack(oPC)));
+        }
+    }
+    SetLocalInt(oPC, ARENA_LVAR_SPAWN_N, nSize);
+
+    SendMessageToPC(oPC, "[Arena] Fala " + IntToString(nWave + 1) + "/" +
+        IntToString(ARENA_WAVES_PER_FIGHT) + " wchodzi na piasek!");
+}
+
+void ArenaCheckWave(object oPC)
+{
+    if(!GetLocalInt(oPC, ARENA_LVAR_IN_FIGHT)) return;
+    if(!GetIsObjectValid(oPC))                 return;
+
+    if(GetIsDead(oPC))
+    {
+        ArenaHandleLoss(oPC);
+        return;
+    }
+
+    // Count down the timeout so fights don't linger forever.
+    int nLeft = GetLocalInt(oPC, ARENA_LVAR_TIMEOUT) - ARENA_CHECK_DELAY;
+    SetLocalInt(oPC, ARENA_LVAR_TIMEOUT, nLeft);
+    if(nLeft <= 0)
+    {
+        SendMessageToPC(oPC, "[Arena] Czas się skończył. Walka przegrana z powodu opieszałości.");
+        ArenaClearSpawns(oPC);
+        ArenaHandleLoss(oPC);
+        return;
+    }
+
+    // Count arena creatures that are still alive.
+    int nCount = GetLocalInt(oPC, ARENA_LVAR_SPAWN_N);
+    int nAlive = 0;
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        object oC = GetLocalObject(oPC, "ARENA_C_" + IntToString(i));
+        if(GetIsObjectValid(oC) && !GetIsDead(oC))
+            nAlive++;
+    }
+
+    if(nAlive > 0)
+    {
+        DelayCommand(IntToFloat(ARENA_CHECK_DELAY), ArenaCheckWave(oPC));
+        return;
+    }
+
+    // Wave cleared — advance or declare victory.
+    int nWave = GetLocalInt(oPC, ARENA_LVAR_WAVE) + 1;
+    SetLocalInt(oPC, ARENA_LVAR_WAVE, nWave);
+
+    if(nWave >= ARENA_WAVES_PER_FIGHT)
+    {
+        ArenaHandleWin(oPC);
+    }
+    else
+    {
+        SendMessageToPC(oPC, "[Arena] Fala " + IntToString(nWave) + " pokonana. Chwila wytchnienia...");
+        DelayCommand(2.0, ArenaSpawnWave(oPC, nWave));
+        DelayCommand(2.0 + IntToFloat(ARENA_CHECK_DELAY), ArenaCheckWave(oPC));
+    }
+}
+
+void ArenaHandleWin(object oPC)
+{
+    SetLocalInt(oPC, ARENA_LVAR_IN_FIGHT, 0);
+    int    nLeague    = GetLocalInt(oPC, ARENA_LVAR_FT_LG);
+    int    nInfGain   = ArenaLeagueInfamy(nLeague);
+    string sUuid      = GetObjectUUID(oPC);
+
+    ArenaRecordWin(sUuid, nLeague, nInfGain);
+
+    json   jF      = ArenaGetFighter(sUuid);
+    int    nWins   = JsonGetInt(JsonObjectGet(jF, "total_wins"));
+    string sTitle  = ArenaTitleFromWins(nWins);
+
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+        EffectVisualEffect(VFX_IMP_GOOD_HELP), oPC, 5.0);
+    FloatingTextStringOnCreature("Zwycięstwo! +" + IntToString(nInfGain) + " infamii", oPC, FALSE);
+    SendMessageToPC(oPC, "[Arena] Wszystkie fale pokonane. Infamia +" + IntToString(nInfGain) +
+        ". Tytuł: " + sTitle + ".");
+
+    // Special fanfare when the fighter crosses a title threshold for the first time.
+    if(nWins == ARENA_WINS_FIGHTER || nWins == ARENA_WINS_VETERAN || nWins == ARENA_WINS_LEGEND)
+    {
+        FloatingTextStringOnCreature("Nowy tytuł: " + sTitle + "!", oPC, FALSE);
+        ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+            EffectVisualEffect(VFX_FNF_LOS_NORMAL_20), oPC, 3.0);
+        SendMessageToPC(oPC, "[Arena] Tłum skanduje twoje imię. Tytuł '" + sTitle + "' jest twój.");
+    }
+
+    int nToken = NuiFindWindow(oPC, ARENA_WINDOW);
+    if(nToken != 0)
+    {
+        ArenaFeedLeaderboard(oPC, nToken);
+        ArenaFeedStatus(oPC, nToken);
+    }
+}
+
+void ArenaHandleLoss(object oPC)
+{
+    SetLocalInt(oPC, ARENA_LVAR_IN_FIGHT, 0);
+    string sUuid = GetObjectUUID(oPC);
+    ArenaRecordLoss(sUuid, ARENA_INF_LOSS);
+
+    FloatingTextStringOnCreature("Porażka... -" + IntToString(ARENA_INF_LOSS) + " infamii", oPC, FALSE);
+    SendMessageToPC(oPC, "[Arena] Porażka. Blizny uczą lepiej niż słowa. Infamia -" +
+        IntToString(ARENA_INF_LOSS) + ".");
+
+    int nToken = NuiFindWindow(oPC, ARENA_WINDOW);
+    if(nToken != 0)
+    {
+        ArenaFeedLeaderboard(oPC, nToken);
+        ArenaFeedStatus(oPC, nToken);
+    }
+}
+
+void ArenaStartFight(object oPC)
+{
+    if(GetLocalInt(oPC, ARENA_LVAR_IN_FIGHT))
+    {
+        SendMessageToPC(oPC, "[Arena] Walka już trwa.");
+        return;
+    }
+
+    int nLeague = GetLocalInt(oPC, ARENA_LVAR_LEAGUE);
+    if(nLeague == 0) nLeague = ARENA_LEAGUE_RECRUIT;
+
+    SetLocalInt(oPC, ARENA_LVAR_IN_FIGHT, 1);
+    SetLocalInt(oPC, ARENA_LVAR_WAVE,     0);
+    SetLocalInt(oPC, ARENA_LVAR_FT_LG,   nLeague);
+    SetLocalInt(oPC, ARENA_LVAR_TIMEOUT,  ARENA_TIMEOUT_SEC);
+
+    SendMessageToPC(oPC, "[Arena] Wchodzisz na piasek. Liga: " + ArenaLeagueName(nLeague) +
+        ". " + IntToString(ARENA_WAVES_PER_FIGHT) + " fale. Powodzenia.");
+    FloatingTextStringOnCreature("Arena — " + ArenaLeagueName(nLeague), oPC, FALSE);
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY, EffectVisualEffect(VFX_IMP_DOOM), oPC, 2.0);
+
+    ArenaSpawnWave(oPC, 0);
+    DelayCommand(IntToFloat(ARENA_CHECK_DELAY), ArenaCheckWave(oPC));
+
+    int nToken = NuiFindWindow(oPC, ARENA_WINDOW);
+    if(nToken != 0)
+        ArenaFeedStatus(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// NUI: leaderboard view
+// ----------------------------------------------------------------
+
+json ArenaBuildLeaderboardView(object oPC)
+{
+    float fRowH   = GetNuiScaleDimension(oPC, 26.0);
+    float fHdrH   = GetNuiScaleDimension(oPC, 28.0);
+    float fRankW  = GetNuiScaleDimension(oPC, 32.0);
+    float fNameW  = GetNuiScaleDimension(oPC, 180.0);
+    float fLeagW  = GetNuiScaleDimension(oPC, 90.0);
+    float fNumW   = GetNuiScaleDimension(oPC, 58.0);
+
+    // Header
+    json jHdr = JsonArray();
+    jHdr = JsonArrayInsert(jHdr, NuiWidth(NuiLabel(JsonString("#"),       JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE)), fRankW));
+    jHdr = JsonArrayInsert(jHdr, NuiWidth(NuiLabel(JsonString("Imię"),   JsonInt(NUI_HALIGN_LEFT),   JsonInt(NUI_VALIGN_MIDDLE)), fNameW));
+    jHdr = JsonArrayInsert(jHdr, NuiWidth(NuiLabel(JsonString("Liga"),   JsonInt(NUI_HALIGN_LEFT),   JsonInt(NUI_VALIGN_MIDDLE)), fLeagW));
+    jHdr = JsonArrayInsert(jHdr, NuiWidth(NuiLabel(JsonString("Zwyc."),  JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE)), fNumW));
+    jHdr = JsonArrayInsert(jHdr, NuiWidth(NuiLabel(JsonString("Poraż."), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE)), fNumW));
+    jHdr = JsonArrayInsert(jHdr, NuiLabel(JsonString("Infamia"),         JsonInt(NUI_HALIGN_RIGHT),  JsonInt(NUI_VALIGN_MIDDLE)));
+
+    // Row template
+    json jRankCell = NuiWidth(NuiLabel(NuiBind(ARENA_BIND_BD_RANK), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE)), fRankW);
+    json jNameCell = NuiWidth(NuiLabel(NuiBind(ARENA_BIND_BD_NAME), JsonInt(NUI_HALIGN_LEFT),   JsonInt(NUI_VALIGN_MIDDLE)), fNameW);
+    json jLgCell   = NuiWidth(NuiLabel(NuiBind(ARENA_BIND_BD_LG),   JsonInt(NUI_HALIGN_LEFT),   JsonInt(NUI_VALIGN_MIDDLE)), fLeagW);
+    json jWinCell  = NuiWidth(NuiLabel(NuiBind(ARENA_BIND_BD_WINS), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE)), fNumW);
+    json jLossCell = NuiWidth(NuiLabel(NuiBind(ARENA_BIND_BD_LOSS), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE)), fNumW);
+    json jInfCell  = NuiLabel(NuiBind(ARENA_BIND_BD_INF),           JsonInt(NUI_HALIGN_RIGHT),  JsonInt(NUI_VALIGN_MIDDLE));
+
+    json jCellRow = JsonArray();
+    jCellRow = JsonArrayInsert(jCellRow, jRankCell);
+    jCellRow = JsonArrayInsert(jCellRow, jNameCell);
+    jCellRow = JsonArrayInsert(jCellRow, jLgCell);
+    jCellRow = JsonArrayInsert(jCellRow, jWinCell);
+    jCellRow = JsonArrayInsert(jCellRow, jLossCell);
+    jCellRow = JsonArrayInsert(jCellRow, jInfCell);
+
+    json jRowGrp = NuiGroup(NuiRow(jCellRow), TRUE, NUI_SCROLLBARS_NONE);
+    json jTmpl   = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jRowGrp, 0.0, TRUE));
+
+    float fListH = GetNuiScaleDimension(oPC, ARENA_H - 90.0);
+    json jList   = NuiList(jTmpl, NuiBind(ARENA_BIND_BD_COUNT), fRowH);
+    jList        = NuiHeight(jList, fListH);
+
+    json jCols = JsonArray();
+    jCols = JsonArrayInsert(jCols, NuiHeight(NuiRow(jHdr), fHdrH));
+    jCols = JsonArrayInsert(jCols, jList);
+
+    return NuiCol(jCols);
+}
+
+// ----------------------------------------------------------------
+// NUI: my-status view
+// ----------------------------------------------------------------
+
+json ArenaBuildStatusView(object oPC)
+{
+    float fLblH = GetNuiScaleDimension(oPC, 26.0);
+    float fBtnH = GetNuiScaleDimension(oPC, 32.0);
+    float fBigH = GetNuiScaleDimension(oPC, 42.0);
+    float fLblW = GetNuiScaleDimension(oPC, 120.0);
+    float fBtnW = GetNuiScaleDimension(oPC, 145.0);
+
+    json jRows = JsonArray();
+
+    // --- Stats block ---
+    {
+        json r = JsonArray();
+        r = JsonArrayInsert(r, NuiWidth(NuiLabel(JsonString("Wojownik:"), JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE)), fLblW));
+        r = JsonArrayInsert(r, NuiLabel(NuiBind(ARENA_BIND_MY_NAME), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)));
+        jRows = JsonArrayInsert(jRows, NuiHeight(NuiRow(r), fLblH));
+    }
+    {
+        json r = JsonArray();
+        r = JsonArrayInsert(r, NuiWidth(NuiLabel(JsonString("Najwyższa liga:"), JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE)), fLblW));
+        r = JsonArrayInsert(r, NuiWidth(NuiLabel(NuiBind(ARENA_BIND_MY_LG),   JsonInt(NUI_HALIGN_LEFT),  JsonInt(NUI_VALIGN_MIDDLE)), GetNuiScaleDimension(oPC, 110.0)));
+        r = JsonArrayInsert(r, NuiWidth(NuiLabel(JsonString("Infamia:"),        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE)), GetNuiScaleDimension(oPC, 70.0)));
+        r = JsonArrayInsert(r, NuiLabel(NuiBind(ARENA_BIND_MY_INF), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)));
+        jRows = JsonArrayInsert(jRows, NuiHeight(NuiRow(r), fLblH));
+    }
+    {
+        json r = JsonArray();
+        r = JsonArrayInsert(r, NuiWidth(NuiLabel(JsonString("Zwycięstwa:"), JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE)), fLblW));
+        r = JsonArrayInsert(r, NuiWidth(NuiLabel(NuiBind(ARENA_BIND_MY_WINS), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)), GetNuiScaleDimension(oPC, 110.0)));
+        r = JsonArrayInsert(r, NuiWidth(NuiLabel(JsonString("Porażki:"),      JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE)), GetNuiScaleDimension(oPC, 70.0)));
+        r = JsonArrayInsert(r, NuiLabel(NuiBind(ARENA_BIND_MY_LOSS), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)));
+        jRows = JsonArrayInsert(jRows, NuiHeight(NuiRow(r), fLblH));
+    }
+    {
+        json r = JsonArray();
+        r = JsonArrayInsert(r, NuiWidth(NuiLabel(JsonString("Tytuł:"), JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE)), fLblW));
+        r = JsonArrayInsert(r, NuiLabel(NuiBind(ARENA_BIND_MY_TITLE), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)));
+        jRows = JsonArrayInsert(jRows, NuiHeight(NuiRow(r), fLblH));
+    }
+
+    jRows = JsonArrayInsert(jRows, CreateEmptyRow(oPC, 14.0));
+
+    // --- League selector ---
+    {
+        json r = JsonArray();
+        r = JsonArrayInsert(r, NuiLabel(JsonString("Wybierz ligę:"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)));
+        jRows = JsonArrayInsert(jRows, NuiHeight(NuiRow(r), fLblH));
+    }
+    {
+        json jB1 = NuiEncouraged(NuiId(NuiButton(JsonString("Rekrut (+50)")),   ARENA_BTN_L1), NuiBind(ARENA_BIND_L1_ENC));
+        jB1 = NuiWidth(jB1, fBtnW);
+        jB1 = NuiHeight(jB1, fBtnH);
+        json jB2 = NuiEncouraged(NuiId(NuiButton(JsonString("Wojownik (+120)")), ARENA_BTN_L2), NuiBind(ARENA_BIND_L2_ENC));
+        jB2 = NuiWidth(jB2, fBtnW);
+        jB2 = NuiHeight(jB2, fBtnH);
+        json jB3 = NuiEncouraged(NuiId(NuiButton(JsonString("Mistrz (+250)")),  ARENA_BTN_L3), NuiBind(ARENA_BIND_L3_ENC));
+        jB3 = NuiWidth(jB3, fBtnW);
+        jB3 = NuiHeight(jB3, fBtnH);
+
+        json r = JsonArray();
+        r = JsonArrayInsert(r, jB1);
+        r = JsonArrayInsert(r, NuiSpacer());
+        r = JsonArrayInsert(r, jB2);
+        r = JsonArrayInsert(r, NuiSpacer());
+        r = JsonArrayInsert(r, jB3);
+        jRows = JsonArrayInsert(jRows, NuiHeight(NuiRow(r), fBtnH));
+    }
+
+    jRows = JsonArrayInsert(jRows, CreateEmptyRow(oPC, 18.0));
+
+    // --- Fight button ---
+    {
+        json jFight = NuiId(NuiButton(NuiBind(ARENA_BIND_FIGHT_LB)), ARENA_BTN_FIGHT);
+        jFight = NuiEnabled(jFight, NuiBind(ARENA_BIND_FIGHT_EN));
+        jFight = NuiHeight(jFight, fBigH);
+
+        json r = JsonArray();
+        r = JsonArrayInsert(r, NuiWidth(NuiSpacer(), GetNuiScaleDimension(oPC, 80.0)));
+        r = JsonArrayInsert(r, jFight);
+        r = JsonArrayInsert(r, NuiWidth(NuiSpacer(), GetNuiScaleDimension(oPC, 80.0)));
+        jRows = JsonArrayInsert(jRows, NuiHeight(NuiRow(r), fBigH));
+    }
+
+    jRows = JsonArrayInsert(jRows, NuiSpacer());
+
+    // --- Flavor text ---
+    {
+        json jFlavor = NuiLabel(NuiBind(ARENA_BIND_FLAVOR), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+        jFlavor = NuiStyleForegroundColor(jFlavor, NuiColor(160, 100, 60));
+        json r = JsonArray();
+        r = JsonArrayInsert(r, jFlavor);
+        jRows = JsonArrayInsert(jRows, NuiHeight(NuiRow(r), fLblH));
+    }
+
+    return NuiCol(jRows);
+}
+
+// ----------------------------------------------------------------
+// NUI: window creation and tab bar
+// ----------------------------------------------------------------
+
+json ArenaBuildTabBar(object oPC)
+{
+    float fBtnH = GetNuiScaleDimension(oPC, 30.0);
+    float fBtnW = GetNuiScaleDimension(oPC, 150.0);
+
+    json jTabBoard = NuiId(NuiButton(JsonString("Tabela Chwały")), ARENA_BTN_TAB_BOARD);
+    jTabBoard = NuiWidth(jTabBoard, fBtnW);
+    jTabBoard = NuiHeight(jTabBoard, fBtnH);
+
+    json jTabMine = NuiId(NuiButton(JsonString("Moje Walki")), ARENA_BTN_TAB_MINE);
+    jTabMine = NuiWidth(jTabMine, fBtnW);
+    jTabMine = NuiHeight(jTabMine, fBtnH);
+
+    json jClose = NuiId(NuiButton(JsonString("X")), ARENA_BTN_CLOSE);
+    jClose = NuiWidth(jClose, GetNuiScaleDimension(oPC, 28.0));
+    jClose = NuiHeight(jClose, fBtnH);
+
+    json jRow = JsonArray();
+    jRow = JsonArrayInsert(jRow, jTabBoard);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), GetNuiScaleDimension(oPC, 4.0)));
+    jRow = JsonArrayInsert(jRow, jTabMine);
+    jRow = JsonArrayInsert(jRow, NuiSpacer());
+    jRow = JsonArrayInsert(jRow, jClose);
+
+    return NuiHeight(NuiRow(jRow), fBtnH);
+}
+
+void ArenaOpenWindow(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, ARENA_WINDOW);
+    if(nToken != 0)
+    {
+        NuiSetGroupLayout(oPC, nToken, ARENA_GRP_SWAP, ArenaBuildLeaderboardView(oPC));
+        SetLocalString(oPC, ARENA_LVAR_TAB, "board");
+        ArenaFeedLeaderboard(oPC, nToken);
+        ArenaFeedStatus(oPC, nToken);
+        return;
+    }
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  -
+                 GetNuiScaleDimension(oPC, ARENA_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) -
+                 GetNuiScaleDimension(oPC, ARENA_H)) / 2.0;
+    json jGeom = NuiRect(fCX, fCY, GetNuiScaleDimension(oPC, ARENA_W), GetNuiScaleDimension(oPC, ARENA_H));
+
+    json jSwapGrp = NuiGroup(ArenaBuildLeaderboardView(oPC), FALSE, NUI_SCROLLBARS_NONE);
+    jSwapGrp = NuiId(jSwapGrp, ARENA_GRP_SWAP);
+
+    json jRootCols = JsonArray();
+    jRootCols = JsonArrayInsert(jRootCols, ArenaBuildTabBar(oPC));
+    jRootCols = JsonArrayInsert(jRootCols, jSwapGrp);
+    json jRoot = NuiCol(jRootCols);
+
+    json jWin = NuiWindow(jRoot,
+        JsonBool(FALSE),
+        NuiBind(ARENA_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    nToken = NuiCreate(oPC, jWin, ARENA_WINDOW, ARENA_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, ARENA_WIN_GEOM, jGeom);
+
+    SetLocalString(oPC, ARENA_LVAR_TAB, "board");
+    if(GetLocalInt(oPC, ARENA_LVAR_LEAGUE) == 0)
+        SetLocalInt(oPC, ARENA_LVAR_LEAGUE, ARENA_LEAGUE_RECRUIT);
+
+    ArenaFeedLeaderboard(oPC, nToken);
+    ArenaFeedStatus(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Feed functions
+// ----------------------------------------------------------------
+
+void ArenaFeedLeaderboard(object oPC, int nToken)
+{
+    json jBoard = ArenaGetLeaderboard(ARENA_BOARD_ROWS);
+    int  nRows  = JsonGetLength(jBoard);
+
+    json jRanks  = JsonArray();
+    json jNames  = JsonArray();
+    json jLeagues= JsonArray();
+    json jWins   = JsonArray();
+    json jLosses = JsonArray();
+    json jInf    = JsonArray();
+
+    int i;
+    for(i = 0; i < nRows; i++)
+    {
+        json jR  = JsonArrayGet(jBoard, i);
+        jRanks   = JsonArrayInsert(jRanks,   JsonString(IntToString(JsonGetInt(JsonObjectGet(jR, "rank")))));
+        jNames   = JsonArrayInsert(jNames,   JsonObjectGet(jR, "char_name"));
+        jLeagues = JsonArrayInsert(jLeagues, JsonString(ArenaLeagueName(JsonGetInt(JsonObjectGet(jR, "best_league")))));
+        jWins    = JsonArrayInsert(jWins,    JsonString(IntToString(JsonGetInt(JsonObjectGet(jR, "total_wins")))));
+        jLosses  = JsonArrayInsert(jLosses,  JsonString(IntToString(JsonGetInt(JsonObjectGet(jR, "total_losses")))));
+        jInf     = JsonArrayInsert(jInf,     JsonString(IntToString(JsonGetInt(JsonObjectGet(jR, "infamy")))));
+    }
+
+    // Pad empty rows so the list renders at a fixed height.
+    for(i = nRows; i < ARENA_BOARD_ROWS; i++)
+    {
+        jRanks   = JsonArrayInsert(jRanks,   JsonString(""));
+        jNames   = JsonArrayInsert(jNames,   JsonString(""));
+        jLeagues = JsonArrayInsert(jLeagues, JsonString(""));
+        jWins    = JsonArrayInsert(jWins,    JsonString(""));
+        jLosses  = JsonArrayInsert(jLosses,  JsonString(""));
+        jInf     = JsonArrayInsert(jInf,     JsonString(""));
+    }
+
+    NuiSetBind(oPC, nToken, ARENA_BIND_BD_COUNT, JsonInt(ARENA_BOARD_ROWS));
+    NuiSetBind(oPC, nToken, ARENA_BIND_BD_RANK,  jRanks);
+    NuiSetBind(oPC, nToken, ARENA_BIND_BD_NAME,  jNames);
+    NuiSetBind(oPC, nToken, ARENA_BIND_BD_LG,    jLeagues);
+    NuiSetBind(oPC, nToken, ARENA_BIND_BD_WINS,  jWins);
+    NuiSetBind(oPC, nToken, ARENA_BIND_BD_LOSS,  jLosses);
+    NuiSetBind(oPC, nToken, ARENA_BIND_BD_INF,   jInf);
+}
+
+void ArenaFeedStatus(object oPC, int nToken)
+{
+    string sUuid = GetObjectUUID(oPC);
+    json   jF    = ArenaGetFighter(sUuid);
+    if(JsonGetType(jF) == JSON_TYPE_NULL)
+    {
+        ArenaRegisterFighter(oPC);
+        jF = ArenaGetFighter(sUuid);
+        if(JsonGetType(jF) == JSON_TYPE_NULL) return;
+    }
+
+    int    nWins   = JsonGetInt(JsonObjectGet(jF, "total_wins"));
+    int    nLosses = JsonGetInt(JsonObjectGet(jF, "total_losses"));
+    int    nLeague = JsonGetInt(JsonObjectGet(jF, "best_league"));
+    int    nInfamy = JsonGetInt(JsonObjectGet(jF, "infamy"));
+    string sTitle  = ArenaTitleFromWins(nWins);
+
+    NuiSetBind(oPC, nToken, ARENA_BIND_MY_NAME,  JsonString(GetName(oPC)));
+    NuiSetBind(oPC, nToken, ARENA_BIND_MY_LG,    JsonString(ArenaLeagueName(nLeague)));
+    NuiSetBind(oPC, nToken, ARENA_BIND_MY_WINS,  JsonString(IntToString(nWins)));
+    NuiSetBind(oPC, nToken, ARENA_BIND_MY_LOSS,  JsonString(IntToString(nLosses)));
+    NuiSetBind(oPC, nToken, ARENA_BIND_MY_INF,   JsonString(IntToString(nInfamy)));
+    NuiSetBind(oPC, nToken, ARENA_BIND_MY_TITLE, JsonString(sTitle));
+
+    int    nInFight = GetLocalInt(oPC, ARENA_LVAR_IN_FIGHT);
+    NuiSetBind(oPC, nToken, ARENA_BIND_FIGHT_EN, JsonBool(!nInFight));
+    NuiSetBind(oPC, nToken, ARENA_BIND_FIGHT_LB, JsonString(nInFight ? "Walka trwa..." : "— WALCZ! —"));
+
+    string sFlavor;
+    if(nInFight)
+        sFlavor = "Walka trwa. Zabij lub zgiń.";
+    else if(nWins >= ARENA_WINS_LEGEND)
+        sFlavor = "Legenda przemawia ciszą. Wróg wie, że przegra.";
+    else if(nWins >= ARENA_WINS_VETERAN)
+        sFlavor = "Piasek pamięta każdą kroplę. Ty też pamiętasz.";
+    else if(nWins > 0)
+        sFlavor = "Krew woła z areny. Czyż twoje żyły nie odpowiadają?";
+    else
+        sFlavor = "Nikt cię tu nie zna. Zmień to.";
+    NuiSetBind(oPC, nToken, ARENA_BIND_FLAVOR, JsonString(sFlavor));
+
+    int nSel = GetLocalInt(oPC, ARENA_LVAR_LEAGUE);
+    if(nSel == 0) nSel = ARENA_LEAGUE_RECRUIT;
+    NuiSetBind(oPC, nToken, ARENA_BIND_L1_ENC, JsonBool(nSel == ARENA_LEAGUE_RECRUIT));
+    NuiSetBind(oPC, nToken, ARENA_BIND_L2_ENC, JsonBool(nSel == ARENA_LEAGUE_WARRIOR));
+    NuiSetBind(oPC, nToken, ARENA_BIND_L3_ENC, JsonBool(nSel == ARENA_LEAGUE_CHAMPION));
+}

--- a/Arena Gladiatorow/scripts/lib_gla_def.nss
+++ b/Arena Gladiatorow/scripts/lib_gla_def.nss
@@ -1,0 +1,88 @@
+#include "lib_nui"
+#include "sql_gla"
+
+// Forward declarations
+void ArenaOpenWindow(object oPC);
+void ArenaFeedLeaderboard(object oPC, int nToken);
+void ArenaFeedStatus(object oPC, int nToken);
+void ArenaCheckWave(object oPC);
+void ArenaSpawnWave(object oPC, int nWave);
+void ArenaHandleWin(object oPC);
+void ArenaHandleLoss(object oPC);
+void ArenaClearSpawns(object oPC);
+
+// ----------------------------------------------------------------
+// Window / event identifiers
+// ----------------------------------------------------------------
+
+const string ARENA_WINDOW        = "ARENA_WINDOW";
+const string ARENA_EV_SCRIPT     = "lib_gla_ev";
+const string ARENA_WIN_GEOM      = "arena_win_geom";
+const string ARENA_GRP_SWAP      = "arena_grp_swap";
+
+// Buttons
+const string ARENA_BTN_CLOSE     = "arena_btn_close";
+const string ARENA_BTN_TAB_BOARD = "arena_btn_tab_board";
+const string ARENA_BTN_TAB_MINE  = "arena_btn_tab_mine";
+const string ARENA_BTN_L1        = "arena_btn_l1";
+const string ARENA_BTN_L2        = "arena_btn_l2";
+const string ARENA_BTN_L3        = "arena_btn_l3";
+const string ARENA_BTN_FIGHT     = "arena_btn_fight";
+
+// Leaderboard list binds (array-bound)
+const string ARENA_BIND_BD_RANK  = "arena_bd_rank";
+const string ARENA_BIND_BD_NAME  = "arena_bd_name";
+const string ARENA_BIND_BD_LG    = "arena_bd_lg";
+const string ARENA_BIND_BD_WINS  = "arena_bd_wins";
+const string ARENA_BIND_BD_LOSS  = "arena_bd_loss";
+const string ARENA_BIND_BD_INF   = "arena_bd_inf";
+const string ARENA_BIND_BD_COUNT = "arena_bd_count";
+
+// My status binds (scalar)
+const string ARENA_BIND_MY_NAME  = "arena_my_name";
+const string ARENA_BIND_MY_LG    = "arena_my_lg";
+const string ARENA_BIND_MY_WINS  = "arena_my_wins";
+const string ARENA_BIND_MY_LOSS  = "arena_my_loss";
+const string ARENA_BIND_MY_INF   = "arena_my_inf";
+const string ARENA_BIND_MY_TITLE = "arena_my_title";
+const string ARENA_BIND_FLAVOR   = "arena_flavor";
+const string ARENA_BIND_FIGHT_EN = "arena_fight_en";
+const string ARENA_BIND_FIGHT_LB = "arena_fight_lb";
+const string ARENA_BIND_L1_ENC   = "arena_l1_enc";
+const string ARENA_BIND_L2_ENC   = "arena_l2_enc";
+const string ARENA_BIND_L3_ENC   = "arena_l3_enc";
+
+// Local variables stored on PC
+const string ARENA_LVAR_TAB      = "ARENA_TAB";
+const string ARENA_LVAR_LEAGUE   = "ARENA_LEAGUE_SEL";
+const string ARENA_LVAR_IN_FIGHT = "ARENA_IN_FIGHT";
+const string ARENA_LVAR_WAVE     = "ARENA_WAVE";
+const string ARENA_LVAR_FT_LG    = "ARENA_FT_LG";
+const string ARENA_LVAR_SPAWN_N  = "ARENA_SPAWN_N";
+const string ARENA_LVAR_TIMEOUT  = "ARENA_TIMEOUT";
+
+// League constants
+const int ARENA_LEAGUE_RECRUIT   = 1;
+const int ARENA_LEAGUE_WARRIOR   = 2;
+const int ARENA_LEAGUE_CHAMPION  = 3;
+
+// Fight config
+const int ARENA_WAVES_PER_FIGHT  = 3;
+const int ARENA_CHECK_DELAY      = 5;
+const int ARENA_TIMEOUT_SEC      = 180;
+
+// Infamy per league win / per loss
+const int ARENA_INF_WIN_L1       = 50;
+const int ARENA_INF_WIN_L2       = 120;
+const int ARENA_INF_WIN_L3       = 250;
+const int ARENA_INF_LOSS         = 15;
+
+// Total-win thresholds for title upgrades
+const int ARENA_WINS_FIGHTER     = 5;
+const int ARENA_WINS_VETERAN     = 20;
+const int ARENA_WINS_LEGEND      = 50;
+
+// Layout
+const int   ARENA_BOARD_ROWS     = 10;
+const float ARENA_W              = 700.0;
+const float ARENA_H              = 500.0;

--- a/Arena Gladiatorow/scripts/lib_gla_ev.nss
+++ b/Arena Gladiatorow/scripts/lib_gla_ev.nss
@@ -1,0 +1,99 @@
+#include "lib_gla"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+
+    if(nToken != NuiFindWindow(oPC, ARENA_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_OPEN)
+    {
+        ArenaFeedLeaderboard(oPC, nToken);
+        ArenaFeedStatus(oPC, nToken);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        // Nothing to clean up here — the fight continues if in progress.
+        return;
+    }
+
+    if(sEvent != EVENT_TYPE_CLICK) return;
+
+    // ---- Tab buttons ----
+    if(sElem == ARENA_BTN_TAB_BOARD)
+    {
+        SetLocalString(oPC, ARENA_LVAR_TAB, "board");
+        NuiSetGroupLayout(oPC, nToken, ARENA_GRP_SWAP, ArenaBuildLeaderboardView(oPC));
+        ArenaFeedLeaderboard(oPC, nToken);
+        return;
+    }
+
+    if(sElem == ARENA_BTN_TAB_MINE)
+    {
+        SetLocalString(oPC, ARENA_LVAR_TAB, "mine");
+        NuiSetGroupLayout(oPC, nToken, ARENA_GRP_SWAP, ArenaBuildStatusView(oPC));
+        ArenaFeedStatus(oPC, nToken);
+        return;
+    }
+
+    if(sElem == ARENA_BTN_CLOSE)
+    {
+        NuiDestroy(oPC, nToken);
+        return;
+    }
+
+    // ---- League selector ----
+    if(sElem == ARENA_BTN_L1)
+    {
+        if(GetLocalInt(oPC, ARENA_LVAR_IN_FIGHT))
+        {
+            SendMessageToPC(oPC, "[Arena] Nie możesz zmieniać ligi w trakcie walki.");
+            return;
+        }
+        SetLocalInt(oPC, ARENA_LVAR_LEAGUE, ARENA_LEAGUE_RECRUIT);
+        NuiSetBind(oPC, nToken, ARENA_BIND_L1_ENC, JsonBool(TRUE));
+        NuiSetBind(oPC, nToken, ARENA_BIND_L2_ENC, JsonBool(FALSE));
+        NuiSetBind(oPC, nToken, ARENA_BIND_L3_ENC, JsonBool(FALSE));
+        return;
+    }
+
+    if(sElem == ARENA_BTN_L2)
+    {
+        if(GetLocalInt(oPC, ARENA_LVAR_IN_FIGHT))
+        {
+            SendMessageToPC(oPC, "[Arena] Nie możesz zmieniać ligi w trakcie walki.");
+            return;
+        }
+        SetLocalInt(oPC, ARENA_LVAR_LEAGUE, ARENA_LEAGUE_WARRIOR);
+        NuiSetBind(oPC, nToken, ARENA_BIND_L1_ENC, JsonBool(FALSE));
+        NuiSetBind(oPC, nToken, ARENA_BIND_L2_ENC, JsonBool(TRUE));
+        NuiSetBind(oPC, nToken, ARENA_BIND_L3_ENC, JsonBool(FALSE));
+        return;
+    }
+
+    if(sElem == ARENA_BTN_L3)
+    {
+        if(GetLocalInt(oPC, ARENA_LVAR_IN_FIGHT))
+        {
+            SendMessageToPC(oPC, "[Arena] Nie możesz zmieniać ligi w trakcie walki.");
+            return;
+        }
+        SetLocalInt(oPC, ARENA_LVAR_LEAGUE, ARENA_LEAGUE_CHAMPION);
+        NuiSetBind(oPC, nToken, ARENA_BIND_L1_ENC, JsonBool(FALSE));
+        NuiSetBind(oPC, nToken, ARENA_BIND_L2_ENC, JsonBool(FALSE));
+        NuiSetBind(oPC, nToken, ARENA_BIND_L3_ENC, JsonBool(TRUE));
+        return;
+    }
+
+    // ---- Fight button ----
+    if(sElem == ARENA_BTN_FIGHT)
+    {
+        ArenaStartFight(oPC);
+        return;
+    }
+}

--- a/Arena Gladiatorow/scripts/lib_nui.nss
+++ b/Arena Gladiatorow/scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Arena Gladiatorow/scripts/lib_nui_utility.nss
+++ b/Arena Gladiatorow/scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Arena Gladiatorow/scripts/sql_gla.nss
+++ b/Arena Gladiatorow/scripts/sql_gla.nss
@@ -1,0 +1,121 @@
+// Campaign database name used for all arena queries.
+const string ARENA_DB = "arena";
+
+void ArenaCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign(ARENA_DB,
+        "CREATE TABLE IF NOT EXISTS arena_fighters ("
+        "uuid         TEXT PRIMARY KEY, "
+        "char_name    TEXT    DEFAULT '', "
+        "total_wins   INTEGER DEFAULT 0, "
+        "total_losses INTEGER DEFAULT 0, "
+        "best_league  INTEGER DEFAULT 1, "
+        "infamy       INTEGER DEFAULT 0, "
+        "last_fought  INTEGER DEFAULT 0)");
+    SqlStep(q);
+}
+
+void ArenaRegisterFighter(object oPC)
+{
+    string sUuid = GetObjectUUID(oPC);
+    string sName = GetName(oPC);
+
+    sqlquery q = SqlPrepareQueryCampaign(ARENA_DB,
+        "INSERT OR IGNORE INTO arena_fighters (uuid, char_name) VALUES (@uuid, @name)");
+    SqlBindString(q, "@uuid", sUuid);
+    SqlBindString(q, "@name", sName);
+    SqlStep(q);
+
+    // Keep display name fresh (character renames, etc.)
+    q = SqlPrepareQueryCampaign(ARENA_DB,
+        "UPDATE arena_fighters SET char_name = @name WHERE uuid = @uuid");
+    SqlBindString(q, "@name", sName);
+    SqlBindString(q, "@uuid", sUuid);
+    SqlStep(q);
+}
+
+// Returns JsonObject with keys total_wins, total_losses, best_league, infamy.
+// Returns JsonNull() if the fighter is not registered yet.
+json ArenaGetFighter(string sUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign(ARENA_DB,
+        "SELECT total_wins, total_losses, best_league, infamy "
+        "FROM arena_fighters WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", sUuid);
+    if(!SqlStep(q)) return JsonNull();
+
+    json j = JsonObject();
+    j = JsonObjectSet(j, "total_wins",   JsonInt(SqlGetInt(q, 0)));
+    j = JsonObjectSet(j, "total_losses", JsonInt(SqlGetInt(q, 1)));
+    j = JsonObjectSet(j, "best_league",  JsonInt(SqlGetInt(q, 2)));
+    j = JsonObjectSet(j, "infamy",       JsonInt(SqlGetInt(q, 3)));
+    return j;
+}
+
+void ArenaRecordWin(string sUuid, int nLeague, int nInfGain)
+{
+    sqlquery q = SqlPrepareQueryCampaign(ARENA_DB,
+        "UPDATE arena_fighters SET "
+        "total_wins  = total_wins + 1, "
+        "infamy      = infamy + @inf, "
+        "best_league = MAX(best_league, @league), "
+        "last_fought = strftime('%s','now') "
+        "WHERE uuid = @uuid");
+    SqlBindInt   (q, "@inf",    nInfGain);
+    SqlBindInt   (q, "@league", nLeague);
+    SqlBindString(q, "@uuid",   sUuid);
+    SqlStep(q);
+}
+
+void ArenaRecordLoss(string sUuid, int nInfPenalty)
+{
+    sqlquery q = SqlPrepareQueryCampaign(ARENA_DB,
+        "UPDATE arena_fighters SET "
+        "total_losses = total_losses + 1, "
+        "infamy       = MAX(0, infamy - @pen), "
+        "last_fought  = strftime('%s','now') "
+        "WHERE uuid = @uuid");
+    SqlBindInt   (q, "@pen",  nInfPenalty);
+    SqlBindString(q, "@uuid", sUuid);
+    SqlStep(q);
+}
+
+// Returns JsonArray of top-nLimit fighters ordered by infamy desc.
+// Each element: {rank, char_name, best_league, total_wins, total_losses, infamy}
+json ArenaGetLeaderboard(int nLimit)
+{
+    json jBoard = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign(ARENA_DB,
+        "SELECT char_name, best_league, total_wins, total_losses, infamy "
+        "FROM arena_fighters "
+        "ORDER BY infamy DESC, total_wins DESC "
+        "LIMIT @n");
+    SqlBindInt(q, "@n", nLimit);
+
+    int nRank = 1;
+    while(SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "rank",         JsonInt   (nRank));
+        jRow = JsonObjectSet(jRow, "char_name",    JsonString(SqlGetString(q, 0)));
+        jRow = JsonObjectSet(jRow, "best_league",  JsonInt   (SqlGetInt   (q, 1)));
+        jRow = JsonObjectSet(jRow, "total_wins",   JsonInt   (SqlGetInt   (q, 2)));
+        jRow = JsonObjectSet(jRow, "total_losses", JsonInt   (SqlGetInt   (q, 3)));
+        jRow = JsonObjectSet(jRow, "infamy",       JsonInt   (SqlGetInt   (q, 4)));
+        jBoard = JsonArrayInsert(jBoard, jRow);
+        nRank++;
+    }
+    return jBoard;
+}
+
+// Returns position of sUuid in the leaderboard (1-based), 0 if not found.
+int ArenaGetRank(string sUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign(ARENA_DB,
+        "SELECT COUNT(*) FROM arena_fighters f2 "
+        "JOIN arena_fighters f1 ON f1.uuid = @uuid "
+        "WHERE f2.infamy > f1.infamy OR (f2.infamy = f1.infamy AND f2.total_wins > f1.total_wins)");
+    SqlBindString(q, "@uuid", sUuid);
+    if(SqlStep(q)) return SqlGetInt(q, 0) + 1;
+    return 0;
+}

--- a/Arena Gladiatorow/scripts/sys_on_enter.nss
+++ b/Arena Gladiatorow/scripts/sys_on_enter.nss
@@ -1,0 +1,21 @@
+#include "lib_gla"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC)) return;
+
+    ArenaRegisterFighter(oPC);
+
+    json   jF     = ArenaGetFighter(GetObjectUUID(oPC));
+    int    nWins  = JsonGetInt(JsonObjectGet(jF, "total_wins"));
+    int    nRank  = ArenaGetRank(GetObjectUUID(oPC));
+    string sTitle = ArenaTitleFromWins(nWins);
+
+    if(nWins > 0)
+    {
+        string sMsg = "[Arena] Witaj, " + sTitle + " " + GetName(oPC) +
+            ". Twoja pozycja w tabeli: #" + IntToString(nRank) + ".";
+        DelayCommand(3.0, SendMessageToPC(oPC, sMsg));
+    }
+}

--- a/Arena Gladiatorow/scripts/sys_on_load.nss
+++ b/Arena Gladiatorow/scripts/sys_on_load.nss
@@ -1,0 +1,6 @@
+#include "lib_gla_def"
+
+void main()
+{
+    ArenaCreateTables();
+}

--- a/Arena Gladiatorow/scripts/test_gla.nss
+++ b/Arena Gladiatorow/scripts/test_gla.nss
@@ -1,0 +1,12 @@
+// Attach to the OnUsed event of an "Arena Board" placeable in the module.
+// The placeable acts as the entry point: clicking it opens the arena NUI.
+#include "lib_gla"
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    ArenaRegisterFighter(oPC);
+    ArenaOpenWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

System areny gladiatorów z trójligowym PvE (Rekrut / Wojownik / Mistrz), trwałą bazą danych infamii i tablicą wyników. Gracz podchodzi do tablicy areny, otwiera NUI i walczy z falami potworów o rosnącej trudności.

## Mechanika

- **3 ligi:** Rekrut (2 potwory/fala, +50 inf), Wojownik (3, +120), Mistrz (4, +250). Porażka kosztuje 15 infamii.
- **3 fale na walkę:** w każdej fali nieco cięższe blueprinty; między falami 2 s przerwy. Timeout 180 s zabezpiecza przed porzuconą walką.
- **Tytuły:** Nowicjusz → Gladiator (5 w.) → Weteran Areny (20 w.) → Legenda Krwi (50 w.). Przekroczenie progu wyzwala efekt wizualny `VFX_FNF_LOS_NORMAL_20`.
- **Tabela Chwały:** top-10 graczy wg infamii, widoczna w NUI przez `NuiList` z array-bindami. Odświeżana po każdej zakończonej walce.
- **Detekcja końca walki:** `DelayCommand`-chain co 5 s sprawdza `GetIsDead` dla każdego spawnowanego NPC (przechowywanych jako `ARENA_C_0..N` na obiekcie PC).

## Pliki

| Plik | Rola |
|------|------|
| `lib_gla_def.nss` | Stałe, bind-ID, parametry lig |
| `sql_gla.nss` | Schemat DB, CRUD fighters, leaderboard |
| `lib_gla.nss` | Spawn fal, obsługa win/loss, budowanie NUI, feed funkcje |
| `lib_gla_ev.nss` | Handler NUI eventów (zakładki, liga, walcz) |
| `sys_on_load.nss` | `CREATE TABLE IF NOT EXISTS` przy starcie |
| `sys_on_enter.nss` | Rejestracja gracza, powitanie z tytułem i pozycją |
| `test_gla.nss` | OnUsed na placeable tablicy areny |
| `lib_nui.nss` / `lib_nui_utility.nss` | Standardowe narzędzia NUI (kopia) |
| `INTEGRATION.md` | Instrukcja podpinania hooków |

## Zależności

- **NWNX:** brak
- **SQL:** campaign DB o nazwie `arena`, tabela `arena_fighters`, idempotentna migracja
- **NWN EE:** ≥ 8193.36 (NUI, `SqlPrepareQueryCampaign`, `NuiList`, `NuiSetGroupLayout`)

## Jak włączyć w istniejącym module

1. Dodaj skrypty do haka modułu.
2. Podepnij `sys_on_load.nss` pod `OnModuleLoad` i `sys_on_enter.nss` pod `OnClientEnter`.
3. Utwórz placeable (np. `plc_pedestal`) z `OnUsed = test_gla` w dowolnym miejscu z otwartą przestrzenią ~8 m.
4. NUI script engine widni automatycznie przez `lib_gla_ev.nss` przekazany do `NuiCreate`.

## Co celowo pominięto

- **Zakłady graczy** — rozszerzenie przyszłości; brak zaufanego mechanizmu escrow.
- **Spectators NUI** — wymagałoby osobnego okna i subskrypcji heartbeatu.
- **Nagrody przedmiotowe** — `ArenaHandleWin` można rozszerzyć o loot; celowo pusta by DM mógł sam zdecydować.
- **PvP arena** — tylko PvE; walki PC vs PC wymagają osobnej logiki zgody.
- **Dedykowany obszar** — system działa w dowolnym miejscu, blueprinty spawnują się w pobliżu gracza przez `GenerateNewLocation`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WyFL5tjdXbMTG2KjSrAyeT)_