### PR TITLE
feat: Epitafium (system nagrobków i hołdów)

### DIFF
--- a/Epitafium/INTEGRATION.md
+++ b/Epitafium/INTEGRATION.md
@@ -1,0 +1,85 @@
+# Epitafium — Instrukcja integracji
+
+## Co to jest
+
+Moduł tworzy fizyczne nagrobki w miejscach śmierci PC. Gracz po śmierci
+może wyryć epitafium (max 200 znaków) i podać przyczynę. Inni gracze
+mogą kliknąć nagrobek, przeczytać napis i złożyć hołd (50 zł → buff
+AC+1 / Spot+2 na 1h). Nagrobki persystują przez 30 dni w kampanijnym
+SQLite i są respawnowane przy każdym załadowaniu modułu.
+
+## Zależności
+
+- NWN:EE (NUI API)
+- Brak NWNX (opcjonalnie: NWNX_Object dla lepszej trwałości placeabli)
+- Placeable resref `plc_grvmark1` z podstawowej gry (kamień nagrobny)
+
+## Hooki do podpięcia
+
+| Zdarzenie modułu       | Skrypt             |
+|------------------------|--------------------|
+| OnModuleLoad           | `sys_on_load`      |
+| OnPlayerDeath          | `sys_on_pdeath`    |
+
+Jeśli masz już własny `OnModuleLoad` / `OnPlayerDeath`, dodaj wywołania
+na końcu istniejących skryptów:
+
+```nss
+// W swoim OnModuleLoad:
+#include "lib_tomb"
+// ... twój kod ...
+TombCreateTables();
+TombDeleteExpired();
+TombRespawnAll();
+
+// W swoim OnPlayerDeath:
+#include "lib_tomb"
+// ... twój kod ...
+object oPC = GetLastPlayerDied();
+if(GetIsObjectValid(oPC) && GetIsPC(oPC) && !GetIsDM(oPC))
+    TombOnDeath(oPC);
+```
+
+## Opcjonalne: przekazanie zabójcy
+
+Jeśli twój moduł korzysta ze zdarzenia OnCreatureDeath dla PC, możesz
+tam ustawić:
+
+```nss
+// W OnCreatureDeath (na PC):
+SetLocalObject(OBJECT_SELF, "TOMB_KILLER", GetKiller());
+```
+
+Skrypt `sys_on_pdeath` odczyta ten lvar i wypełni pole przyczyny śmierci.
+Bez tego pola gracz może wpisać przyczynę ręcznie w oknie NUI.
+
+## Test
+
+1. Umieść w obszarze testowym placeable z `OnUsed = test_tomb`.
+2. Uruchom moduł, wejdź jako PC, użyj placeable.
+3. Pierwsze użycie → okno epitafium z lokalizacją placeable.
+4. Wpisz tekst, kliknij "Wyryt napis" → nagrobek pojawia się w miejscu.
+5. Użyj placeable ponownie → okno odczytu nagrobka z przyciskiem hołdu.
+6. Kliknij "Złóż hołd" (50 zł) → buff + aktualizacja licznika.
+7. Zrestartuj moduł → nagrobek powinien pojawić się ponownie (respawn).
+
+## Weryfikacja resrefa
+
+Użyty resref `plc_grvmark1` to standardowy kamień nagrobny z NWN.
+Jeśli chcesz użyć własnego placeabla z haka, zmień stałą
+`TOMB_STONE_RESREF` w `lib_tomb_def.nss`.
+
+## Co celowo pominięto
+
+- **Admin NUI** z listą wszystkich nagrobków — można dodać jako
+  rozszerzenie (wystarczy odczytać `TombGetAllActive()` i wyświetlić
+  w oknie).
+- **Animacja rycia** (emote przy tworzeniu nagrobka) — wymaga
+  `AssignCommand` z `ActionPlayAnimation`, można dodać w `TombFinalizeMemorial`.
+- **Unikalne placeable per obszar** — obecna implementacja używa jednego
+  resrefa; zróżnicowanie wyglądu w zależności od biome/obszaru możliwe
+  przez zamianę `TOMB_STONE_RESREF` na funkcję wybierającą po tagu obszaru.
+- **Limit nagrobków per PC** — nie wprowadzono; można dodać sprawdzenie
+  COUNT w SQL przed insertem.
+- **NWNX** — nie jest wymagany; bez NWNX placeables nie są trwałe po
+  twardym resecie serwera, ale SQL je odtwarza przy OnModuleLoad.

--- a/Epitafium/Scripts/lib_nui.nss
+++ b/Epitafium/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Epitafium/Scripts/lib_nui_utility.nss
+++ b/Epitafium/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Epitafium/Scripts/lib_tomb.nss
+++ b/Epitafium/Scripts/lib_tomb.nss
@@ -1,0 +1,418 @@
+// lib_tomb.nss — NUI layout, window management and placeable spawning for Epitafium
+
+#include "lib_tomb_def"
+
+// ----------------------------------------------------------------
+// Write-epitaph window
+// ----------------------------------------------------------------
+
+json BuildTombWriteLayout(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 32.0);
+    float fRowH  = GetNuiScaleDimension(oPC, 28.0);
+    float fEpiH  = GetNuiScaleDimension(oPC, 130.0);
+
+    // Character name (read-only)
+    json jNameLbl = NuiLabel(JsonString("Postać:"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jNameLbl = NuiWidth(jNameLbl, GetNuiScaleDimension(oPC, 80.0));
+    jNameLbl = NuiHeight(jNameLbl, fRowH);
+
+    json jNameVal = NuiLabel(NuiBind(TOMB_BIND_W_NAME), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jNameVal = NuiStyleForegroundColor(jNameVal, NuiColor(220, 200, 140));
+    jNameVal = NuiHeight(jNameVal, fRowH);
+
+    json jNameRow = JsonArray();
+    jNameRow = JsonArrayInsert(jNameRow, jNameLbl);
+    jNameRow = JsonArrayInsert(jNameRow, jNameVal);
+
+    // Separator label
+    json jSepLbl = NuiLabel(
+        JsonString("─────────────────────────────────────────────"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jSepLbl = NuiStyleForegroundColor(jSepLbl, NuiColor(80, 60, 40));
+    jSepLbl = NuiHeight(jSepLbl, GetNuiScaleDimension(oPC, 18.0));
+
+    // Cause of death (editable — player can adjust flavor)
+    json jCauseLbl = NuiLabel(JsonString("Przyczyna:"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jCauseLbl = NuiWidth(jCauseLbl, GetNuiScaleDimension(oPC, 90.0));
+    jCauseLbl = NuiHeight(jCauseLbl, fBtnH);
+
+    json jCauseField = NuiTextEdit(JsonString(""), NuiBind(TOMB_BIND_W_CAUSE), TOMB_CAUSE_MAX, FALSE);
+    jCauseField = NuiHeight(jCauseField, fBtnH);
+
+    json jCauseRow = JsonArray();
+    jCauseRow = JsonArrayInsert(jCauseRow, jCauseLbl);
+    jCauseRow = JsonArrayInsert(jCauseRow, jCauseField);
+
+    // Epitaph header
+    json jEpiLbl = NuiLabel(
+        JsonString("Ostatnie słowa (max 200 znaków):"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jEpiLbl = NuiStyleForegroundColor(jEpiLbl, NuiColor(180, 160, 100));
+    jEpiLbl = NuiHeight(jEpiLbl, GetNuiScaleDimension(oPC, 22.0));
+
+    // Epitaph text area
+    json jEpiField = NuiTextEdit(
+        JsonString("Tu spoczywają moje ostatnie słowa..."),
+        NuiBind(TOMB_BIND_W_EPITAPH),
+        TOMB_EPITAPH_MAX, TRUE);
+    jEpiField = NuiHeight(jEpiField, fEpiH);
+
+    // Remaining chars hint
+    json jHintLbl = NuiLabel(NuiBind(TOMB_BIND_W_HINT), JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jHintLbl = NuiStyleForegroundColor(jHintLbl, NuiColor(120, 100, 70));
+    jHintLbl = NuiHeight(jHintLbl, GetNuiScaleDimension(oPC, 20.0));
+
+    // Buttons
+    json jEngraveBtn = NuiButton(JsonString("Wyryt napis"));
+    jEngraveBtn = NuiId(jEngraveBtn, TOMB_BTN_ENGRAVE);
+    jEngraveBtn = NuiWidth(jEngraveBtn, GetNuiScaleDimension(oPC, 130.0));
+    jEngraveBtn = NuiHeight(jEngraveBtn, fBtnH);
+
+    json jSkipBtn = NuiButton(JsonString("Pomiń"));
+    jSkipBtn = NuiId(jSkipBtn, TOMB_BTN_SKIP);
+    jSkipBtn = NuiWidth(jSkipBtn, GetNuiScaleDimension(oPC, 80.0));
+    jSkipBtn = NuiHeight(jSkipBtn, fBtnH);
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jEngraveBtn);
+    jBtnRow = JsonArrayInsert(jBtnRow, jSkipBtn);
+
+    // Assemble
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(jNameRow));
+    jCol = JsonArrayInsert(jCol, jSepLbl);
+    jCol = JsonArrayInsert(jCol, NuiRow(jCauseRow));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jEpiLbl);
+    jCol = JsonArrayInsert(jCol, jEpiField);
+    jCol = JsonArrayInsert(jCol, jHintLbl);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+
+    json jSide = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    float fContent = GetNuiScaleDimension(oPC, 500.0);
+    json jMainRow = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiCol(jCol), fContent));
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    return NuiRow(jMainRow);
+}
+
+void TombCreateWriteWindow(object oPC)
+{
+    if(NuiFindWindow(oPC, TOMB_WIN_WRITE) != 0)
+        NuiDestroy(oPC, NuiFindWindow(oPC, TOMB_WIN_WRITE));
+
+    float fW = GetNuiScaleDimension(oPC, TOMB_WRITE_W);
+    float fH = GetNuiScaleDimension(oPC, TOMB_WRITE_H);
+    float fX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - fW) / 2.0;
+    float fY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - fH) / 2.0;
+
+    json jWin = NuiWindow(
+        BuildTombWriteLayout(oPC),
+        JsonString("Ostatnie Słowa"),
+        NuiRect(fX, fY, fW, fH),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE),
+        JsonBool(TRUE));
+
+    int nToken = NuiCreate(oPC, jWin, TOMB_WIN_WRITE, TOMB_EV_SCRIPT);
+
+    // Pre-fill fields
+    string sCause = GetLocalString(oPC, TOMB_LVAR_CAUSE);
+    if(sCause == "") sCause = "poległ(a) w walce";
+
+    NuiSetBind(oPC, nToken, TOMB_BIND_W_NAME,    JsonString(GetName(oPC)));
+    NuiSetBind(oPC, nToken, TOMB_BIND_W_CAUSE,   JsonString(sCause));
+    NuiSetBind(oPC, nToken, TOMB_BIND_W_EPITAPH, JsonString(""));
+    NuiSetBind(oPC, nToken, TOMB_BIND_W_HINT,    JsonString("0 / 200"));
+
+    NuiSetBindWatch(oPC, nToken, TOMB_BIND_W_EPITAPH, TRUE);
+}
+
+// ----------------------------------------------------------------
+// Read-memorial window
+// ----------------------------------------------------------------
+
+json BuildTombReadLayout(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 32.0);
+    float fEpiH  = GetNuiScaleDimension(oPC, 120.0);
+
+    // "Tu spoczywa..." header
+    json jHeader = NuiLabel(NuiBind(TOMB_BIND_R_HEADER),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jHeader = NuiStyleForegroundColor(jHeader, NuiColor(220, 200, 140));
+    jHeader = NuiHeight(jHeader, GetNuiScaleDimension(oPC, 34.0));
+
+    // Ornamental separator
+    json jOrn = NuiLabel(
+        JsonString("✦ ─────────────────────────── ✦"),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jOrn = NuiStyleForegroundColor(jOrn, NuiColor(90, 70, 45));
+    jOrn = NuiHeight(jOrn, GetNuiScaleDimension(oPC, 20.0));
+
+    // Date + cause row
+    json jDateLbl = NuiLabel(NuiBind(TOMB_BIND_R_DATE),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jDateLbl = NuiStyleForegroundColor(jDateLbl, NuiColor(160, 140, 100));
+    jDateLbl = NuiHeight(jDateLbl, GetNuiScaleDimension(oPC, 24.0));
+
+    json jCauseLbl = NuiLabel(NuiBind(TOMB_BIND_R_CAUSE),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jCauseLbl = NuiStyleForegroundColor(jCauseLbl, NuiColor(160, 100, 80));
+    jCauseLbl = NuiHeight(jCauseLbl, GetNuiScaleDimension(oPC, 24.0));
+
+    json jMetaRow = JsonArray();
+    jMetaRow = JsonArrayInsert(jMetaRow, jDateLbl);
+    jMetaRow = JsonArrayInsert(jMetaRow, NuiSpacer());
+    jMetaRow = JsonArrayInsert(jMetaRow, jCauseLbl);
+
+    // Epitaph text block
+    json jEpiText = NuiGroup(NuiText(NuiBind(TOMB_BIND_R_EPITAPH), FALSE), TRUE, NUI_SCROLLBARS_AUTO);
+    jEpiText = NuiHeight(jEpiText, fEpiH);
+
+    // Tribute count
+    json jTribLbl = NuiLabel(NuiBind(TOMB_BIND_R_TRIBUTE),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jTribLbl = NuiStyleForegroundColor(jTribLbl, NuiColor(130, 110, 80));
+    jTribLbl = NuiHeight(jTribLbl, GetNuiScaleDimension(oPC, 22.0));
+
+    // Buttons
+    json jTribBtn = NuiButton(NuiBind(TOMB_BIND_R_BTN_TRB));
+    jTribBtn = NuiId(jTribBtn, TOMB_BTN_TRIBUTE);
+    jTribBtn = NuiEnabled(jTribBtn, NuiBind(TOMB_BIND_R_BTN_ENA));
+    jTribBtn = NuiWidth(jTribBtn, GetNuiScaleDimension(oPC, 180.0));
+    jTribBtn = NuiHeight(jTribBtn, fBtnH);
+    jTribBtn = NuiTooltip(jTribBtn, JsonString(
+        "Złóż hołd poległemu. Kosztuje " + IntToString(TOMB_TRIBUTE_COST)
+        + " zł, lecz błogosławieństwo poległego sprzyja ci przez godzinę."));
+
+    json jCloseBtn = NuiButton(JsonString("Zamknij"));
+    jCloseBtn = NuiId(jCloseBtn, TOMB_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, GetNuiScaleDimension(oPC, 90.0));
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, jTribBtn);
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jCloseBtn);
+
+    // Assemble
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jHeader);
+    jCol = JsonArrayInsert(jCol, jOrn);
+    jCol = JsonArrayInsert(jCol, NuiRow(jMetaRow));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, jEpiText);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, jTribLbl);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+
+    json jSide = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    float fContent = GetNuiScaleDimension(oPC, 460.0);
+    json jMainRow = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiCol(jCol), fContent));
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    return NuiRow(jMainRow);
+}
+
+void FeedTombReadWindow(object oPC, int nToken, json jMem)
+{
+    string sName    = JsonGetString(JsonObjectGet(jMem, "char_name"));
+    string sCause   = JsonGetString(JsonObjectGet(jMem, "cause"));
+    string sEpitaph = JsonGetString(JsonObjectGet(jMem, "epitaph"));
+    int    nDiedAt  = JsonGetInt   (JsonObjectGet(jMem, "died_at"));
+    int    nTribs   = JsonGetInt   (JsonObjectGet(jMem, "tribute_cnt"));
+
+    string sDate = TombFormatDate(nDiedAt);
+
+    NuiSetBind(oPC, nToken, TOMB_BIND_R_HEADER,
+        JsonString("Tu spoczywa " + sName));
+    NuiSetBind(oPC, nToken, TOMB_BIND_R_DATE,
+        JsonString(sDate));
+    NuiSetBind(oPC, nToken, TOMB_BIND_R_CAUSE,
+        JsonString(sCause));
+    NuiSetBind(oPC, nToken, TOMB_BIND_R_EPITAPH,
+        JsonString(sEpitaph != "" ? "\"" + sEpitaph + "\"" : "— brak słów —"));
+
+    string sTribText;
+    if(nTribs == 0)     sTribText = "Nikt jeszcze nie złożył tu hołdu.";
+    else if(nTribs == 1) sTribText = "1 pielgrzym złożył tu hołd.";
+    else                sTribText = IntToString(nTribs) + " pielgrzymów złożyło tu hołd.";
+    NuiSetBind(oPC, nToken, TOMB_BIND_R_TRIBUTE, JsonString(sTribText));
+
+    // Tribute button — disabled for own tombstone
+    string sMyUuid = GetObjectUUID(oPC);
+    string sOwner  = JsonGetString(JsonObjectGet(jMem, "char_uuid"));
+    int bCanTrib   = (sMyUuid != sOwner);
+    NuiSetBind(oPC, nToken, TOMB_BIND_R_BTN_TRB,
+        JsonString("Złóż hołd (" + IntToString(TOMB_TRIBUTE_COST) + " zł)"));
+    NuiSetBind(oPC, nToken, TOMB_BIND_R_BTN_ENA, JsonBool(bCanTrib));
+}
+
+void TombCreateReadWindow(object oPC, int nMemorialId)
+{
+    json jMem = TombGetMemorial(nMemorialId);
+    if(JsonGetType(jMem) == JSON_TYPE_NULL)
+    {
+        SendMessageToPC(oPC, "[Epitafium] Nagrobek jest zniszczony — zapis zatarł czas.");
+        return;
+    }
+
+    if(NuiFindWindow(oPC, TOMB_WIN_READ) != 0)
+        NuiDestroy(oPC, NuiFindWindow(oPC, TOMB_WIN_READ));
+
+    float fW = GetNuiScaleDimension(oPC, TOMB_READ_W);
+    float fH = GetNuiScaleDimension(oPC, TOMB_READ_H);
+    float fX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - fW) / 2.0;
+    float fY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - fH) / 2.0;
+
+    json jWin = NuiWindow(
+        BuildTombReadLayout(oPC),
+        JsonString("Nagrobek"),
+        NuiRect(fX, fY, fW, fH),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE),
+        JsonBool(TRUE));
+
+    int nToken = NuiCreate(oPC, jWin, TOMB_WIN_READ, TOMB_EV_SCRIPT);
+
+    SetLocalInt(oPC, TOMB_LVAR_MEM_ID, nMemorialId);
+    FeedTombReadWindow(oPC, nToken, jMem);
+}
+
+// ----------------------------------------------------------------
+// Tombstone placeable
+// ----------------------------------------------------------------
+
+void TombSpawnStone(int nId, json jMem)
+{
+    string sAreaTag = JsonGetString(JsonObjectGet(jMem, "area_tag"));
+    float  fX       = JsonGetFloat (JsonObjectGet(jMem, "pos_x"));
+    float  fY       = JsonGetFloat (JsonObjectGet(jMem, "pos_y"));
+    float  fZ       = JsonGetFloat (JsonObjectGet(jMem, "pos_z"));
+    string sName    = JsonGetString(JsonObjectGet(jMem, "char_name"));
+
+    object oArea = GetObjectByTag(sAreaTag);
+    if(!GetIsObjectValid(oArea)) return;
+
+    string sStoneTag = "tomb_" + IntToString(nId);
+    location lSpawn  = Location(oArea, Vector(fX, fY, fZ), 0.0);
+
+    object oStone = CreateObject(OBJECT_TYPE_PLACEABLE, TOMB_STONE_RESREF, lSpawn, FALSE, sStoneTag);
+    if(!GetIsObjectValid(oStone)) return;
+
+    SetName(oStone, "Nagrobek — " + sName);
+    SetDescription(oStone, TombBuildStoneDesc(jMem));
+    SetLocalInt(oStone, TOMB_LVAR_STONE_ID, nId);
+    SetEventScript(oStone, EVENT_SCRIPT_PLACEABLE_ON_USED, TOMB_STONE_SCRIPT);
+}
+
+// ----------------------------------------------------------------
+// Finalise — called when PC clicks "Wyryt napis"
+// ----------------------------------------------------------------
+
+void TombFinalizeMemorial(object oPC, int nToken)
+{
+    string sEpitaph = JsonGetString(NuiGetBind(oPC, nToken, TOMB_BIND_W_EPITAPH));
+    string sCause   = JsonGetString(NuiGetBind(oPC, nToken, TOMB_BIND_W_CAUSE));
+    string sAreaTag = GetLocalString(oPC, TOMB_LVAR_AREA);
+    float  fX       = GetLocalFloat (oPC, TOMB_LVAR_POS_X);
+    float  fY       = GetLocalFloat (oPC, TOMB_LVAR_POS_Y);
+    float  fZ       = GetLocalFloat (oPC, TOMB_LVAR_POS_Z);
+
+    if(sAreaTag == "")
+    {
+        SendMessageToPC(oPC, "[Epitafium] Nie można ustalić miejsca śmierci.");
+        NuiDestroy(oPC, nToken);
+        TombClearDeathLvars(oPC);
+        return;
+    }
+
+    if(sCause == "") sCause = "poległ(a) w walce";
+
+    int nId = TombInsertMemorial(
+        GetObjectUUID(oPC), GetName(oPC), sAreaTag,
+        fX, fY, fZ, sCause, sEpitaph);
+
+    NuiDestroy(oPC, nToken);
+    TombClearDeathLvars(oPC);
+
+    if(nId <= 0)
+    {
+        SendMessageToPC(oPC, "[Epitafium] Błąd zapisu — dłuto ześlizgnęło się z kamienia.");
+        return;
+    }
+
+    json jMem = TombGetMemorial(nId);
+    TombSpawnStone(nId, jMem);
+
+    FloatingTextStringOnCreature(
+        "Kamień przyjął twoje ostatnie słowa...", oPC, FALSE);
+}
+
+// ----------------------------------------------------------------
+// Tribute — called from event handler
+// ----------------------------------------------------------------
+
+void TombPayTribute(object oPC, int nToken, int nMemId)
+{
+    if(GetGold(oPC) < TOMB_TRIBUTE_COST)
+    {
+        SendMessageToPC(oPC, "[Epitafium] Nie masz dość złota, by złożyć godny hołd (" +
+            IntToString(TOMB_TRIBUTE_COST) + " zł).");
+        return;
+    }
+
+    AssignCommand(oPC, TakeGoldFromCreature(TOMB_TRIBUTE_COST, oPC, TRUE));
+    TombAddTribute(nMemId, 1);
+
+    // Blessing: AC +1 / Spot +2 for 1 hour
+    effect eFx = EffectLinkEffects(
+        EffectACIncrease(1, AC_DEFLECTION_BONUS),
+        EffectSkillIncrease(SKILL_SPOT, 2));
+    eFx = SupernaturalEffect(EffectLinkEffects(eFx,
+        EffectVisualEffect(VFX_DUR_GLOW_LIGHT_YELLOW)));
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eFx, oPC,
+        IntToFloat(TOMB_TRIBUTE_DUR));
+
+    FloatingTextStringOnCreature(
+        "Błogosławieństwo Poległego spływa na ciebie...", oPC, FALSE);
+
+    // Refresh read window
+    json jMem = TombGetMemorial(nMemId);
+    if(JsonGetType(jMem) != JSON_TYPE_NULL)
+        FeedTombReadWindow(oPC, nToken, jMem);
+
+    // Update stone description if it exists in the current area
+    string sStoneTag = "tomb_" + IntToString(nMemId);
+    object oStone = GetObjectByTag(sStoneTag);
+    if(GetIsObjectValid(oStone))
+        SetDescription(oStone, TombBuildStoneDesc(jMem));
+}
+
+// ----------------------------------------------------------------
+// Respawn all persisted memorials on module load
+// ----------------------------------------------------------------
+
+void TombRespawnAll()
+{
+    json jAll  = TombGetAllActive();
+    int  nCount = JsonGetLength(jAll);
+    int  i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jMem = JsonArrayGet(jAll, i);
+        int  nId  = JsonGetInt(JsonObjectGet(jMem, "id"));
+        TombSpawnStone(nId, jMem);
+    }
+}

--- a/Epitafium/Scripts/lib_tomb_def.nss
+++ b/Epitafium/Scripts/lib_tomb_def.nss
@@ -1,0 +1,128 @@
+// lib_tomb_def.nss — constants, bind IDs and forward declarations for Epitafium
+
+#include "lib_nui"
+#include "sql_tomb"
+
+void TombCreateWriteWindow(object oPC);
+void TombCreateReadWindow(object oPC, int nMemorialId);
+void TombFinalizeMemorial(object oPC, int nToken);
+void TombSpawnStone(int nId, json jMem);
+void TombRespawnAll();
+
+// ----------------------------------------------------------------
+// Window identifiers
+// ----------------------------------------------------------------
+
+const string TOMB_WIN_WRITE   = "TOMB_WIN_WRITE";
+const string TOMB_WIN_READ    = "TOMB_WIN_READ";
+const string TOMB_EV_SCRIPT   = "lib_tomb_ev";
+
+// ----------------------------------------------------------------
+// Write-window bind IDs
+// ----------------------------------------------------------------
+
+const string TOMB_BIND_W_NAME    = "tomb_w_name";    // character name label
+const string TOMB_BIND_W_CAUSE   = "tomb_w_cause";   // editable cause of death
+const string TOMB_BIND_W_EPITAPH = "tomb_w_epitaph"; // epitaph text edit
+const string TOMB_BIND_W_HINT    = "tomb_w_hint";    // remaining-chars hint
+
+// ----------------------------------------------------------------
+// Read-window bind IDs
+// ----------------------------------------------------------------
+
+const string TOMB_BIND_R_HEADER  = "tomb_r_header";  // "Tu spoczywa X"
+const string TOMB_BIND_R_DATE    = "tomb_r_date";    // date of death
+const string TOMB_BIND_R_CAUSE   = "tomb_r_cause";   // cause of death
+const string TOMB_BIND_R_EPITAPH = "tomb_r_epitaph"; // epitaph body
+const string TOMB_BIND_R_TRIBUTE = "tomb_r_tribute"; // tribute count label
+const string TOMB_BIND_R_BTN_TRB = "tomb_r_trblbl";  // tribute button label
+const string TOMB_BIND_R_BTN_ENA = "tomb_r_trbena";  // tribute button enabled
+
+// ----------------------------------------------------------------
+// Button IDs
+// ----------------------------------------------------------------
+
+const string TOMB_BTN_ENGRAVE  = "tomb_btn_engrave"; // confirm epitaph
+const string TOMB_BTN_SKIP     = "tomb_btn_skip";    // skip tombstone
+const string TOMB_BTN_CLOSE    = "tomb_btn_close";   // close read window
+const string TOMB_BTN_TRIBUTE  = "tomb_btn_tribute"; // pay tribute
+
+// ----------------------------------------------------------------
+// Local variables on PC
+// ----------------------------------------------------------------
+
+const string TOMB_LVAR_AREA    = "TOMB_AREA";    // area tag at death
+const string TOMB_LVAR_POS_X   = "TOMB_POS_X";
+const string TOMB_LVAR_POS_Y   = "TOMB_POS_Y";
+const string TOMB_LVAR_POS_Z   = "TOMB_POS_Z";
+const string TOMB_LVAR_CAUSE   = "TOMB_CAUSE";   // auto-detected cause
+const string TOMB_LVAR_MEM_ID  = "TOMB_MEM_ID";  // id of the memorial last read
+
+// ----------------------------------------------------------------
+// Local variable on tombstone placeable
+// ----------------------------------------------------------------
+
+const string TOMB_LVAR_STONE_ID = "TOMB_MEM_ID"; // memorial id stored on the stone
+
+// ----------------------------------------------------------------
+// Layout
+// ----------------------------------------------------------------
+
+const float TOMB_WRITE_W    = 540.0;
+const float TOMB_WRITE_H    = 400.0;
+const float TOMB_READ_W     = 500.0;
+const float TOMB_READ_H     = 360.0;
+const int   TOMB_EPITAPH_MAX = 200;
+const int   TOMB_CAUSE_MAX   = 80;
+
+// ----------------------------------------------------------------
+// Game constants
+// ----------------------------------------------------------------
+
+// Gold cost for paying tribute at a tombstone.
+const int   TOMB_TRIBUTE_COST  = 50;
+
+// Duration of the tribute buff in seconds (1 hour).
+const int   TOMB_TRIBUTE_DUR   = 3600;
+
+// Resref of the tombstone placeable (base NWN grave marker).
+// Use "plc_grvmark1" or another stone marker from your hak.
+const string TOMB_STONE_RESREF = "plc_grvmark1";
+
+// OnUsed script placed on each dynamically spawned tombstone.
+const string TOMB_STONE_SCRIPT = "tomb_use";
+
+// ----------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------
+
+// Builds the short stone description shown in the examine tooltip.
+string TombBuildStoneDesc(json jMem)
+{
+    string sName    = JsonGetString(JsonObjectGet(jMem, "char_name"));
+    string sCause   = JsonGetString(JsonObjectGet(jMem, "cause"));
+    string sEpitaph = JsonGetString(JsonObjectGet(jMem, "epitaph"));
+    int    nDiedAt  = JsonGetInt   (JsonObjectGet(jMem, "died_at"));
+    int    nTribs   = JsonGetInt   (JsonObjectGet(jMem, "tribute_cnt"));
+
+    string sDate = TombFormatDate(nDiedAt);
+
+    string sDesc = "Tu spoczywa " + sName + ".\n"
+                 + sCause + " (" + sDate + ").\n";
+    if(sEpitaph != "")
+        sDesc = sDesc + "\n\"" + sEpitaph + "\"\n";
+    if(nTribs > 0)
+        sDesc = sDesc + "\nHołd złożyli: " + IntToString(nTribs) + " pielgrzym"
+                      + (nTribs == 1 ? "" : "ów") + ".";
+    return sDesc;
+}
+
+// Cleans per-death local vars from the PC after the write window is done.
+void TombClearDeathLvars(object oPC)
+{
+    DeleteLocalString(oPC, TOMB_LVAR_AREA);
+    DeleteLocalFloat (oPC, TOMB_LVAR_POS_X);
+    DeleteLocalFloat (oPC, TOMB_LVAR_POS_Y);
+    DeleteLocalFloat (oPC, TOMB_LVAR_POS_Z);
+    DeleteLocalString(oPC, TOMB_LVAR_CAUSE);
+}

--- a/Epitafium/Scripts/lib_tomb_ev.nss
+++ b/Epitafium/Scripts/lib_tomb_ev.nss
@@ -1,0 +1,114 @@
+// lib_tomb_ev.nss — NUI event handler for Epitafium
+
+#include "lib_tomb"
+
+// ----------------------------------------------------------------
+// Write-window helpers
+// ----------------------------------------------------------------
+
+void HandleWriteWatch(object oPC, int nToken, string sElem)
+{
+    if(sElem != TOMB_BIND_W_EPITAPH) return;
+
+    string sText = JsonGetString(NuiGetBind(oPC, nToken, TOMB_BIND_W_EPITAPH));
+    int    nLen  = GetStringLength(sText);
+    int    nLeft = TOMB_EPITAPH_MAX - nLen;
+
+    string sHint = IntToString(nLen) + " / " + IntToString(TOMB_EPITAPH_MAX);
+    if(nLeft < 30)
+        sHint = sHint + "  (zostało " + IntToString(nLeft) + ")";
+
+    NuiSetBind(oPC, nToken, TOMB_BIND_W_HINT, JsonString(sHint));
+}
+
+void HandleWriteClick(object oPC, int nToken, string sElem)
+{
+    if(sElem == TOMB_BTN_ENGRAVE)
+    {
+        TombFinalizeMemorial(oPC, nToken);
+        return;
+    }
+    if(sElem == TOMB_BTN_SKIP)
+    {
+        NuiDestroy(oPC, nToken);
+        TombClearDeathLvars(oPC);
+        SendMessageToPC(oPC, "[Epitafium] Nie zostawiasz po sobie słów...");
+        return;
+    }
+}
+
+void HandleWriteClose(object oPC)
+{
+    // Closing without confirming = same as skip
+    TombClearDeathLvars(oPC);
+}
+
+// ----------------------------------------------------------------
+// Read-window helpers
+// ----------------------------------------------------------------
+
+void HandleReadClick(object oPC, int nToken, string sElem)
+{
+    if(sElem == TOMB_BTN_CLOSE)
+    {
+        NuiDestroy(oPC, nToken);
+        DeleteLocalInt(oPC, TOMB_LVAR_MEM_ID);
+        return;
+    }
+    if(sElem == TOMB_BTN_TRIBUTE)
+    {
+        int nId = GetLocalInt(oPC, TOMB_LVAR_MEM_ID);
+        if(nId > 0)
+            TombPayTribute(oPC, nToken, nId);
+        return;
+    }
+}
+
+// ----------------------------------------------------------------
+// Main dispatch
+// ----------------------------------------------------------------
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+
+    // ---- Write window ----
+    if(nToken == NuiFindWindow(oPC, TOMB_WIN_WRITE))
+    {
+        if(sEvent == EVENT_TYPE_WATCH)
+        {
+            HandleWriteWatch(oPC, nToken, sElem);
+            return;
+        }
+        if(sEvent == EVENT_TYPE_CLICK)
+        {
+            HandleWriteClick(oPC, nToken, sElem);
+            return;
+        }
+        if(sEvent == EVENT_TYPE_CLOSE)
+        {
+            HandleWriteClose(oPC);
+            return;
+        }
+        return;
+    }
+
+    // ---- Read window ----
+    if(nToken == NuiFindWindow(oPC, TOMB_WIN_READ))
+    {
+        if(sEvent == EVENT_TYPE_CLICK)
+        {
+            HandleReadClick(oPC, nToken, sElem);
+            return;
+        }
+        if(sEvent == EVENT_TYPE_CLOSE)
+        {
+            DeleteLocalInt(oPC, TOMB_LVAR_MEM_ID);
+            return;
+        }
+        return;
+    }
+}

--- a/Epitafium/Scripts/sql_tomb.nss
+++ b/Epitafium/Scripts/sql_tomb.nss
@@ -1,0 +1,136 @@
+// sql_tomb.nss — SQLite schema and query wrappers for Epitafium
+
+const int TOMB_EXPIRY_DAYS = 30;
+
+void TombCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("epitafium",
+        "CREATE TABLE IF NOT EXISTS tomb_memorials ("
+        "  id          INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "  char_uuid   TEXT    NOT NULL DEFAULT '',"
+        "  char_name   TEXT    NOT NULL DEFAULT '',"
+        "  area_tag    TEXT    NOT NULL DEFAULT '',"
+        "  pos_x       REAL    NOT NULL DEFAULT 0,"
+        "  pos_y       REAL    NOT NULL DEFAULT 0,"
+        "  pos_z       REAL    NOT NULL DEFAULT 0,"
+        "  cause       TEXT    NOT NULL DEFAULT '',"
+        "  epitaph     TEXT    NOT NULL DEFAULT '',"
+        "  tribute_cnt INTEGER NOT NULL DEFAULT 0,"
+        "  died_at     INTEGER NOT NULL DEFAULT 0,"
+        "  expires_at  INTEGER NOT NULL DEFAULT 0"
+        ")");
+    SqlStep(q);
+}
+
+// Returns newly inserted memorial id, or 0 on failure.
+int TombInsertMemorial(
+    string sCharUuid, string sCharName, string sAreaTag,
+    float fX, float fY, float fZ,
+    string sCause, string sEpitaph)
+{
+    sqlquery q = SqlPrepareQueryCampaign("epitafium",
+        "INSERT INTO tomb_memorials "
+        "  (char_uuid, char_name, area_tag, pos_x, pos_y, pos_z, cause, epitaph, died_at, expires_at) "
+        "VALUES "
+        "  (@uuid, @name, @area, @x, @y, @z, @cause, @epi, "
+        "   strftime('%s','now'), strftime('%s','now') + @days * 86400)");
+    SqlBindString(q, "@uuid",  sCharUuid);
+    SqlBindString(q, "@name",  sCharName);
+    SqlBindString(q, "@area",  sAreaTag);
+    SqlBindFloat (q, "@x",     fX);
+    SqlBindFloat (q, "@y",     fY);
+    SqlBindFloat (q, "@z",     fZ);
+    SqlBindString(q, "@cause", sCause);
+    SqlBindString(q, "@epi",   sEpitaph);
+    SqlBindInt   (q, "@days",  TOMB_EXPIRY_DAYS);
+    SqlStep(q);
+
+    sqlquery qId = SqlPrepareQueryCampaign("epitafium", "SELECT last_insert_rowid()");
+    if(SqlStep(qId)) return SqlGetInt(qId, 0);
+    return 0;
+}
+
+// Returns a json object {id, char_uuid, char_name, area_tag, pos_x, pos_y, pos_z,
+//                        cause, epitaph, tribute_cnt, died_at, expires_at}
+// or JSON_NULL if not found.
+json TombGetMemorial(int nId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("epitafium",
+        "SELECT id, char_uuid, char_name, area_tag, pos_x, pos_y, pos_z, "
+        "       cause, epitaph, tribute_cnt, died_at, expires_at "
+        "FROM tomb_memorials WHERE id = @id");
+    SqlBindInt(q, "@id", nId);
+    if(!SqlStep(q)) return JsonNull();
+
+    json j = JsonObject();
+    j = JsonObjectSet(j, "id",          JsonInt   (SqlGetInt   (q, 0)));
+    j = JsonObjectSet(j, "char_uuid",   JsonString(SqlGetString(q, 1)));
+    j = JsonObjectSet(j, "char_name",   JsonString(SqlGetString(q, 2)));
+    j = JsonObjectSet(j, "area_tag",    JsonString(SqlGetString(q, 3)));
+    j = JsonObjectSet(j, "pos_x",       JsonFloat (SqlGetFloat (q, 4)));
+    j = JsonObjectSet(j, "pos_y",       JsonFloat (SqlGetFloat (q, 5)));
+    j = JsonObjectSet(j, "pos_z",       JsonFloat (SqlGetFloat (q, 6)));
+    j = JsonObjectSet(j, "cause",       JsonString(SqlGetString(q, 7)));
+    j = JsonObjectSet(j, "epitaph",     JsonString(SqlGetString(q, 8)));
+    j = JsonObjectSet(j, "tribute_cnt", JsonInt   (SqlGetInt   (q, 9)));
+    j = JsonObjectSet(j, "died_at",     JsonInt   (SqlGetInt   (q, 10)));
+    j = JsonObjectSet(j, "expires_at",  JsonInt   (SqlGetInt   (q, 11)));
+    return j;
+}
+
+// Returns JsonArray of all active (not expired) memorials.
+json TombGetAllActive()
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("epitafium",
+        "SELECT id, char_uuid, char_name, area_tag, pos_x, pos_y, pos_z, "
+        "       cause, epitaph, tribute_cnt, died_at, expires_at "
+        "FROM tomb_memorials "
+        "WHERE expires_at > strftime('%s','now') "
+        "ORDER BY died_at DESC");
+    while(SqlStep(q))
+    {
+        json j = JsonObject();
+        j = JsonObjectSet(j, "id",          JsonInt   (SqlGetInt   (q, 0)));
+        j = JsonObjectSet(j, "char_uuid",   JsonString(SqlGetString(q, 1)));
+        j = JsonObjectSet(j, "char_name",   JsonString(SqlGetString(q, 2)));
+        j = JsonObjectSet(j, "area_tag",    JsonString(SqlGetString(q, 3)));
+        j = JsonObjectSet(j, "pos_x",       JsonFloat (SqlGetFloat (q, 4)));
+        j = JsonObjectSet(j, "pos_y",       JsonFloat (SqlGetFloat (q, 5)));
+        j = JsonObjectSet(j, "pos_z",       JsonFloat (SqlGetFloat (q, 6)));
+        j = JsonObjectSet(j, "cause",       JsonString(SqlGetString(q, 7)));
+        j = JsonObjectSet(j, "epitaph",     JsonString(SqlGetString(q, 8)));
+        j = JsonObjectSet(j, "tribute_cnt", JsonInt   (SqlGetInt   (q, 9)));
+        j = JsonObjectSet(j, "died_at",     JsonInt   (SqlGetInt   (q, 10)));
+        j = JsonObjectSet(j, "expires_at",  JsonInt   (SqlGetInt   (q, 11)));
+        jRows = JsonArrayInsert(jRows, j);
+    }
+    return jRows;
+}
+
+void TombAddTribute(int nId, int nAmount)
+{
+    sqlquery q = SqlPrepareQueryCampaign("epitafium",
+        "UPDATE tomb_memorials SET tribute_cnt = tribute_cnt + @n WHERE id = @id");
+    SqlBindInt(q, "@n",  nAmount);
+    SqlBindInt(q, "@id", nId);
+    SqlStep(q);
+}
+
+// Removes memorials whose expires_at has passed.
+void TombDeleteExpired()
+{
+    sqlquery q = SqlPrepareQueryCampaign("epitafium",
+        "DELETE FROM tomb_memorials WHERE expires_at <= strftime('%s','now')");
+    SqlStep(q);
+}
+
+// Formats a unix timestamp as "DD.MM.RRRR HH:MM" via SQLite.
+string TombFormatDate(int nUnix)
+{
+    sqlquery q = SqlPrepareQueryCampaign("epitafium",
+        "SELECT strftime('%d.%m.%Y %H:%M', @ts, 'unixepoch')");
+    SqlBindInt(q, "@ts", nUnix);
+    if(SqlStep(q)) return SqlGetString(q, 0);
+    return "??";
+}

--- a/Epitafium/Scripts/sys_on_load.nss
+++ b/Epitafium/Scripts/sys_on_load.nss
@@ -1,0 +1,11 @@
+// sys_on_load.nss — Module OnModuleLoad hook for Epitafium
+// Hook: Module → Events → OnModuleLoad → "sys_on_load"
+
+#include "lib_tomb"
+
+void main()
+{
+    TombCreateTables();
+    TombDeleteExpired();
+    TombRespawnAll();
+}

--- a/Epitafium/Scripts/sys_on_pdeath.nss
+++ b/Epitafium/Scripts/sys_on_pdeath.nss
@@ -1,0 +1,47 @@
+// sys_on_pdeath.nss — Module OnPlayerDeath hook for Epitafium
+// Hook: Module → Events → OnPlayerDeath → "sys_on_pdeath"
+//
+// Captures the death location, attempts to detect the killer's name,
+// then opens the epitaph write window after a short delay so the
+// player has time to process the death screen.
+
+#include "lib_tomb"
+
+void TombOnDeath(object oPC)
+{
+    // Store death location before the body is moved.
+    object oArea  = GetArea(oPC);
+    vector vPos   = GetPosition(oPC);
+
+    SetLocalString(oPC, TOMB_LVAR_AREA,  GetTag(oArea));
+    SetLocalFloat (oPC, TOMB_LVAR_POS_X, vPos.x);
+    SetLocalFloat (oPC, TOMB_LVAR_POS_Y, vPos.y);
+    SetLocalFloat (oPC, TOMB_LVAR_POS_Z, vPos.z);
+
+    // Try to name the killer. GetLastKiller() is PC-level, but
+    // many servers store it via SetLocalObject in the PC's OnDeath.
+    // We fall back to a generic string if unavailable.
+    object oKiller = GetLocalObject(oPC, "TOMB_KILLER");
+    string sCause  = "poległ(a) w walce";
+    if(GetIsObjectValid(oKiller))
+    {
+        if(GetIsPC(oKiller))
+            sCause = "poległ(a) z ręki " + GetName(oKiller);
+        else
+            sCause = "zabity/a przez " + GetName(oKiller);
+        DeleteLocalObject(oPC, "TOMB_KILLER");
+    }
+    SetLocalString(oPC, TOMB_LVAR_CAUSE, sCause);
+
+    // Delay to let the death screen settle before opening NUI.
+    DelayCommand(4.0, TombCreateWriteWindow(oPC));
+}
+
+void main()
+{
+    object oPC = GetLastPlayerDied();
+    if(!GetIsObjectValid(oPC)) return;
+    if(!GetIsPC(oPC) || GetIsDM(oPC)) return;
+
+    TombOnDeath(oPC);
+}

--- a/Epitafium/Scripts/test_tomb.nss
+++ b/Epitafium/Scripts/test_tomb.nss
@@ -1,0 +1,53 @@
+// test_tomb.nss — OnUsed demo script for a test placeable.
+//
+// Place a placeable in the test area (e.g. a lever or barrel),
+// set its OnUsed script to "test_tomb", then use it in-game.
+//
+// First use:  simulates a player death at the placeable's location
+//             and opens the write-epitaph window.
+// Second use: opens a read window for memorial id 1 (if it exists).
+//
+// This lets you test both NUI panels without actually dying.
+
+#include "lib_tomb"
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsObjectValid(oPC) || !GetIsPC(oPC)) return;
+
+    int nMode = GetLocalInt(OBJECT_SELF, "TEST_TOMB_MODE");
+
+    if(nMode == 0)
+    {
+        // Simulate death at this placeable's location
+        object oArea  = GetArea(OBJECT_SELF);
+        vector vPos   = GetPosition(OBJECT_SELF);
+
+        SetLocalString(oPC, TOMB_LVAR_AREA,  GetTag(oArea));
+        SetLocalFloat (oPC, TOMB_LVAR_POS_X, vPos.x);
+        SetLocalFloat (oPC, TOMB_LVAR_POS_Y, vPos.y);
+        SetLocalFloat (oPC, TOMB_LVAR_POS_Z, vPos.z);
+        SetLocalString(oPC, TOMB_LVAR_CAUSE, "zabity/a przez testowego trolla");
+
+        SendMessageToPC(oPC, "[Test Epitafium] Otwieranie okna zapisu epitafium...");
+        TombCreateWriteWindow(oPC);
+
+        SetLocalInt(OBJECT_SELF, "TEST_TOMB_MODE", 1);
+    }
+    else
+    {
+        // Show the first memorial in the DB
+        json jAll = TombGetAllActive();
+        if(JsonGetLength(jAll) == 0)
+        {
+            SendMessageToPC(oPC, "[Test Epitafium] Brak nagrobków w bazie — najpierw zapisz epitafium.");
+            return;
+        }
+        int nId = JsonGetInt(JsonObjectGet(JsonArrayGet(jAll, 0), "id"));
+        SendMessageToPC(oPC, "[Test Epitafium] Otwieranie nagrobka id=" + IntToString(nId) + "...");
+        TombCreateReadWindow(oPC, nId);
+
+        SetLocalInt(OBJECT_SELF, "TEST_TOMB_MODE", 0);
+    }
+}

--- a/Epitafium/Scripts/tomb_use.nss
+++ b/Epitafium/Scripts/tomb_use.nss
@@ -1,0 +1,23 @@
+// tomb_use.nss — OnUsed script placed on every dynamically spawned tombstone placeable.
+// SetEventScript(oStone, EVENT_SCRIPT_PLACEABLE_ON_USED, "tomb_use") is called
+// inside TombSpawnStone() whenever a new stone is created.
+
+#include "lib_tomb"
+
+void main()
+{
+    object oPC  = GetLastUsedBy();
+    object oSelf = OBJECT_SELF;
+
+    if(!GetIsObjectValid(oPC) || !GetIsPC(oPC) || GetIsDM(oPC))
+        return;
+
+    int nId = GetLocalInt(oSelf, TOMB_LVAR_STONE_ID);
+    if(nId <= 0)
+    {
+        SendMessageToPC(oPC, "[Epitafium] Napis na kamieniu jest zbyt zatarty, by go odczytać.");
+        return;
+    }
+
+    TombCreateReadWindow(oPC, nId);
+}


### PR DESCRIPTION
## Co to robi

Moduł **Epitafium** tworzy fizyczne, persystentne nagrobki w miejscach śmierci graczy. Każdy PC po śmierci może wyryć epitafium (do 200 znaków) i spersonalizować opis przyczyny. Nagrobki materialnie istnieją w świecie jako placeables, inne postacie mogą je odczytać i złożyć hołd. Moduł buduje żywy cmentarz z historii porażek, wzmacniając atmosferę gothic dark fantasy.

## Mechanika

1. **Śmierć → okno epitafium** (`sys_on_pdeath` → `DelayCommand(4s)` → `TombCreateWriteWindow`): edytowalne pole przyczyny śmierci (auto-wykrywanie lub ręczne), multi-line pole epitafium z licznikiem 200 znaków i hintem, przyciski "Wyryt napis" / "Pomiń".

2. **Nagrobek w świecie** (`TombSpawnStone`): `CreateObject(PLACEABLE, "plc_grvmark1", lDeath)` z `SetEventScript(oStone, ON_USED, "tomb_use")`; `SetDescription` z pełnym opisem; lvar `TOMB_MEM_ID` → `tomb_use.nss` otwiera okno odczytu.

3. **Hołd** (`TombPayTribute`): koszt 50 zł, buff `EffectACIncrease(1) + EffectSkillIncrease(SKILL_SPOT, 2)` na 1 godzinę z VFX poświaty; licznik hołdów inkrementowany w SQL i odświeżany na kamieniu i w oknie NUI.

4. **Persystencja**: kampanijny SQLite (`epitafium`), tabela `tomb_memorials`; `sys_on_load` wywołuje `TombDeleteExpired()` + `TombRespawnAll()` — nagrobki odtwarzane przy każdym starcie serwera przez 30 dni.

## Pliki

| Plik | Rola |
|------|------|
| `sql_tomb.nss` | Schemat SQLite, CRUD: INSERT/SELECT/UPDATE/DELETE z named params |
| `lib_tomb_def.nss` | Stałe okien, bindów, przycisków, LVARów; `TombBuildStoneDesc`, `TombClearDeathLvars` |
| `lib_tomb.nss` | Layout NUI (write + read), `TombFinalizeMemorial`, `TombSpawnStone`, `TombPayTribute`, `TombRespawnAll` |
| `lib_tomb_ev.nss` | Dispatcher NUI: watch (hint znaków), click (engrave/skip/close/tribute), close |
| `sys_on_load.nss` | OnModuleLoad: tabele + cleanup + respawn |
| `sys_on_pdeath.nss` | OnPlayerDeath: zapis lokalizacji, opcjonalne `TOMB_KILLER` lvar, `DelayCommand` |
| `tomb_use.nss` | OnUsed placeable: otwiera okno odczytu po LVAR |
| `test_tomb.nss` | Demo: symuluje śmierć + przełącza write/read bez prawdziwej śmierci |
| `INTEGRATION.md` | Integracja, resref, opcje rozszerzenia |

## Zależności (NWNX? SQL?)

- **SQL**: `SqlPrepareQueryCampaign("epitafium", ...)` — kampanijny SQLite, brak NWNX
- **NWNX**: **nie wymagany**; bez NWNX dynamiczne placeables nie przeżywają hard resetu OS, ale `TombRespawnAll()` w `OnModuleLoad` je odtwarza
- **Placeable resref**: `plc_grvmark1` (kamienny nagrobek, baza NWN:EE)

## Jak włączyć w istniejącym module

```nss
// OnModuleLoad (dodaj na końcu istniejącego skryptu):
#include "lib_tomb"
TombCreateTables(); TombDeleteExpired(); TombRespawnAll();

// OnPlayerDeath (dodaj na końcu):
#include "lib_tomb"
object oPC = GetLastPlayerDied();
if(GetIsPC(oPC) && !GetIsDM(oPC)) TombOnDeath(oPC);
```

Opcjonalnie, w OnCreatureDeath PC: `SetLocalObject(OBJECT_SELF, "TOMB_KILLER", GetKiller())` — podaje czytelną przyczynę śmierci.

## Co celowo pominięto

- **Admin NUI z listą nagrobków** — `TombGetAllActive()` jest gotowe, okno do dodania jako rozszerzenie
- **Limit nagrobków per PC** — wymagałoby SELECT COUNT per UUID przed insertem; DM może czyścić przez SQL
- **Animacja rycia** (emote) — `AssignCommand(oPC, ActionPlayAnimation(...))` do dodania w `TombFinalizeMemorial`
- **Zróżnicowanie resrefa** po biome — zmiana `TOMB_STONE_RESREF` na funkcję wyboru po tagu obszaru


---
_Generated by [Claude Code](https://claude.ai/code/session_01RbzP1UuqgRLwQDRwiDdLAA)_