### PR TITLE
feat: Tribunal — Trybunał Inkwizycji

### DIFF
--- a/Tribunal/INTEGRATION.md
+++ b/Tribunal/INTEGRATION.md
@@ -1,0 +1,45 @@
+# Tribunal – Integracja z modułem
+
+## Hooki modułu
+
+| Zdarzenie | Skrypt do dodania | Działanie |
+|---|---|---|
+| `OnModuleLoad` | `sys_on_load` | Tworzy tabele SQL w bazie kampanii `tribunal` |
+| `OnClientEnter` | `sys_on_enter` | Rejestruje gracza w bazie; informuje o otwartych sprawach |
+| `NUI event` | `lib_trib_ev` | Handler zdarzeń NUI (wpisać w pole NUI Event Script przy `NuiCreate`) |
+
+Skrypt `lib_trib_ev` jest podawany **automatycznie** wewnątrz `TribOpenWindow()` jako czwarty argument `NuiCreate`. Nie trzeba go mapować ręcznie — wystarczy upewnić się, że plik jest skompilowany w HAK/moduł.
+
+## Placeable testowy
+
+1. Stwórz placeable (np. Noticeboard / Tablice ogłoszeń) w dowolnym obszarze.
+2. Ustaw skrypt `test_trib` jako `OnUsed`.
+3. Użyj plaeable jako gracz lub DM — otworzy się okno Trybunału.
+
+## Wyrok Wygnania
+
+Aby wygnanie działało, umieść w module waypoint z tagiem `TRIB_EXILE_AREA` (stała w `lib_trib_def.nss`). Jeśli waypoint nie istnieje, gracz otrzymuje komunikat, ale nie jest teleportowany.
+
+## Zależności
+
+- **Czyste NWScript + NUI** — brak NWNX.
+- SQLite przez `SqlPrepareQueryCampaign("tribunal", ...)` — dane persystowane w pliku kampanii `tribunal.sqlite`.
+- `lib_nui.nss` i `lib_nui_utility.nss` — standardowe helpery z tego repo (wymagane w HAK).
+
+## Integracja z innymi systemami
+
+Moduł eksponuje trzy local-int na postaci oskarżonego:
+
+| Zmienna | Wartość | Znaczenie |
+|---|---|---|
+| `TRIB_IMPRISONED` | 1 | Postać skazana na więzienie |
+| `TRIB_EXILED` | 1 | Postać skazana na wygnanie |
+| `TRIB_DEATH_MARK` | 1 | Postać nosi wyrok śmierci |
+
+Moduł Prison może sprawdzać `GetLocalInt(oPC, "TRIB_IMPRISONED")` przed wpuszczeniem do celi. System PvP może sprawdzać `TRIB_DEATH_MARK`, aby zezwolić na atak.
+
+## Co celowo pominięto
+
+- Odwołanie od wyroku (appeal) — wymagałoby drugiej instancji lub głosowania DM; można dołożyć później jako widok w tym samym oknie.
+- Ograniczenie w czasie (np. wyrok wygasa po X dniach) — trywialne do dodania w SQL (`resolved_at + X * 86400 > now`), ale zależy od decyzji projektowej.
+- Powiadomienie DM o nowym oskarżeniu — brak standardowego mechanizmu w NWN bez NWNX; rozwiązanie: `SendMessageToAllDMs()`.

--- a/Tribunal/Scripts/lib_trib.nss
+++ b/Tribunal/Scripts/lib_trib.nss
@@ -1,0 +1,649 @@
+#include "lib_trib_def"
+
+// ----------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------
+
+string TribVerdictLabel(int nVerdict)
+{
+    switch(nVerdict)
+    {
+        case TRIB_VERDICT_INNOCENT: return "Niewinny";
+        case TRIB_VERDICT_JAIL:     return "Uwięziony";
+        case TRIB_VERDICT_EXILE:    return "Wygnanie";
+        case TRIB_VERDICT_DEATH:    return "Wyrok Śmierci";
+    }
+    return "W toku";
+}
+
+json TribVerdictColor(int nVerdict)
+{
+    switch(nVerdict)
+    {
+        case TRIB_VERDICT_INNOCENT: return NuiColor(100, 220, 100);
+        case TRIB_VERDICT_JAIL:     return NuiColor(220, 180,  60);
+        case TRIB_VERDICT_EXILE:    return NuiColor(200, 100,  40);
+        case TRIB_VERDICT_DEATH:    return NuiColor(220,  50,  50);
+    }
+    return NuiColor(180, 180, 180);
+}
+
+// ----------------------------------------------------------------
+// Case-list view
+// ----------------------------------------------------------------
+
+json BuildTribCaseListView(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 30.0);
+    float fRowH  = GetNuiScaleDimension(oPC, 26.0);
+    float fListH = GetNuiScaleDimension(oPC, 400.0);
+
+    json jHdr = NuiLabel(JsonString("Sprawy Trybunału Inkwizycji"),
+                         JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jHdr = NuiHeight(jHdr, fBtnH);
+
+    float fNameW   = GetNuiScaleDimension(oPC, 190.0);
+    float fStatusW = GetNuiScaleDimension(oPC, 120.0);
+
+    json jNameLbl = NuiLabel(NuiBind(TRIB_BIND_LIST_NAME),
+                             JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jNameLbl = NuiStyleForegroundColor(jNameLbl, NuiBind(TRIB_BIND_LIST_COLOR));
+
+    json jChargeLbl = NuiLabel(NuiBind(TRIB_BIND_LIST_CHARGE),
+                               JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jChargeLbl = NuiStyleForegroundColor(jChargeLbl, NuiBind(TRIB_BIND_LIST_COLOR));
+
+    json jStatusLbl = NuiLabel(NuiBind(TRIB_BIND_LIST_STATUS),
+                               JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jStatusLbl = NuiWidth(jStatusLbl, fStatusW);
+    jStatusLbl = NuiStyleForegroundColor(jStatusLbl, NuiBind(TRIB_BIND_LIST_COLOR));
+
+    json jCellCols = JsonArray();
+    jCellCols = JsonArrayInsert(jCellCols,
+        NuiWidth(NuiCol(JsonArrayInsert(JsonArray(), jNameLbl)), fNameW));
+    jCellCols = JsonArrayInsert(jCellCols, jChargeLbl);
+    jCellCols = JsonArrayInsert(jCellCols, jStatusLbl);
+
+    json jCell = NuiGroup(NuiRow(jCellCols), TRUE, NUI_SCROLLBARS_NONE);
+    jCell = NuiId(jCell, TRIB_BTN_ROW);
+    jCell = NuiEncouraged(jCell, NuiBind(TRIB_BIND_LIST_ENC));
+
+    json jTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jCell, 0.0, TRUE));
+    json jList = NuiList(jTmpl, NuiBind(TRIB_BIND_LIST_COUNT), fRowH);
+    jList = NuiHeight(jList, fListH);
+
+    json jAccuseBtn = NuiButton(JsonString("Złóż Oskarżenie"));
+    jAccuseBtn = NuiId(jAccuseBtn, TRIB_BTN_ACCUSE);
+    jAccuseBtn = NuiWidth(jAccuseBtn, GetNuiScaleDimension(oPC, 180.0));
+    jAccuseBtn = NuiHeight(jAccuseBtn, fBtnH);
+
+    json jBotRow = JsonArray();
+    jBotRow = JsonArrayInsert(jBotRow, NuiSpacer());
+    jBotRow = JsonArrayInsert(jBotRow, jAccuseBtn);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jHdr);
+    jCol = JsonArrayInsert(jCol, jList);
+    jCol = JsonArrayInsert(jCol, NuiRow(jBotRow));
+
+    json jSide     = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    float fContent = GetNuiScaleDimension(oPC, 680.0);
+    json jRoot = JsonArray();
+    jRoot = JsonArrayInsert(jRoot, jSide);
+    jRoot = JsonArrayInsert(jRoot, NuiWidth(NuiCol(jCol), fContent));
+    jRoot = JsonArrayInsert(jRoot, jSide);
+    return NuiRow(jRoot);
+}
+
+// ----------------------------------------------------------------
+// Case-detail view
+// ----------------------------------------------------------------
+
+json BuildTribDetailView(object oPC)
+{
+    float fBtnH   = GetNuiScaleDimension(oPC, 30.0);
+    float fFieldH = GetNuiScaleDimension(oPC, 90.0);
+    float fSentH  = GetNuiScaleDimension(oPC, 28.0);
+    float fLblH   = GetNuiScaleDimension(oPC, 22.0);
+
+    json jHdr = NuiLabel(NuiBind(TRIB_BIND_DETAIL_HDR),
+                         JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jHdr = NuiHeight(jHdr, GetNuiScaleDimension(oPC, 28.0));
+
+    json jChargeLbl = NuiLabel(NuiBind(TRIB_BIND_DETAIL_CHARGE),
+                               JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jChargeLbl = NuiHeight(jChargeLbl, fLblH);
+
+    json jAccLbl = NuiLabel(NuiBind(TRIB_BIND_DETAIL_ACC),
+                            JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jAccLbl = NuiHeight(jAccLbl, fLblH);
+
+    json jEvidSectionLbl = NuiLabel(JsonString("Dowody Inkwizycji:"),
+                                    JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jEvidSectionLbl = NuiHeight(jEvidSectionLbl, fLblH);
+
+    json jEvidTxt = NuiGroup(NuiText(NuiBind(TRIB_BIND_EVIDENCE_TXT), FALSE),
+                             TRUE, NUI_SCROLLBARS_AUTO);
+    jEvidTxt = NuiHeight(jEvidTxt, fFieldH);
+
+    json jDefSectionLbl = NuiLabel(JsonString("Zeznanie Obrony:"),
+                                   JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jDefSectionLbl = NuiHeight(jDefSectionLbl, fLblH);
+
+    json jDefEdit = NuiTextEdit(JsonString(""), NuiBind(TRIB_BIND_DEFENSE_TXT),
+                                TRIB_MAX_DEFENSE, TRUE);
+    jDefEdit = NuiEnabled(jDefEdit, NuiBind(TRIB_BIND_DEF_ENA));
+    jDefEdit = NuiHeight(jDefEdit, fFieldH);
+
+    json jStatusLbl = NuiLabel(NuiBind(TRIB_BIND_STATUS_LBL),
+                               JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jStatusLbl = NuiHeight(jStatusLbl, fLblH);
+
+    // Sentence input (judge fills before clicking verdict)
+    json jSentSection = NuiLabel(JsonString("Uzasadnienie wyroku:"),
+                                 JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jSentSection = NuiHeight(jSentSection, fLblH);
+
+    json jSentEdit = NuiTextEdit(JsonString(""), NuiBind(TRIB_BIND_SENTENCE_TXT),
+                                 TRIB_MAX_SENTENCE, FALSE);
+    jSentEdit = NuiEnabled(jSentEdit, NuiBind(TRIB_BIND_VERDICT_ENA));
+    jSentEdit = NuiHeight(jSentEdit, fSentH);
+
+    // Four verdict buttons
+    float fVerdW = GetNuiScaleDimension(oPC, 148.0);
+
+    json jJailBtn = NuiButton(JsonString("Uwięziony"));
+    jJailBtn = NuiId(jJailBtn, TRIB_BTN_GUILTY_JAIL);
+    jJailBtn = NuiEnabled(jJailBtn, NuiBind(TRIB_BIND_VERDICT_ENA));
+    jJailBtn = NuiWidth(jJailBtn, fVerdW);
+    jJailBtn = NuiHeight(jJailBtn, fBtnH);
+    jJailBtn = NuiTooltip(jJailBtn, JsonString("Skazuje oskarżonego na dożywotnie więzienie."));
+
+    json jExileBtn = NuiButton(JsonString("Wygnanie"));
+    jExileBtn = NuiId(jExileBtn, TRIB_BTN_GUILTY_EXILE);
+    jExileBtn = NuiEnabled(jExileBtn, NuiBind(TRIB_BIND_VERDICT_ENA));
+    jExileBtn = NuiWidth(jExileBtn, fVerdW);
+    jExileBtn = NuiHeight(jExileBtn, fBtnH);
+    jExileBtn = NuiTooltip(jExileBtn, JsonString("Wypędza oskarżonego z terytorium. Pieczęć wygnania nie może być zdjęta bez Trybunału."));
+
+    json jDeathBtn = NuiButton(JsonString("Wyrok Śmierci"));
+    jDeathBtn = NuiId(jDeathBtn, TRIB_BTN_GUILTY_DEATH);
+    jDeathBtn = NuiEnabled(jDeathBtn, NuiBind(TRIB_BIND_VERDICT_ENA));
+    jDeathBtn = NuiWidth(jDeathBtn, fVerdW);
+    jDeathBtn = NuiHeight(jDeathBtn, fBtnH);
+    jDeathBtn = NuiTooltip(jDeathBtn, JsonString("Naznacza oskarżonego piętnem śmierci. Każdy gracz może go bezkarnie zabić."));
+
+    json jInnocentBtn = NuiButton(JsonString("Niewinny"));
+    jInnocentBtn = NuiId(jInnocentBtn, TRIB_BTN_INNOCENT);
+    jInnocentBtn = NuiEnabled(jInnocentBtn, NuiBind(TRIB_BIND_VERDICT_ENA));
+    jInnocentBtn = NuiWidth(jInnocentBtn, fVerdW);
+    jInnocentBtn = NuiHeight(jInnocentBtn, fBtnH);
+    jInnocentBtn = NuiTooltip(jInnocentBtn, JsonString("Oczyszcza oskarżonego z zarzutów. Znosi wszelkie kary."));
+
+    json jVerdRow = JsonArray();
+    jVerdRow = JsonArrayInsert(jVerdRow, jJailBtn);
+    jVerdRow = JsonArrayInsert(jVerdRow, jExileBtn);
+    jVerdRow = JsonArrayInsert(jVerdRow, jDeathBtn);
+    jVerdRow = JsonArrayInsert(jVerdRow, jInnocentBtn);
+
+    // Bottom action bar
+    json jBackBtn = NuiButton(JsonString("Wróć"));
+    jBackBtn = NuiId(jBackBtn, TRIB_BTN_BACK);
+    jBackBtn = NuiWidth(jBackBtn, GetNuiScaleDimension(oPC, 80.0));
+    jBackBtn = NuiHeight(jBackBtn, fBtnH);
+
+    json jSubDefBtn = NuiButton(JsonString("Złóż Zeznanie"));
+    jSubDefBtn = NuiId(jSubDefBtn, TRIB_BTN_SUBMIT_DEF);
+    jSubDefBtn = NuiEnabled(jSubDefBtn, NuiBind(TRIB_BIND_DEF_ENA));
+    jSubDefBtn = NuiWidth(jSubDefBtn, GetNuiScaleDimension(oPC, 140.0));
+    jSubDefBtn = NuiHeight(jSubDefBtn, fBtnH);
+
+    json jSubEvidBtn = NuiButton(JsonString("Zaktualizuj Dowody"));
+    jSubEvidBtn = NuiId(jSubEvidBtn, TRIB_BTN_SUBMIT_EVID);
+    jSubEvidBtn = NuiEnabled(jSubEvidBtn, NuiBind(TRIB_BIND_VERDICT_ENA));
+    jSubEvidBtn = NuiWidth(jSubEvidBtn, GetNuiScaleDimension(oPC, 160.0));
+    jSubEvidBtn = NuiHeight(jSubEvidBtn, fBtnH);
+
+    json jBotRow = JsonArray();
+    jBotRow = JsonArrayInsert(jBotRow, jBackBtn);
+    jBotRow = JsonArrayInsert(jBotRow, NuiSpacer());
+    jBotRow = JsonArrayInsert(jBotRow, jSubDefBtn);
+    jBotRow = JsonArrayInsert(jBotRow, jSubEvidBtn);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jHdr);
+    jCol = JsonArrayInsert(jCol, jChargeLbl);
+    jCol = JsonArrayInsert(jCol, jAccLbl);
+    jCol = JsonArrayInsert(jCol, jEvidSectionLbl);
+    jCol = JsonArrayInsert(jCol, jEvidTxt);
+    jCol = JsonArrayInsert(jCol, jDefSectionLbl);
+    jCol = JsonArrayInsert(jCol, jDefEdit);
+    jCol = JsonArrayInsert(jCol, jStatusLbl);
+    jCol = JsonArrayInsert(jCol, jSentSection);
+    jCol = JsonArrayInsert(jCol, jSentEdit);
+    jCol = JsonArrayInsert(jCol, NuiRow(jVerdRow));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBotRow));
+
+    json jSide     = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    float fContent = GetNuiScaleDimension(oPC, 680.0);
+    json jRoot = JsonArray();
+    jRoot = JsonArrayInsert(jRoot, jSide);
+    jRoot = JsonArrayInsert(jRoot, NuiWidth(NuiCol(jCol), fContent));
+    jRoot = JsonArrayInsert(jRoot, jSide);
+    return NuiRow(jRoot);
+}
+
+// ----------------------------------------------------------------
+// Accuse view
+// ----------------------------------------------------------------
+
+json BuildTribAccuseView(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 30.0);
+    float fEvidH = GetNuiScaleDimension(oPC, 200.0);
+    float fLblH  = GetNuiScaleDimension(oPC, 22.0);
+
+    json jHdr = NuiLabel(JsonString("Złóż Oskarżenie przed Inkwizycją"),
+                         JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jHdr = NuiHeight(jHdr, fBtnH);
+
+    // Target selection row
+    json jTargetLbl = NuiLabel(NuiBind(TRIB_BIND_TARGET_LBL),
+                               JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+
+    json jSearchEdit = NuiTextEdit(JsonString("Szukaj po imieniu..."),
+                                   NuiBind(TRIB_BIND_SEARCH_TXT), 40, FALSE);
+    jSearchEdit = NuiWidth(jSearchEdit, GetNuiScaleDimension(oPC, 200.0));
+    jSearchEdit = NuiHeight(jSearchEdit, fBtnH);
+
+    json jSearchBtn = NuiButton(JsonString("Szukaj"));
+    jSearchBtn = NuiId(jSearchBtn, TRIB_BTN_SEARCH);
+    jSearchBtn = NuiWidth(jSearchBtn, GetNuiScaleDimension(oPC, 80.0));
+    jSearchBtn = NuiHeight(jSearchBtn, fBtnH);
+
+    json jTargetRow = JsonArray();
+    jTargetRow = JsonArrayInsert(jTargetRow, jTargetLbl);
+    jTargetRow = JsonArrayInsert(jTargetRow, NuiSpacer());
+    jTargetRow = JsonArrayInsert(jTargetRow, jSearchEdit);
+    jTargetRow = JsonArrayInsert(jTargetRow, jSearchBtn);
+
+    // Charge row
+    json jChargePfx = NuiLabel(JsonString("Zarzut:"),
+                               JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jChargePfx = NuiWidth(jChargePfx, GetNuiScaleDimension(oPC, 80.0));
+    jChargePfx = NuiHeight(jChargePfx, fBtnH);
+
+    json jChargeEdit = NuiTextEdit(JsonString(""), NuiBind(TRIB_BIND_CHARGE_TXT),
+                                   TRIB_MAX_CHARGE, FALSE);
+    jChargeEdit = NuiHeight(jChargeEdit, fBtnH);
+
+    json jChargeRow = JsonArray();
+    jChargeRow = JsonArrayInsert(jChargeRow, jChargePfx);
+    jChargeRow = JsonArrayInsert(jChargeRow, jChargeEdit);
+
+    // Evidence block
+    json jEvidPfx = NuiLabel(JsonString("Dowody (opcjonalnie):"),
+                             JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jEvidPfx = NuiHeight(jEvidPfx, fLblH);
+
+    json jEvidEdit = NuiTextEdit(JsonString(""), NuiBind(TRIB_BIND_EVID2_TXT),
+                                 TRIB_MAX_EVIDENCE, TRUE);
+    jEvidEdit = NuiHeight(jEvidEdit, fEvidH);
+
+    // Bottom bar
+    json jSubmitBtn = NuiButton(JsonString("Złóż Oskarżenie"));
+    jSubmitBtn = NuiId(jSubmitBtn, TRIB_BTN_SUBMIT_ACC);
+    jSubmitBtn = NuiEnabled(jSubmitBtn, NuiBind(TRIB_BIND_SUBMIT_ENA));
+    jSubmitBtn = NuiWidth(jSubmitBtn, GetNuiScaleDimension(oPC, 180.0));
+    jSubmitBtn = NuiHeight(jSubmitBtn, fBtnH);
+
+    json jBackBtn = NuiButton(JsonString("Anuluj"));
+    jBackBtn = NuiId(jBackBtn, TRIB_BTN_BACK);
+    jBackBtn = NuiWidth(jBackBtn, GetNuiScaleDimension(oPC, 80.0));
+    jBackBtn = NuiHeight(jBackBtn, fBtnH);
+
+    json jBotRow = JsonArray();
+    jBotRow = JsonArrayInsert(jBotRow, jBackBtn);
+    jBotRow = JsonArrayInsert(jBotRow, NuiSpacer());
+    jBotRow = JsonArrayInsert(jBotRow, jSubmitBtn);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jHdr);
+    jCol = JsonArrayInsert(jCol, NuiRow(jTargetRow));
+    jCol = JsonArrayInsert(jCol, NuiRow(jChargeRow));
+    jCol = JsonArrayInsert(jCol, jEvidPfx);
+    jCol = JsonArrayInsert(jCol, jEvidEdit);
+    jCol = JsonArrayInsert(jCol, NuiRow(jBotRow));
+
+    json jSide     = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    float fContent = GetNuiScaleDimension(oPC, 680.0);
+    json jRoot = JsonArray();
+    jRoot = JsonArrayInsert(jRoot, jSide);
+    jRoot = JsonArrayInsert(jRoot, NuiWidth(NuiCol(jCol), fContent));
+    jRoot = JsonArrayInsert(jRoot, jSide);
+    return NuiRow(jRoot);
+}
+
+// ----------------------------------------------------------------
+// Window open / view swap
+// ----------------------------------------------------------------
+
+void TribOpenWindow(object oPC)
+{
+    if(NuiFindWindow(oPC, TRIB_WINDOW) != 0)
+    {
+        NuiSetGroupLayout(oPC, NuiFindWindow(oPC, TRIB_WINDOW),
+                          TRIB_GRP_SWAP, BuildTribCaseListView(oPC));
+        SwapToCaseListView(oPC, NuiFindWindow(oPC, TRIB_WINDOW));
+        return;
+    }
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))
+                 - GetNuiScaleDimension(oPC, TRIB_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT))
+                 - GetNuiScaleDimension(oPC, TRIB_H)) / 2.0;
+    json jGeom = NuiRect(fCX, fCY,
+                         GetNuiScaleDimension(oPC, TRIB_W),
+                         GetNuiScaleDimension(oPC, TRIB_H));
+
+    float fBtnH = GetNuiScaleDimension(oPC, 30.0);
+    json jCloseBtn = NuiButton(JsonString("X"));
+    jCloseBtn = NuiId(jCloseBtn, TRIB_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, GetNuiScaleDimension(oPC, 30.0));
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jTopBar = JsonArray();
+    jTopBar = JsonArrayInsert(jTopBar, NuiSpacer());
+    jTopBar = JsonArrayInsert(jTopBar, jCloseBtn);
+
+    json jSwapGrp = NuiGroup(BuildTribCaseListView(oPC), FALSE, NUI_SCROLLBARS_NONE);
+    jSwapGrp = NuiId(jSwapGrp, TRIB_GRP_SWAP);
+
+    json jRootChildren = JsonArray();
+    jRootChildren = JsonArrayInsert(jRootChildren, NuiRow(jTopBar));
+    jRootChildren = JsonArrayInsert(jRootChildren, jSwapGrp);
+
+    json jWin = NuiWindow(NuiCol(jRootChildren),
+        JsonBool(FALSE),
+        NuiBind(TRIB_WIN_GEOM),
+        JsonBool(FALSE), JsonBool(FALSE),
+        JsonBool(FALSE), JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    int nToken = NuiCreate(oPC, jWin, TRIB_WINDOW, TRIB_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, TRIB_WIN_GEOM, jGeom);
+
+    SwapToCaseListView(oPC, nToken);
+}
+
+void SwapToCaseListView(object oPC, int nToken)
+{
+    NuiSetGroupLayout(oPC, nToken, TRIB_GRP_SWAP, BuildTribCaseListView(oPC));
+    DeleteLocalInt(oPC, TRIB_LVAR_CASE_ID);
+    FeedCaseList(oPC, nToken);
+}
+
+void SwapToCaseDetailView(object oPC, int nToken, int nCaseId)
+{
+    NuiSetGroupLayout(oPC, nToken, TRIB_GRP_SWAP, BuildTribDetailView(oPC));
+    SetLocalInt(oPC, TRIB_LVAR_CASE_ID, nCaseId);
+    FeedCaseDetail(oPC, nToken, nCaseId);
+}
+
+void SwapToAccuseView(object oPC, int nToken)
+{
+    DeleteLocalString(oPC, TRIB_LVAR_TARGET_UUID);
+    DeleteLocalString(oPC, TRIB_LVAR_TARGET_NAME);
+    NuiSetGroupLayout(oPC, nToken, TRIB_GRP_SWAP, BuildTribAccuseView(oPC));
+    FeedAccuseView(oPC, nToken);
+    NuiSetBindWatch(oPC, nToken, TRIB_BIND_CHARGE_TXT, TRUE);
+}
+
+// ----------------------------------------------------------------
+// Feed – case list
+// ----------------------------------------------------------------
+
+void FeedCaseList(object oPC, int nToken)
+{
+    json jCases = TribGetAllCases();
+    int  nCount = JsonGetLength(jCases);
+
+    json jNames    = JsonArray();
+    json jCharges  = JsonArray();
+    json jStatuses = JsonArray();
+    json jColors   = JsonArray();
+    json jEncs     = JsonArray();
+
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jRow    = JsonArrayGet(jCases, i);
+        string sDef  = JsonGetString(JsonObjectGet(jRow, "defendant_name"));
+        string sChg  = JsonGetString(JsonObjectGet(jRow, "charge"));
+        int nVerdict = JsonGetInt   (JsonObjectGet(jRow, "verdict"));
+
+        jNames    = JsonArrayInsert(jNames,    JsonString(sDef));
+        jCharges  = JsonArrayInsert(jCharges,  JsonString(sChg));
+        jStatuses = JsonArrayInsert(jStatuses, JsonString(TribVerdictLabel(nVerdict)));
+        jColors   = JsonArrayInsert(jColors,   TribVerdictColor(nVerdict));
+        jEncs     = JsonArrayInsert(jEncs,     JsonBool(FALSE));
+    }
+
+    NuiSetBind(oPC, nToken, TRIB_BIND_LIST_NAME,   jNames);
+    NuiSetBind(oPC, nToken, TRIB_BIND_LIST_CHARGE,  jCharges);
+    NuiSetBind(oPC, nToken, TRIB_BIND_LIST_STATUS,  jStatuses);
+    NuiSetBind(oPC, nToken, TRIB_BIND_LIST_COLOR,   jColors);
+    NuiSetBind(oPC, nToken, TRIB_BIND_LIST_ENC,     jEncs);
+    NuiSetBind(oPC, nToken, TRIB_BIND_LIST_COUNT,   JsonInt(nCount));
+}
+
+// ----------------------------------------------------------------
+// Feed – case detail
+// ----------------------------------------------------------------
+
+void FeedCaseDetail(object oPC, int nToken, int nCaseId)
+{
+    json jCase = TribGetCase(nCaseId);
+    if(JsonGetType(jCase) == JSON_TYPE_NULL)
+    {
+        SwapToCaseListView(oPC, nToken);
+        return;
+    }
+
+    string sDefName  = JsonGetString(JsonObjectGet(jCase, "defendant_name"));
+    string sAccName  = JsonGetString(JsonObjectGet(jCase, "accuser_name"));
+    string sCharge   = JsonGetString(JsonObjectGet(jCase, "charge"));
+    string sEvidence = JsonGetString(JsonObjectGet(jCase, "evidence"));
+    string sDefense  = JsonGetString(JsonObjectGet(jCase, "defense"));
+    string sSentence = JsonGetString(JsonObjectGet(jCase, "sentence"));
+    int    nVerdict  = JsonGetInt   (JsonObjectGet(jCase, "verdict"));
+    int    nCreated  = JsonGetInt   (JsonObjectGet(jCase, "created_at"));
+    string sDefUUID  = JsonGetString(JsonObjectGet(jCase, "defendant_uuid"));
+    string sAccUUID  = JsonGetString(JsonObjectGet(jCase, "accuser_uuid"));
+
+    string sHdr = "Sprawa #" + IntToString(nCaseId)
+                  + "  —  " + sDefName
+                  + "  —  " + TribFormatDateSQL(nCreated);
+
+    string sEvidDisplay = sEvidence;
+    if(sEvidDisplay == "") sEvidDisplay = "(Inkwizycja nie przedstawiła jeszcze dowodów)";
+
+    NuiSetBind(oPC, nToken, TRIB_BIND_DETAIL_HDR,    JsonString(sHdr));
+    NuiSetBind(oPC, nToken, TRIB_BIND_DETAIL_CHARGE,
+               JsonString("Zarzut: " + sCharge));
+    NuiSetBind(oPC, nToken, TRIB_BIND_DETAIL_ACC,
+               JsonString("Oskarżyciel: " + sAccName));
+    NuiSetBind(oPC, nToken, TRIB_BIND_EVIDENCE_TXT,  JsonString(sEvidDisplay));
+    NuiSetBind(oPC, nToken, TRIB_BIND_DEFENSE_TXT,   JsonString(sDefense));
+    NuiSetBind(oPC, nToken, TRIB_BIND_SENTENCE_TXT,  JsonString(sSentence));
+    NuiSetBind(oPC, nToken, TRIB_BIND_STATUS_LBL,
+               JsonString("Status: " + TribVerdictLabel(nVerdict)));
+
+    string sMyUUID = GetObjectUUID(oPC);
+    int bIsJudge   = GetIsDM(oPC);
+    int bIsDef     = (sMyUUID == sDefUUID);
+    int bIsAcc     = (sMyUUID == sAccUUID);
+    int bPending   = (nVerdict == TRIB_VERDICT_PENDING);
+
+    // Verdict buttons and evidence editing: DM only, pending cases only
+    NuiSetBind(oPC, nToken, TRIB_BIND_VERDICT_ENA, JsonBool(bIsJudge && bPending));
+    // Defense textarea: defendant or accuser (supplementing evidence) while pending
+    NuiSetBind(oPC, nToken, TRIB_BIND_DEF_ENA,     JsonBool((bIsDef || bIsAcc) && bPending));
+
+    NuiSetBindWatch(oPC, nToken, TRIB_BIND_DEFENSE_TXT, bPending);
+}
+
+// ----------------------------------------------------------------
+// Feed – accuse view
+// ----------------------------------------------------------------
+
+void FeedAccuseView(object oPC, int nToken)
+{
+    string sName  = GetLocalString(oPC, TRIB_LVAR_TARGET_NAME);
+    int    bHas   = (sName != "");
+
+    NuiSetBind(oPC, nToken, TRIB_BIND_TARGET_LBL,
+               JsonString(bHas ? "Oskarżony: " + sName : "Oskarżony: (nie wybrano)"));
+    NuiSetBind(oPC, nToken, TRIB_BIND_SEARCH_TXT,  JsonString(""));
+    NuiSetBind(oPC, nToken, TRIB_BIND_CHARGE_TXT,  JsonString(""));
+    NuiSetBind(oPC, nToken, TRIB_BIND_EVID2_TXT,   JsonString(""));
+    NuiSetBind(oPC, nToken, TRIB_BIND_SUBMIT_ENA,  JsonBool(FALSE));
+}
+
+// ----------------------------------------------------------------
+// Verdict enforcement – game consequences
+// ----------------------------------------------------------------
+
+void TribApplyVerdict(object oPC, int nCaseId, int nVerdict, string sSentence)
+{
+    json jCase = TribGetCase(nCaseId);
+    if(JsonGetType(jCase) == JSON_TYPE_NULL) return;
+    if(JsonGetInt(JsonObjectGet(jCase, "verdict")) != TRIB_VERDICT_PENDING) return;
+
+    string sDefUUID = JsonGetString(JsonObjectGet(jCase, "defendant_uuid"));
+    string sDefName = JsonGetString(JsonObjectGet(jCase, "defendant_name"));
+
+    TribSetVerdict(nCaseId, nVerdict, sSentence);
+
+    // Build global announcement
+    string sVerd = TribVerdictLabel(nVerdict);
+    string sMsg  = "[Trybunał] Wyrok w sprawie " + sDefName + ": " + sVerd + ".";
+    if(sSentence != "") sMsg = sMsg + " " + sSentence;
+
+    // Broadcast to all online players
+    object oBroadcast = GetFirstPC();
+    while(GetIsObjectValid(oBroadcast))
+    {
+        SendMessageToPC(oBroadcast, sMsg);
+        oBroadcast = GetNextPC();
+    }
+
+    // Find defendant online; effects only apply if present
+    object oTarget = GetFirstPC();
+    while(GetIsObjectValid(oTarget))
+    {
+        if(GetObjectUUID(oTarget) == sDefUUID) break;
+        oTarget = GetNextPC();
+    }
+    if(!GetIsObjectValid(oTarget)) return;
+
+    switch(nVerdict)
+    {
+        case TRIB_VERDICT_JAIL:
+            SetLocalInt(oTarget, TRIB_LVAR_IMPRISONED, 1);
+            // Slow + ethereal shimmer as visual marker; other systems check TRIB_IMPRISONED
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                EffectLinkEffects(EffectSlow(),
+                    EffectVisualEffect(VFX_DUR_ETHEREAL_VISAGE)),
+                oTarget);
+            FloatingTextStringOnCreature(
+                "Pieczęć Inkwizycji oplata cię łańcuchami winy. Nie ma ucieczki.",
+                oTarget, FALSE);
+            break;
+
+        case TRIB_VERDICT_EXILE:
+            SetLocalInt(oTarget, TRIB_LVAR_EXILED, 1);
+            FloatingTextStringOnCreature(
+                "Wygnanie! Piętno Trybunału wskazuje ci bramę. Nie wracaj.",
+                oTarget, FALSE);
+            // Jump to exile landing waypoint if placed in the module
+            object oExile = GetWaypointByTag(TRIB_EXILE_AREA_TAG);
+            if(GetIsObjectValid(oExile))
+                AssignCommand(oTarget, ActionJumpToObject(oExile, FALSE));
+            break;
+
+        case TRIB_VERDICT_DEATH:
+            SetLocalInt(oTarget, TRIB_LVAR_DEATH_MARK, 1);
+            // Persistent evil aura marks the condemned visually
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                EffectVisualEffect(VFX_DUR_EVIL_PROTECTION),
+                oTarget);
+            FloatingTextStringOnCreature(
+                "Nosisz piętno wyroku śmierci. Inkwizycja wyciągnie ku tobie rękę.",
+                oTarget, FALSE);
+            break;
+
+        case TRIB_VERDICT_INNOCENT:
+            // Clear all tribunal state and remove penalty effects
+            DeleteLocalInt(oTarget, TRIB_LVAR_IMPRISONED);
+            DeleteLocalInt(oTarget, TRIB_LVAR_EXILED);
+            DeleteLocalInt(oTarget, TRIB_LVAR_DEATH_MARK);
+            RemoveAllEffects(oTarget);
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                EffectVisualEffect(VFX_IMP_HOLY_AID), oTarget, 3.0);
+            FloatingTextStringOnCreature(
+                "Trybunał uznał cię za niewinnego. Niechaj blask prawdy cię ochroni.",
+                oTarget, FALSE);
+            break;
+    }
+}
+
+// ----------------------------------------------------------------
+// Search popup (select defendant)
+// ----------------------------------------------------------------
+
+void TribShowSearchPopup(object oPC, json jResults)
+{
+    if(NuiFindWindow(oPC, TRIB_WIN_SEARCH) != 0)
+        NuiDestroy(oPC, NuiFindWindow(oPC, TRIB_WIN_SEARCH));
+
+    int   nCount = JsonGetLength(jResults);
+    float fRowH  = GetNuiScaleDimension(oPC, 26.0);
+    float fW     = GetNuiScaleDimension(oPC, 380.0);
+    float fH     = GetNuiScaleDimension(oPC, 220.0);
+    float fX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - fW) / 2.0;
+    float fY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - fH) / 2.0;
+
+    json jNameLbl = NuiLabel(NuiBind(TRIB_BIND_SRCH_NAME),
+                             JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    json jCell = NuiGroup(NuiRow(JsonArrayInsert(JsonArray(), jNameLbl)),
+                          TRUE, NUI_SCROLLBARS_NONE);
+    jCell = NuiId(jCell, TRIB_BTN_SRCH_ROW);
+    jCell = NuiEncouraged(jCell, NuiBind(TRIB_BIND_SRCH_ENC));
+
+    json jTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jCell, 0.0, TRUE));
+    json jList = NuiList(jTmpl, NuiBind(TRIB_BIND_SRCH_COUNT), fRowH);
+    jList = NuiHeight(jList, GetNuiScaleDimension(oPC, 160.0));
+
+    json jWin = NuiWindow(NuiCol(JsonArrayInsert(JsonArray(), jList)),
+        JsonString("Wybierz Oskarżonego"),
+        NuiRect(fX, fY, fW, fH),
+        JsonBool(FALSE), JsonBool(FALSE), JsonBool(TRUE),
+        JsonBool(FALSE), JsonBool(TRUE));
+
+    int nPopToken = NuiCreate(oPC, jWin, TRIB_WIN_SEARCH, TRIB_EV_SCRIPT);
+
+    json jNames = JsonArray();
+    json jEncs  = JsonArray();
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jEntry = JsonArrayGet(jResults, i);
+        jNames = JsonArrayInsert(jNames,
+            JsonString(JsonGetString(JsonObjectGet(jEntry, "char_name"))));
+        jEncs  = JsonArrayInsert(jEncs, JsonBool(FALSE));
+    }
+    NuiSetBind(oPC, nPopToken, TRIB_BIND_SRCH_NAME,  jNames);
+    NuiSetBind(oPC, nPopToken, TRIB_BIND_SRCH_ENC,   jEncs);
+    NuiSetBind(oPC, nPopToken, TRIB_BIND_SRCH_COUNT, JsonInt(nCount));
+}

--- a/Tribunal/Scripts/lib_trib_def.nss
+++ b/Tribunal/Scripts/lib_trib_def.nss
@@ -1,0 +1,128 @@
+#include "lib_nui"
+#include "sql_trib"
+
+// Forward declarations
+void TribOpenWindow(object oPC);
+void SwapToCaseListView(object oPC, int nToken);
+void SwapToCaseDetailView(object oPC, int nToken, int nCaseId);
+void SwapToAccuseView(object oPC, int nToken);
+void FeedCaseList(object oPC, int nToken);
+void FeedCaseDetail(object oPC, int nToken, int nCaseId);
+void FeedAccuseView(object oPC, int nToken);
+void TribApplyVerdict(object oPC, int nCaseId, int nVerdict, string sSentence);
+void TribShowSearchPopup(object oPC, json jResults);
+
+// ----------------------------------------------------------------
+// Window / group identifiers
+// ----------------------------------------------------------------
+
+const string TRIB_WINDOW        = "TRIB_WINDOW";
+const string TRIB_EV_SCRIPT     = "lib_trib_ev";
+const string TRIB_GRP_SWAP      = "TRIB_GRP_SWAP";
+const string TRIB_WIN_GEOM      = "trib_win_geom";
+const string TRIB_WIN_SEARCH    = "TRIB_WIN_SEARCH";
+
+// ----------------------------------------------------------------
+// Case-list bind names
+// ----------------------------------------------------------------
+
+const string TRIB_BIND_LIST_NAME    = "trib_lst_name";
+const string TRIB_BIND_LIST_CHARGE  = "trib_lst_charge";
+const string TRIB_BIND_LIST_STATUS  = "trib_lst_status";
+const string TRIB_BIND_LIST_COLOR   = "trib_lst_color";
+const string TRIB_BIND_LIST_ENC     = "trib_lst_enc";
+const string TRIB_BIND_LIST_COUNT   = "trib_lst_cnt";
+
+// ----------------------------------------------------------------
+// Case-detail bind names
+// ----------------------------------------------------------------
+
+const string TRIB_BIND_DETAIL_HDR   = "trib_det_hdr";
+const string TRIB_BIND_DETAIL_CHARGE= "trib_det_charge";
+const string TRIB_BIND_DETAIL_ACC   = "trib_det_acc";
+const string TRIB_BIND_EVIDENCE_TXT = "trib_evid_txt";
+const string TRIB_BIND_DEFENSE_TXT  = "trib_def_txt";
+const string TRIB_BIND_DEF_ENA      = "trib_def_ena";
+const string TRIB_BIND_SENTENCE_TXT = "trib_sent_txt";
+const string TRIB_BIND_VERDICT_ENA  = "trib_verd_ena";
+const string TRIB_BIND_STATUS_LBL   = "trib_stat_lbl";
+
+// ----------------------------------------------------------------
+// Accuse-view bind names
+// ----------------------------------------------------------------
+
+const string TRIB_BIND_SEARCH_TXT   = "trib_srch_txt";
+const string TRIB_BIND_TARGET_LBL   = "trib_tgt_lbl";
+const string TRIB_BIND_CHARGE_TXT   = "trib_chg_txt";
+const string TRIB_BIND_EVID2_TXT    = "trib_evid2_txt";
+const string TRIB_BIND_SUBMIT_ENA   = "trib_sub_ena";
+
+// ----------------------------------------------------------------
+// Search-popup bind names
+// ----------------------------------------------------------------
+
+const string TRIB_BIND_SRCH_NAME    = "trib_sn";
+const string TRIB_BIND_SRCH_ENC     = "trib_se";
+const string TRIB_BIND_SRCH_COUNT   = "trib_sc";
+
+// ----------------------------------------------------------------
+// Button identifiers
+// ----------------------------------------------------------------
+
+const string TRIB_BTN_CLOSE         = "trib_btn_close";
+const string TRIB_BTN_ACCUSE        = "trib_btn_accuse";
+const string TRIB_BTN_BACK          = "trib_btn_back";
+const string TRIB_BTN_SUBMIT_DEF    = "trib_btn_subdef";
+const string TRIB_BTN_SUBMIT_EVID   = "trib_btn_subevid";
+const string TRIB_BTN_GUILTY_JAIL   = "trib_btn_jail";
+const string TRIB_BTN_GUILTY_EXILE  = "trib_btn_exile";
+const string TRIB_BTN_GUILTY_DEATH  = "trib_btn_death";
+const string TRIB_BTN_INNOCENT      = "trib_btn_innocent";
+const string TRIB_BTN_ROW           = "trib_btn_row";
+const string TRIB_BTN_SEARCH        = "trib_btn_srch";
+const string TRIB_BTN_SUBMIT_ACC    = "trib_btn_subacc";
+const string TRIB_BTN_SRCH_ROW      = "trib_srow";
+
+// ----------------------------------------------------------------
+// PC local-variable keys
+// ----------------------------------------------------------------
+
+const string TRIB_LVAR_CASE_ID      = "TRIB_CASE_ID";
+const string TRIB_LVAR_TARGET_UUID  = "TRIB_TARGET_UUID";
+const string TRIB_LVAR_TARGET_NAME  = "TRIB_TARGET_NAME";
+const string TRIB_LVAR_SEARCH_RES   = "TRIB_SEARCH_RES";
+
+// Persistent verdict state (read by other systems, e.g. Prison module)
+const string TRIB_LVAR_IMPRISONED   = "TRIB_IMPRISONED";
+const string TRIB_LVAR_DEATH_MARK   = "TRIB_DEATH_MARK";
+const string TRIB_LVAR_EXILED       = "TRIB_EXILED";
+
+// ----------------------------------------------------------------
+// Verdict codes
+// ----------------------------------------------------------------
+
+const int    TRIB_VERDICT_PENDING   = 0;
+const int    TRIB_VERDICT_INNOCENT  = 1;
+const int    TRIB_VERDICT_JAIL      = 2;
+const int    TRIB_VERDICT_EXILE     = 3;
+const int    TRIB_VERDICT_DEATH     = 4;
+
+// ----------------------------------------------------------------
+// Field limits
+// ----------------------------------------------------------------
+
+const int    TRIB_MAX_CHARGE        = 120;
+const int    TRIB_MAX_EVIDENCE      = 800;
+const int    TRIB_MAX_DEFENSE       = 800;
+const int    TRIB_MAX_SENTENCE      = 120;
+const int    TRIB_MAX_OPEN_PER_DEF  = 3;
+
+// ----------------------------------------------------------------
+// Layout
+// ----------------------------------------------------------------
+
+const float  TRIB_W                 = 720.0;
+const float  TRIB_H                 = 540.0;
+
+// Tag of the waypoint / placeable used as exile landing point
+const string TRIB_EXILE_AREA_TAG    = "TRIB_EXILE_AREA";

--- a/Tribunal/Scripts/lib_trib_ev.nss
+++ b/Tribunal/Scripts/lib_trib_ev.nss
@@ -1,0 +1,220 @@
+#include "lib_trib"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    // ---- Search popup (select defendant) ----
+    if(nToken == NuiFindWindow(oPC, TRIB_WIN_SEARCH))
+    {
+        if(sEvent == EVENT_TYPE_MOUSEDOWN && sElem == TRIB_BTN_SRCH_ROW)
+        {
+            json jRes = GetLocalJson(oPC, TRIB_LVAR_SEARCH_RES);
+            if(nIdx < 0 || nIdx >= JsonGetLength(jRes)) return;
+
+            json   jEntry = JsonArrayGet(jRes, nIdx);
+            string sUuid  = JsonGetString(JsonObjectGet(jEntry, "uuid"));
+            string sName  = JsonGetString(JsonObjectGet(jEntry, "char_name"));
+
+            SetLocalString(oPC, TRIB_LVAR_TARGET_UUID, sUuid);
+            SetLocalString(oPC, TRIB_LVAR_TARGET_NAME, sName);
+            NuiDestroy(oPC, nToken);
+
+            int nMain = NuiFindWindow(oPC, TRIB_WINDOW);
+            if(nMain)
+            {
+                NuiSetBind(oPC, nMain, TRIB_BIND_TARGET_LBL,
+                           JsonString("Oskarżony: " + sName));
+                string sCharge = JsonGetString(NuiGetBind(oPC, nMain, TRIB_BIND_CHARGE_TXT));
+                NuiSetBind(oPC, nMain, TRIB_BIND_SUBMIT_ENA,
+                           JsonBool(sCharge != "" && sUuid != ""));
+            }
+        }
+        return;
+    }
+
+    if(nToken != NuiFindWindow(oPC, TRIB_WINDOW)) return;
+
+    // ---- Window closed ----
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalString(oPC, TRIB_LVAR_TARGET_UUID);
+        DeleteLocalString(oPC, TRIB_LVAR_TARGET_NAME);
+        DeleteLocalInt   (oPC, TRIB_LVAR_CASE_ID);
+        DeleteLocalJson  (oPC, TRIB_LVAR_SEARCH_RES);
+        return;
+    }
+
+    // ---- Watch: charge field enables submit button ----
+    if(sEvent == EVENT_TYPE_WATCH && sElem == TRIB_BIND_CHARGE_TXT)
+    {
+        string sCharge = JsonGetString(NuiGetBind(oPC, nToken, TRIB_BIND_CHARGE_TXT));
+        string sTarget = GetLocalString(oPC, TRIB_LVAR_TARGET_UUID);
+        NuiSetBind(oPC, nToken, TRIB_BIND_SUBMIT_ENA,
+                   JsonBool(sCharge != "" && sTarget != ""));
+        return;
+    }
+
+    // ---- Click / mousedown dispatch ----
+    if(sEvent != EVENT_TYPE_CLICK && sEvent != EVENT_TYPE_MOUSEDOWN) return;
+
+    if(sElem == TRIB_BTN_CLOSE)
+    {
+        NuiDestroy(oPC, nToken);
+        return;
+    }
+
+    if(sElem == TRIB_BTN_ACCUSE)
+    {
+        SwapToAccuseView(oPC, nToken);
+        return;
+    }
+
+    if(sElem == TRIB_BTN_BACK)
+    {
+        SwapToCaseListView(oPC, nToken);
+        return;
+    }
+
+    // Row click in case list
+    if(sElem == TRIB_BTN_ROW && sEvent == EVENT_TYPE_MOUSEDOWN)
+    {
+        json jCases = TribGetAllCases();
+        if(nIdx < 0 || nIdx >= JsonGetLength(jCases)) return;
+        int nCaseId = JsonGetInt(JsonObjectGet(JsonArrayGet(jCases, nIdx), "id"));
+        SwapToCaseDetailView(oPC, nToken, nCaseId);
+        return;
+    }
+
+    // Search for defendant in accuse view
+    if(sElem == TRIB_BTN_SEARCH)
+    {
+        string sQuery = JsonGetString(NuiGetBind(oPC, nToken, TRIB_BIND_SEARCH_TXT));
+        if(sQuery == "")
+        {
+            SendMessageToPC(oPC, "[Trybunał] Wpisz imię, aby szukać.");
+            return;
+        }
+        json jRes = TribSearchPlayers(sQuery, oPC);
+        if(JsonGetLength(jRes) == 0)
+        {
+            SendMessageToPC(oPC, "[Trybunał] Nie znaleziono gracza. Musi się zalogować co najmniej raz.");
+            return;
+        }
+        SetLocalJson(oPC, TRIB_LVAR_SEARCH_RES, jRes);
+        TribShowSearchPopup(oPC, jRes);
+        return;
+    }
+
+    // Submit accusation
+    if(sElem == TRIB_BTN_SUBMIT_ACC)
+    {
+        string sTargetUUID = GetLocalString(oPC, TRIB_LVAR_TARGET_UUID);
+        string sTargetName = GetLocalString(oPC, TRIB_LVAR_TARGET_NAME);
+        if(sTargetUUID == "")
+        {
+            SendMessageToPC(oPC, "[Trybunał] Nie wybrano oskarżonego.");
+            return;
+        }
+        string sCharge = JsonGetString(NuiGetBind(oPC, nToken, TRIB_BIND_CHARGE_TXT));
+        if(sCharge == "")
+        {
+            SendMessageToPC(oPC, "[Trybunał] Zarzut nie może być pusty.");
+            return;
+        }
+        if(TribGetOpenCaseCountFor(sTargetUUID) >= TRIB_MAX_OPEN_PER_DEF)
+        {
+            SendMessageToPC(oPC, "[Trybunał] Oskarżony ma już "
+                + IntToString(TRIB_MAX_OPEN_PER_DEF) + " otwartych spraw. Trybunał odmawia przyjęcia kolejnej.");
+            return;
+        }
+        string sEvid = JsonGetString(NuiGetBind(oPC, nToken, TRIB_BIND_EVID2_TXT));
+        int nId = TribCreateCase(sTargetUUID, sTargetName,
+                                 GetObjectUUID(oPC), GetName(oPC),
+                                 sCharge, sEvid);
+        SendMessageToPC(oPC, "[Trybunał] Oskarżenie złożone. Sprawa #" + IntToString(nId) + ".");
+
+        // Warn defendant if online
+        object oNotify = GetFirstPC();
+        while(GetIsObjectValid(oNotify))
+        {
+            if(GetObjectUUID(oNotify) == sTargetUUID)
+            {
+                SendMessageToPC(oNotify,
+                    "[Trybunał] Złożono przeciwko tobie oskarżenie: \"" + sCharge + "\".");
+                FloatingTextStringOnCreature(
+                    "Inkwizycja skierowała ku tobie swój wzrok...", oNotify, FALSE);
+                break;
+            }
+            oNotify = GetNextPC();
+        }
+
+        DeleteLocalString(oPC, TRIB_LVAR_TARGET_UUID);
+        DeleteLocalString(oPC, TRIB_LVAR_TARGET_NAME);
+        SwapToCaseListView(oPC, nToken);
+        return;
+    }
+
+    // Submit defense testimony
+    if(sElem == TRIB_BTN_SUBMIT_DEF)
+    {
+        int nCaseId = GetLocalInt(oPC, TRIB_LVAR_CASE_ID);
+        if(nCaseId <= 0) return;
+        string sDefense = JsonGetString(NuiGetBind(oPC, nToken, TRIB_BIND_DEFENSE_TXT));
+        TribUpdateDefense(nCaseId, sDefense);
+        SendMessageToPC(oPC, "[Trybunał] Zeznanie zostało złożone.");
+        return;
+    }
+
+    // Update evidence (judge only)
+    if(sElem == TRIB_BTN_SUBMIT_EVID)
+    {
+        if(!GetIsDM(oPC))
+        {
+            SendMessageToPC(oPC, "[Trybunał] Tylko Inkwizycja może uzupełniać dowody.");
+            return;
+        }
+        int nCaseId = GetLocalInt(oPC, TRIB_LVAR_CASE_ID);
+        if(nCaseId <= 0) return;
+        string sEvid = JsonGetString(NuiGetBind(oPC, nToken, TRIB_BIND_EVIDENCE_TXT));
+        TribUpdateEvidence(nCaseId, sEvid);
+        SendMessageToPC(oPC, "[Trybunał] Dowody zaktualizowane.");
+        return;
+    }
+
+    // Verdicts — all require DM
+    if(!GetIsDM(oPC)) return;
+
+    int nCaseId  = GetLocalInt(oPC, TRIB_LVAR_CASE_ID);
+    if(nCaseId <= 0) return;
+    string sSent = JsonGetString(NuiGetBind(oPC, nToken, TRIB_BIND_SENTENCE_TXT));
+
+    if(sElem == TRIB_BTN_GUILTY_JAIL)
+    {
+        TribApplyVerdict(oPC, nCaseId, TRIB_VERDICT_JAIL, sSent);
+        SwapToCaseDetailView(oPC, nToken, nCaseId);
+        return;
+    }
+    if(sElem == TRIB_BTN_GUILTY_EXILE)
+    {
+        TribApplyVerdict(oPC, nCaseId, TRIB_VERDICT_EXILE, sSent);
+        SwapToCaseDetailView(oPC, nToken, nCaseId);
+        return;
+    }
+    if(sElem == TRIB_BTN_GUILTY_DEATH)
+    {
+        TribApplyVerdict(oPC, nCaseId, TRIB_VERDICT_DEATH, sSent);
+        SwapToCaseDetailView(oPC, nToken, nCaseId);
+        return;
+    }
+    if(sElem == TRIB_BTN_INNOCENT)
+    {
+        TribApplyVerdict(oPC, nCaseId, TRIB_VERDICT_INNOCENT, sSent);
+        SwapToCaseDetailView(oPC, nToken, nCaseId);
+        return;
+    }
+}

--- a/Tribunal/Scripts/sql_trib.nss
+++ b/Tribunal/Scripts/sql_trib.nss
@@ -1,0 +1,164 @@
+void TribCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("tribunal",
+        "CREATE TABLE IF NOT EXISTS trib_cases ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "defendant_uuid TEXT NOT NULL, "
+        "defendant_name TEXT NOT NULL, "
+        "accuser_uuid TEXT NOT NULL, "
+        "accuser_name TEXT NOT NULL, "
+        "charge TEXT DEFAULT '', "
+        "evidence TEXT DEFAULT '', "
+        "defense TEXT DEFAULT '', "
+        "verdict INTEGER DEFAULT 0, "
+        "sentence TEXT DEFAULT '', "
+        "created_at INTEGER DEFAULT 0, "
+        "resolved_at INTEGER DEFAULT 0)");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("tribunal",
+        "CREATE TABLE IF NOT EXISTS trib_players ("
+        "uuid TEXT PRIMARY KEY, "
+        "char_name TEXT DEFAULT '', "
+        "last_online INTEGER DEFAULT 0)");
+    SqlStep(q);
+}
+
+void TribRegisterPlayer(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("tribunal",
+        "INSERT OR REPLACE INTO trib_players (uuid, char_name, last_online) "
+        "VALUES (@uuid, @name, strftime('%s','now'))");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindString(q, "@name", GetName(oPC));
+    SqlStep(q);
+}
+
+int TribCreateCase(string sDefUUID, string sDefName,
+                   string sAccUUID, string sAccName,
+                   string sCharge,  string sEvidence)
+{
+    sqlquery q = SqlPrepareQueryCampaign("tribunal",
+        "INSERT INTO trib_cases "
+        "(defendant_uuid, defendant_name, accuser_uuid, accuser_name, charge, evidence, created_at) "
+        "VALUES (@duuid, @dname, @auuid, @aname, @charge, @evid, strftime('%s','now'))");
+    SqlBindString(q, "@duuid",  sDefUUID);
+    SqlBindString(q, "@dname",  sDefName);
+    SqlBindString(q, "@auuid",  sAccUUID);
+    SqlBindString(q, "@aname",  sAccName);
+    SqlBindString(q, "@charge", sCharge);
+    SqlBindString(q, "@evid",   sEvidence);
+    SqlStep(q);
+    sqlquery qId = SqlPrepareQueryCampaign("tribunal", "SELECT last_insert_rowid()");
+    if(SqlStep(qId)) return SqlGetInt(qId, 0);
+    return 0;
+}
+
+json TribGetAllCases()
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("tribunal",
+        "SELECT id, defendant_name, accuser_name, charge, verdict "
+        "FROM trib_cases ORDER BY verdict ASC, created_at DESC LIMIT 50");
+    while(SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "id",             JsonInt   (SqlGetInt   (q, 0)));
+        jRow = JsonObjectSet(jRow, "defendant_name", JsonString(SqlGetString(q, 1)));
+        jRow = JsonObjectSet(jRow, "accuser_name",   JsonString(SqlGetString(q, 2)));
+        jRow = JsonObjectSet(jRow, "charge",         JsonString(SqlGetString(q, 3)));
+        jRow = JsonObjectSet(jRow, "verdict",        JsonInt   (SqlGetInt   (q, 4)));
+        jRows = JsonArrayInsert(jRows, jRow);
+    }
+    return jRows;
+}
+
+json TribGetCase(int nId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("tribunal",
+        "SELECT id, defendant_uuid, defendant_name, accuser_uuid, accuser_name, "
+        "charge, evidence, defense, verdict, sentence, created_at, resolved_at "
+        "FROM trib_cases WHERE id = @id");
+    SqlBindInt(q, "@id", nId);
+    if(!SqlStep(q)) return JsonNull();
+    json jCase = JsonObject();
+    jCase = JsonObjectSet(jCase, "id",             JsonInt   (SqlGetInt   (q, 0)));
+    jCase = JsonObjectSet(jCase, "defendant_uuid", JsonString(SqlGetString(q, 1)));
+    jCase = JsonObjectSet(jCase, "defendant_name", JsonString(SqlGetString(q, 2)));
+    jCase = JsonObjectSet(jCase, "accuser_uuid",   JsonString(SqlGetString(q, 3)));
+    jCase = JsonObjectSet(jCase, "accuser_name",   JsonString(SqlGetString(q, 4)));
+    jCase = JsonObjectSet(jCase, "charge",         JsonString(SqlGetString(q, 5)));
+    jCase = JsonObjectSet(jCase, "evidence",       JsonString(SqlGetString(q, 6)));
+    jCase = JsonObjectSet(jCase, "defense",        JsonString(SqlGetString(q, 7)));
+    jCase = JsonObjectSet(jCase, "verdict",        JsonInt   (SqlGetInt   (q, 8)));
+    jCase = JsonObjectSet(jCase, "sentence",       JsonString(SqlGetString(q, 9)));
+    jCase = JsonObjectSet(jCase, "created_at",     JsonInt   (SqlGetInt   (q, 10)));
+    jCase = JsonObjectSet(jCase, "resolved_at",    JsonInt   (SqlGetInt   (q, 11)));
+    return jCase;
+}
+
+void TribUpdateEvidence(int nId, string sEvidence)
+{
+    sqlquery q = SqlPrepareQueryCampaign("tribunal",
+        "UPDATE trib_cases SET evidence = @evid WHERE id = @id");
+    SqlBindString(q, "@evid", sEvidence);
+    SqlBindInt   (q, "@id",   nId);
+    SqlStep(q);
+}
+
+void TribUpdateDefense(int nId, string sDefense)
+{
+    sqlquery q = SqlPrepareQueryCampaign("tribunal",
+        "UPDATE trib_cases SET defense = @def WHERE id = @id");
+    SqlBindString(q, "@def", sDefense);
+    SqlBindInt   (q, "@id",  nId);
+    SqlStep(q);
+}
+
+void TribSetVerdict(int nId, int nVerdict, string sSentence)
+{
+    sqlquery q = SqlPrepareQueryCampaign("tribunal",
+        "UPDATE trib_cases SET verdict = @v, sentence = @s, "
+        "resolved_at = strftime('%s','now') WHERE id = @id");
+    SqlBindInt   (q, "@v",  nVerdict);
+    SqlBindString(q, "@s",  sSentence);
+    SqlBindInt   (q, "@id", nId);
+    SqlStep(q);
+}
+
+json TribSearchPlayers(string sQuery, object oSelf)
+{
+    json jResults = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("tribunal",
+        "SELECT uuid, char_name FROM trib_players "
+        "WHERE LOWER(char_name) LIKE LOWER('%' || @q || '%') "
+        "AND uuid != @self LIMIT 8");
+    SqlBindString(q, "@q",    sQuery);
+    SqlBindString(q, "@self", GetObjectUUID(oSelf));
+    while(SqlStep(q))
+    {
+        json jEntry = JsonObject();
+        jEntry = JsonObjectSet(jEntry, "uuid",      JsonString(SqlGetString(q, 0)));
+        jEntry = JsonObjectSet(jEntry, "char_name", JsonString(SqlGetString(q, 1)));
+        jResults = JsonArrayInsert(jResults, jEntry);
+    }
+    return jResults;
+}
+
+string TribFormatDateSQL(int nUnix)
+{
+    sqlquery q = SqlPrepareQueryCampaign("tribunal",
+        "SELECT strftime('%d.%m.%Y', @ts, 'unixepoch')");
+    SqlBindInt(q, "@ts", nUnix);
+    if(SqlStep(q)) return SqlGetString(q, 0);
+    return "";
+}
+
+int TribGetOpenCaseCountFor(string sDefUUID)
+{
+    sqlquery q = SqlPrepareQueryCampaign("tribunal",
+        "SELECT COUNT(*) FROM trib_cases WHERE defendant_uuid = @uuid AND verdict = 0");
+    SqlBindString(q, "@uuid", sDefUUID);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}

--- a/Tribunal/Scripts/sys_on_enter.nss
+++ b/Tribunal/Scripts/sys_on_enter.nss
@@ -1,0 +1,15 @@
+#include "lib_trib_def"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC) || GetIsDMPossessed(oPC)) return;
+
+    TribRegisterPlayer(oPC);
+
+    int nOpen = TribGetOpenCaseCountFor(GetObjectUUID(oPC));
+    if(nOpen > 0)
+        SendMessageToPC(oPC,
+            "[Trybunał] Inkwizycja czeka. Masz " + IntToString(nOpen)
+            + " otwartą sprawę sądową przeciwko tobie.");
+}

--- a/Tribunal/Scripts/sys_on_load.nss
+++ b/Tribunal/Scripts/sys_on_load.nss
@@ -1,0 +1,6 @@
+#include "lib_trib_def"
+
+void main()
+{
+    TribCreateTables();
+}

--- a/Tribunal/Scripts/test_trib.nss
+++ b/Tribunal/Scripts/test_trib.nss
@@ -1,0 +1,10 @@
+#include "lib_trib"
+
+// OnUsed script for a "Tablica Trybunału" placeable.
+// Place a placeable in your test area, assign this script to its OnUsed event.
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+    TribOpenWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

Moduł **Tribunal** implementuje system sądu inkwizycyjnego dla dark-fantasy CRPG. Gracze mogą składać formalne oskarżenia przeciwko innym graczom; oskarżony ma prawo złożyć zeznanie obronne; DM jako sędzia przegląda sprawę, wpisuje uzasadnienie i wydaje jeden z czterech wyroków z natychmiastowym skutkiem w grze.

## Mechanika

1. **Oskarżenie** – dowolny gracz otwiera panel Trybunału, wyszukuje oskarżonego po imieniu (baza trib_players), wpisuje zarzut i opcjonalne dowody wstępne. Sprawa trafia do bazy z werdyktem `0 = W toku`. Oskarżony jest powiadamiany przez `SendMessageToPC` jeśli jest online.

2. **Zeznanie obronne** – oskarżony (oraz oskarżyciel) widzą sprawę w liście, otwierają ją i mogą wypełnić pole obrony oraz zapisać je przyciskiem „Złóż Zeznanie".

3. **Wyrok (DM tylko)** – Sędzia (DM) widzi aktywne przyciski wyroków. Po wpisaniu uzasadnienia wybiera:
   - **Uwięziony** → `EffectSlow + VFX_DUR_ETHEREAL_VISAGE`, `TRIB_IMPRISONED = 1`
   - **Wygnanie** → teleport do waypointa `TRIB_EXILE_AREA`, `TRIB_EXILED = 1`
   - **Wyrok Śmierci** → `VFX_DUR_EVIL_PROTECTION`, `TRIB_DEATH_MARK = 1` (inne systemy mogą zezwalać na PvP)
   - **Niewinny** → `RemoveAllEffects`, czyszczenie wszystkich LVAR, `VFX_IMP_HOLY_AID`

   Wyrok jest ogłaszany `SendMessageToPC` do wszystkich online i zapisany w bazie z timestampem.

## Pliki

| Plik | Opis |
|---|---|
| `Tribunal/Scripts/sql_trib.nss` | Schema SQLite, pełne CRUD |
| `Tribunal/Scripts/lib_trib_def.nss` | Stałe, bind-name, forward declarations |
| `Tribunal/Scripts/lib_trib.nss` | Budowanie NUI (3 widoki + popup), logika wyroku |
| `Tribunal/Scripts/lib_trib_ev.nss` | Handler NUI eventów (click/watch/close) |
| `Tribunal/Scripts/sys_on_load.nss` | `OnModuleLoad` – inicjalizacja tabel |
| `Tribunal/Scripts/sys_on_enter.nss` | `OnClientEnter` – rejestracja gracza, ostrzeżenie |
| `Tribunal/Scripts/test_trib.nss` | `OnUsed` placeable – otwiera okno Trybunału |
| `Tribunal/INTEGRATION.md` | Hooki, waypoint wygnania, cross-system API |

## Zależności (NWNX? SQL?)

- **Czyste NWScript + NUI** — zero NWNX.
- SQLite via `SqlPrepareQueryCampaign("tribunal", ...)` — plik `tribunal.sqlite` w katalogu kampanii.
- `lib_nui.nss` i `lib_nui_utility.nss` z tego repo (standardowe helpery).

## Jak włączyć w istniejącym module

1. Dodaj skrypty z `Tribunal/Scripts/` do HAK lub bezpośrednio do modułu.
2. Podepnij `sys_on_load` do zdarzenia `OnModuleLoad` (lub wywołaj `TribCreateTables()` w swoim istniejącym on-load skrypcie przez `#include "lib_trib_def"`).
3. Podepnij `sys_on_enter` do `OnClientEnter`.
4. Umieść placeable (np. tablica ogłoszeń) z `test_trib` jako `OnUsed`. Opcjonalnie: waypoint z tagiem `TRIB_EXILE_AREA` dla wyroku wygnania.

## Co celowo pominięto

- **Odwołanie od wyroku** – wymagałoby drugiej instancji lub głosowania; można dołożyć jako nowy widok w tym samym swap-group bez zmian w DB.
- **Wygasanie wyroków po czasie** – trywialne SQL (`resolved_at + X*86400`), pominięte jako decyzja projektowa serwera.
- **Powiadomienie DM o nowym oskarżeniu** – brak `SendMessageToAllDMs()` bez NWNX; serwer może owinąć `TribCreateCase()` własnym callbackiem.
- **Plik .mod** – środowisko nie posiada narzędzi do pakowania .mod; zamiast tego INTEGRATION.md.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CdaQSRPJoXjrkKWiYVuvDS)_