### PR TITLE
feat: Więzy Krwi (Blood Bonds)

### DIFF
--- a/Więzy Krwi/INTEGRATION.md
+++ b/Więzy Krwi/INTEGRATION.md
@@ -1,0 +1,67 @@
+# Więzy Krwi — Instrukcja integracji
+
+## Co to robi
+
+System umożliwia graczom zawieranie magicznych kontraktów krwi z innymi graczami.
+Każdy kontrakt jest pieczętowany PŻ obu stron i przechowywany trwale w SQLite.
+
+## Hooki modułu do podpięcia
+
+| Hook NWN                | Skrypt w module        |
+|-------------------------|------------------------|
+| OnModuleLoad            | `sys_on_load`          |
+| OnClientEnter           | `sys_on_enter`         |
+| OnModuleHeartbeat       | `sys_on_hb`            |
+| OnPlayerDeath           | `sys_on_pc_killed`     |
+| OnNuiEvent              | `lib_wkr_ev`           |
+| OnPlayerTarget          | wywołaj `WkrOnPlayerTarget(GetLastPlayerToSelectTarget())` |
+
+Jeśli moduł ma już skrypty OnModuleLoad / OnClientEnter / OnHeartbeat,
+dopisz wywołania funkcji z `lib_wkr` do istniejących skryptów.
+
+## OnPlayerTarget
+
+NWN nie ma dedykowanego hooka — `EnterTargetingMode` wywołuje event
+`OnPlayerTarget` na module. Jeśli korzystasz z innego modułu który też
+używa trybu celowania, rozróżnij kontekst przez zmienną lokalną lub
+sprawdź czy gracz ma otwarty token WKR_WINDOW:
+
+```nss
+#include "lib_wkr"
+void main()
+{
+    object oPC = GetLastPlayerToSelectTarget();
+    if(NuiFindWindow(oPC, WKR_WINDOW) != 0)
+        WkrOnPlayerTarget(oPC);
+    // ... inne systemy
+}
+```
+
+## Baza danych
+
+Dane przechowywane są w kampanii o nazwie `wkr` (plik `wkr.sqlite`).
+Tabela tworzona idempotentnie przy `OnModuleLoad`.
+
+## Testowanie
+
+1. Umieść placeable z OnUsed = `test_wkr` na mapie testowej.
+2. Uruchom dwa konta (DM + PC lub dwa PC).
+3. PC A używa placeable → otwiera się okno Więzy Krwi.
+4. PC A: zakładka „Zaproś" → wybierz typ, wpisz kwotę (dla Długu), kliknij PC B.
+5. PC B otrzymuje powiadomienie; otwiera okno i klika „Przyjmij".
+6. Oboje tracą 5 PŻ; powiązanie pojawia się na liście obu graczy.
+
+## Zależności NWNX
+
+Brak. Moduł używa wyłącznie NWScript + natywnego NUI + `SqlPrepareQueryCampaign`.
+
+## Ograniczenia i pominięcia
+
+- Przy Długu Krwi i offline'owym wierzycielu złoto jest odnotowywane
+  w `terms_json.paid_offline` — wymagana ręczna dystrybucja przez DM.
+- Rozwiązanie więzi jest jednostronne (nie wymaga zgody partnera) —
+  by wymagać konsensusu, dodaj pole `dissolve_request_uuid` do tabeli.
+- Brak UI powiadomień push — gracze są informowani przez `SendMessageToPC`
+  i `FloatingTextStringOnCreature`.
+- Klątwa za Straż Krwi nie jest automatycznie aplikowana za śmierć podopiecznego
+  bez strażnika — wymaga dodatkowego hooka `OnPlayerDeath` z logiką lokalizacji.

--- a/Więzy Krwi/scripts/lib_wkr.nss
+++ b/Więzy Krwi/scripts/lib_wkr.nss
@@ -1,0 +1,901 @@
+#include "lib_wkr_def"
+#include "sql_wkr"
+
+// ----------------------------------------------------------------
+// Text helpers
+// ----------------------------------------------------------------
+
+string WkrTypeName(int nType)
+{
+    switch(nType)
+    {
+        case WKR_TYPE_DEBT:  return "Dług Krwi";
+        case WKR_TYPE_OATH:  return "Przysięga Krwi";
+        case WKR_TYPE_GUARD: return "Straż Krwi";
+    }
+    return "—";
+}
+
+string WkrStatusText(int nSt)
+{
+    switch(nSt)
+    {
+        case WKR_STATUS_PENDING:   return "Oczekuje";
+        case WKR_STATUS_ACTIVE:    return "Aktywny";
+        case WKR_STATUS_VIOLATED:  return "Naruszony";
+        case WKR_STATUS_FULFILLED: return "Wypełniony";
+        case WKR_STATUS_DISSOLVED: return "Rozwiązany";
+    }
+    return "—";
+}
+
+json WkrStatusColor(int nSt)
+{
+    switch(nSt)
+    {
+        case WKR_STATUS_PENDING:   return NuiColor(200, 200,  80);
+        case WKR_STATUS_ACTIVE:    return NuiColor( 80, 200,  80);
+        case WKR_STATUS_VIOLATED:  return NuiColor(220,  60,  60);
+        case WKR_STATUS_FULFILLED: return NuiColor(100, 160, 220);
+        case WKR_STATUS_DISSOLVED: return NuiColor(140, 140, 140);
+    }
+    return NuiColor(255, 255, 255);
+}
+
+int WkrIsInit(object oPC, json jBond)
+{
+    return JsonGetString(JsonObjectGet(jBond, "initiator_uuid")) == GetObjectUUID(oPC);
+}
+
+string WkrPartnerName(object oPC, json jBond)
+{
+    if(WkrIsInit(oPC, jBond))
+        return JsonGetString(JsonObjectGet(jBond, "partner_name"));
+    return JsonGetString(JsonObjectGet(jBond, "initiator_name"));
+}
+
+string WkrPartnerUuid(object oPC, json jBond)
+{
+    if(WkrIsInit(oPC, jBond))
+        return JsonGetString(JsonObjectGet(jBond, "partner_uuid"));
+    return JsonGetString(JsonObjectGet(jBond, "initiator_uuid"));
+}
+
+string WkrTermsSummary(object oPC, json jBond)
+{
+    int nType    = JsonGetInt(JsonObjectGet(jBond, "bond_type"));
+    json jTerms  = JsonParse(JsonGetString(JsonObjectGet(jBond, "terms_json")));
+    int nExpires = JsonGetInt(JsonObjectGet(jBond, "expires_at"));
+
+    switch(nType)
+    {
+        case WKR_TYPE_DEBT:
+        {
+            int nGold = JsonGetInt(JsonObjectGet(jTerms, "gold"));
+            string sExp = nExpires > 0 ? WkrFormatTs(nExpires) : "bezterminowo";
+            string sRole = WkrIsInit(oPC, jBond) ? "Dłużnik" : "Wierzyciel";
+            return sRole + " — " + IntToString(nGold) + " gp — termin: " + sExp;
+        }
+        case WKR_TYPE_OATH:
+            return "Bliskość: +1 do rzutów obronnych. Zdrada: klątwa KON/MĄD.";
+        case WKR_TYPE_GUARD:
+        {
+            string sInitRole = JsonGetString(JsonObjectGet(jTerms, "init_role"));
+            string sMyRole   = WkrIsInit(oPC, jBond) ? sInitRole : (sInitRole == "guard" ? "ward" : "guard");
+            return sMyRole == "guard" ? "Twoja rola: Strażnik (+2 KP blisko)." : "Twoja rola: Podopieczny (−3 obrażeń blisko).";
+        }
+    }
+    return "";
+}
+
+// ----------------------------------------------------------------
+// Effects
+// ----------------------------------------------------------------
+
+void WkrApplyCurse(object oTarget, int nType, int nId)
+{
+    string sTag = WKR_FX_CURSE + IntToString(nId);
+    effect eCurse;
+    switch(nType)
+    {
+        case WKR_TYPE_DEBT:
+            eCurse = EffectAbilityDecrease(ABILITY_CHARISMA, 4);
+            break;
+        case WKR_TYPE_OATH:
+            eCurse = EffectLinkEffects(
+                EffectAbilityDecrease(ABILITY_CONSTITUTION, 3),
+                EffectAbilityDecrease(ABILITY_WISDOM, 3));
+            break;
+        case WKR_TYPE_GUARD:
+            eCurse = EffectLinkEffects(
+                EffectAbilityDecrease(ABILITY_DEXTERITY, 2),
+                EffectAbilityDecrease(ABILITY_STRENGTH, 2));
+            break;
+        default:
+            eCurse = EffectAbilityDecrease(ABILITY_CHARISMA, 2);
+    }
+    eCurse = TagEffect(eCurse, sTag);
+    eCurse = ExtraordinaryEffect(eCurse);
+    ApplyEffectToObject(DURATION_TYPE_PERMANENT, eCurse, oTarget);
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectVisualEffect(VFX_IMP_DOOM), oTarget);
+    FloatingTextStringOnCreature("Krwiste więzy pękają — klątwa spada na ciebie!", oTarget, FALSE);
+}
+
+void WkrRemoveCurse(object oTarget, int nId)
+{
+    string sTag = WKR_FX_CURSE + IntToString(nId);
+    effect eEff = GetFirstEffect(oTarget);
+    while(GetIsEffectValid(eEff))
+    {
+        if(GetEffectTag(eEff) == sTag) RemoveEffect(oTarget, eEff);
+        eEff = GetNextEffect(oTarget);
+    }
+}
+
+void WkrRemoveProxFx(object oTarget, int nId)
+{
+    string sTag = WKR_FX_PROX + IntToString(nId);
+    effect eEff = GetFirstEffect(oTarget);
+    while(GetIsEffectValid(eEff))
+    {
+        if(GetEffectTag(eEff) == sTag) RemoveEffect(oTarget, eEff);
+        eEff = GetNextEffect(oTarget);
+    }
+}
+
+int WkrHasProxFx(object oTarget, int nId)
+{
+    string sTag = WKR_FX_PROX + IntToString(nId);
+    effect eEff = GetFirstEffect(oTarget);
+    while(GetIsEffectValid(eEff))
+    {
+        if(GetEffectTag(eEff) == sTag) return TRUE;
+        eEff = GetNextEffect(oTarget);
+    }
+    return FALSE;
+}
+
+// ----------------------------------------------------------------
+// Heartbeat logic
+// ----------------------------------------------------------------
+
+// Searches online PCs for a given UUID; returns OBJECT_INVALID if offline.
+object WkrFindPC(string sUuid)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        if(GetObjectUUID(oPC) == sUuid) return oPC;
+        oPC = GetNextPC();
+    }
+    return OBJECT_INVALID;
+}
+
+void WkrUpdateProximityForPC(object oPC)
+{
+    string sUuid = GetObjectUUID(oPC);
+    json jBonds  = WkrGetBonds(sUuid);
+    int nCount   = JsonGetLength(jBonds);
+    int i;
+
+    for(i = 0; i < nCount; i++)
+    {
+        json jBond = JsonArrayGet(jBonds, i);
+        int nSt    = JsonGetInt(JsonObjectGet(jBond, "status"));
+        if(nSt != WKR_STATUS_ACTIVE) continue;
+
+        int nType = JsonGetInt(JsonObjectGet(jBond, "bond_type"));
+        if(nType != WKR_TYPE_OATH && nType != WKR_TYPE_GUARD) continue;
+
+        int nId    = JsonGetInt(JsonObjectGet(jBond, "id"));
+        string sPartUuid = WkrPartnerUuid(oPC, jBond);
+        object oPartner  = WkrFindPC(sPartUuid);
+
+        int bNear = GetIsObjectValid(oPartner)
+                 && GetArea(oPC) == GetArea(oPartner)
+                 && GetDistanceBetween(oPC, oPartner) <= WKR_PROXIMITY_DIST;
+
+        int bHas = WkrHasProxFx(oPC, nId);
+
+        if(bNear && !bHas)
+        {
+            effect eBonus;
+            string sTag = WKR_FX_PROX + IntToString(nId);
+
+            if(nType == WKR_TYPE_OATH)
+            {
+                eBonus = EffectSavingThrowIncrease(SAVING_THROW_ALL, 1, SAVING_THROW_TYPE_ALL);
+            }
+            else
+            {
+                json jTerms  = JsonParse(JsonGetString(JsonObjectGet(jBond, "terms_json")));
+                string sInitR = JsonGetString(JsonObjectGet(jTerms, "init_role"));
+                string sMyR   = WkrIsInit(oPC, jBond) ? sInitR : (sInitR == "guard" ? "ward" : "guard");
+
+                if(sMyR == "guard")
+                    eBonus = EffectACIncrease(2, AC_DODGE_BONUS, AC_VS_DAMAGE_TYPE_ALL);
+                else
+                    eBonus = EffectDamageReduction(3, DAMAGE_POWER_PLUS_ONE, 0);
+            }
+
+            eBonus = TagEffect(eBonus, WKR_FX_PROX + IntToString(nId));
+            eBonus = SupernaturalEffect(eBonus);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, eBonus, oPC);
+        }
+        else if(!bNear && bHas)
+        {
+            WkrRemoveProxFx(oPC, nId);
+        }
+    }
+}
+
+void WkrCheckOverdueDebts()
+{
+    json jOverdue = WkrGetOverdueDebts();
+    int nCount    = JsonGetLength(jOverdue);
+    int i;
+
+    for(i = 0; i < nCount; i++)
+    {
+        json   jRow      = JsonArrayGet(jOverdue, i);
+        int    nId       = JsonGetInt(JsonObjectGet(jRow, "id"));
+        string sDebtor   = JsonGetString(JsonObjectGet(jRow, "initiator_uuid"));
+        string sDebtorN  = JsonGetString(JsonObjectGet(jRow, "initiator_name"));
+        string sCreditor = JsonGetString(JsonObjectGet(jRow, "partner_uuid"));
+
+        WkrSetStatus(nId, WKR_STATUS_VIOLATED);
+
+        object oDebtor = WkrFindPC(sDebtor);
+        if(GetIsObjectValid(oDebtor))
+            WkrApplyCurse(oDebtor, WKR_TYPE_DEBT, nId);
+
+        object oCreditor = WkrFindPC(sCreditor);
+        if(GetIsObjectValid(oCreditor))
+            SendMessageToPC(oCreditor,
+                "[Więzy Krwi] " + sDebtorN + " nie spłacił długu — klątwa spada na dłużnika.");
+    }
+}
+
+// Restores curse effects for a PC logging in (curse may have been applied while offline).
+void WkrRestoreOnEnter(object oPC)
+{
+    string sUuid  = GetObjectUUID(oPC);
+    json jBonds   = WkrGetBonds(sUuid);
+    int nCount    = JsonGetLength(jBonds);
+    int i;
+
+    for(i = 0; i < nCount; i++)
+    {
+        json jBond  = JsonArrayGet(jBonds, i);
+        int nSt     = JsonGetInt(JsonObjectGet(jBond, "status"));
+        int nId     = JsonGetInt(JsonObjectGet(jBond, "id"));
+        int nType   = JsonGetInt(JsonObjectGet(jBond, "bond_type"));
+        int bIsInit = WkrIsInit(oPC, jBond);
+
+        // Re-apply curse if this PC was the violator (debtor for debt, either for oath/guard).
+        if(nSt == WKR_STATUS_VIOLATED)
+        {
+            // Only the initiator is the debtor for DEBT type.
+            // For OATH/GUARD violation the status gets set on the PC who betrayed,
+            // but we store violation globally. Re-apply to this PC conservatively
+            // — let a DM remove manually if needed.
+            if(nType == WKR_TYPE_DEBT && bIsInit)
+                WkrApplyCurse(oPC, nType, nId);
+            else if(nType != WKR_TYPE_DEBT)
+                WkrApplyCurse(oPC, nType, nId);
+        }
+    }
+
+    // Check for pending invite stored offline via LVAR — inform player.
+    int nPendId = GetLocalInt(oPC, WKR_LVAR_PEND_ID);
+    if(nPendId > 0)
+    {
+        string sFrom = GetLocalString(oPC, WKR_LVAR_PEND_FROM);
+        SendMessageToPC(oPC,
+            "[Więzy Krwi] Czeka na ciebie zaproszenie od: " + sFrom +
+            ". Otwórz okno Więzy Krwi → Zaproś, aby odpowiedzieć.");
+    }
+}
+
+// ----------------------------------------------------------------
+// NUI — Window builder
+// ----------------------------------------------------------------
+
+json WkrBuildWindow(object oPC)
+{
+    // ---- Tab row ----
+    json jTabs = JsonArray();
+    jTabs = JsonArrayInsert(jTabs,
+        NuiButton(JsonString("Aktywne więzi"), WKR_BTN_TAB_LIST));
+    jTabs = JsonArrayInsert(jTabs,
+        NuiButton(JsonString("Zaproś do więzi"), WKR_BTN_TAB_INV));
+    json jTabRow = NuiRow(jTabs);
+
+    // ============================
+    // LIST VIEW
+    // ============================
+    // Header
+    json jLHdr = JsonArray();
+    jLHdr = JsonArrayInsert(jLHdr,
+        NuiLabel(JsonString("Partner"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)));
+    jLHdr = JsonArrayInsert(jLHdr,
+        NuiWidth(NuiLabel(JsonString("Rodzaj / Status"), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE)), 170.0));
+    json jListHdrRow = NuiRow(jLHdr);
+
+    // List rows template
+    json jColName = NuiListTemplateCell(
+        NuiLabel(NuiBind(WKR_BIND_ROW_NAME), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)),
+        0.0, TRUE);
+    json jColInfo = NuiListTemplateCell(
+        NuiButtonSelect(NuiBind(WKR_BIND_ROW_INFO), WKR_BTN_ROW, NuiBind(WKR_BIND_ROW_ENC)),
+        170.0, FALSE);
+    json jTemplate = JsonArray();
+    jTemplate = JsonArrayInsert(jTemplate, jColName);
+    jTemplate = JsonArrayInsert(jTemplate, jColInfo);
+
+    json jList = NuiList(jTemplate, NuiBind(WKR_BIND_ROW_COUNT), 28.0);
+    jList = NuiHeight(jList, 150.0);
+    jList = NuiScrollbars(jList, NUI_SCROLLBARS_Y);
+
+    // Detail panel
+    json jDtlCols = JsonArray();
+
+    json jDtlHdr = NuiForegroundColor(
+        NuiLabel(NuiBind(WKR_BIND_DTL_HDR), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)),
+        NuiColor(220, 160, 80));
+
+    json jRowPar = JsonArray();
+    jRowPar = JsonArrayInsert(jRowPar,
+        NuiWidth(NuiLabel(JsonString("Partner:"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)), 90.0));
+    jRowPar = JsonArrayInsert(jRowPar,
+        NuiLabel(NuiBind(WKR_BIND_DTL_PAR), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)));
+
+    json jRowTerms = JsonArray();
+    jRowTerms = JsonArrayInsert(jRowTerms,
+        NuiWidth(NuiLabel(JsonString("Warunki:"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)), 90.0));
+    jRowTerms = JsonArrayInsert(jRowTerms,
+        NuiLabel(NuiBind(WKR_BIND_DTL_TERMS), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)));
+
+    json jRowSt = JsonArray();
+    jRowSt = JsonArrayInsert(jRowSt,
+        NuiWidth(NuiLabel(JsonString("Status:"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)), 90.0));
+    json jStLbl = NuiForegroundColor(
+        NuiLabel(NuiBind(WKR_BIND_DTL_ST), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)),
+        NuiBind(WKR_BIND_DTL_ST_COL));
+    jRowSt = JsonArrayInsert(jRowSt, jStLbl);
+
+    json jRowExp = JsonArray();
+    jRowExp = JsonArrayInsert(jRowExp,
+        NuiWidth(NuiLabel(JsonString("Termin:"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)), 90.0));
+    jRowExp = JsonArrayInsert(jRowExp,
+        NuiLabel(NuiBind(WKR_BIND_DTL_EXP), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)));
+
+    json jDtlBtns = JsonArray();
+    jDtlBtns = JsonArrayInsert(jDtlBtns,
+        NuiEnabled(NuiButton(NuiBind(WKR_BIND_PAY_LBL), WKR_BTN_PAY), NuiBind(WKR_BIND_PAY_ENA)));
+    jDtlBtns = JsonArrayInsert(jDtlBtns,
+        NuiEnabled(NuiButton(JsonString("Rozwiąż"), WKR_BTN_DISSOLVE), NuiBind(WKR_BIND_DISS_ENA)));
+
+    jDtlCols = JsonArrayInsert(jDtlCols, NuiSpacer());
+    jDtlCols = JsonArrayInsert(jDtlCols, jDtlHdr);
+    jDtlCols = JsonArrayInsert(jDtlCols, NuiRow(jRowPar));
+    jDtlCols = JsonArrayInsert(jDtlCols, NuiRow(jRowTerms));
+    jDtlCols = JsonArrayInsert(jDtlCols, NuiRow(jRowSt));
+    jDtlCols = JsonArrayInsert(jDtlCols, NuiRow(jRowExp));
+    jDtlCols = JsonArrayInsert(jDtlCols, NuiRow(jDtlBtns));
+
+    json jDetailGroup = NuiGroup(NuiCol(jDtlCols), TRUE, NUI_SCROLLBARS_NONE);
+    jDetailGroup = NuiHeight(jDetailGroup, 185.0);
+    jDetailGroup = NuiVisible(jDetailGroup, NuiBind(WKR_BIND_DTL_VIS));
+
+    json jListCols = JsonArray();
+    jListCols = JsonArrayInsert(jListCols, jListHdrRow);
+    jListCols = JsonArrayInsert(jListCols, jList);
+    jListCols = JsonArrayInsert(jListCols, jDetailGroup);
+    json jListView = NuiVisible(NuiGroup(NuiCol(jListCols), FALSE, NUI_SCROLLBARS_NONE), NuiBind(WKR_BIND_VIS_LIST));
+
+    // ============================
+    // INVITE VIEW
+    // ============================
+    json jInvCols = JsonArray();
+
+    // Type selector
+    json jTypeHdr = NuiForegroundColor(
+        NuiLabel(JsonString("Rodzaj więzi:"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)),
+        NuiColor(200, 160, 100));
+    jInvCols = JsonArrayInsert(jInvCols, jTypeHdr);
+
+    json jTypeBtns = JsonArray();
+    jTypeBtns = JsonArrayInsert(jTypeBtns,
+        NuiButtonSelect(JsonString("Dług Krwi"), WKR_BTN_TYPE_DEBT, NuiBind(WKR_BIND_T1_SEL)));
+    jTypeBtns = JsonArrayInsert(jTypeBtns,
+        NuiButtonSelect(JsonString("Przysięga"), WKR_BTN_TYPE_OATH, NuiBind(WKR_BIND_T2_SEL)));
+    jTypeBtns = JsonArrayInsert(jTypeBtns,
+        NuiButtonSelect(JsonString("Straż Krwi"), WKR_BTN_TYPE_GUARD, NuiBind(WKR_BIND_T3_SEL)));
+    jInvCols = JsonArrayInsert(jInvCols, NuiRow(jTypeBtns));
+
+    json jTypeDesc = NuiHeight(NuiForegroundColor(
+        NuiLabel(NuiBind(WKR_BIND_TYPE_DESC), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_TOP)),
+        NuiColor(160, 160, 160)), 36.0);
+    jInvCols = JsonArrayInsert(jInvCols, jTypeDesc);
+
+    // Gold input (shown for DEBT only)
+    json jGoldRow = JsonArray();
+    jGoldRow = JsonArrayInsert(jGoldRow,
+        NuiWidth(NuiLabel(JsonString("Kwota (gp):"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)), 110.0));
+    jGoldRow = JsonArrayInsert(jGoldRow, NuiTextEdit(JsonString(""), WKR_BIND_GOLD_TXT, 8, FALSE));
+    json jGoldGroup = NuiVisible(NuiGroup(NuiRow(jGoldRow), FALSE, NUI_SCROLLBARS_NONE), NuiBind(WKR_BIND_SHOW_GOLD));
+    jInvCols = JsonArrayInsert(jInvCols, jGoldGroup);
+
+    // Role selector (shown for GUARD only)
+    json jRoleRow = JsonArray();
+    jRoleRow = JsonArrayInsert(jRoleRow,
+        NuiWidth(NuiLabel(JsonString("Twoja rola:"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)), 110.0));
+    jRoleRow = JsonArrayInsert(jRoleRow,
+        NuiButtonSelect(JsonString("Strażnik"), WKR_BTN_ROLE_GUARD, NuiBind(WKR_BIND_ROLE_G)));
+    jRoleRow = JsonArrayInsert(jRoleRow,
+        NuiButtonSelect(JsonString("Podopieczny"), WKR_BTN_ROLE_WARD, NuiBind(WKR_BIND_ROLE_W)));
+    json jRoleGroup = NuiVisible(NuiGroup(NuiRow(jRoleRow), FALSE, NUI_SCROLLBARS_NONE), NuiBind(WKR_BIND_SHOW_ROLE));
+    jInvCols = JsonArrayInsert(jInvCols, jRoleGroup);
+
+    // Partner row
+    json jPartRow = JsonArray();
+    jPartRow = JsonArrayInsert(jPartRow,
+        NuiWidth(NuiLabel(JsonString("Partner:"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)), 110.0));
+    jPartRow = JsonArrayInsert(jPartRow,
+        NuiLabel(NuiBind(WKR_BIND_PNAME), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)));
+    jPartRow = JsonArrayInsert(jPartRow,
+        NuiWidth(NuiButton(JsonString("Wskaż ↗"), WKR_BTN_PICK), 90.0));
+    jInvCols = JsonArrayInsert(jInvCols, NuiRow(jPartRow));
+
+    json jHpNote = NuiForegroundColor(
+        NuiLabel(JsonString("Zapieczętowanie kosztuje " + IntToString(WKR_SEAL_HP_COST) + " PŻ z obu stron."),
+            JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)),
+        NuiColor(200, 100, 100));
+    jInvCols = JsonArrayInsert(jInvCols, jHpNote);
+
+    jInvCols = JsonArrayInsert(jInvCols,
+        NuiEnabled(NuiButton(JsonString("⚔  Zapieczętuj więź  (−" + IntToString(WKR_SEAL_HP_COST) + " PŻ)"), WKR_BTN_SEAL),
+            NuiBind(WKR_BIND_SEAL_ENA)));
+
+    json jPendLbl = NuiForegroundColor(
+        NuiLabel(NuiBind(WKR_BIND_PEND_LBL), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)),
+        NuiColor(200, 180, 80));
+    jInvCols = JsonArrayInsert(jInvCols, jPendLbl);
+
+    jInvCols = JsonArrayInsert(jInvCols,
+        NuiEnabled(NuiButton(JsonString("✓  Przyjmij zaproszenie  (−" + IntToString(WKR_SEAL_HP_COST) + " PŻ)"), WKR_BTN_ACCEPT),
+            NuiBind(WKR_BIND_ACC_ENA)));
+
+    json jInvView = NuiVisible(NuiGroup(NuiCol(jInvCols), FALSE, NUI_SCROLLBARS_NONE), NuiBind(WKR_BIND_VIS_INV));
+
+    // ============================
+    // ROOT
+    // ============================
+    json jRoot = JsonArray();
+    jRoot = JsonArrayInsert(jRoot, jTabRow);
+    jRoot = JsonArrayInsert(jRoot, jListView);
+    jRoot = JsonArrayInsert(jRoot, jInvView);
+    jRoot = JsonArrayInsert(jRoot, NuiButton(JsonString("Zamknij"), WKR_BTN_CLOSE));
+
+    return NuiWindow(NuiCol(jRoot), JsonString("⚔  Więzy Krwi"),
+        NuiBind(WINDOW_GEOMETRY), JsonBool(FALSE), JsonBool(FALSE),
+        JsonBool(TRUE), JsonBool(FALSE), JsonBool(TRUE));
+}
+
+// ----------------------------------------------------------------
+// Feed helpers (called after open and after data changes)
+// ----------------------------------------------------------------
+
+void WkrFeedList(object oPC, int nToken)
+{
+    json jBonds = WkrGetBonds(GetObjectUUID(oPC));
+    SetLocalJson(oPC, WKR_LVAR_BONDS_JSON, jBonds);
+
+    int nCount = JsonGetLength(jBonds);
+    json jNames = JsonArray();
+    json jInfos = JsonArray();
+    json jEncs  = JsonArray();
+    int nSelId  = GetLocalInt(oPC, WKR_LVAR_SEL_ID);
+    int i;
+
+    for(i = 0; i < nCount; i++)
+    {
+        json jB     = JsonArrayGet(jBonds, i);
+        int nId     = JsonGetInt(JsonObjectGet(jB, "id"));
+        int nType   = JsonGetInt(JsonObjectGet(jB, "bond_type"));
+        int nSt     = JsonGetInt(JsonObjectGet(jB, "status"));
+        string sPar = WkrPartnerName(oPC, jB);
+
+        jNames = JsonArrayInsert(jNames, JsonString(sPar));
+        jInfos = JsonArrayInsert(jInfos,
+            JsonString(WkrTypeName(nType) + " — " + WkrStatusText(nSt)));
+        jEncs  = JsonArrayInsert(jEncs, JsonBool(nId == nSelId));
+    }
+
+    NuiSetBind(oPC, nToken, WKR_BIND_ROW_NAME,  jNames);
+    NuiSetBind(oPC, nToken, WKR_BIND_ROW_INFO,  jInfos);
+    NuiSetBind(oPC, nToken, WKR_BIND_ROW_ENC,   jEncs);
+    NuiSetBind(oPC, nToken, WKR_BIND_ROW_COUNT, JsonInt(nCount));
+}
+
+void WkrFeedDetail(object oPC, int nToken, int nId)
+{
+    if(nId <= 0)
+    {
+        NuiSetBind(oPC, nToken, WKR_BIND_DTL_VIS, JsonBool(FALSE));
+        return;
+    }
+    json jBond = WkrGetBond(nId);
+    if(JsonGetType(jBond) == JSON_TYPE_NULL)
+    {
+        NuiSetBind(oPC, nToken, WKR_BIND_DTL_VIS, JsonBool(FALSE));
+        return;
+    }
+
+    int nType   = JsonGetInt(JsonObjectGet(jBond, "bond_type"));
+    int nSt     = JsonGetInt(JsonObjectGet(jBond, "status"));
+    int nExp    = JsonGetInt(JsonObjectGet(jBond, "expires_at"));
+    string sPar = WkrPartnerName(oPC, jBond);
+
+    NuiSetBind(oPC, nToken, WKR_BIND_DTL_VIS,    JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, WKR_BIND_DTL_HDR,    JsonString(WkrTypeName(nType)));
+    NuiSetBind(oPC, nToken, WKR_BIND_DTL_PAR,    JsonString(sPar));
+    NuiSetBind(oPC, nToken, WKR_BIND_DTL_TERMS,  JsonString(WkrTermsSummary(oPC, jBond)));
+    NuiSetBind(oPC, nToken, WKR_BIND_DTL_ST,     JsonString(WkrStatusText(nSt)));
+    NuiSetBind(oPC, nToken, WKR_BIND_DTL_ST_COL, WkrStatusColor(nSt));
+    NuiSetBind(oPC, nToken, WKR_BIND_DTL_EXP,
+        JsonString(nExp > 0 ? WkrFormatTs(nExp) : "—"));
+
+    int bIsInit = WkrIsInit(oPC, jBond);
+    json jTerms = JsonParse(JsonGetString(JsonObjectGet(jBond, "terms_json")));
+    int nDebt   = JsonGetInt(JsonObjectGet(jTerms, "gold"));
+    int bDebtMine = nType == WKR_TYPE_DEBT && bIsInit;
+    int bCanPay   = bDebtMine && (nSt == WKR_STATUS_ACTIVE || nSt == WKR_STATUS_VIOLATED)
+                 && GetGold(oPC) >= nDebt && nDebt > 0;
+    NuiSetBind(oPC, nToken, WKR_BIND_PAY_ENA, JsonBool(bCanPay));
+    NuiSetBind(oPC, nToken, WKR_BIND_PAY_LBL,
+        JsonString("Spłać dług (" + IntToString(nDebt) + " gp)"));
+
+    int bCanDiss = nSt == WKR_STATUS_ACTIVE || nSt == WKR_STATUS_PENDING;
+    NuiSetBind(oPC, nToken, WKR_BIND_DISS_ENA, JsonBool(bCanDiss));
+}
+
+void WkrShowListView(object oPC, int nToken)
+{
+    NuiSetBind(oPC, nToken, WKR_BIND_VIS_LIST, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, WKR_BIND_VIS_INV,  JsonBool(FALSE));
+    SetLocalInt(oPC, WKR_LVAR_VIEW, 0);
+    WkrFeedList(oPC, nToken);
+    WkrFeedDetail(oPC, nToken, GetLocalInt(oPC, WKR_LVAR_SEL_ID));
+}
+
+void WkrShowInviteView(object oPC, int nToken)
+{
+    NuiSetBind(oPC, nToken, WKR_BIND_VIS_LIST, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, WKR_BIND_VIS_INV,  JsonBool(TRUE));
+    SetLocalInt(oPC, WKR_LVAR_VIEW, 1);
+
+    int nType = GetLocalInt(oPC, WKR_LVAR_INV_TYPE);
+    if(nType == 0) nType = WKR_TYPE_DEBT;
+
+    NuiSetBind(oPC, nToken, WKR_BIND_T1_SEL, JsonBool(nType == WKR_TYPE_DEBT));
+    NuiSetBind(oPC, nToken, WKR_BIND_T2_SEL, JsonBool(nType == WKR_TYPE_OATH));
+    NuiSetBind(oPC, nToken, WKR_BIND_T3_SEL, JsonBool(nType == WKR_TYPE_GUARD));
+    NuiSetBind(oPC, nToken, WKR_BIND_SHOW_GOLD, JsonBool(nType == WKR_TYPE_DEBT));
+    NuiSetBind(oPC, nToken, WKR_BIND_SHOW_ROLE, JsonBool(nType == WKR_TYPE_GUARD));
+
+    string sDesc;
+    switch(nType)
+    {
+        case WKR_TYPE_DEBT:
+            sDesc = "Pożyczka. Niespłacona do terminu klnie dłużnika utratą 4 PKC.";
+            break;
+        case WKR_TYPE_OATH:
+            sDesc = "Wzajemna przysięga. Bliskość +1 do obrony. Zdrada: −3 KON i MĄD.";
+            break;
+        case WKR_TYPE_GUARD:
+            sDesc = "Strażnik zyska +2 KP, podopieczny −3 obrażeń, gdy stoją obok siebie.";
+            break;
+    }
+    NuiSetBind(oPC, nToken, WKR_BIND_TYPE_DESC, JsonString(sDesc));
+
+    string sPName = GetLocalString(oPC, WKR_LVAR_P_NAME);
+    NuiSetBind(oPC, nToken, WKR_BIND_PNAME, JsonString(sPName == "" ? "(nie wybrano)" : sPName));
+
+    int bCanSeal = sPName != "" && GetLocalString(oPC, WKR_LVAR_P_UUID) != "";
+    NuiSetBind(oPC, nToken, WKR_BIND_SEAL_ENA, JsonBool(bCanSeal));
+
+    // Pending invite
+    int nPendId = GetLocalInt(oPC, WKR_LVAR_PEND_ID);
+    string sPendFrom = GetLocalString(oPC, WKR_LVAR_PEND_FROM);
+    NuiSetBind(oPC, nToken, WKR_BIND_PEND_LBL,
+        JsonString(nPendId > 0 ? "Zaproszenie od: " + sPendFrom : ""));
+    NuiSetBind(oPC, nToken, WKR_BIND_ACC_ENA, JsonBool(nPendId > 0));
+
+    int bIsGuard = GetLocalInt(oPC, WKR_LVAR_IS_GUARD) != 0;
+    NuiSetBind(oPC, nToken, WKR_BIND_ROLE_G, JsonBool(bIsGuard));
+    NuiSetBind(oPC, nToken, WKR_BIND_ROLE_W, JsonBool(!bIsGuard));
+}
+
+// ----------------------------------------------------------------
+// Window open / close
+// ----------------------------------------------------------------
+
+void WkrOpen(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, WKR_WINDOW);
+    if(nToken != 0)
+    {
+        WkrShowListView(oPC, nToken);
+        return;
+    }
+
+    nToken = NuiCreate(oPC, WkrBuildWindow(oPC), WKR_WINDOW);
+    if(nToken == 0) return;
+
+    NuiSetBind(oPC, nToken, WINDOW_GEOMETRY, NuiRect(60.0, 60.0, 470.0, 540.0));
+
+    WkrShowListView(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Actions
+// ----------------------------------------------------------------
+
+void WkrOnPlayerTarget(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, WKR_WINDOW);
+    if(nToken == 0) return;
+
+    object oTarget = GetTargetingModeSelectedObject();
+    if(!GetIsObjectValid(oTarget) || !GetIsPC(oTarget) || oTarget == oPC)
+    {
+        SendMessageToPC(oPC, "[Więzy Krwi] Musisz wskazać innego gracza.");
+        return;
+    }
+
+    string sUuid = GetObjectUUID(oTarget);
+    string sName = GetName(oTarget);
+    SetLocalString(oPC, WKR_LVAR_P_UUID, sUuid);
+    SetLocalString(oPC, WKR_LVAR_P_NAME, sName);
+
+    NuiSetBind(oPC, nToken, WKR_BIND_PNAME, JsonString(sName));
+    NuiSetBind(oPC, nToken, WKR_BIND_SEAL_ENA, JsonBool(TRUE));
+}
+
+void WkrHandleSeal(object oPC, int nToken)
+{
+    string sMyUuid  = GetObjectUUID(oPC);
+    string sMyName  = GetName(oPC);
+    string sPUuid   = GetLocalString(oPC, WKR_LVAR_P_UUID);
+    string sPName   = GetLocalString(oPC, WKR_LVAR_P_NAME);
+
+    if(sPUuid == "")
+    {
+        SendMessageToPC(oPC, "[Więzy Krwi] Brak wybranego partnera.");
+        return;
+    }
+
+    object oPartner = WkrFindPC(sPUuid);
+    if(!GetIsObjectValid(oPartner))
+    {
+        SendMessageToPC(oPC, "[Więzy Krwi] Partner nie jest teraz w grze.");
+        return;
+    }
+
+    if(WkrCountActive(sMyUuid) >= WKR_MAX_ACTIVE)
+    {
+        SendMessageToPC(oPC, "[Więzy Krwi] Masz już " + IntToString(WKR_MAX_ACTIVE) + " aktywnych więzi.");
+        return;
+    }
+
+    int nType = GetLocalInt(oPC, WKR_LVAR_INV_TYPE);
+    if(nType == 0) nType = WKR_TYPE_DEBT;
+
+    json jTerms  = JsonObject();
+    int nExpires = 0;
+
+    if(nType == WKR_TYPE_DEBT)
+    {
+        string sGold = JsonGetString(NuiGetBind(oPC, nToken, WKR_BIND_GOLD_TXT));
+        int nGold    = StringToInt(sGold);
+        if(nGold <= 0)
+        {
+            SendMessageToPC(oPC, "[Więzy Krwi] Podaj dodatnią kwotę długu.");
+            return;
+        }
+        jTerms   = JsonObjectSet(jTerms, "gold", JsonInt(nGold));
+        nExpires = WkrNow() + WKR_DEBT_HOURS * 3600;
+    }
+    else if(nType == WKR_TYPE_GUARD)
+    {
+        int bIsGuard = GetLocalInt(oPC, WKR_LVAR_IS_GUARD) != 0;
+        jTerms = JsonObjectSet(jTerms, "init_role", JsonString(bIsGuard ? "guard" : "ward"));
+    }
+
+    // HP cost
+    if(GetCurrentHitPoints(oPC) <= WKR_SEAL_HP_COST)
+    {
+        SendMessageToPC(oPC, "[Więzy Krwi] Za mało PŻ, by przyłożyć pieczęć.");
+        return;
+    }
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectDamage(WKR_SEAL_HP_COST, DAMAGE_TYPE_MAGICAL, DAMAGE_POWER_PLUS_ONE), oPC);
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectVisualEffect(VFX_IMP_MAGICAL_VISION), oPC);
+
+    int nId = WkrCreateBond(sMyUuid, sMyName, sPUuid, sPName, nType, JsonDump(jTerms), nExpires);
+    if(nId == 0)
+    {
+        SendMessageToPC(oPC, "[Więzy Krwi] Błąd tworzenia więzi.");
+        return;
+    }
+
+    SetLocalInt   (oPartner, WKR_LVAR_PEND_ID,   nId);
+    SetLocalString(oPartner, WKR_LVAR_PEND_FROM,  sMyName);
+
+    SendMessageToPC(oPartner,
+        "[Więzy Krwi] " + sMyName + " proponuje ci więź: " + WkrTypeName(nType) +
+        ". Otwórz okno Więzy Krwi → Zaproś, aby odpowiedzieć.");
+    FloatingTextStringOnCreature("Krew wycieka z dłoni — więź oczekuje na odwzajemnienie…", oPC, FALSE);
+
+    // Refresh partner's invite panel if open
+    int nPToken = NuiFindWindow(oPartner, WKR_WINDOW);
+    if(nPToken != 0 && GetLocalInt(oPartner, WKR_LVAR_VIEW) == 1)
+        WkrShowInviteView(oPartner, nPToken);
+
+    // Clear local state
+    DeleteLocalString(oPC, WKR_LVAR_P_UUID);
+    DeleteLocalString(oPC, WKR_LVAR_P_NAME);
+    SetLocalInt(oPC, WKR_LVAR_INV_TYPE, 0);
+    WkrShowListView(oPC, nToken);
+}
+
+void WkrHandleAccept(object oPC, int nToken)
+{
+    int nId = GetLocalInt(oPC, WKR_LVAR_PEND_ID);
+    if(nId <= 0)
+    {
+        SendMessageToPC(oPC, "[Więzy Krwi] Brak aktywnego zaproszenia.");
+        return;
+    }
+
+    if(GetCurrentHitPoints(oPC) <= WKR_SEAL_HP_COST)
+    {
+        SendMessageToPC(oPC, "[Więzy Krwi] Za mało PŻ, by przyłożyć pieczęć.");
+        return;
+    }
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectDamage(WKR_SEAL_HP_COST, DAMAGE_TYPE_MAGICAL, DAMAGE_POWER_PLUS_ONE), oPC);
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectVisualEffect(VFX_IMP_MAGICAL_VISION), oPC);
+
+    WkrActivateBond(nId);
+    DeleteLocalInt   (oPC, WKR_LVAR_PEND_ID);
+    DeleteLocalString(oPC, WKR_LVAR_PEND_FROM);
+
+    json jBond = WkrGetBond(nId);
+    string sInitUuid = JsonGetString(JsonObjectGet(jBond, "initiator_uuid"));
+    int nType        = JsonGetInt(JsonObjectGet(jBond, "bond_type"));
+
+    object oInit = WkrFindPC(sInitUuid);
+    if(GetIsObjectValid(oInit))
+    {
+        SendMessageToPC(oInit,
+            "[Więzy Krwi] " + GetName(oPC) + " przyłożył pieczęć — więź " + WkrTypeName(nType) + " jest aktywna.");
+        FloatingTextStringOnCreature("Pieczęć krwi pulsuje słabo — więź zawarta.", oInit, FALSE);
+        int nIToken = NuiFindWindow(oInit, WKR_WINDOW);
+        if(nIToken != 0)
+            WkrShowListView(oInit, nIToken);
+    }
+
+    FloatingTextStringOnCreature("Pieczęć krwi pulsuje słabo — więź zawarta.", oPC, FALSE);
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectVisualEffect(VFX_IMP_HOLY_AID), oPC);
+
+    WkrShowListView(oPC, nToken);
+}
+
+void WkrHandlePay(object oPC, int nToken)
+{
+    int nId = GetLocalInt(oPC, WKR_LVAR_SEL_ID);
+    if(nId <= 0) return;
+
+    json jBond = WkrGetBond(nId);
+    if(JsonGetType(jBond) == JSON_TYPE_NULL) return;
+
+    int nType = JsonGetInt(JsonObjectGet(jBond, "bond_type"));
+    if(nType != WKR_TYPE_DEBT || !WkrIsInit(oPC, jBond)) return;
+
+    json jTerms  = JsonParse(JsonGetString(JsonObjectGet(jBond, "terms_json")));
+    int nGold    = JsonGetInt(JsonObjectGet(jTerms, "gold"));
+    if(GetGold(oPC) < nGold)
+    {
+        SendMessageToPC(oPC, "[Więzy Krwi] Niewystarczająca ilość złota.");
+        return;
+    }
+
+    AssignCommand(oPC, TakeGoldFromCreature(nGold, oPC, TRUE));
+
+    string sCredUuid = JsonGetString(JsonObjectGet(jBond, "partner_uuid"));
+    object oCreditor = WkrFindPC(sCredUuid);
+    if(GetIsObjectValid(oCreditor))
+    {
+        GiveGoldToCreature(oCreditor, nGold);
+        SendMessageToPC(oCreditor,
+            "[Więzy Krwi] " + GetName(oPC) + " spłacił dług: " + IntToString(nGold) + " gp.");
+    }
+    else
+    {
+        // Creditor offline — mark gold as stored in terms for manual distribution
+        jTerms = JsonObjectSet(jTerms, "paid_offline", JsonInt(nGold));
+        WkrUpdateTerms(nId, JsonDump(jTerms));
+    }
+
+    int nSt = JsonGetInt(JsonObjectGet(jBond, "status"));
+    if(nSt == WKR_STATUS_VIOLATED) WkrRemoveCurse(oPC, nId);
+
+    WkrSetStatus(nId, WKR_STATUS_FULFILLED);
+    FloatingTextStringOnCreature("Dług spłacony — pieczęć krwi gaśnie.", oPC, FALSE);
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectVisualEffect(VFX_IMP_DISPEL), oPC);
+
+    SetLocalInt(oPC, WKR_LVAR_SEL_ID, 0);
+    WkrShowListView(oPC, nToken);
+}
+
+void WkrHandleDissolve(object oPC, int nToken)
+{
+    int nId = GetLocalInt(oPC, WKR_LVAR_SEL_ID);
+    if(nId <= 0) return;
+
+    json jBond = WkrGetBond(nId);
+    if(JsonGetType(jBond) == JSON_TYPE_NULL) return;
+
+    WkrSetStatus(nId, WKR_STATUS_DISSOLVED);
+    WkrRemoveProxFx(oPC, nId);
+
+    string sPartUuid = WkrPartnerUuid(oPC, jBond);
+    object oPartner  = WkrFindPC(sPartUuid);
+    if(GetIsObjectValid(oPartner))
+    {
+        WkrRemoveProxFx(oPartner, nId);
+        SendMessageToPC(oPartner,
+            "[Więzy Krwi] " + GetName(oPC) + " rozwiązał powiązanie jednostronnie.");
+        int nPToken = NuiFindWindow(oPartner, WKR_WINDOW);
+        if(nPToken != 0)
+            WkrShowListView(oPartner, nPToken);
+    }
+
+    FloatingTextStringOnCreature("Więź rozerwana — krwawa pieczęć zanika.", oPC, FALSE);
+    ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectVisualEffect(VFX_IMP_DISPEL), oPC);
+
+    SetLocalInt(oPC, WKR_LVAR_SEL_ID, 0);
+    WkrShowListView(oPC, nToken);
+}
+
+// Called from sys_on_pc_killed to detect oath betrayal.
+void WkrCheckBetrayal(object oKiller, object oVictim)
+{
+    if(!GetIsPC(oKiller) || !GetIsPC(oVictim)) return;
+
+    string sKillerUuid = GetObjectUUID(oKiller);
+    string sVictimUuid = GetObjectUUID(oVictim);
+
+    json jBonds = WkrGetBonds(sKillerUuid);
+    int nCount  = JsonGetLength(jBonds);
+    int i;
+
+    for(i = 0; i < nCount; i++)
+    {
+        json jBond = JsonArrayGet(jBonds, i);
+        if(JsonGetInt(JsonObjectGet(jBond, "bond_type")) != WKR_TYPE_OATH) continue;
+        if(JsonGetInt(JsonObjectGet(jBond, "status")) != WKR_STATUS_ACTIVE) continue;
+
+        string sPartner = WkrPartnerUuid(oKiller, jBond);
+        if(sPartner != sVictimUuid) continue;
+
+        int nId = JsonGetInt(JsonObjectGet(jBond, "id"));
+        WkrSetStatus(nId, WKR_STATUS_VIOLATED);
+        WkrApplyCurse(oKiller, WKR_TYPE_OATH, nId);
+        WkrRemoveProxFx(oKiller, nId);
+        SendMessageToPC(oKiller, "[Więzy Krwi] Złamałeś przysięgę krwi — klątwa spada.");
+    }
+}

--- a/Więzy Krwi/scripts/lib_wkr_def.nss
+++ b/Więzy Krwi/scripts/lib_wkr_def.nss
@@ -1,0 +1,107 @@
+#include "nw_inc_nui"
+
+// Replicate the subset of lib_nui constants we need so this module is
+// self-contained and does not depend on another module's lib_nui.nss.
+const string EVENT_TYPE_WATCH    = "watch";
+const string EVENT_TYPE_OPEN     = "open";
+const string EVENT_TYPE_CLOSE    = "close";
+const string EVENT_TYPE_CLICK    = "click";
+const string EVENT_TYPE_MOUSEUP  = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN= "mousedown";
+const string WINDOW_GEOMETRY     = "geometry";
+
+const string WKR_WINDOW         = "WKR_WINDOW";
+const string WKR_EV_SCRIPT      = "lib_wkr_ev";
+
+// Bond types
+const int WKR_TYPE_DEBT         = 1; // Dług Krwi — gold loan with deadline
+const int WKR_TYPE_OATH         = 2; // Przysięga Krwi — loyalty oath, proximity bonus
+const int WKR_TYPE_GUARD        = 3; // Straż Krwi — protector / ward roles
+
+// Bond status
+const int WKR_STATUS_PENDING    = 0;
+const int WKR_STATUS_ACTIVE     = 1;
+const int WKR_STATUS_VIOLATED   = 2;
+const int WKR_STATUS_FULFILLED  = 3;
+const int WKR_STATUS_DISSOLVED  = 4;
+
+// Costs and limits
+const int WKR_SEAL_HP_COST      = 5;
+const int WKR_MAX_ACTIVE        = 5;
+const float WKR_PROXIMITY_DIST  = 10.0; // meters for oath/guard bonuses
+
+// Default debt lifetime: 720 in-game hours (30 days at 24h/day)
+const int WKR_DEBT_HOURS        = 720;
+
+// Effect tag prefixes
+const string WKR_FX_PROX        = "WKR_PROX_";  // proximity bonus tag
+const string WKR_FX_CURSE       = "WKR_CURSE_"; // violation curse tag
+
+// List binds (arrays)
+const string WKR_BIND_ROW_NAME  = "wkr_row_name";
+const string WKR_BIND_ROW_INFO  = "wkr_row_info";
+const string WKR_BIND_ROW_ENC   = "wkr_row_enc";
+const string WKR_BIND_ROW_COUNT = "wkr_row_count";
+
+// Detail panel binds
+const string WKR_BIND_DTL_VIS   = "wkr_dtl_vis";
+const string WKR_BIND_DTL_HDR   = "wkr_dtl_hdr";
+const string WKR_BIND_DTL_PAR   = "wkr_dtl_par";
+const string WKR_BIND_DTL_TERMS = "wkr_dtl_terms";
+const string WKR_BIND_DTL_ST    = "wkr_dtl_st";
+const string WKR_BIND_DTL_ST_COL= "wkr_dtl_st_col";
+const string WKR_BIND_DTL_EXP   = "wkr_dtl_exp";
+const string WKR_BIND_PAY_ENA   = "wkr_pay_ena";
+const string WKR_BIND_PAY_LBL   = "wkr_pay_lbl";
+const string WKR_BIND_DISS_ENA  = "wkr_diss_ena";
+
+// Invite view binds
+const string WKR_BIND_PNAME     = "wkr_pname";
+const string WKR_BIND_GOLD_TXT  = "wkr_gold_txt";
+const string WKR_BIND_TYPE_DESC = "wkr_type_desc";
+const string WKR_BIND_SEAL_ENA  = "wkr_seal_ena";
+const string WKR_BIND_PEND_LBL  = "wkr_pend_lbl";
+const string WKR_BIND_ACC_ENA   = "wkr_acc_ena";
+
+// Visibility toggles
+const string WKR_BIND_VIS_LIST  = "wkr_vis_list";
+const string WKR_BIND_VIS_INV   = "wkr_vis_inv";
+const string WKR_BIND_SHOW_GOLD = "wkr_show_gold";
+const string WKR_BIND_SHOW_ROLE = "wkr_show_role";
+
+// Type selector toggles
+const string WKR_BIND_T1_SEL    = "wkr_t1_sel";
+const string WKR_BIND_T2_SEL    = "wkr_t2_sel";
+const string WKR_BIND_T3_SEL    = "wkr_t3_sel";
+
+// Guard role toggles
+const string WKR_BIND_ROLE_G    = "wkr_role_g";
+const string WKR_BIND_ROLE_W    = "wkr_role_w";
+
+// Buttons
+const string WKR_BTN_CLOSE      = "wkr_btn_close";
+const string WKR_BTN_TAB_LIST   = "wkr_btn_tab_list";
+const string WKR_BTN_TAB_INV    = "wkr_btn_tab_inv";
+const string WKR_BTN_ROW        = "wkr_btn_row";
+const string WKR_BTN_PAY        = "wkr_btn_pay";
+const string WKR_BTN_DISSOLVE   = "wkr_btn_dissolve";
+const string WKR_BTN_PICK       = "wkr_btn_pick";
+const string WKR_BTN_SEAL       = "wkr_btn_seal";
+const string WKR_BTN_ACCEPT     = "wkr_btn_accept";
+const string WKR_BTN_TYPE_DEBT  = "wkr_btn_t1";
+const string WKR_BTN_TYPE_OATH  = "wkr_btn_t2";
+const string WKR_BTN_TYPE_GUARD = "wkr_btn_t3";
+const string WKR_BTN_ROLE_GUARD = "wkr_btn_rg";
+const string WKR_BTN_ROLE_WARD  = "wkr_btn_rw";
+
+// Local variables on PC
+const string WKR_LVAR_SEL_ID    = "WKR_SEL_ID";
+const string WKR_LVAR_INV_TYPE  = "WKR_INV_TYPE";
+const string WKR_LVAR_P_UUID    = "WKR_P_UUID";
+const string WKR_LVAR_P_NAME    = "WKR_P_NAME";
+const string WKR_LVAR_IS_GUARD  = "WKR_IS_GUARD";
+const string WKR_LVAR_VIEW      = "WKR_VIEW"; // 0=list, 1=invite
+const string WKR_LVAR_PEND_ID   = "WKR_PEND_ID";
+const string WKR_LVAR_PEND_FROM = "WKR_PEND_FROM";
+const string WKR_LVAR_BONDS_JSON= "WKR_BONDS_JSON";
+const string WKR_LVAR_HB_TICK   = "WKR_HB_TICK";

--- a/Więzy Krwi/scripts/lib_wkr_ev.nss
+++ b/Więzy Krwi/scripts/lib_wkr_ev.nss
@@ -1,0 +1,135 @@
+#include "lib_wkr"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    if(nToken != NuiFindWindow(oPC, WKR_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        // No pending state to clean up except transient targeting vars.
+        return;
+    }
+
+    if(sEvent != EVENT_TYPE_CLICK && sEvent != EVENT_TYPE_MOUSEDOWN) return;
+
+    // ---- Tab navigation ----
+    if(sElem == WKR_BTN_TAB_LIST)
+    {
+        WkrShowListView(oPC, nToken);
+        return;
+    }
+    if(sElem == WKR_BTN_TAB_INV)
+    {
+        WkrShowInviteView(oPC, nToken);
+        return;
+    }
+
+    // ---- Close ----
+    if(sElem == WKR_BTN_CLOSE)
+    {
+        NuiDestroy(oPC, nToken);
+        return;
+    }
+
+    // ---- List row click ----
+    if(sElem == WKR_BTN_ROW)
+    {
+        json jBonds = GetLocalJson(oPC, WKR_LVAR_BONDS_JSON);
+        if(nIdx < 0 || nIdx >= JsonGetLength(jBonds)) return;
+
+        json jBond = JsonArrayGet(jBonds, nIdx);
+        int  nId   = JsonGetInt(JsonObjectGet(jBond, "id"));
+
+        int nPrev = GetLocalInt(oPC, WKR_LVAR_SEL_ID);
+        if(nPrev == nId)
+        {
+            // Toggle off
+            SetLocalInt(oPC, WKR_LVAR_SEL_ID, 0);
+            WkrFeedList(oPC, nToken);
+            WkrFeedDetail(oPC, nToken, 0);
+            return;
+        }
+
+        SetLocalInt(oPC, WKR_LVAR_SEL_ID, nId);
+        WkrFeedList(oPC, nToken);
+        WkrFeedDetail(oPC, nToken, nId);
+        return;
+    }
+
+    // ---- Detail actions ----
+    if(sElem == WKR_BTN_PAY)
+    {
+        WkrHandlePay(oPC, nToken);
+        return;
+    }
+    if(sElem == WKR_BTN_DISSOLVE)
+    {
+        WkrHandleDissolve(oPC, nToken);
+        return;
+    }
+
+    // ---- Invite form: type selectors ----
+    if(sElem == WKR_BTN_TYPE_DEBT)
+    {
+        SetLocalInt(oPC, WKR_LVAR_INV_TYPE, WKR_TYPE_DEBT);
+        WkrShowInviteView(oPC, nToken);
+        return;
+    }
+    if(sElem == WKR_BTN_TYPE_OATH)
+    {
+        SetLocalInt(oPC, WKR_LVAR_INV_TYPE, WKR_TYPE_OATH);
+        WkrShowInviteView(oPC, nToken);
+        return;
+    }
+    if(sElem == WKR_BTN_TYPE_GUARD)
+    {
+        SetLocalInt(oPC, WKR_LVAR_INV_TYPE, WKR_TYPE_GUARD);
+        WkrShowInviteView(oPC, nToken);
+        return;
+    }
+
+    // ---- Guard role selectors ----
+    if(sElem == WKR_BTN_ROLE_GUARD)
+    {
+        SetLocalInt(oPC, WKR_LVAR_IS_GUARD, 1);
+        NuiSetBind(oPC, nToken, WKR_BIND_ROLE_G, JsonBool(TRUE));
+        NuiSetBind(oPC, nToken, WKR_BIND_ROLE_W, JsonBool(FALSE));
+        return;
+    }
+    if(sElem == WKR_BTN_ROLE_WARD)
+    {
+        SetLocalInt(oPC, WKR_LVAR_IS_GUARD, 0);
+        NuiSetBind(oPC, nToken, WKR_BIND_ROLE_G, JsonBool(FALSE));
+        NuiSetBind(oPC, nToken, WKR_BIND_ROLE_W, JsonBool(TRUE));
+        return;
+    }
+
+    // ---- Partner picker ----
+    if(sElem == WKR_BTN_PICK)
+    {
+        NuiSetBind(oPC, nToken, WKR_BIND_SEAL_ENA, JsonBool(FALSE));
+        EnterTargetingMode(oPC, OBJECT_TYPE_CREATURE);
+        SendMessageToPC(oPC, "[Więzy Krwi] Kliknij na gracza, którego chcesz zaprosić do więzi.");
+        return;
+    }
+
+    // ---- Seal (create bond invite) ----
+    if(sElem == WKR_BTN_SEAL)
+    {
+        WkrHandleSeal(oPC, nToken);
+        return;
+    }
+
+    // ---- Accept pending invite ----
+    if(sElem == WKR_BTN_ACCEPT)
+    {
+        WkrHandleAccept(oPC, nToken);
+        return;
+    }
+}

--- a/Więzy Krwi/scripts/sql_wkr.nss
+++ b/Więzy Krwi/scripts/sql_wkr.nss
@@ -1,0 +1,177 @@
+#include "lib_wkr_def"
+
+void WkrCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("wkr",
+        "CREATE TABLE IF NOT EXISTS wkr_bonds ("
+        "id              INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "initiator_uuid  TEXT NOT NULL, "
+        "initiator_name  TEXT DEFAULT '', "
+        "partner_uuid    TEXT NOT NULL, "
+        "partner_name    TEXT DEFAULT '', "
+        "bond_type       INTEGER NOT NULL DEFAULT 1, "
+        "status          INTEGER NOT NULL DEFAULT 0, "
+        "terms_json      TEXT NOT NULL DEFAULT '{}', "
+        "sealed_at       INTEGER DEFAULT 0, "
+        "expires_at      INTEGER DEFAULT 0"
+        ")");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("wkr",
+        "CREATE INDEX IF NOT EXISTS idx_wkr_init ON wkr_bonds(initiator_uuid)");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("wkr",
+        "CREATE INDEX IF NOT EXISTS idx_wkr_part ON wkr_bonds(partner_uuid)");
+    SqlStep(q);
+}
+
+// Returns all non-terminal bonds involving this PC.
+json WkrGetBonds(string sUuid)
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("wkr",
+        "SELECT id, initiator_uuid, initiator_name, partner_uuid, partner_name, "
+        "bond_type, status, terms_json, sealed_at, expires_at "
+        "FROM wkr_bonds "
+        "WHERE (initiator_uuid = @uuid OR partner_uuid = @uuid) "
+        "  AND status NOT IN (3, 4) "
+        "ORDER BY id DESC");
+    SqlBindString(q, "@uuid", sUuid);
+    while(SqlStep(q))
+    {
+        json jR = JsonObject();
+        jR = JsonObjectSet(jR, "id",             JsonInt   (SqlGetInt   (q, 0)));
+        jR = JsonObjectSet(jR, "initiator_uuid", JsonString(SqlGetString(q, 1)));
+        jR = JsonObjectSet(jR, "initiator_name", JsonString(SqlGetString(q, 2)));
+        jR = JsonObjectSet(jR, "partner_uuid",   JsonString(SqlGetString(q, 3)));
+        jR = JsonObjectSet(jR, "partner_name",   JsonString(SqlGetString(q, 4)));
+        jR = JsonObjectSet(jR, "bond_type",      JsonInt   (SqlGetInt   (q, 5)));
+        jR = JsonObjectSet(jR, "status",         JsonInt   (SqlGetInt   (q, 6)));
+        jR = JsonObjectSet(jR, "terms_json",     JsonString(SqlGetString(q, 7)));
+        jR = JsonObjectSet(jR, "sealed_at",      JsonInt   (SqlGetInt   (q, 8)));
+        jR = JsonObjectSet(jR, "expires_at",     JsonInt   (SqlGetInt   (q, 9)));
+        jRows = JsonArrayInsert(jRows, jR);
+    }
+    return jRows;
+}
+
+json WkrGetBond(int nId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("wkr",
+        "SELECT id, initiator_uuid, initiator_name, partner_uuid, partner_name, "
+        "bond_type, status, terms_json, sealed_at, expires_at "
+        "FROM wkr_bonds WHERE id = @id");
+    SqlBindInt(q, "@id", nId);
+    if(!SqlStep(q)) return JsonNull();
+    json jR = JsonObject();
+    jR = JsonObjectSet(jR, "id",             JsonInt   (SqlGetInt   (q, 0)));
+    jR = JsonObjectSet(jR, "initiator_uuid", JsonString(SqlGetString(q, 1)));
+    jR = JsonObjectSet(jR, "initiator_name", JsonString(SqlGetString(q, 2)));
+    jR = JsonObjectSet(jR, "partner_uuid",   JsonString(SqlGetString(q, 3)));
+    jR = JsonObjectSet(jR, "partner_name",   JsonString(SqlGetString(q, 4)));
+    jR = JsonObjectSet(jR, "bond_type",      JsonInt   (SqlGetInt   (q, 5)));
+    jR = JsonObjectSet(jR, "status",         JsonInt   (SqlGetInt   (q, 6)));
+    jR = JsonObjectSet(jR, "terms_json",     JsonString(SqlGetString(q, 7)));
+    jR = JsonObjectSet(jR, "sealed_at",      JsonInt   (SqlGetInt   (q, 8)));
+    jR = JsonObjectSet(jR, "expires_at",     JsonInt   (SqlGetInt   (q, 9)));
+    return jR;
+}
+
+int WkrCreateBond(string sInitUuid, string sInitName,
+                  string sPartUuid, string sPartName,
+                  int nType, string sTerms, int nExpires)
+{
+    sqlquery q = SqlPrepareQueryCampaign("wkr",
+        "INSERT INTO wkr_bonds "
+        "(initiator_uuid, initiator_name, partner_uuid, partner_name, "
+        " bond_type, status, terms_json, sealed_at, expires_at) "
+        "VALUES (@iu, @in, @pu, @pn, @type, 0, @terms, 0, @exp)");
+    SqlBindString(q, "@iu",    sInitUuid);
+    SqlBindString(q, "@in",    sInitName);
+    SqlBindString(q, "@pu",    sPartUuid);
+    SqlBindString(q, "@pn",    sPartName);
+    SqlBindInt   (q, "@type",  nType);
+    SqlBindString(q, "@terms", sTerms);
+    SqlBindInt   (q, "@exp",   nExpires);
+    SqlStep(q);
+    sqlquery qId = SqlPrepareQueryCampaign("wkr", "SELECT last_insert_rowid()");
+    if(SqlStep(qId)) return SqlGetInt(qId, 0);
+    return 0;
+}
+
+void WkrActivateBond(int nId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("wkr",
+        "UPDATE wkr_bonds SET status = 1, sealed_at = strftime('%s','now') WHERE id = @id");
+    SqlBindInt(q, "@id", nId);
+    SqlStep(q);
+}
+
+void WkrSetStatus(int nId, int nStatus)
+{
+    sqlquery q = SqlPrepareQueryCampaign("wkr",
+        "UPDATE wkr_bonds SET status = @st WHERE id = @id");
+    SqlBindInt(q, "@st", nStatus);
+    SqlBindInt(q, "@id", nId);
+    SqlStep(q);
+}
+
+void WkrUpdateTerms(int nId, string sTerms)
+{
+    sqlquery q = SqlPrepareQueryCampaign("wkr",
+        "UPDATE wkr_bonds SET terms_json = @t WHERE id = @id");
+    SqlBindString(q, "@t",  sTerms);
+    SqlBindInt   (q, "@id", nId);
+    SqlStep(q);
+}
+
+int WkrCountActive(string sUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign("wkr",
+        "SELECT COUNT(*) FROM wkr_bonds "
+        "WHERE (initiator_uuid = @uuid OR partner_uuid = @uuid) AND status IN (0,1)");
+    SqlBindString(q, "@uuid", sUuid);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// Fetch debt bonds that have passed their deadline and are still active.
+json WkrGetOverdueDebts()
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("wkr",
+        "SELECT id, initiator_uuid, initiator_name, partner_uuid, partner_name "
+        "FROM wkr_bonds "
+        "WHERE bond_type = 1 AND status = 1 "
+        "  AND expires_at > 0 AND expires_at < strftime('%s','now')");
+    while(SqlStep(q))
+    {
+        json jR = JsonObject();
+        jR = JsonObjectSet(jR, "id",             JsonInt   (SqlGetInt   (q, 0)));
+        jR = JsonObjectSet(jR, "initiator_uuid", JsonString(SqlGetString(q, 1)));
+        jR = JsonObjectSet(jR, "initiator_name", JsonString(SqlGetString(q, 2)));
+        jR = JsonObjectSet(jR, "partner_uuid",   JsonString(SqlGetString(q, 3)));
+        jR = JsonObjectSet(jR, "partner_name",   JsonString(SqlGetString(q, 4)));
+        jRows = JsonArrayInsert(jRows, jR);
+    }
+    return jRows;
+}
+
+// Returns "DD.MM.YYYY HH:MM" from a unix timestamp via SQLite.
+string WkrFormatTs(int nTs)
+{
+    sqlquery q = SqlPrepareQueryCampaign("wkr",
+        "SELECT strftime('%d.%m.%Y %H:%M', @ts, 'unixepoch')");
+    SqlBindInt(q, "@ts", nTs);
+    if(SqlStep(q)) return SqlGetString(q, 0);
+    return "—";
+}
+
+// Returns current unix time from SQLite (avoids in-engine time drift).
+int WkrNow()
+{
+    sqlquery q = SqlPrepareQueryCampaign("wkr", "SELECT strftime('%s','now')");
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}

--- a/Więzy Krwi/scripts/sys_on_enter.nss
+++ b/Więzy Krwi/scripts/sys_on_enter.nss
@@ -1,0 +1,9 @@
+#include "lib_wkr"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC) || GetIsDMPossessed(oPC)) return;
+
+    WkrRestoreOnEnter(oPC);
+}

--- a/Więzy Krwi/scripts/sys_on_hb.nss
+++ b/Więzy Krwi/scripts/sys_on_hb.nss
@@ -1,0 +1,20 @@
+#include "lib_wkr"
+
+// Runs on OnModuleHeartbeat. HB fires every 6 seconds in NWN.
+// Proximity updates run every tick; debt violation check runs every
+// WKR_HB_INTERVAL ticks (~1 minute) to avoid excessive SQL queries.
+void main()
+{
+    int nTick = GetLocalInt(GetModule(), WKR_LVAR_HB_TICK) + 1;
+    SetLocalInt(GetModule(), WKR_LVAR_HB_TICK, nTick);
+
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        WkrUpdateProximityForPC(oPC);
+        oPC = GetNextPC();
+    }
+
+    if(nTick % WKR_HB_INTERVAL == 0)
+        WkrCheckOverdueDebts();
+}

--- a/Więzy Krwi/scripts/sys_on_load.nss
+++ b/Więzy Krwi/scripts/sys_on_load.nss
@@ -1,0 +1,6 @@
+#include "sql_wkr"
+
+void main()
+{
+    WkrCreateTables();
+}

--- a/Więzy Krwi/scripts/sys_on_pc_killed.nss
+++ b/Więzy Krwi/scripts/sys_on_pc_killed.nss
@@ -1,0 +1,12 @@
+#include "lib_wkr"
+
+// OnPlayerDeath (or OnCreatureDeath if a PC dies):
+// Hook into OnPlayerDeath in the module. The killer is GetLastKiller().
+void main()
+{
+    object oVictim = GetLastPlayerDied();
+    if(!GetIsObjectValid(oVictim)) return;
+
+    object oKiller = GetLastKiller();
+    WkrCheckBetrayal(oKiller, oVictim);
+}

--- a/Więzy Krwi/scripts/test_wkr.nss
+++ b/Więzy Krwi/scripts/test_wkr.nss
@@ -1,0 +1,11 @@
+#include "lib_wkr"
+
+// OnUsed script for the demo placeable (e.g. a blood-stained stone altar).
+// Place an object with this script as its OnUsed event to test the module.
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    WkrOpen(oPC);
+}


### PR DESCRIPTION
## Co to robi

System umożliwia graczom zawieranie magicznych kontraktów krwi z innymi graczami. Kontrakt jest pieczętowany HP obu stron (koszt 5 PŻ każdej), przechowywany trwale w SQLite i monitorowany przez heartbeat modułu. Naruszenie umowy aplikuje permanentny efekt klątwowy dopóki nie zostanie ręcznie zdjęty (spłata długu) lub przez DM-a.

## Mechanika

**Trzy typy więzi:**

| Typ | Efekt bliskości (≤10m, ten sam obszar) | Klątwa za naruszenie |
|---|---|---|
| **Dług Krwi** | — | Dłużnik: −4 PKC (Charyzma) po upływie terminu (domyślnie 720h in-game) |
| **Przysięga Krwi** | Oboje: +1 do wszystkich rzutów obronnych (SupernaturalEffect) | Zdrajca (zabił partnera): −3 KON i −3 MĄD |
| **Straż Krwi** | Strażnik: +2 KP (dodge), Podopieczny: redukcja obrażeń 3/+1 | Zbiegły strażnik: −2 ZRE i −2 SIŁ |

**Przepływ:**
1. Gracz A otwiera okno (NUI), zakładka „Zaproś" — wybiera typ, ewentualnie kwotę / rolę, wskazuje PC B (tryb celowania).
2. Gracz A klika „Zapieczętuj" — traci 5 PŻ, rekord trafia do DB ze statusem PENDING, partner dostaje powiadomienie.
3. Gracz B otwiera zakładkę „Zaproś" — widzi zaproszenie z informacją od kogo, klika „Przyjmij" — traci 5 PŻ, bond przechodzi do ACTIVE.
4. Heartbeat co ~6s aktualizuje efekty bliskości; co ~1 min sprawdza przeterminowane długi.
5. Gracz A (dłużnik) może otworzyć szczegóły i kliknąć „Spłać dług" — złoto trafia do wierzyciela (jeśli online) lub jest odnotowane w terms_json.
6. Każda strona może jednostronnie Rozwiązać aktywną więź; klątwa nie jest aplikowana, efekty bliskości znikają.

## Pliki

```
Więzy Krwi/
├── scripts/
│   ├── lib_wkr_def.nss    — stałe typów, statusów, bind-ów NUI, przycisków, tagów efektów
│   ├── sql_wkr.nss        — schemat wkr_bonds + CRUD (SqlPrepareQueryCampaign)
│   ├── lib_wkr.nss        — rdzeń: efekty, heartbeat, NUI builder, akcje (≈890 LOC)
│   ├── lib_wkr_ev.nss     — handler NUI eventów (switch po NuiGetEventType)
│   ├── sys_on_load.nss    — OnModuleLoad: CREATE TABLE IF NOT EXISTS
│   ├── sys_on_enter.nss   — OnClientEnter: przywraca klątwy, informuje o pending invite
│   ├── sys_on_hb.nss      — OnModuleHeartbeat: prox-efekty + sprawdzanie długów
│   ├── sys_on_pc_killed.nss — OnPlayerDeath: detekcja zdrady OATH
│   └── test_wkr.nss       — OnUsed na placeable testowym
└── INTEGRATION.md         — instrukcja integracji, tabela hooków, ograniczenia
```

**Łącznie:** 1378 LOC NWScript.

## Zależności (NWNX? SQL?)

- **NWNX:** brak — wyłącznie NWScript + natywne NUI + `SqlPrepareQueryCampaign`.
- **SQL:** kampania `wkr` (plik `wkr.sqlite`), tabela `wkr_bonds`, dwa indeksy.

## Jak włączyć w istniejącym module

| Hook NWN | Skrypt |
|---|---|
| OnModuleLoad | `sys_on_load` (lub wywołaj `WkrCreateTables()`) |
| OnClientEnter | `sys_on_enter` (lub wywołaj `WkrRestoreOnEnter(oPC)`) |
| OnModuleHeartbeat | `sys_on_hb` |
| OnPlayerDeath | `sys_on_pc_killed` (lub wywołaj `WkrCheckBetrayal(GetLastKiller(), GetLastPlayerDied())`) |
| OnNuiEvent | `lib_wkr_ev` |
| OnPlayerTarget | wywołaj `WkrOnPlayerTarget(GetLastPlayerToSelectTarget())` gdy `NuiFindWindow(oPC, WKR_WINDOW) != 0` |

Placeable testowy: ustaw OnUsed = `test_wkr`.

## Co celowo pominięto

- **Offline payment delivery:** gdy wierzyciel jest offline w momencie spłaty, złoto znika z inwentarza dłużnika i jest odnotowane w `terms_json.paid_offline` — wymaga ręcznego działania DM lub rozszerzenia o integrację z Mailbox.
- **Konsensualne rozwiązanie:** rozwiązanie jest jednostronne; by wymagać zgody obu stron należy dodać pole `dissolve_request_uuid` do tabeli i drugi krok potwierdzenia.
- **Klątwa za Straż Krwi przy śmierci podopiecznego bez strażnika:** wymagałoby dodatkowego hooka `OnPlayerDeath` z logiką porównania lokalizacji obu graczy — celowo uproszczone.
- **Licznik więzi po stronie partnera:** `WkrCountActive` sprawdza inicjatora, ale nie blokuje partnera przed przyjęciem jeśli sam ma już MAX_ACTIVE — pomijalne przy domyślnym limicie 5.

---
_Generated by [Claude Code](https://claude.ai/code/session_0145Cqjk2vwVeC3SStstK5tu)_