### PR TITLE
feat: Relic Vault (Skarbiec Relikwii)

### DIFF
--- a/Relic Vault/INTEGRATION.md
+++ b/Relic Vault/INTEGRATION.md
@@ -1,0 +1,77 @@
+# Relic Vault — Integracja
+
+## Wymagania
+
+- NWN:EE 8193.36+ (wymaga `TagEffect` / `GetEffectTag`, `EffectRegenerate`, `SqlPrepareQueryCampaign`)
+- Brak zależności NWNX
+- Brak własnego HAK (brak grafik — używa wbudowanych zasobów silnika)
+
+## Pliki
+
+| Plik | Rola |
+|------|------|
+| `sql_rlc.nss` | Schemat SQLite i wszystkie zapytania |
+| `lib_rlc_def.nss` | Stałe: ID bindów, ID relikwii, koszty, tagi efektów |
+| `lib_rlc.nss` | Rdzeń: dane relikwii, budowa okna NUI, feed, efekty, tick klątwy |
+| `lib_rlc_ev.nss` | Handler zdarzeń NUI (`NuiGetEventType` switch) |
+| `sys_on_load.nss` | Wywołaj z OnModuleLoad — tworzy tabelę `rlc_attunements` |
+| `sys_on_enter.nss` | Wywołaj z OnClientEnter — przywraca efekty po relogu, sprawdza tick klątwy |
+| `sys_on_hbeat.nss` | Wywołaj z OnHeartbeat — eskaluje klątwy online graczy (~co 6 min) |
+| `test_rlc.nss` | OnUsed na placeablu demonstracyjnym |
+
+## Jak podpiąć w istniejącym module
+
+```nss
+// OnModuleLoad — dodaj wywołanie:
+#include "sql_rlc"
+void main() {
+    RlcCreateTables();
+    // ... reszta twojego on_load
+}
+
+// OnClientEnter — dodaj wywołanie:
+#include "lib_rlc"
+void main() {
+    object oPC = GetEnteringObject();
+    if(GetIsPC(oPC)) {
+        RlcApplyEffects(oPC);
+        RlcCheckCurseTick(oPC);
+    }
+    // ... reszta twojego on_enter
+}
+
+// OnHeartbeat — dodaj wywołanie:
+#include "lib_rlc"
+void main() {
+    // throttle jest wbudowany — wywołuj bezwarunkowo
+    RlcOnHeartbeat(); // patrz niżej
+    // ... reszta twojego heartbeatu
+}
+```
+
+> Uwaga: `sys_on_hbeat.nss` zawiera logikę throttle wewnątrz `main()`. Przy integracji
+> wytnij zawartość do osobnej funkcji `void RlcOnHeartbeat()` w `lib_rlc.nss`.
+
+## Jak otworzyć okno
+
+Dowolny skrypt po stronie serwera:
+```nss
+#include "lib_rlc"
+RlcShowWindow(oPC);
+```
+
+## Mechanika w skrócie
+
+- 6 relikwii, każda może być dzierżona przez jedną postać jednocześnie.
+- Atunowanie: 500 sz. Uwolnienie: 200 sz.
+- Co **10 minut realnych** klątwa wzrasta o 1 (max 5). Na poziomie 5 moc się podwaja.
+- Oczyszczenie: 1000 sz, 60% szansy na redukcję klątwy o 1 — można powtarzać.
+- Po relogu efekty są przywracane z SQL; gracze offline nie otrzymują ticków po powrocie
+  (tylko jeden tick catch-up w `sys_on_enter.nss`).
+
+## Co celowo pominięto
+
+- HAK / grafiki relikwii — możliwe rozszerzenie z własnym `rlc_*.tga`.
+- Fizyczne itemy relikwii w ekwipunku — uproszczono do systemu czystych efektów.
+- Animacje / VFX przy atunowaniu — można dodać `ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectVisualEffect(...))`.
+- Wielokrotny catch-up ticków przy długiej nieobecności — świadomy wybór: gracze nie mogą przegapić eskalacji przez unikanie logowania.

--- a/Relic Vault/scripts/lib_nui.nss
+++ b/Relic Vault/scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Relic Vault/scripts/lib_nui_utility.nss
+++ b/Relic Vault/scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Relic Vault/scripts/lib_rlc.nss
+++ b/Relic Vault/scripts/lib_rlc.nss
@@ -1,0 +1,499 @@
+#include "lib_rlc_def"
+
+void RlcShowWindow(object oPC);
+void RlcFeedList(object oPC, int nToken);
+void RlcFeedDetail(object oPC, int nToken);
+void RlcApplyEffects(object oPC);
+void RlcRemoveEffects(object oPC);
+void RlcCheckCurseTick(object oPC);
+
+// ----------------------------------------------------------------
+// Relic data
+// ----------------------------------------------------------------
+
+string RlcRelicName(int nId)
+{
+    switch(nId)
+    {
+        case RLC_RELIC_EYE:     return "Oko Tyranów";
+        case RLC_RELIC_BLADE:   return "Miecz Zdrajcy";
+        case RLC_RELIC_CHALICE: return "Kielich Zatracenia";
+        case RLC_RELIC_CROWN:   return "Korona Popiołów";
+        case RLC_RELIC_SEAL:    return "Pieczęć Nicości";
+        case RLC_RELIC_CLAW:    return "Szpon Bestii";
+    }
+    return "Nieznana Relikwia";
+}
+
+string RlcRelicLore(int nId)
+{
+    switch(nId)
+    {
+        case RLC_RELIC_EYE:
+            return "Skamieniałe oko wyłupione z czoła licza-tyrana. Wciąż patrzy.\n\n"
+                   "Mówi się, że posiadacz widzi przez ciemność i czyta kłamstwa jak "
+                   "otwartą księgę — lecz każdej nocy oko przegląda mu przez powiekę "
+                   "i wysysa mądrość jak sok z mroku. Pieczęć krwi pulsuje słabo...";
+        case RLC_RELIC_BLADE:
+            return "Obsydianowy sztylet wykuty przez zdrajcę dla własnego pana. "
+                   "Pita krwią obu.\n\nSzept ostrza jest słodki: \"Pamiętasz tę ranę? "
+                   "Tamten zadał ją pierwszy. Pamiętasz?\" Im dłużej się słucha, "
+                   "tym trudniej odróżnić swoje myśli od jego.";
+        case RLC_RELIC_CHALICE:
+            return "Srebrny kielich, którego dna nikt nie widział. "
+                   "Napełnia się sam czarnym winem o smaku miedzi i nadziei.\n\n"
+                   "Pijący regeneruje rany, lecz krew gęstnieje z każdym łykiem — "
+                   "serce musi pompować coraz mocniej. Po pewnym czasie żyły ciemnieją "
+                   "i przebijają przez skórę jak atrament.";
+        case RLC_RELIC_CROWN:
+            return "Szara korona popiołów. Noszono ją przez jedenaście wojen. "
+                   "Nie jeden raz pogardzono nią w trumnie — bo nikt nie mógł jej zdjąć.\n\n"
+                   "Ciężar jest symboliczny. Przynajmniej na początku. "
+                   "Z czasem korona wydaje się rosnąć, a nogi coraz trudniej unieść.";
+        case RLC_RELIC_SEAL:
+            return "Obsydianowy dysk ze znakiem Pustki wyrytym szkłem ze spalonego "
+                   "Astral-Bastionu. Żadne zaklęcie nie przeniknie bariery noszącego.\n\n"
+                   "Niestety — żadne zaklęcie nie wypłynie też na zewnątrz. "
+                   "Myśli zaczynają wypełniać ciszę, którą pieczęć tworzy wokół umysłu.";
+        case RLC_RELIC_CLAW:
+            return "Czarny szpon oderwany od istoty bez nazwy. Kość jest zimna "
+                   "i pokryta grzbietami jak grzebień.\n\nNie ma sensu szukać "
+                   "zwierzęcia, z którego pochodzi. Uderzenia szarpią i rozrywają. "
+                   "Mięśnie ramienia coraz bardziej przypominają te, do których "
+                   "szpon pierwotnie należał.";
+    }
+    return "";
+}
+
+string RlcPowerDesc(int nId, int bAmp)
+{
+    switch(nId)
+    {
+        case RLC_RELIC_EYE:     return bAmp ? "+4 do wszystkich rzutów obronnych (wzmocnione)" : "+2 do wszystkich rzutów obronnych";
+        case RLC_RELIC_BLADE:   return bAmp ? "+4 do trafienia i obrażeń (wzmocnione)"         : "+2 do trafienia i obrażeń";
+        case RLC_RELIC_CHALICE: return bAmp ? "Regeneracja 2 PW / 6 sekund (wzmocnione)"       : "Regeneracja 1 PW / 6 sekund";
+        case RLC_RELIC_CROWN:   return bAmp ? "+6 do KP — ugięcie (wzmocnione)"                 : "+3 do KP — ugięcie";
+        case RLC_RELIC_SEAL:    return bAmp ? "Odporność na zaklęcia 22 (wzmocnione)"           : "Odporność na zaklęcia 15";
+        case RLC_RELIC_CLAW:    return bAmp ? "+2k6 obrażeń magicznych (wzmocnione)"            : "+1k6 obrażeń magicznych";
+    }
+    return "";
+}
+
+string RlcCurseDesc(int nId, int nLevel)
+{
+    if(nLevel <= 0) return "brak";
+    switch(nId)
+    {
+        case RLC_RELIC_EYE:     return "Mądrość -"        + IntToString(nLevel);
+        case RLC_RELIC_BLADE:   return "Charyzma -"        + IntToString(nLevel);
+        case RLC_RELIC_CHALICE: return "Kondycja -"        + IntToString(nLevel);
+        case RLC_RELIC_CROWN:   return "Zręczność -"       + IntToString(nLevel);
+        case RLC_RELIC_SEAL:    return "Inteligencja -"    + IntToString(nLevel);
+        case RLC_RELIC_CLAW:    return "Siła -"            + IntToString(nLevel);
+    }
+    return "";
+}
+
+// ----------------------------------------------------------------
+// Effect application / removal
+// ----------------------------------------------------------------
+
+void RlcRemoveEffects(object oPC)
+{
+    effect eFX = GetFirstEffect(oPC);
+    while(GetIsEffectValid(eFX))
+    {
+        string sTag = GetEffectTag(eFX);
+        effect eNext = GetNextEffect(oPC);
+        if(sTag == RLC_TAG_POWER || sTag == RLC_TAG_CURSE)
+            RemoveEffect(oPC, eFX);
+        eFX = eNext;
+    }
+}
+
+void RlcApplyEffects(object oPC)
+{
+    RlcRemoveEffects(oPC);
+
+    int nRelicId = RlcGetAttuned(oPC);
+    if(nRelicId == 0) return;
+
+    int nCurse = RlcGetCurseLevel(oPC);
+    int bAmp   = (nCurse >= RLC_CURSE_MAX);
+
+    // Power effect
+    switch(nRelicId)
+    {
+        case RLC_RELIC_EYE:
+        {
+            int nB = bAmp ? 4 : 2;
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectSavingThrowIncrease(SAVING_THROW_ALL, nB), RLC_TAG_POWER), oPC);
+            break;
+        }
+        case RLC_RELIC_BLADE:
+        {
+            int nB = bAmp ? 4 : 2;
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAttackIncrease(nB, ATTACK_BONUS_MISC), RLC_TAG_POWER), oPC);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectDamageBonus(nB, DAMAGE_TYPE_MAGICAL), RLC_TAG_POWER), oPC);
+            break;
+        }
+        case RLC_RELIC_CHALICE:
+        {
+            int nRegen = bAmp ? 2 : 1;
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectRegenerate(nRegen, 6.0), RLC_TAG_POWER), oPC);
+            break;
+        }
+        case RLC_RELIC_CROWN:
+        {
+            int nAC = bAmp ? 6 : 3;
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectACIncrease(nAC, AC_DEFLECTION_BONUS), RLC_TAG_POWER), oPC);
+            break;
+        }
+        case RLC_RELIC_SEAL:
+        {
+            int nSR = bAmp ? 22 : 15;
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectSpellResistanceIncrease(nSR), RLC_TAG_POWER), oPC);
+            break;
+        }
+        case RLC_RELIC_CLAW:
+        {
+            int nDmg = bAmp ? DAMAGE_BONUS_2d6 : DAMAGE_BONUS_1d6;
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectDamageBonus(nDmg, DAMAGE_TYPE_MAGICAL), RLC_TAG_POWER), oPC);
+            break;
+        }
+    }
+
+    // Curse effect (penalty grows each tick)
+    if(nCurse <= 0) return;
+
+    int nAbility = ABILITY_WISDOM;
+    switch(nRelicId)
+    {
+        case RLC_RELIC_EYE:     nAbility = ABILITY_WISDOM;       break;
+        case RLC_RELIC_BLADE:   nAbility = ABILITY_CHARISMA;     break;
+        case RLC_RELIC_CHALICE: nAbility = ABILITY_CONSTITUTION; break;
+        case RLC_RELIC_CROWN:   nAbility = ABILITY_DEXTERITY;    break;
+        case RLC_RELIC_SEAL:    nAbility = ABILITY_INTELLIGENCE; break;
+        case RLC_RELIC_CLAW:    nAbility = ABILITY_STRENGTH;     break;
+    }
+    ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+        TagEffect(EffectAbilityDecrease(nAbility, nCurse), RLC_TAG_CURSE), oPC);
+}
+
+// ----------------------------------------------------------------
+// Curse tick (call from heartbeat and on-enter)
+// ----------------------------------------------------------------
+
+void RlcCheckCurseTick(object oPC)
+{
+    if(RlcGetAttuned(oPC) == 0) return;
+    if(!RlcNeedsCurseTick(oPC)) return;
+
+    int nNew = RlcTickCurse(oPC);
+    if(nNew < 0) return;
+
+    string sMsg;
+    if(nNew >= RLC_CURSE_MAX)
+        sMsg = "[Relikwia] Klątwa osiągnęła szczyt. Moc relikwii rozkwita — i zatruwa.";
+    else
+        sMsg = "[Relikwia] Klątwa się wzmacnia — poziom " + IntToString(nNew) + "/" + IntToString(RLC_CURSE_MAX) + ".";
+    SendMessageToPC(oPC, sMsg);
+
+    RlcApplyEffects(oPC);
+
+    int nToken = NuiFindWindow(oPC, RLC_WINDOW);
+    if(nToken != 0)
+    {
+        RlcFeedList(oPC, nToken);
+        RlcFeedDetail(oPC, nToken);
+    }
+}
+
+// ----------------------------------------------------------------
+// NUI layout builders
+// ----------------------------------------------------------------
+
+json RlcBuildListPanel(object oPC)
+{
+    float fRowH = GetNuiScaleDimension(oPC, 52.0);
+    float fPanW = GetNuiScaleDimension(oPC, 210.0);
+
+    json jNameLbl = NuiLabel(NuiBind(RLC_BIND_ROW_NAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jNameLbl = NuiStyleForegroundColor(jNameLbl, NuiBind(RLC_BIND_ROW_COLOR));
+
+    json jStatusLbl = NuiLabel(NuiBind(RLC_BIND_ROW_STATUS),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jStatusLbl = NuiHeight(jStatusLbl, GetNuiScaleDimension(oPC, 18.0));
+
+    json jCellCol = JsonArray();
+    jCellCol = JsonArrayInsert(jCellCol, jNameLbl);
+    jCellCol = JsonArrayInsert(jCellCol, jStatusLbl);
+
+    json jCell = NuiGroup(NuiCol(jCellCol), TRUE, NUI_SCROLLBARS_NONE);
+    jCell = NuiId(jCell, RLC_BTN_ROW);
+    jCell = NuiEncouraged(jCell, NuiBind(RLC_BIND_ROW_ENC));
+
+    json jTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jCell, 0.0, TRUE));
+    json jList = NuiList(jTmpl, JsonInt(RLC_RELIC_COUNT), fRowH);
+
+    return NuiWidth(NuiCol(JsonArrayInsert(JsonArray(), jList)), fPanW);
+}
+
+json RlcBuildDetailPanel(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 30.0);
+    float fLoreH = GetNuiScaleDimension(oPC, 160.0);
+
+    json jRelicName = NuiLabel(NuiBind(RLC_BIND_DET_NAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRelicName = NuiHeight(jRelicName, GetNuiScaleDimension(oPC, 32.0));
+
+    json jLore = NuiGroup(NuiText(NuiBind(RLC_BIND_DET_LORE), FALSE), TRUE, NUI_SCROLLBARS_AUTO);
+    jLore = NuiHeight(jLore, fLoreH);
+
+    // Power row
+    json jPwrLbl = NuiLabel(JsonString("Moc:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jPwrLbl = NuiWidth(jPwrLbl, GetNuiScaleDimension(oPC, 46.0));
+    json jPwrVal = NuiLabel(NuiBind(RLC_BIND_DET_POWER),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    json jPwrRow = JsonArray();
+    jPwrRow = JsonArrayInsert(jPwrRow, jPwrLbl);
+    jPwrRow = JsonArrayInsert(jPwrRow, jPwrVal);
+
+    // Curse label
+    json jCurseLbl = NuiLabel(NuiBind(RLC_BIND_CURSE_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jCurseLbl = NuiHeight(jCurseLbl, GetNuiScaleDimension(oPC, 22.0));
+
+    // Curse progress bar
+    json jBar = NuiProgressBar(NuiBind(RLC_BIND_CURSE_PROG));
+    jBar = NuiHeight(jBar, GetNuiScaleDimension(oPC, 16.0));
+    jBar = NuiTooltip(jBar, JsonString("Poziom klątwy — 0 (uśpiona) do 5 (obudzona)"));
+
+    // Active curse description
+    json jCurseVal = NuiLabel(NuiBind(RLC_BIND_DET_CURSE),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jCurseVal = NuiHeight(jCurseVal, GetNuiScaleDimension(oPC, 22.0));
+
+    // Holder info
+    json jHolderLbl = NuiLabel(NuiBind(RLC_BIND_HOLDER_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jHolderLbl = NuiHeight(jHolderLbl, GetNuiScaleDimension(oPC, 22.0));
+
+    // Action buttons
+    string sAttuneLabel  = "Atunuj ("  + IntToString(RLC_GOLD_ATTUNE)  + " sz)";
+    string sReleaseLabel = "Uwolnij (" + IntToString(RLC_GOLD_RELEASE) + " sz)";
+    string sPurifyLabel  = "Oczyść ("  + IntToString(RLC_GOLD_PURIFY)  + " sz, " + IntToString(RLC_PURIFY_CHANCE) + "%)";
+
+    json jAttuneBtn = NuiButton(JsonString(sAttuneLabel));
+    jAttuneBtn = NuiId(jAttuneBtn, RLC_BTN_ATTUNE);
+    jAttuneBtn = NuiEnabled(jAttuneBtn, NuiBind(RLC_BIND_ATTUNE_ENA));
+    jAttuneBtn = NuiWidth(jAttuneBtn, GetNuiScaleDimension(oPC, 160.0));
+    jAttuneBtn = NuiHeight(jAttuneBtn, fBtnH);
+    jAttuneBtn = NuiTooltip(jAttuneBtn, JsonString("Zwiąż swoją wolę z relikwią. Możesz dzierżyć tylko jedną naraz."));
+
+    json jRelBtn = NuiButton(JsonString(sReleaseLabel));
+    jRelBtn = NuiId(jRelBtn, RLC_BTN_RELEASE);
+    jRelBtn = NuiEnabled(jRelBtn, NuiBind(RLC_BIND_RELEAS_ENA));
+    jRelBtn = NuiWidth(jRelBtn, GetNuiScaleDimension(oPC, 160.0));
+    jRelBtn = NuiHeight(jRelBtn, fBtnH);
+    jRelBtn = NuiTooltip(jRelBtn, JsonString("Zerwij więź siłą woli. Klątwa i moc ustępują — cena to rytuał oczyszczenia."));
+
+    json jPurBtn = NuiButton(JsonString(sPurifyLabel));
+    jPurBtn = NuiId(jPurBtn, RLC_BTN_PURIFY);
+    jPurBtn = NuiEnabled(jPurBtn, NuiBind(RLC_BIND_PURIFY_ENA));
+    jPurBtn = NuiWidth(jPurBtn, GetNuiScaleDimension(oPC, 260.0));
+    jPurBtn = NuiHeight(jPurBtn, fBtnH);
+    jPurBtn = NuiTooltip(jPurBtn, JsonString("Rytuał oczyszczenia — " + IntToString(RLC_PURIFY_CHANCE) + "% szansy na redukcję klątwy o 1."));
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, jAttuneBtn);
+    jBtnRow = JsonArrayInsert(jBtnRow, jRelBtn);
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jPurBtn);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jRelicName);
+    jCol = JsonArrayInsert(jCol, jLore);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jPwrRow));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, jCurseLbl);
+    jCol = JsonArrayInsert(jCol, jBar);
+    jCol = JsonArrayInsert(jCol, jCurseVal);
+    jCol = JsonArrayInsert(jCol, jHolderLbl);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 10.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+
+    return NuiCol(jCol);
+}
+
+void RlcShowWindow(object oPC)
+{
+    if(NuiFindWindow(oPC, RLC_WINDOW) != 0)
+    {
+        int nToken = NuiFindWindow(oPC, RLC_WINDOW);
+        RlcFeedList(oPC, nToken);
+        RlcFeedDetail(oPC, nToken);
+        return;
+    }
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))
+                - GetNuiScaleDimension(oPC, RLC_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT))
+                - GetNuiScaleDimension(oPC, RLC_H)) / 2.0;
+    json jGeom = NuiRect(fCX, fCY, GetNuiScaleDimension(oPC, RLC_W), GetNuiScaleDimension(oPC, RLC_H));
+
+    json jClose = NuiButton(JsonString("X"));
+    jClose = NuiId(jClose, RLC_BTN_CLOSE);
+    jClose = NuiWidth(jClose, GetNuiScaleDimension(oPC, 28.0));
+    jClose = NuiHeight(jClose, GetNuiScaleDimension(oPC, 28.0));
+
+    json jTitleLbl = NuiLabel(JsonString("Skarbiec Relikwii"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+
+    json jTitleRow = JsonArray();
+    jTitleRow = JsonArrayInsert(jTitleRow, jTitleLbl);
+    jTitleRow = JsonArrayInsert(jTitleRow, NuiSpacer());
+    jTitleRow = JsonArrayInsert(jTitleRow, jClose);
+
+    // Split view: fixed-width list on the left, elastic detail on the right
+    json jContentRow = JsonArray();
+    jContentRow = JsonArrayInsert(jContentRow, RlcBuildListPanel(oPC));
+    jContentRow = JsonArrayInsert(jContentRow, NuiSpacer());
+    jContentRow = JsonArrayInsert(jContentRow, RlcBuildDetailPanel(oPC));
+
+    json jRoot = JsonArray();
+    jRoot = JsonArrayInsert(jRoot, NuiRow(jTitleRow));
+    jRoot = JsonArrayInsert(jRoot, NuiRow(jContentRow));
+
+    json jWin = NuiWindow(NuiCol(jRoot),
+        JsonBool(FALSE),
+        NuiBind(RLC_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    int nToken = NuiCreate(oPC, jWin, RLC_WINDOW, RLC_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, RLC_WIN_GEOM, jGeom);
+
+    // Default selection = first relic
+    if(GetLocalInt(oPC, RLC_LVAR_SEL) < 1)
+        SetLocalInt(oPC, RLC_LVAR_SEL, 1);
+
+    RlcFeedList(oPC, nToken);
+    RlcFeedDetail(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Feed functions
+// ----------------------------------------------------------------
+
+void RlcFeedList(object oPC, int nToken)
+{
+    int nMyRelic = RlcGetAttuned(oPC);
+    int nSel     = GetLocalInt(oPC, RLC_LVAR_SEL);
+
+    json jNames    = JsonArray();
+    json jStatuses = JsonArray();
+    json jColors   = JsonArray();
+    json jEncs     = JsonArray();
+
+    int i;
+    for(i = 1; i <= RLC_RELIC_COUNT; i++)
+    {
+        string sHolder = RlcGetHolder(i);
+        string sStatus;
+        json jColor;
+
+        if(i == nMyRelic)
+        {
+            int nCurse = RlcGetCurseLevel(oPC);
+            sStatus = "Twoja — klątwa: " + IntToString(nCurse) + "/" + IntToString(RLC_CURSE_MAX);
+            jColor  = NuiColor(200, 170, 60); // gold
+        }
+        else if(sHolder == "")
+        {
+            sStatus = "Wolna";
+            jColor  = NuiColor(210, 210, 210); // light
+        }
+        else
+        {
+            sStatus = sHolder;
+            jColor  = NuiColor(120, 120, 120); // dimmed
+        }
+
+        jNames    = JsonArrayInsert(jNames,    JsonString(RlcRelicName(i)));
+        jStatuses = JsonArrayInsert(jStatuses, JsonString(sStatus));
+        jColors   = JsonArrayInsert(jColors,   jColor);
+        jEncs     = JsonArrayInsert(jEncs,     JsonBool(i == nSel));
+    }
+
+    NuiSetBind(oPC, nToken, RLC_BIND_ROW_NAME,   jNames);
+    NuiSetBind(oPC, nToken, RLC_BIND_ROW_STATUS, jStatuses);
+    NuiSetBind(oPC, nToken, RLC_BIND_ROW_COLOR,  jColors);
+    NuiSetBind(oPC, nToken, RLC_BIND_ROW_ENC,    jEncs);
+}
+
+void RlcFeedDetail(object oPC, int nToken)
+{
+    int nSel     = GetLocalInt(oPC, RLC_LVAR_SEL);
+    int nMyRelic = RlcGetAttuned(oPC);
+    int nMyCurse = RlcGetCurseLevel(oPC);
+
+    if(nSel < 1 || nSel > RLC_RELIC_COUNT)
+        nSel = 1;
+
+    string sHolder = RlcGetHolder(nSel);
+    int bIsMine    = (nSel == nMyRelic);
+    int bFree      = (sHolder == "");
+    int bIHaveOne  = (nMyRelic != 0);
+
+    int   nDispCurse = bIsMine ? nMyCurse : 0;
+    float fProgress  = bIsMine
+        ? IntToFloat(nMyCurse) / IntToFloat(RLC_CURSE_MAX)
+        : 0.0;
+    int bAmp = bIsMine && (nMyCurse >= RLC_CURSE_MAX);
+
+    string sCurseLbl;
+    if(bIsMine)
+        sCurseLbl = "Klątwa: " + IntToString(nMyCurse) + " / " + IntToString(RLC_CURSE_MAX)
+                  + (bAmp ? "  [OBUDZONA]" : "");
+    else if(!bFree)
+        sCurseLbl = "Klątwa: nieznana (relikwia dzierżona)";
+    else
+        sCurseLbl = "Klątwa: 0 — relikwia jest wolna";
+
+    string sCurseDesc = "Przekleństwo: " + RlcCurseDesc(nSel, nDispCurse);
+
+    string sHolderLbl;
+    if(bIsMine)
+        sHolderLbl = "To twoja relikwia.";
+    else if(!bFree)
+        sHolderLbl = "Dzierżona przez: " + sHolder;
+    else
+        sHolderLbl = "Relikwia jest wolna.";
+
+    NuiSetBind(oPC, nToken, RLC_BIND_DET_NAME,   JsonString(RlcRelicName(nSel)));
+    NuiSetBind(oPC, nToken, RLC_BIND_DET_LORE,   JsonString(RlcRelicLore(nSel)));
+    NuiSetBind(oPC, nToken, RLC_BIND_DET_POWER,  JsonString(RlcPowerDesc(nSel, bAmp)));
+    NuiSetBind(oPC, nToken, RLC_BIND_CURSE_LBL,  JsonString(sCurseLbl));
+    NuiSetBind(oPC, nToken, RLC_BIND_CURSE_PROG, JsonFloat(fProgress));
+    NuiSetBind(oPC, nToken, RLC_BIND_DET_CURSE,  JsonString(sCurseDesc));
+    NuiSetBind(oPC, nToken, RLC_BIND_HOLDER_LBL, JsonString(sHolderLbl));
+
+    NuiSetBind(oPC, nToken, RLC_BIND_ATTUNE_ENA, JsonBool(bFree && !bIHaveOne));
+    NuiSetBind(oPC, nToken, RLC_BIND_RELEAS_ENA, JsonBool(bIsMine));
+    NuiSetBind(oPC, nToken, RLC_BIND_PURIFY_ENA, JsonBool(bIsMine && nMyCurse > 0));
+}

--- a/Relic Vault/scripts/lib_rlc_def.nss
+++ b/Relic Vault/scripts/lib_rlc_def.nss
@@ -1,0 +1,76 @@
+#include "lib_nui"
+#include "sql_rlc"
+
+// ----------------------------------------------------------------
+// Window & event script
+// ----------------------------------------------------------------
+const string RLC_WINDOW    = "RLC_WINDOW";
+const string RLC_EV_SCRIPT = "lib_rlc_ev";
+const string RLC_WIN_GEOM  = "rlc_win_geom";
+
+// ----------------------------------------------------------------
+// List-panel binds  (arrays, one entry per relic)
+// ----------------------------------------------------------------
+const string RLC_BIND_ROW_NAME   = "rlc_row_name";
+const string RLC_BIND_ROW_STATUS = "rlc_row_status";
+const string RLC_BIND_ROW_COLOR  = "rlc_row_color";
+const string RLC_BIND_ROW_ENC    = "rlc_row_enc";
+
+// ----------------------------------------------------------------
+// Detail-panel binds
+// ----------------------------------------------------------------
+const string RLC_BIND_DET_NAME   = "rlc_det_name";
+const string RLC_BIND_DET_LORE   = "rlc_det_lore";
+const string RLC_BIND_DET_POWER  = "rlc_det_power";
+const string RLC_BIND_DET_CURSE  = "rlc_det_curse";
+const string RLC_BIND_CURSE_LBL  = "rlc_curse_lbl";
+const string RLC_BIND_CURSE_PROG = "rlc_curse_prog";
+const string RLC_BIND_HOLDER_LBL = "rlc_holder_lbl";
+const string RLC_BIND_ATTUNE_ENA = "rlc_att_ena";
+const string RLC_BIND_RELEAS_ENA = "rlc_rel_ena";
+const string RLC_BIND_PURIFY_ENA = "rlc_pur_ena";
+
+// ----------------------------------------------------------------
+// Button IDs
+// ----------------------------------------------------------------
+const string RLC_BTN_CLOSE   = "rlc_close";
+const string RLC_BTN_ROW     = "rlc_row";
+const string RLC_BTN_ATTUNE  = "rlc_attune";
+const string RLC_BTN_RELEASE = "rlc_release";
+const string RLC_BTN_PURIFY  = "rlc_purify";
+
+// ----------------------------------------------------------------
+// Per-PC LVARs
+// ----------------------------------------------------------------
+const string RLC_LVAR_SEL = "RLC_SEL_ID"; // currently selected relic (1..6)
+
+// ----------------------------------------------------------------
+// Relic IDs
+// ----------------------------------------------------------------
+const int RLC_RELIC_EYE     = 1; // Oko Tyranów
+const int RLC_RELIC_BLADE   = 2; // Miecz Zdrajcy
+const int RLC_RELIC_CHALICE = 3; // Kielich Zatracenia
+const int RLC_RELIC_CROWN   = 4; // Korona Popiołów
+const int RLC_RELIC_SEAL    = 5; // Pieczęć Nicości
+const int RLC_RELIC_CLAW    = 6; // Szpon Bestii
+const int RLC_RELIC_COUNT   = 6;
+
+// ----------------------------------------------------------------
+// Economy
+// ----------------------------------------------------------------
+const int RLC_GOLD_ATTUNE  = 500;  // cost to attune
+const int RLC_GOLD_RELEASE = 200;  // cost to voluntarily release
+const int RLC_GOLD_PURIFY  = 1000; // cost per purification attempt
+const int RLC_PURIFY_CHANCE = 60;  // % chance purification reduces curse by 1
+
+// ----------------------------------------------------------------
+// Layout
+// ----------------------------------------------------------------
+const float RLC_W = 780.0;
+const float RLC_H = 530.0;
+
+// ----------------------------------------------------------------
+// Effect tags for clean removal
+// ----------------------------------------------------------------
+const string RLC_TAG_POWER = "RLC_POWER";
+const string RLC_TAG_CURSE = "RLC_CURSE";

--- a/Relic Vault/scripts/lib_rlc_ev.nss
+++ b/Relic Vault/scripts/lib_rlc_ev.nss
@@ -1,0 +1,161 @@
+#include "lib_rlc"
+
+// ----------------------------------------------------------------
+// Attune handler
+// ----------------------------------------------------------------
+
+void RlcHandleAttune(object oPC, int nToken)
+{
+    int nSel = GetLocalInt(oPC, RLC_LVAR_SEL);
+    if(nSel < 1 || nSel > RLC_RELIC_COUNT) return;
+
+    if(RlcGetAttuned(oPC) != 0)
+    {
+        SendMessageToPC(oPC, "[Relikwia] Już dzierżysz relikwię. Najpierw ją uwolnij.");
+        return;
+    }
+
+    if(RlcGetHolder(nSel) != "")
+    {
+        SendMessageToPC(oPC, "[Relikwia] Ta relikwia jest już w czyjejś mocy.");
+        RlcFeedList(oPC, nToken);
+        RlcFeedDetail(oPC, nToken);
+        return;
+    }
+
+    if(GetGold(oPC) < RLC_GOLD_ATTUNE)
+    {
+        SendMessageToPC(oPC, "[Relikwia] Potrzebujesz " + IntToString(RLC_GOLD_ATTUNE) + " sztuk złota na rytuał atunowania.");
+        return;
+    }
+
+    AssignCommand(oPC, TakeGoldFromCreature(RLC_GOLD_ATTUNE, oPC, TRUE));
+    RlcAttuneRelic(oPC, nSel);
+    RlcApplyEffects(oPC);
+
+    SendMessageToPC(oPC, "[Relikwia] Związałeś się z " + RlcRelicName(nSel) + ". Moc płynie — i klątwa razem z nią.");
+    RlcFeedList(oPC, nToken);
+    RlcFeedDetail(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Release handler
+// ----------------------------------------------------------------
+
+void RlcHandleRelease(object oPC, int nToken)
+{
+    int nMyRelic = RlcGetAttuned(oPC);
+    if(nMyRelic == 0) return;
+
+    if(GetGold(oPC) < RLC_GOLD_RELEASE)
+    {
+        SendMessageToPC(oPC, "[Relikwia] Potrzebujesz " + IntToString(RLC_GOLD_RELEASE) + " sztuk złota na rytuał uwolnienia.");
+        return;
+    }
+
+    string sName = RlcRelicName(nMyRelic);
+    AssignCommand(oPC, TakeGoldFromCreature(RLC_GOLD_RELEASE, oPC, TRUE));
+    RlcRemoveEffects(oPC);
+    RlcReleaseRelic(oPC);
+
+    SendMessageToPC(oPC, "[Relikwia] Uwolniłeś się od " + sName + ". Pustka, którą po sobie zostawiła, jest głośna.");
+    RlcFeedList(oPC, nToken);
+    RlcFeedDetail(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Purify handler
+// ----------------------------------------------------------------
+
+void RlcHandlePurify(object oPC, int nToken)
+{
+    int nMyRelic = RlcGetAttuned(oPC);
+    if(nMyRelic == 0) return;
+
+    int nCurse = RlcGetCurseLevel(oPC);
+    if(nCurse <= 0)
+    {
+        SendMessageToPC(oPC, "[Relikwia] Nie ma czego oczyszczać — klątwa nie zdążyła się jeszcze zakorzenić.");
+        return;
+    }
+
+    if(GetGold(oPC) < RLC_GOLD_PURIFY)
+    {
+        SendMessageToPC(oPC, "[Relikwia] Potrzebujesz " + IntToString(RLC_GOLD_PURIFY) + " sztuk złota na rytuał oczyszczenia.");
+        return;
+    }
+
+    AssignCommand(oPC, TakeGoldFromCreature(RLC_GOLD_PURIFY, oPC, TRUE));
+
+    int nRoll = Random(100) + 1;
+    if(nRoll <= RLC_PURIFY_CHANCE)
+    {
+        int nNew = RlcPurifyDB(oPC);
+        RlcApplyEffects(oPC);
+        SendMessageToPC(oPC, "[Relikwia] Rytuał powiódł się. Klątwa zredukowana do poziomu " + IntToString(nNew) + ".");
+    }
+    else
+    {
+        SendMessageToPC(oPC, "[Relikwia] Rytuał się nie powiódł. Klątwa jest głębiej zakorzeniona niż sądziłeś.");
+    }
+
+    RlcFeedList(oPC, nToken);
+    RlcFeedDetail(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Main event handler
+// ----------------------------------------------------------------
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    if(nToken != NuiFindWindow(oPC, RLC_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalInt(oPC, RLC_LVAR_SEL);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_MOUSEDOWN && sElem == RLC_BTN_ROW)
+    {
+        // nIdx is 0-based; relic IDs are 1-based
+        int nRelicId = nIdx + 1;
+        if(nRelicId < 1 || nRelicId > RLC_RELIC_COUNT) return;
+
+        SetLocalInt(oPC, RLC_LVAR_SEL, nRelicId);
+        RlcFeedList(oPC, nToken);
+        RlcFeedDetail(oPC, nToken);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == RLC_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+        if(sElem == RLC_BTN_ATTUNE)
+        {
+            RlcHandleAttune(oPC, nToken);
+            return;
+        }
+        if(sElem == RLC_BTN_RELEASE)
+        {
+            RlcHandleRelease(oPC, nToken);
+            return;
+        }
+        if(sElem == RLC_BTN_PURIFY)
+        {
+            RlcHandlePurify(oPC, nToken);
+            return;
+        }
+    }
+}

--- a/Relic Vault/scripts/sql_rlc.nss
+++ b/Relic Vault/scripts/sql_rlc.nss
@@ -1,0 +1,119 @@
+const string RLC_DB              = "rlc";
+const int    RLC_CURSE_MAX       = 5;
+const int    RLC_CURSE_TICK_SECS = 600; // 10 real minutes between curse escalations
+
+void RlcCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign(RLC_DB,
+        "CREATE TABLE IF NOT EXISTS rlc_attunements ("
+        "char_uuid TEXT PRIMARY KEY, "
+        "char_name TEXT NOT NULL DEFAULT '', "
+        "relic_id  INTEGER NOT NULL, "
+        "curse_level INTEGER NOT NULL DEFAULT 0, "
+        "attuned_at  INTEGER NOT NULL DEFAULT 0, "
+        "last_tick   INTEGER NOT NULL DEFAULT 0)");
+    SqlStep(q);
+}
+
+// Returns the relic_id the PC is currently attuned to, or 0 if none.
+int RlcGetAttuned(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign(RLC_DB,
+        "SELECT relic_id FROM rlc_attunements WHERE char_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+int RlcGetCurseLevel(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign(RLC_DB,
+        "SELECT curse_level FROM rlc_attunements WHERE char_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// Returns the character name of whoever holds this relic, "" if unoccupied.
+string RlcGetHolder(int nRelicId)
+{
+    sqlquery q = SqlPrepareQueryCampaign(RLC_DB,
+        "SELECT char_name FROM rlc_attunements WHERE relic_id = @rid");
+    SqlBindInt(q, "@rid", nRelicId);
+    if(SqlStep(q)) return SqlGetString(q, 0);
+    return "";
+}
+
+void RlcAttuneRelic(object oPC, int nRelicId)
+{
+    sqlquery q = SqlPrepareQueryCampaign(RLC_DB,
+        "INSERT INTO rlc_attunements "
+        "(char_uuid, char_name, relic_id, curse_level, attuned_at, last_tick) "
+        "VALUES (@uuid, @name, @rid, 0, strftime('%s','now'), strftime('%s','now'))");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindString(q, "@name", GetName(oPC));
+    SqlBindInt   (q, "@rid",  nRelicId);
+    SqlStep(q);
+}
+
+void RlcReleaseRelic(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign(RLC_DB,
+        "DELETE FROM rlc_attunements WHERE char_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+// Increments curse by 1 (capped at RLC_CURSE_MAX) and resets last_tick.
+// Returns the new curse level, or -1 if the PC has no attunement.
+int RlcTickCurse(object oPC)
+{
+    sqlquery qGet = SqlPrepareQueryCampaign(RLC_DB,
+        "SELECT curse_level FROM rlc_attunements WHERE char_uuid = @uuid");
+    SqlBindString(qGet, "@uuid", GetObjectUUID(oPC));
+    if(!SqlStep(qGet)) return -1;
+
+    int nCurrent = SqlGetInt(qGet, 0);
+    int nNew     = (nCurrent < RLC_CURSE_MAX) ? nCurrent + 1 : RLC_CURSE_MAX;
+
+    sqlquery qUp = SqlPrepareQueryCampaign(RLC_DB,
+        "UPDATE rlc_attunements "
+        "SET curse_level = @lvl, last_tick = strftime('%s','now') "
+        "WHERE char_uuid = @uuid");
+    SqlBindInt   (qUp, "@lvl",  nNew);
+    SqlBindString(qUp, "@uuid", GetObjectUUID(oPC));
+    SqlStep(qUp);
+    return nNew;
+}
+
+// Reduces curse by 1 (min 0). Returns new level, or -1 if not attuned.
+int RlcPurifyDB(object oPC)
+{
+    sqlquery qGet = SqlPrepareQueryCampaign(RLC_DB,
+        "SELECT curse_level FROM rlc_attunements WHERE char_uuid = @uuid");
+    SqlBindString(qGet, "@uuid", GetObjectUUID(oPC));
+    if(!SqlStep(qGet)) return -1;
+
+    int nCurrent = SqlGetInt(qGet, 0);
+    int nNew     = (nCurrent > 0) ? nCurrent - 1 : 0;
+
+    sqlquery qUp = SqlPrepareQueryCampaign(RLC_DB,
+        "UPDATE rlc_attunements SET curse_level = @lvl WHERE char_uuid = @uuid");
+    SqlBindInt   (qUp, "@lvl",  nNew);
+    SqlBindString(qUp, "@uuid", GetObjectUUID(oPC));
+    SqlStep(qUp);
+    return nNew;
+}
+
+// Returns TRUE when enough real time has passed and the curse is not yet maxed.
+int RlcNeedsCurseTick(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign(RLC_DB,
+        "SELECT (strftime('%s','now') - last_tick) >= @secs AND curse_level < @max "
+        "FROM rlc_attunements WHERE char_uuid = @uuid");
+    SqlBindInt   (q, "@secs", RLC_CURSE_TICK_SECS);
+    SqlBindInt   (q, "@max",  RLC_CURSE_MAX);
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return FALSE;
+}

--- a/Relic Vault/scripts/sys_on_enter.nss
+++ b/Relic Vault/scripts/sys_on_enter.nss
@@ -1,0 +1,13 @@
+#include "lib_rlc"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC)) return;
+
+    // Permanent effects don't persist through server restarts — reapply on login.
+    RlcApplyEffects(oPC);
+
+    // If the player was offline long enough for curse escalation, catch up one tick.
+    RlcCheckCurseTick(oPC);
+}

--- a/Relic Vault/scripts/sys_on_hbeat.nss
+++ b/Relic Vault/scripts/sys_on_hbeat.nss
@@ -1,0 +1,22 @@
+#include "lib_rlc"
+
+void main()
+{
+    // Throttle: run the full PC sweep only ~once per 60 heartbeats (~6 min real time).
+    // The SQL timestamp guard in RlcNeedsCurseTick prevents double escalation regardless.
+    int nCount = GetLocalInt(GetModule(), "RLC_HB_COUNT");
+    nCount++;
+    if(nCount < 60)
+    {
+        SetLocalInt(GetModule(), "RLC_HB_COUNT", nCount);
+        return;
+    }
+    SetLocalInt(GetModule(), "RLC_HB_COUNT", 0);
+
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        RlcCheckCurseTick(oPC);
+        oPC = GetNextPC();
+    }
+}

--- a/Relic Vault/scripts/sys_on_load.nss
+++ b/Relic Vault/scripts/sys_on_load.nss
@@ -1,0 +1,6 @@
+#include "sql_rlc"
+
+void main()
+{
+    RlcCreateTables();
+}

--- a/Relic Vault/scripts/test_rlc.nss
+++ b/Relic Vault/scripts/test_rlc.nss
@@ -1,0 +1,14 @@
+#include "lib_rlc"
+
+// Place this script in the OnUsed event of a placeable (e.g. a stone altar or chest).
+// Using it opens the Relic Vault window and grants 2000 gp if the PC is broke.
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    if(GetGold(oPC) < 2000)
+        GiveGoldToCreature(oPC, 2000);
+
+    RlcShowWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

System przeklętych starożytnych relikwii z pełnym UI NUI. Gracze mogą atunować się do jednej z 6 unikalnych relikwii, każda daje potężny buff, lecz klątwa narasta z czasem i wymaga złota lub rytuału oczyszczenia, by ją powstrzymać.

## Mechanika

- **6 relikwii**, każda dzierżona przez jedną postać naraz — lista w UI pokazuje kto co ma, co tworzy napięcie społeczne bez walki
- **Klątwa eskaluje** co 10 minut realnych (sprawdzana przez SQL timestamp w `RlcNeedsCurseTick`): poziom 0→5; na poziomie 5 moc relikwii podwaja się, ale kara atrybutowa sięga -5
- **Atunowanie**: 500 sz → efekty `TagEffect`-owane aplikowane jako `DURATION_TYPE_PERMANENT`
- **Uwolnienie**: 200 sz → efekty zdejmowane po tagu, rekord usuwany z SQL
- **Oczyszczenie**: 1000 sz, 60% szansy na redukcję klątwy o 1; można powtarzać
- Po relogu efekty przywracane z SQL przez `sys_on_enter.nss`

### Relikwie i efekty

| Relikwia | Moc (normalnie / wzmocniona) | Klątwa |
|---|---|---|
| Oko Tyranów | +2 / +4 do wszystkich rzutów obronnych | Mądrość -N |
| Miecz Zdrajcy | +2 / +4 do trafienia i obrażeń (mag.) | Charyzma -N |
| Kielich Zatracenia | Regeneracja 1 / 2 PW / 6 s | Kondycja -N |
| Korona Popiołów | +3 / +6 do KP (ugięcie) | Zręczność -N |
| Pieczęć Nicości | SR 15 / 22 | Inteligencja -N |
| Szpon Bestii | +1k6 / +2k6 obrażeń mag. | Siła -N |

## Pliki

```
Relic Vault/
  scripts/
    sql_rlc.nss          — schemat rlc_attunements + CRUD + cursor-tick queries
    lib_rlc_def.nss      — wszystkie stałe (bind IDs, relic IDs, koszty, tagi efektów)
    lib_rlc.nss          — rdzeń: dane relikwii, efekty TagEffect, NUI builder, feed
    lib_rlc_ev.nss       — handler NUI eventów (click, mousedown, close)
    sys_on_load.nss      — CREATE TABLE IF NOT EXISTS przy starcie modułu
    sys_on_enter.nss     — przywróć efekty + catch-up tick przy logowaniu
    sys_on_hbeat.nss     — throttlowany sweep eskalacji klątwy (~co 6 min)
    test_rlc.nss         — OnUsed na placeablu demonstracyjnym
    lib_nui.nss          — (kopia współdzielona, konwencja projektu)
    lib_nui_utility.nss  — (kopia współdzielona, konwencja projektu)
  INTEGRATION.md         — instrukcja podpięcia, tabela plików, co pominięto
```

## Zależności (NWNX? SQL?)

- **NWNX**: brak — wyłącznie base NWN:EE API
- **SQL**: `SqlPrepareQueryCampaign` na bazie `"rlc"` (plik `rlc.sqlite` w katalogu serwera)
- **NWN:EE min. wersja**: 8193.36+ (`TagEffect` / `GetEffectTag`, `EffectRegenerate`)

## Jak włączyć w istniejącym module

```nss
// OnModuleLoad:
#include "sql_rlc"
RlcCreateTables();

// OnClientEnter:
#include "lib_rlc"
if(GetIsPC(oPC)) { RlcApplyEffects(oPC); RlcCheckCurseTick(oPC); }

// OnHeartbeat — skopiuj zawartość sys_on_hbeat.nss lub wywołaj jako include
```

Dowolny trigger otwierający UI:
```nss
#include "lib_rlc"
RlcShowWindow(oPC);
```

## Co celowo pominięto

- **HAK / własne grafiki** — brak zasobów graficznych; ikony bazują na wbudowanych resref-ach
- **Fizyczne itemy relikwii** w ekwipunku gracza — uproszczono do czystego systemu efektów i SQL; można rozszerzyć o item z ResRef `rlc_item_N` jako "klucz dostępu"
- **Mechanizm kradzieży** relikwii od innego gracza — świadome uproszczenie v1; lista w UI pokazuje posiadacza co tworzy interakcję społeczną
- **Wielokrotny catch-up** ticków przy długiej nieobecności — gracz otrzymuje max 1 tick przy logowaniu, nie może przegapić eskalacji przez unikanie serwera

---
_Generated by [Claude Code](https://claude.ai/code/session_0167iAjn1fr84gs8apy2PZza)_