### PR TITLE
feat: Seasons — Koło Pór Roku

### DIFF
--- a/Seasons/INTEGRATION.md
+++ b/Seasons/INTEGRATION.md
@@ -1,0 +1,59 @@
+# Seasons — Koło Pór Roku
+
+Integracja modułu w istniejącym projekcie NWN:EE.
+
+## Hooki modułowe
+
+| Zdarzenie modułu | Skrypt               | Uwagi                                      |
+|------------------|----------------------|--------------------------------------------|
+| OnModuleLoad     | `sys_on_load.nss`    | Tworzy tabele SQLite, startuje pętlę ticku |
+| OnClientEnter    | `sys_on_enter.nss`   | Nakłada efekty pogody na wchodzącego PC    |
+| OnNuiEvent       | `lib_sea_ev.nss`     | Obsługuje kliknięcia w oknach NUI          |
+
+Jeśli moduł ma już skrypty hookujące, dodaj wywołania np.:
+```
+// W OnModuleLoad:
+ExecuteScript("sys_on_load", GetModule());
+
+// W OnClientEnter (na końcu istniejącego skryptu):
+ExecuteScript("sys_on_enter", GetEnteringObject());
+
+// W OnNuiEvent (dodaj do switcha lub na początku):
+ExecuteScript("lib_sea_ev", OBJECT_SELF);
+```
+
+## Placeable testowy
+
+1. Stwórz dowolny placeable (np. słup, wiatrowskaz).
+2. Ustaw jego skrypt `OnUsed` na `test_sea`.
+3. Gracze i DM mogą go kliknąć, by otworzyć okno informacyjne lub panel sterowania.
+
+## SQLite / Baza danych
+
+Moduł korzysta z `SqlPrepareQueryCampaign("seasons", ...)`.
+Dane zapisywane są w kampanii o nazwie **seasons** — plik `seasons.sqlite3`
+ląduje w katalogu danych użytkownika NWN (obok `nwnplayer.ini`).
+
+Tabele:
+- `sea_state(id, season, weather, season_changed, weather_changed)` — jedna wiersz, globalny stan serwera
+- `sea_areas(area_tag, climate)` — strefy klimatyczne per obszar (tag obszaru)
+
+## Zależności
+
+- **NWN:EE ≥ 8193.15** — wymagane `TagEffect` / `GetEffectTag` oraz pełne API NUI.
+- Brak NWNX. Brak zewnętrznych bibliotek.
+
+## Jak przetestować
+
+1. W toolsecie lub skryptem DM ustaw skrypt `OnModuleLoad = sys_on_load`.
+2. Zaloguj się jako gracz → sprawdź wiadomość `[Klimat]` w konsoli.
+3. Zaloguj się jako DM i kliknij placeable → pojawi się panel kontrolny.
+4. Naciśnij `>` obok "Pogoda" i zmień na "Zamieć" → gracze na zewnątrz otrzymają kary i obrażenia zimnem co minutę.
+5. Kliknij klimat "Arktyczny" dla bieżącego obszaru → kolejna automatyczna zmiana pogody preferuje Zamieć/Śnieg.
+
+## Co celowo pominięto
+
+- Brak własnych modeli/ikon pogodowych w hak — można dodać `sea_icon_*.tga` i odwoływać się przez stałą w `lib_sea_def`.
+- Brak per-PC ubrania/ekwipunku redukującego kary pogodowe (ciepłe ubrania) — warstwa rozszerzenia.
+- Brak efektów wizualnych obszarowych (deszcz, śnieg) — wymagałoby NWNX lub dedykowanych area-VFX.
+- Brak komendy `/pogoda` — można dodać przez hook `OnPlayerChat`.

--- a/Seasons/scripts/lib_nui.nss
+++ b/Seasons/scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Seasons/scripts/lib_nui_utility.nss
+++ b/Seasons/scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Seasons/scripts/lib_sea.nss
+++ b/Seasons/scripts/lib_sea.nss
@@ -1,0 +1,667 @@
+#include "lib_sea_def"
+
+// ----------------------------------------------------------------
+// Name helpers
+// ----------------------------------------------------------------
+
+string SeaGetSeasonName(int nSeason)
+{
+    switch (nSeason)
+    {
+        case SEA_SEASON_SPRING: return "Wiosna Odrodzenia";
+        case SEA_SEASON_SUMMER: return "Lato Skwaru";
+        case SEA_SEASON_AUTUMN: return "Jesień Żniw Krwi";
+        case SEA_SEASON_WINTER: return "Zima Śmierci";
+        case SEA_SEASON_DYING:  return "Tydzień Umierającego Boga";
+    }
+    return "Nieznana Pora";
+}
+
+string SeaGetWeatherName(int nWeather)
+{
+    switch (nWeather)
+    {
+        case SEA_WEATHER_CLEAR:    return "Pogodnie";
+        case SEA_WEATHER_OVERCAST: return "Zachmurzenie";
+        case SEA_WEATHER_RAIN:     return "Deszcz";
+        case SEA_WEATHER_STORM:    return "Burza";
+        case SEA_WEATHER_SNOW:     return "Śnieg";
+        case SEA_WEATHER_BLIZZARD: return "Zamieć";
+        case SEA_WEATHER_DROUGHT:  return "Susza";
+    }
+    return "Nieznana Pogoda";
+}
+
+string SeaGetClimateName(int nClimate)
+{
+    switch (nClimate)
+    {
+        case SEA_CLIMATE_TEMPERATE: return "Umiarkowany";
+        case SEA_CLIMATE_ARCTIC:    return "Arktyczny";
+        case SEA_CLIMATE_DESERT:    return "Pustynny";
+        case SEA_CLIMATE_COASTAL:   return "Nadmorski";
+        case SEA_CLIMATE_CURSED:    return "Przeklęty";
+    }
+    return "Nieznany";
+}
+
+string SeaGetWeatherEffectDesc(int nWeather)
+{
+    switch (nWeather)
+    {
+        case SEA_WEATHER_CLEAR:
+            return "Cisza. Powietrze jest chłodne i czyste.";
+        case SEA_WEATHER_OVERCAST:
+            return "Szare niebo ciąży nad ziemią. -1 Nasłuchiwanie.";
+        case SEA_WEATHER_RAIN:
+            return "Deszcz utrudnia ruch. -20% prędkość, -1 Reflex.";
+        case SEA_WEATHER_STORM:
+            return "Burza grzmi. -40% prędkość, -2 Reflex, -2 Nasłuchiwanie. Ryzyko pioruna.";
+        case SEA_WEATHER_SNOW:
+            return "Śnieg prószy cicho. -20% prędkość, -2 Zwinność.";
+        case SEA_WEATHER_BLIZZARD:
+            return "Zamieć pożera ciepło. -40% prędkość, -4 Siła i Zwinność. Odmrożenia co minutę.";
+        case SEA_WEATHER_DROUGHT:
+            return "Żar pali skórę. -2 Kondycja, +25% podatność na ogień.";
+    }
+    return "";
+}
+
+// ----------------------------------------------------------------
+// Season / weather cycling
+// ----------------------------------------------------------------
+
+int SeaNextSeason(int nSeason)
+{
+    // SPRING -> SUMMER -> AUTUMN -> WINTER -> DYING -> SPRING
+    nSeason++;
+    if (nSeason >= SEA_SEASON_COUNT) nSeason = 0;
+    return nSeason;
+}
+
+int SeaPrevSeason(int nSeason)
+{
+    nSeason--;
+    if (nSeason < 0) nSeason = SEA_SEASON_COUNT - 1;
+    return nSeason;
+}
+
+int SeaNextWeather(int nWeather)
+{
+    nWeather++;
+    if (nWeather >= SEA_WEATHER_COUNT) nWeather = 0;
+    return nWeather;
+}
+
+int SeaPrevWeather(int nWeather)
+{
+    nWeather--;
+    if (nWeather < 0) nWeather = SEA_WEATHER_COUNT - 1;
+    return nWeather;
+}
+
+// Weighted random weather selection based on season + climate
+int SeaPickWeather(int nSeason, int nClimate)
+{
+    int r = Random(100);
+
+    if (nClimate == SEA_CLIMATE_CURSED)
+        return (r < 50) ? SEA_WEATHER_STORM : SEA_WEATHER_BLIZZARD;
+
+    if (nClimate == SEA_CLIMATE_DESERT)
+    {
+        if (nSeason == SEA_SEASON_SUMMER) return (r < 60) ? SEA_WEATHER_DROUGHT : SEA_WEATHER_CLEAR;
+        return (r < 50) ? SEA_WEATHER_CLEAR : SEA_WEATHER_OVERCAST;
+    }
+
+    if (nClimate == SEA_CLIMATE_ARCTIC)
+    {
+        if (nSeason == SEA_SEASON_WINTER || nSeason == SEA_SEASON_DYING)
+            return (r < 55) ? SEA_WEATHER_BLIZZARD : SEA_WEATHER_SNOW;
+        if (nSeason == SEA_SEASON_AUTUMN)
+            return (r < 40) ? SEA_WEATHER_SNOW : (r < 70 ? SEA_WEATHER_OVERCAST : SEA_WEATHER_CLEAR);
+        return (r < 25) ? SEA_WEATHER_SNOW : (r < 55 ? SEA_WEATHER_OVERCAST : SEA_WEATHER_CLEAR);
+    }
+
+    if (nClimate == SEA_CLIMATE_COASTAL)
+    {
+        if (nSeason == SEA_SEASON_AUTUMN)
+            return (r < 40) ? SEA_WEATHER_STORM : (r < 70 ? SEA_WEATHER_RAIN : SEA_WEATHER_OVERCAST);
+        if (nSeason == SEA_SEASON_WINTER)
+            return (r < 30) ? SEA_WEATHER_STORM : (r < 60 ? SEA_WEATHER_RAIN : SEA_WEATHER_SNOW);
+    }
+
+    // Temperate (and coastal fallthrough)
+    switch (nSeason)
+    {
+        case SEA_SEASON_SPRING:
+            if (r < 30) return SEA_WEATHER_CLEAR;
+            if (r < 60) return SEA_WEATHER_RAIN;
+            if (r < 80) return SEA_WEATHER_OVERCAST;
+            return SEA_WEATHER_STORM;
+
+        case SEA_SEASON_SUMMER:
+            if (r < 50) return SEA_WEATHER_CLEAR;
+            if (r < 70) return SEA_WEATHER_OVERCAST;
+            if (r < 85) return SEA_WEATHER_DROUGHT;
+            return SEA_WEATHER_STORM;
+
+        case SEA_SEASON_AUTUMN:
+            if (r < 25) return SEA_WEATHER_CLEAR;
+            if (r < 55) return SEA_WEATHER_OVERCAST;
+            if (r < 75) return SEA_WEATHER_RAIN;
+            return SEA_WEATHER_STORM;
+
+        case SEA_SEASON_WINTER:
+            if (r < 20) return SEA_WEATHER_CLEAR;
+            if (r < 45) return SEA_WEATHER_SNOW;
+            if (r < 70) return SEA_WEATHER_OVERCAST;
+            return SEA_WEATHER_BLIZZARD;
+
+        case SEA_SEASON_DYING:
+            if (r < 40) return SEA_WEATHER_BLIZZARD;
+            if (r < 70) return SEA_WEATHER_STORM;
+            return SEA_WEATHER_OVERCAST;
+    }
+    return SEA_WEATHER_CLEAR;
+}
+
+// ----------------------------------------------------------------
+// Area check
+// ----------------------------------------------------------------
+
+// Returns TRUE if the PC is in a natural (sky-exposed) area
+int SeaIsOutdoor(object oPC)
+{
+    object oArea = GetArea(oPC);
+    if (!GetIsObjectValid(oArea)) return FALSE;
+    return GetIsAreaNatural(oArea);
+}
+
+// ----------------------------------------------------------------
+// Effect management
+// ----------------------------------------------------------------
+
+void SeaRemoveWeatherEffects(object oPC)
+{
+    effect e = GetFirstEffect(oPC);
+    while (GetIsEffectValid(e))
+    {
+        effect eNext = GetNextEffect(oPC);
+        if (GetEffectTag(e) == SEA_EFFECT_TAG)
+            RemoveEffect(oPC, e);
+        e = eNext;
+    }
+}
+
+void SeaApplyWeatherEffects(object oPC)
+{
+    if (!GetIsPC(oPC)) return;
+
+    SeaRemoveWeatherEffects(oPC);
+
+    json jState = SeaGetStateRow();
+    if (JsonGetType(jState) == JSON_TYPE_NULL) return;
+
+    int nWeather = JsonGetInt(JsonObjectGet(jState, "weather"));
+    int nSeason  = JsonGetInt(JsonObjectGet(jState, "season"));
+
+    // Dying Season: save penalty applies even indoors
+    if (nSeason == SEA_SEASON_DYING)
+    {
+        effect eDying = TagEffect(
+            EffectSavingThrowDecrease(SAVING_THROW_ALL, 2, SAVING_THROW_TYPE_ALL),
+            SEA_EFFECT_TAG);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eDying, oPC);
+    }
+
+    if (!SeaIsOutdoor(oPC)) return;
+
+    switch (nWeather)
+    {
+        case SEA_WEATHER_CLEAR:
+            break;
+
+        case SEA_WEATHER_OVERCAST:
+        {
+            effect e = TagEffect(EffectSkillDecrease(SKILL_LISTEN, 1), SEA_EFFECT_TAG);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, e, oPC);
+            break;
+        }
+
+        case SEA_WEATHER_RAIN:
+        {
+            effect eSpd = TagEffect(EffectMovementSpeedDecrease(20), SEA_EFFECT_TAG);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, eSpd, oPC);
+            effect eRef = TagEffect(
+                EffectSavingThrowDecrease(SAVING_THROW_REFLEX, 1, SAVING_THROW_TYPE_ALL),
+                SEA_EFFECT_TAG);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, eRef, oPC);
+            break;
+        }
+
+        case SEA_WEATHER_STORM:
+        {
+            effect eSpd = TagEffect(EffectMovementSpeedDecrease(40), SEA_EFFECT_TAG);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, eSpd, oPC);
+            effect eRef = TagEffect(
+                EffectSavingThrowDecrease(SAVING_THROW_REFLEX, 2, SAVING_THROW_TYPE_ALL),
+                SEA_EFFECT_TAG);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, eRef, oPC);
+            effect eLis = TagEffect(EffectSkillDecrease(SKILL_LISTEN, 2), SEA_EFFECT_TAG);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, eLis, oPC);
+            break;
+        }
+
+        case SEA_WEATHER_SNOW:
+        {
+            effect eSpd = TagEffect(EffectMovementSpeedDecrease(20), SEA_EFFECT_TAG);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, eSpd, oPC);
+            effect eDex = TagEffect(EffectAbilityDecrease(ABILITY_DEXTERITY, 2), SEA_EFFECT_TAG);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, eDex, oPC);
+            break;
+        }
+
+        case SEA_WEATHER_BLIZZARD:
+        {
+            effect eSpd = TagEffect(EffectMovementSpeedDecrease(40), SEA_EFFECT_TAG);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, eSpd, oPC);
+            effect eStr = TagEffect(EffectAbilityDecrease(ABILITY_STRENGTH, 4), SEA_EFFECT_TAG);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, eStr, oPC);
+            effect eDex = TagEffect(EffectAbilityDecrease(ABILITY_DEXTERITY, 4), SEA_EFFECT_TAG);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, eDex, oPC);
+            break;
+        }
+
+        case SEA_WEATHER_DROUGHT:
+        {
+            effect eCon = TagEffect(EffectAbilityDecrease(ABILITY_CONSTITUTION, 2), SEA_EFFECT_TAG);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, eCon, oPC);
+            effect eFire = TagEffect(EffectDamageImmunityDecrease(DAMAGE_TYPE_FIRE, 25), SEA_EFFECT_TAG);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, eFire, oPC);
+            break;
+        }
+    }
+}
+
+void SeaUpdateAllPCs()
+{
+    object oPC = GetFirstPC();
+    while (GetIsObjectValid(oPC))
+    {
+        SeaApplyWeatherEffects(oPC);
+        oPC = GetNextPC();
+    }
+}
+
+void SeaNotifyAll(string sMsg)
+{
+    object oPC = GetFirstPC();
+    while (GetIsObjectValid(oPC))
+    {
+        FloatingTextStringOnCreature(sMsg, oPC, FALSE);
+        SendMessageToPC(oPC, "[Klimat] " + sMsg);
+        oPC = GetNextPC();
+    }
+}
+
+// ----------------------------------------------------------------
+// NUI helpers
+// ----------------------------------------------------------------
+
+string SeaNextChangeStr(int nWeatherChanged)
+{
+    int nNow  = SeaGetNow();
+    int nLeft = SEA_WEATHER_INTERVAL - (nNow - nWeatherChanged);
+    if (nLeft <= 0) return "wkrótce";
+    int nH = nLeft / 3600;
+    int nM = (nLeft % 3600) / 60;
+    if (nH > 0) return IntToString(nH) + "g " + IntToString(nM) + "m";
+    return IntToString(nM) + " min";
+}
+
+// ----------------------------------------------------------------
+// Player window
+// ----------------------------------------------------------------
+
+json BuildSeaPlayerLayout(object oPC)
+{
+    float fLbl  = GetNuiScaleDimension(oPC, 22.0);
+    float fDesc = GetNuiScaleDimension(oPC, 60.0);
+    float fBtn  = GetNuiScaleDimension(oPC, 28.0);
+
+    json jSeaLbl = NuiHeight(
+        NuiLabel(NuiBind(SEA_BIND_SEASON_LBL), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)),
+        fLbl);
+    json jWeaLbl = NuiHeight(
+        NuiLabel(NuiBind(SEA_BIND_WEATHER_LBL), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)),
+        fLbl);
+    json jEffLbl = NuiHeight(
+        NuiLabel(NuiBind(SEA_BIND_EFFECT_LBL), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_TOP)),
+        fDesc);
+    json jNxtLbl = NuiHeight(
+        NuiLabel(NuiBind(SEA_BIND_NEXTCH_LBL), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)),
+        fLbl);
+
+    json jClose = NuiHeight(NuiId(NuiButton(JsonString("Zamknij")), SEA_BTN_CLOSE), fBtn);
+
+    json jCols = JsonArray();
+    jCols = JsonArrayInsert(jCols, NuiRow(JsonArrayInsert(JsonArray(), jSeaLbl)));
+    jCols = JsonArrayInsert(jCols, NuiRow(JsonArrayInsert(JsonArray(), jWeaLbl)));
+    jCols = JsonArrayInsert(jCols, NuiRow(JsonArrayInsert(JsonArray(), jEffLbl)));
+    jCols = JsonArrayInsert(jCols, NuiRow(JsonArrayInsert(JsonArray(), jNxtLbl)));
+    jCols = JsonArrayInsert(jCols, CreateEmptyRow(oPC, 6.0));
+    jCols = JsonArrayInsert(jCols, NuiRow(JsonArrayInsert(JsonArray(), jClose)));
+
+    return NuiCol(jCols);
+}
+
+void SeaFeedPlayerWindow(object oPC, int nToken)
+{
+    json jState = SeaGetStateRow();
+    if (JsonGetType(jState) == JSON_TYPE_NULL) return;
+
+    int nSeason  = JsonGetInt(JsonObjectGet(jState, "season"));
+    int nWeather = JsonGetInt(JsonObjectGet(jState, "weather"));
+    int nWeaChg  = JsonGetInt(JsonObjectGet(jState, "weather_changed"));
+
+    NuiSetBind(oPC, nToken, SEA_BIND_SEASON_LBL,
+        JsonString("Pora roku: " + SeaGetSeasonName(nSeason)));
+    NuiSetBind(oPC, nToken, SEA_BIND_WEATHER_LBL,
+        JsonString("Pogoda: " + SeaGetWeatherName(nWeather)));
+    NuiSetBind(oPC, nToken, SEA_BIND_EFFECT_LBL,
+        JsonString(SeaGetWeatherEffectDesc(nWeather)));
+    NuiSetBind(oPC, nToken, SEA_BIND_NEXTCH_LBL,
+        JsonString("Zmiana za: " + SeaNextChangeStr(nWeaChg)));
+}
+
+void SeaOpenPlayerWindow(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, SEA_WIN_PLAYER);
+    if (nToken != 0)
+    {
+        SeaFeedPlayerWindow(oPC, nToken);
+        return;
+    }
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))
+                 - GetNuiScaleDimension(oPC, SEA_PLY_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT))
+                 - GetNuiScaleDimension(oPC, SEA_PLY_H)) / 2.0;
+    json jGeom = NuiRect(fCX, fCY,
+        GetNuiScaleDimension(oPC, SEA_PLY_W),
+        GetNuiScaleDimension(oPC, SEA_PLY_H));
+
+    json jLayout = BuildSeaPlayerLayout(oPC);
+
+    json jWin = NuiWindow(jLayout,
+        JsonString("Wiatrowskaz"),
+        NuiBind("sea_ply_geom"),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE),
+        JsonBool(TRUE));
+
+    nToken = NuiCreate(oPC, jWin, SEA_WIN_PLAYER, SEA_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, "sea_ply_geom", jGeom);
+    SeaFeedPlayerWindow(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// DM window
+// ----------------------------------------------------------------
+
+json BuildSeaDMLayout(object oPC)
+{
+    float fLbl  = GetNuiScaleDimension(oPC, 22.0);
+    float fBtn  = GetNuiScaleDimension(oPC, 28.0);
+    float fArrow = GetNuiScaleDimension(oPC, 30.0);
+
+    // ---- Season row ----
+    json jSeaHdr = NuiWidth(
+        NuiHeight(NuiLabel(JsonString("Pora roku:"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)), fLbl),
+        GetNuiScaleDimension(oPC, 100.0));
+
+    json jPrevSea = NuiWidth(NuiHeight(
+        NuiId(NuiButton(JsonString("<")), SEA_BTN_PREV_SEA), fBtn), fArrow);
+    json jSeaVal  = NuiHeight(
+        NuiLabel(NuiBind(SEA_BIND_DM_SEA_LBL), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE)), fLbl);
+    json jNextSea = NuiWidth(NuiHeight(
+        NuiId(NuiButton(JsonString(">")), SEA_BTN_NEXT_SEA), fBtn), fArrow);
+
+    json jSeaArr = JsonArray();
+    jSeaArr = JsonArrayInsert(jSeaArr, jSeaHdr);
+    jSeaArr = JsonArrayInsert(jSeaArr, jPrevSea);
+    jSeaArr = JsonArrayInsert(jSeaArr, jSeaVal);
+    jSeaArr = JsonArrayInsert(jSeaArr, jNextSea);
+    json jSeaRow = NuiRow(jSeaArr);
+
+    // ---- Weather row ----
+    json jWeaHdr = NuiWidth(
+        NuiHeight(NuiLabel(JsonString("Pogoda:"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)), fLbl),
+        GetNuiScaleDimension(oPC, 100.0));
+
+    json jPrevWea = NuiWidth(NuiHeight(
+        NuiId(NuiButton(JsonString("<")), SEA_BTN_PREV_WEA), fBtn), fArrow);
+    json jWeaVal  = NuiHeight(
+        NuiLabel(NuiBind(SEA_BIND_DM_WEA_LBL), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE)), fLbl);
+    json jNextWea = NuiWidth(NuiHeight(
+        NuiId(NuiButton(JsonString(">")), SEA_BTN_NEXT_WEA), fBtn), fArrow);
+
+    json jWeaArr = JsonArray();
+    jWeaArr = JsonArrayInsert(jWeaArr, jWeaHdr);
+    jWeaArr = JsonArrayInsert(jWeaArr, jPrevWea);
+    jWeaArr = JsonArrayInsert(jWeaArr, jWeaVal);
+    jWeaArr = JsonArrayInsert(jWeaArr, jNextWea);
+    json jWeaRow = NuiRow(jWeaArr);
+
+    // ---- Area / climate section ----
+    json jAreaHdrLbl = NuiHeight(
+        NuiLabel(JsonString("Klimat bieżącego obszaru:"),
+            JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)),
+        fLbl);
+    json jAreaHdrRow = NuiRow(JsonArrayInsert(JsonArray(), jAreaHdrLbl));
+
+    json jAreaLbl = NuiHeight(
+        NuiLabel(NuiBind(SEA_BIND_DM_AREA_LBL), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)),
+        fLbl);
+    json jAreaRow = NuiRow(JsonArrayInsert(JsonArray(), jAreaLbl));
+
+    // Five climate buttons
+    json jClimArr = JsonArray();
+    int ci;
+    for (ci = 0; ci < SEA_CLIMATE_COUNT; ci++)
+    {
+        json jBtn = NuiHeight(
+            NuiId(NuiButton(JsonString(SeaGetClimateName(ci))),
+                SEA_BTN_CLIMATE + IntToString(ci)),
+            fBtn);
+        jClimArr = JsonArrayInsert(jClimArr, jBtn);
+    }
+    json jClimRow = NuiRow(jClimArr);
+
+    // ---- Close ----
+    json jCloseBtn = NuiHeight(
+        NuiId(NuiButton(JsonString("Zamknij")), SEA_BTN_DM_CLOSE), fBtn);
+    json jCloseRow = NuiRow(JsonArrayInsert(JsonArray(), jCloseBtn));
+
+    json jCols = JsonArray();
+    jCols = JsonArrayInsert(jCols, jSeaRow);
+    jCols = JsonArrayInsert(jCols, jWeaRow);
+    jCols = JsonArrayInsert(jCols, CreateEmptyRow(oPC, 8.0));
+    jCols = JsonArrayInsert(jCols, jAreaHdrRow);
+    jCols = JsonArrayInsert(jCols, jAreaRow);
+    jCols = JsonArrayInsert(jCols, jClimRow);
+    jCols = JsonArrayInsert(jCols, CreateEmptyRow(oPC, 8.0));
+    jCols = JsonArrayInsert(jCols, jCloseRow);
+
+    return NuiCol(jCols);
+}
+
+void SeaFeedDMWindow(object oPC, int nToken)
+{
+    json jState = SeaGetStateRow();
+    if (JsonGetType(jState) == JSON_TYPE_NULL) return;
+
+    int nSeason  = JsonGetInt(JsonObjectGet(jState, "season"));
+    int nWeather = JsonGetInt(JsonObjectGet(jState, "weather"));
+
+    NuiSetBind(oPC, nToken, SEA_BIND_DM_SEA_LBL, JsonString(SeaGetSeasonName(nSeason)));
+    NuiSetBind(oPC, nToken, SEA_BIND_DM_WEA_LBL, JsonString(SeaGetWeatherName(nWeather)));
+
+    object oArea    = GetArea(oPC);
+    string sAreaTag = GetTag(oArea);
+    int nClimate    = SeaGetAreaClimate(sAreaTag);
+    NuiSetBind(oPC, nToken, SEA_BIND_DM_AREA_LBL,
+        JsonString(GetName(oArea) + "  [" + SeaGetClimateName(nClimate) + "]"));
+}
+
+void SeaOpenDMWindow(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, SEA_WIN_DM);
+    if (nToken != 0)
+    {
+        SeaFeedDMWindow(oPC, nToken);
+        return;
+    }
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))
+                 - GetNuiScaleDimension(oPC, SEA_DM_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT))
+                 - GetNuiScaleDimension(oPC, SEA_DM_H)) / 2.0;
+    json jGeom = NuiRect(fCX, fCY,
+        GetNuiScaleDimension(oPC, SEA_DM_W),
+        GetNuiScaleDimension(oPC, SEA_DM_H));
+
+    json jLayout = BuildSeaDMLayout(oPC);
+
+    json jWin = NuiWindow(jLayout,
+        JsonString("Mistrz Klimatu"),
+        NuiBind("sea_dm_geom"),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE),
+        JsonBool(TRUE));
+
+    nToken = NuiCreate(oPC, jWin, SEA_WIN_DM, SEA_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, "sea_dm_geom", jGeom);
+    SeaFeedDMWindow(oPC, nToken);
+}
+
+void SeaOpenWindow(object oPC)
+{
+    if (GetIsDM(oPC) || GetIsDMPossessed(oPC))
+        SeaOpenDMWindow(oPC);
+    else
+        SeaOpenPlayerWindow(oPC);
+}
+
+void SeaUpdateAllWindows()
+{
+    object oPC = GetFirstPC();
+    while (GetIsObjectValid(oPC))
+    {
+        int nPly = NuiFindWindow(oPC, SEA_WIN_PLAYER);
+        if (nPly != 0) SeaFeedPlayerWindow(oPC, nPly);
+
+        int nDM = NuiFindWindow(oPC, SEA_WIN_DM);
+        if (nDM != 0) SeaFeedDMWindow(oPC, nDM);
+
+        oPC = GetNextPC();
+    }
+}
+
+// ----------------------------------------------------------------
+// Periodic tick — called from sea_hb_tick.nss via ExecuteScript
+// ----------------------------------------------------------------
+
+void SeaTick()
+{
+    json jState = SeaGetStateRow();
+    if (JsonGetType(jState) == JSON_TYPE_NULL) return;
+
+    int nNow       = SeaGetNow();
+    int nSeason    = JsonGetInt(JsonObjectGet(jState, "season"));
+    int nWeather   = JsonGetInt(JsonObjectGet(jState, "weather"));
+    int nSeaChg    = JsonGetInt(JsonObjectGet(jState, "season_changed"));
+    int nWeaChg    = JsonGetInt(JsonObjectGet(jState, "weather_changed"));
+
+    int bWeatherUpdated = FALSE;
+
+    // Advance season when its duration has elapsed
+    if (nSeaChg > 0 && (nNow - nSeaChg) >= SEA_SEASON_DURATION)
+    {
+        nSeason = (nSeason >= SEA_SEASON_DYING) ? SEA_SEASON_SPRING : nSeason + 1;
+        SeaSetSeason(nSeason);
+        // Force immediate weather re-roll on season change
+        nWeaChg = 0;
+        SeaNotifyAll("Nadeszła nowa pora roku: " + SeaGetSeasonName(nSeason) + ".");
+    }
+
+    // Advance weather when its interval has elapsed (or never set)
+    if (nWeaChg == 0 || (nNow - nWeaChg) >= SEA_WEATHER_INTERVAL)
+    {
+        // Climate of the first online PC's area, or temperate as fallback
+        int nClimate = SEA_CLIMATE_TEMPERATE;
+        object oRef  = GetFirstPC();
+        if (GetIsObjectValid(oRef))
+            nClimate = SeaGetAreaClimate(GetTag(GetArea(oRef)));
+
+        int nNew = SeaPickWeather(nSeason, nClimate);
+        SeaSetWeather(nNew);
+
+        // Announce only when weather actually changes after first init
+        if (nWeaChg > 0 && nNew != nWeather)
+            SeaNotifyAll(SeaGetSeasonName(nSeason) + ": " + SeaGetWeatherName(nNew) + ".");
+
+        nWeather        = nNew;
+        bWeatherUpdated = TRUE;
+    }
+
+    // Always sync effects (handles indoor/outdoor transitions too)
+    SeaUpdateAllPCs();
+    if (bWeatherUpdated)
+        SeaUpdateAllWindows();
+
+    // Blizzard: 1d4 cold damage per tick for outdoor PCs
+    if (nWeather == SEA_WEATHER_BLIZZARD)
+    {
+        object oPC = GetFirstPC();
+        while (GetIsObjectValid(oPC))
+        {
+            if (SeaIsOutdoor(oPC))
+            {
+                int nDmg = Random(4) + 1;
+                ApplyEffectToObject(DURATION_TYPE_INSTANT,
+                    EffectVisualEffect(VFX_IMP_FROST_S), oPC);
+                ApplyEffectToObject(DURATION_TYPE_INSTANT,
+                    EffectDamage(nDmg, DAMAGE_TYPE_COLD), oPC);
+            }
+            oPC = GetNextPC();
+        }
+    }
+
+    // Storm: 1% chance per tick of a lightning strike (outdoor PCs, DC 18 Fortitude)
+    if (nWeather == SEA_WEATHER_STORM)
+    {
+        object oPC = GetFirstPC();
+        while (GetIsObjectValid(oPC))
+        {
+            if (SeaIsOutdoor(oPC) && Random(100) < 1)
+            {
+                ApplyEffectToObject(DURATION_TYPE_INSTANT,
+                    EffectVisualEffect(VFX_IMP_LIGHTNING_S), oPC);
+                if (!FortitudeSave(oPC, 18, SAVING_THROW_TYPE_ELECTRICITY, OBJECT_SELF))
+                {
+                    int nDmg = d6(2) + 2;
+                    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+                        EffectDamage(nDmg, DAMAGE_TYPE_ELECTRICAL), oPC);
+                    FloatingTextStringOnCreature("Piorun uderza!", oPC, FALSE);
+                }
+            }
+            oPC = GetNextPC();
+        }
+    }
+}

--- a/Seasons/scripts/lib_sea_def.nss
+++ b/Seasons/scripts/lib_sea_def.nss
@@ -1,0 +1,103 @@
+#include "lib_nui"
+#include "sql_sea"
+
+// Forward declarations
+void SeaApplyWeatherEffects(object oPC);
+void SeaRemoveWeatherEffects(object oPC);
+void SeaOpenWindow(object oPC);
+void SeaFeedDMWindow(object oPC, int nToken);
+void SeaFeedPlayerWindow(object oPC, int nToken);
+void SeaUpdateAllPCs();
+void SeaUpdateAllWindows();
+void SeaNotifyAll(string sMsg);
+
+// ----------------------------------------------------------------
+// Season constants
+// ----------------------------------------------------------------
+const int SEA_SEASON_SPRING  = 0;
+const int SEA_SEASON_SUMMER  = 1;
+const int SEA_SEASON_AUTUMN  = 2;
+const int SEA_SEASON_WINTER  = 3;
+const int SEA_SEASON_DYING   = 4; // Tydzień Umierającego Boga — brief transition
+const int SEA_SEASON_COUNT   = 5;
+
+// ----------------------------------------------------------------
+// Weather constants
+// ----------------------------------------------------------------
+const int SEA_WEATHER_CLEAR    = 0;
+const int SEA_WEATHER_OVERCAST = 1;
+const int SEA_WEATHER_RAIN     = 2;
+const int SEA_WEATHER_STORM    = 3;
+const int SEA_WEATHER_SNOW     = 4;
+const int SEA_WEATHER_BLIZZARD = 5;
+const int SEA_WEATHER_DROUGHT  = 6;
+const int SEA_WEATHER_COUNT    = 7;
+
+// ----------------------------------------------------------------
+// Climate zone constants
+// ----------------------------------------------------------------
+const int SEA_CLIMATE_TEMPERATE = 0;
+const int SEA_CLIMATE_ARCTIC    = 1;
+const int SEA_CLIMATE_DESERT    = 2;
+const int SEA_CLIMATE_COASTAL   = 3;
+const int SEA_CLIMATE_CURSED    = 4;
+const int SEA_CLIMATE_COUNT     = 5;
+
+// ----------------------------------------------------------------
+// Timing (real seconds)
+// ----------------------------------------------------------------
+const int   SEA_SEASON_DURATION  = 604800; // 7 days per season
+const int   SEA_WEATHER_INTERVAL = 10800;  // weather changes every 3 hours
+const float SEA_TICK_INTERVAL    = 60.0;   // heartbeat period
+
+// ----------------------------------------------------------------
+// NUI window identifiers
+// ----------------------------------------------------------------
+const string SEA_WIN_PLAYER  = "SEA_WIN_PLAYER";
+const string SEA_WIN_DM      = "SEA_WIN_DM";
+const string SEA_EV_SCRIPT   = "lib_sea_ev";
+
+// ----------------------------------------------------------------
+// NUI bind names — player window
+// ----------------------------------------------------------------
+const string SEA_BIND_SEASON_LBL  = "sea_season_lbl";
+const string SEA_BIND_WEATHER_LBL = "sea_weather_lbl";
+const string SEA_BIND_EFFECT_LBL  = "sea_effect_lbl";
+const string SEA_BIND_NEXTCH_LBL  = "sea_nextch_lbl";
+
+// ----------------------------------------------------------------
+// NUI bind names — DM window
+// ----------------------------------------------------------------
+const string SEA_BIND_DM_SEA_LBL  = "sea_dm_sea_lbl";
+const string SEA_BIND_DM_WEA_LBL  = "sea_dm_wea_lbl";
+const string SEA_BIND_DM_AREA_LBL = "sea_dm_area_lbl";
+
+// ----------------------------------------------------------------
+// NUI button IDs — player window
+// ----------------------------------------------------------------
+const string SEA_BTN_CLOSE        = "sea_btn_close";
+
+// ----------------------------------------------------------------
+// NUI button IDs — DM window
+// (climate buttons: SEA_BTN_CLIMATE + IntToString(0..4))
+// ----------------------------------------------------------------
+const string SEA_BTN_DM_CLOSE   = "sea_dm_close";
+const string SEA_BTN_PREV_SEA   = "sea_btn_prev_sea";
+const string SEA_BTN_NEXT_SEA   = "sea_btn_next_sea";
+const string SEA_BTN_PREV_WEA   = "sea_btn_prev_wea";
+const string SEA_BTN_NEXT_WEA   = "sea_btn_next_wea";
+const string SEA_BTN_CLIMATE    = "sea_btn_clim"; // + "0".."4"
+
+// ----------------------------------------------------------------
+// Effect tag — all weather effects carry this so removal is clean
+// ----------------------------------------------------------------
+const string SEA_EFFECT_TAG     = "SEA_WEATHER_EFF";
+
+// Module-level flags
+const string SEA_LVAR_TICKING   = "SEA_TICKING";
+
+// Window geometry constants
+const float SEA_PLY_W  = 300.0;
+const float SEA_PLY_H  = 230.0;
+const float SEA_DM_W   = 480.0;
+const float SEA_DM_H   = 340.0;

--- a/Seasons/scripts/lib_sea_ev.nss
+++ b/Seasons/scripts/lib_sea_ev.nss
@@ -1,0 +1,72 @@
+#include "lib_sea"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+
+    // ---- Player window ----
+    if (nToken == NuiFindWindow(oPC, SEA_WIN_PLAYER))
+    {
+        if (sEvent == EVENT_TYPE_CLICK && sElem == SEA_BTN_CLOSE)
+            NuiDestroy(oPC, nToken);
+        return;
+    }
+
+    // ---- DM window ----
+    if (nToken != NuiFindWindow(oPC, SEA_WIN_DM)) return;
+    if (!GetIsDM(oPC) && !GetIsDMPossessed(oPC)) return;
+
+    if (sEvent == EVENT_TYPE_CLICK)
+    {
+        if (sElem == SEA_BTN_DM_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        // Season cycling — takes effect immediately
+        if (sElem == SEA_BTN_NEXT_SEA || sElem == SEA_BTN_PREV_SEA)
+        {
+            json jState  = SeaGetStateRow();
+            int  nCur    = JsonGetInt(JsonObjectGet(jState, "season"));
+            int  nNew    = (sElem == SEA_BTN_NEXT_SEA) ? SeaNextSeason(nCur) : SeaPrevSeason(nCur);
+            SeaSetSeason(nNew);
+            SeaUpdateAllPCs();
+            SeaUpdateAllWindows();
+            SeaNotifyAll("Nadeszła nowa pora roku: " + SeaGetSeasonName(nNew) + ".");
+            return;
+        }
+
+        // Weather cycling — takes effect immediately
+        if (sElem == SEA_BTN_NEXT_WEA || sElem == SEA_BTN_PREV_WEA)
+        {
+            json jState  = SeaGetStateRow();
+            int  nCur    = JsonGetInt(JsonObjectGet(jState, "weather"));
+            int  nNew    = (sElem == SEA_BTN_NEXT_WEA) ? SeaNextWeather(nCur) : SeaPrevWeather(nCur);
+            SeaSetWeather(nNew);
+            SeaUpdateAllPCs();
+            SeaUpdateAllWindows();
+            SeaNotifyAll(SeaGetWeatherName(nNew) + " — zmieniła się pogoda.");
+            return;
+        }
+
+        // Climate zone buttons for the DM's current area
+        int ci;
+        for (ci = 0; ci < SEA_CLIMATE_COUNT; ci++)
+        {
+            if (sElem == SEA_BTN_CLIMATE + IntToString(ci))
+            {
+                object oArea    = GetArea(oPC);
+                string sAreaTag = GetTag(oArea);
+                SeaSetAreaClimate(sAreaTag, ci);
+                SendMessageToPC(oPC, "[Klimat] Ustawiono strefę '"
+                    + SeaGetClimateName(ci) + "' dla: " + GetName(oArea) + ".");
+                SeaFeedDMWindow(oPC, nToken);
+                return;
+            }
+        }
+    }
+}

--- a/Seasons/scripts/sea_hb_tick.nss
+++ b/Seasons/scripts/sea_hb_tick.nss
@@ -1,0 +1,9 @@
+#include "lib_sea"
+
+void main()
+{
+    SeaTick();
+
+    // Reschedule the next tick; runs on the module object so it never dies
+    DelayCommand(SEA_TICK_INTERVAL, ExecuteScript("sea_hb_tick", GetModule()));
+}

--- a/Seasons/scripts/sql_sea.nss
+++ b/Seasons/scripts/sql_sea.nss
@@ -1,0 +1,96 @@
+void SeaCreateTables()
+{
+    sqlquery q;
+
+    q = SqlPrepareQueryCampaign("seasons",
+        "CREATE TABLE IF NOT EXISTS sea_state ("
+        "  id              INTEGER PRIMARY KEY,"
+        "  season          INTEGER DEFAULT 0,"
+        "  weather         INTEGER DEFAULT 0,"
+        "  season_changed  INTEGER DEFAULT 0,"
+        "  weather_changed INTEGER DEFAULT 0)");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("seasons",
+        "CREATE TABLE IF NOT EXISTS sea_areas ("
+        "  area_tag TEXT PRIMARY KEY,"
+        "  climate  INTEGER DEFAULT 0)");
+    SqlStep(q);
+
+    // Seed single state row if absent
+    q = SqlPrepareQueryCampaign("seasons",
+        "INSERT OR IGNORE INTO sea_state "
+        "(id, season, weather, season_changed, weather_changed) "
+        "VALUES (1, 0, 0, 0, 0)");
+    SqlStep(q);
+}
+
+json SeaGetStateRow()
+{
+    sqlquery q = SqlPrepareQueryCampaign("seasons",
+        "SELECT season, weather, season_changed, weather_changed "
+        "FROM sea_state WHERE id = 1");
+    if (!SqlStep(q)) return JsonNull();
+
+    json j = JsonObject();
+    j = JsonObjectSet(j, "season",          JsonInt(SqlGetInt(q, 0)));
+    j = JsonObjectSet(j, "weather",         JsonInt(SqlGetInt(q, 1)));
+    j = JsonObjectSet(j, "season_changed",  JsonInt(SqlGetInt(q, 2)));
+    j = JsonObjectSet(j, "weather_changed", JsonInt(SqlGetInt(q, 3)));
+    return j;
+}
+
+void SeaSetSeason(int nSeason)
+{
+    sqlquery q = SqlPrepareQueryCampaign("seasons",
+        "UPDATE sea_state SET season = @s, season_changed = strftime('%s','now') WHERE id = 1");
+    SqlBindInt(q, "@s", nSeason);
+    SqlStep(q);
+}
+
+void SeaSetWeather(int nWeather)
+{
+    sqlquery q = SqlPrepareQueryCampaign("seasons",
+        "UPDATE sea_state SET weather = @w, weather_changed = strftime('%s','now') WHERE id = 1");
+    SqlBindInt(q, "@w", nWeather);
+    SqlStep(q);
+}
+
+void SeaSetState(int nSeason, int nWeather)
+{
+    sqlquery q = SqlPrepareQueryCampaign("seasons",
+        "UPDATE sea_state "
+        "SET season = @s, weather = @w, "
+        "    season_changed = strftime('%s','now'), "
+        "    weather_changed = strftime('%s','now') "
+        "WHERE id = 1");
+    SqlBindInt(q, "@s", nSeason);
+    SqlBindInt(q, "@w", nWeather);
+    SqlStep(q);
+}
+
+int SeaGetAreaClimate(string sAreaTag)
+{
+    sqlquery q = SqlPrepareQueryCampaign("seasons",
+        "SELECT climate FROM sea_areas WHERE area_tag = @tag");
+    SqlBindString(q, "@tag", sAreaTag);
+    if (SqlStep(q)) return SqlGetInt(q, 0);
+    return 0; // SEA_CLIMATE_TEMPERATE
+}
+
+void SeaSetAreaClimate(string sAreaTag, int nClimate)
+{
+    sqlquery q = SqlPrepareQueryCampaign("seasons",
+        "INSERT OR REPLACE INTO sea_areas (area_tag, climate) VALUES (@tag, @c)");
+    SqlBindString(q, "@tag", sAreaTag);
+    SqlBindInt(q, "@c",  nClimate);
+    SqlStep(q);
+}
+
+// Returns current Unix timestamp via SQLite (avoids NWScript date arithmetic)
+int SeaGetNow()
+{
+    sqlquery q = SqlPrepareQueryCampaign("seasons", "SELECT strftime('%s','now')");
+    if (SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}

--- a/Seasons/scripts/sys_on_enter.nss
+++ b/Seasons/scripts/sys_on_enter.nss
@@ -1,0 +1,20 @@
+#include "lib_sea"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if (!GetIsPC(oPC)) return;
+
+    // Apply current weather penalties; also removes stale effects for returning PCs
+    SeaApplyWeatherEffects(oPC);
+
+    // Notify if effects are active
+    json jState = SeaGetStateRow();
+    if (JsonGetType(jState) == JSON_TYPE_NULL) return;
+
+    int nSeason  = JsonGetInt(JsonObjectGet(jState, "season"));
+    int nWeather = JsonGetInt(JsonObjectGet(jState, "weather"));
+
+    string sMsg = SeaGetSeasonName(nSeason) + " — " + SeaGetWeatherName(nWeather) + ".";
+    SendMessageToPC(oPC, "[Klimat] " + sMsg);
+}

--- a/Seasons/scripts/sys_on_load.nss
+++ b/Seasons/scripts/sys_on_load.nss
@@ -1,0 +1,13 @@
+#include "lib_sea_def"
+
+void main()
+{
+    SeaCreateTables();
+
+    // Guard against double-start (e.g. module reload)
+    if (GetLocalInt(GetModule(), SEA_LVAR_TICKING)) return;
+    SetLocalInt(GetModule(), SEA_LVAR_TICKING, 1);
+
+    // Kick off the recurring weather tick
+    DelayCommand(SEA_TICK_INTERVAL, ExecuteScript("sea_hb_tick", GetModule()));
+}

--- a/Seasons/scripts/test_sea.nss
+++ b/Seasons/scripts/test_sea.nss
@@ -1,0 +1,10 @@
+#include "lib_sea"
+
+// Assign as the OnUsed script of a placeable (e.g. a weather vane or stone pillar).
+// DMs receive the full control panel; players receive the read-only weather report.
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if (!GetIsPC(oPC) && !GetIsDM(oPC)) return;
+    SeaOpenWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

Moduł **Seasons** wprowadza server-wide cykl czterech pór roku i siedmiu stanów pogody, napędzanych przez rzeczywisty czas serwera.  Stan jest trwały w kampanijnej bazie SQLite.  Każda pora roku trwa 7 realnych dni; pogoda zmienia się co 3 godziny na podstawie pory roku i strefy klimatycznej obszaru.

## Mechanika

- **Pory roku**: Wiosna Odrodzenia → Lato Skwaru → Jesień Żniw Krwi → Zima Śmierci → Tydzień Umierającego Boga → i z powrotem.  *Tydzień Umierającego Boga* nakłada -2 do wszystkich rzutów obronnych nawet w pomieszczeniach.
- **Pogoda**: Pogodnie / Zachmurzenie / Deszcz / Burza / Śnieg / Zamieć / Susza.  Każda pogoda aplikuje trwałe efekty (oznaczone `TagEffect`) — spowolnienie ruchu, kary do atrybutów, kary do rzutów obronnych.
- **Zagrożenia aktywne**: Zamieć zadaje 1d4 obrażeń zimnem co tick (60 s) outdoorowym PC; Burza ma 1% szansę uderzenia piorunem (DC 18 Fortitude, 2d6+2 elektryczność).
- **Strefy klimatyczne per obszar**: Umiarkowany / Arktyczny / Pustynny / Nadmorski / Przeklęty — wpływają na prawdopodobieństwo losowania pogody.
- **Panel gracza**: otwiera się przez placeable (test_sea.nss) — pokazuje aktualną porę roku, pogodę, opis efektów i szacowany czas następnej zmiany.
- **Panel DM**: natychmiastowa zmiana pory roku i pogody przyciskami `< >`, ustawianie strefy klimatycznej bieżącego obszaru.

## Pliki

```
Seasons/
├── INTEGRATION.md
└── scripts/
    ├── sql_sea.nss          — schemat SQLite, CRUD
    ├── lib_sea_def.nss      — stałe, bind names, deklaracje
    ├── lib_sea.nss          — logika core, efekty, NUI windows, SeaTick()
    ├── lib_sea_ev.nss       — handler NUI eventów
    ├── sys_on_load.nss      — init tabel + start pętli ticku
    ├── sys_on_enter.nss     — nakładanie efektów na wchodzącego PC
    ├── sea_hb_tick.nss      — samoplanuujący tick (co 60 s via DelayCommand)
    ├── test_sea.nss         — OnUsed placeable otwierające okno
    ├── lib_nui.nss          — kopia współdzielonej biblioteki NUI
    └── lib_nui_utility.nss  — kopia współdzielonej biblioteki NUI
```

## Zależności (NWNX? SQL?)

- **NWN:EE ≥ 8193.15** — wymagane `TagEffect` / `GetEffectTag` (tagi efektów) oraz pełne API NUI.
- **SQLite** — baza kampanii `seasons` (plik `seasons.sqlite3`).  Bez NWNX.
- Brak zewnętrznych bibliotek poza standardowymi inkludami NWN:EE.

## Jak włączyć w istniejącym module

1. Skopiuj folder `Seasons/scripts/` do plików skryptowych modułu.
2. Podepnij hooki (lub dodaj wywołania do istniejących skryptów):
   - `OnModuleLoad` → `sys_on_load`
   - `OnClientEnter` → `sys_on_enter`
   - `OnNuiEvent` → `lib_sea_ev`
3. Stwórz placeable z `OnUsed = test_sea` — gracze i DM mogą go kliknąć.
4. Szczegóły w `Seasons/INTEGRATION.md`.

## Co celowo pominięto

- Brak własnych grafik/ikon pogody w HAK (system działa bez nich; można dodać później).
- Brak modyfikatorów ekwipunku (ciepłe ubrania redukujące kary Zamieci) — warstwa rozszerzenia.
- Brak efektów wizualnych obszarowych (opady deszczu/śniegu) — wymagałyby NWNX lub area-VFX.
- Brak komendy `/pogoda` — można dodać przez hook `OnPlayerChat`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YY7YeLGwrGdsmXvuwBDN9S)_