### PR TITLE
feat: Duchy Broni (Blade Spirit)

### DIFF
--- a/Blade Spirit/INTEGRATION.md
+++ b/Blade Spirit/INTEGRATION.md
@@ -1,0 +1,95 @@
+# Blade Spirit — Duchy Broni
+
+## Wymagania
+
+- NWN: Enhanced Edition (NUI, TagEffect, GetObjectUUID na itemach)
+- Brak wymagań NWNX — wszystko działa na czystym NWScript + SQLite (SqlPrepareQueryCampaign)
+
+## Hooki modułu
+
+Ustaw następujące skrypty jako zdarzenia modułu:
+
+| Zdarzenie modułu    | Skrypt               |
+|---------------------|----------------------|
+| OnModuleLoad        | `sys_on_load`        |
+| OnClientEnter       | `sys_on_enter`       |
+| OnClientLeave       | `sys_on_leave`       |
+| OnEquipItem         | `sys_on_equip`       |
+| OnUnEquipItem       | `sys_on_unequip`     |
+| OnPlayerTarget      | `sys_on_target`      |
+
+Jeśli moduł już ma skrypty na tych zdarzeniach, dodaj wywołania funkcji modułu Duchy Broni na końcu istniejących skryptów:
+- `BsCheckAndApplyBonuses(GetEnteringObject());` — w OnClientEnter
+- `BsRemoveBonuses(...)` — w OnClientLeave
+- etc.
+
+## Śledzenie zabójstw
+
+Skrypt `sys_on_death` umieść jako zdarzenie **OnDeath** na każdym potworu (creature), którego zabójstwo ma liczyć się w progresi ducha.
+
+Alternatywnie, jeśli serwer używa NWNX:
+```
+NWNX_Events_SubscribeEvent("NWNX_ON_CREATURE_DEATH_AFTER", "sys_on_death");
+```
+i zmień `GetLastKiller()` na `NWNX_Object_GetCurrentHitPoints(...)` / wymagany adapter.
+
+## Obiekt testowy — Ołtarz Poległych
+
+Stwórz placeable o dowolnym wyglądzie z:
+- OnUsed: `test_bs`
+
+Gracz używa ołtarza → wybiera broń z ekwipunku → otwiera się okno wiązania ducha.
+
+Jeśli gracz trzyma w prawej dłoni już nawiedzoną broń, okno przeglądarki ducha otwiera się bezpośrednio.
+
+## Baza danych SQLite
+
+Tabela: `bs_spirits` w pliku kampanii `blade_spirit`.
+
+```sql
+CREATE TABLE IF NOT EXISTS bs_spirits (
+  item_uuid     TEXT PRIMARY KEY,
+  spirit_name   TEXT NOT NULL DEFAULT '',
+  spirit_class  INTEGER NOT NULL DEFAULT 0,
+  kill_count    INTEGER NOT NULL DEFAULT 0,
+  bound_at      INTEGER NOT NULL DEFAULT 0,
+  appeased_at   INTEGER NOT NULL DEFAULT 0,
+  manifested_at INTEGER NOT NULL DEFAULT 0
+);
+```
+
+## Klasy duchów i premie
+
+| Klasa     | Tier 1         | Tier 2                        | Tier 3                         | Tier 4 (Zmaterializowany)              |
+|-----------|----------------|-------------------------------|--------------------------------|----------------------------------------|
+| Wojownik  | +1 trafienie   | +2 trafienie                  | +3 trafienie, +2 SIŁ           | +4 trafienie, +3 SIŁ                   |
+| Czarownik | +2 Konc.       | +3 Konc., +2 Czaroznawstwo    | +4 Konc., +3 Czaroznawstwo     | +5 Konc., +4 Czaroznawstwo, +2 INT     |
+| Łotrzyk   | +2 Ukrywanie   | +3 Ukryw., +3 Cichy chód      | +5 Ukryw., +4 Cichy chód       | +6 Ukryw., +6 Cichy chód, +1 trafienie |
+| Kapłan    | +2 Leczenie    | +3 Leczenie, +2 Konc.         | +4 Leczenie, +3 Konc.          | +5 Leczenie, +4 Konc., +2 MĄD          |
+
+Ubłaganie ducha (100 sz) dodaje +1 do premii podstawowych przez 6 godzin.
+
+## Progi awansów
+
+| Tier | Nazwa            | Zabójstwa |
+|------|------------------|-----------|
+| 1    | Uśpiony          | 0         |
+| 2    | Niespokojny      | 10        |
+| 3    | Aktywny          | 25        |
+| 4    | Zmaterializowany | 50        |
+
+## Manifestacje (Tier 4, raz na 20 godz.)
+
+| Klasa     | Nazwa                | Efekt                                               |
+|-----------|----------------------|-----------------------------------------------------|
+| Wojownik  | Ostatnia Wola        | Knockdown + 2d10 obrażeń wszystkich wrogów w 5m    |
+| Czarownik | Arcana Uwolniona     | 3d10 magicznych obrażeń wrogów w 7m                |
+| Łotrzyk   | Cień Śmierci         | Improved Invisibility + +4 do trafień przez 3 rundy |
+| Kapłan    | Boskie Wotum         | Ulecz 3d10+10 HP + 3d10 boskich obrażeń wrogów 7m  |
+
+## Co celowo pominięto
+
+- Brak obsługi broni w lewej ręce (dual-wield) — duch reaguje tylko na prawą rękę
+- Brak transferu ducha między przedmiotami — UUID jest stały; jeśli item zostanie zniszczony lub usunięty z DB, duch znika
+- Brak limitów per-PC (gracz może mieć wiele nawiedzonych broni, ale premie z tylko jednej aktywnej)
+- Brak HAK — moduł nie potrzebuje własnych ikon/grafik

--- a/Blade Spirit/Scripts/lib_bs.nss
+++ b/Blade Spirit/Scripts/lib_bs.nss
@@ -1,0 +1,609 @@
+#include "lib_bs_def"
+
+// ----------------------------------------------------------------
+// Tier indicator color
+// ----------------------------------------------------------------
+
+json BsTierColor(int nTier)
+{
+    if(nTier == BS_TIER_DORMANT)    return NuiColor(160, 160, 160);
+    if(nTier == BS_TIER_RESTLESS)   return NuiColor(220, 200, 100);
+    if(nTier == BS_TIER_ACTIVE)     return NuiColor(255, 140, 40);
+    return NuiColor(200, 80, 255);
+}
+
+// ----------------------------------------------------------------
+// Next-tier kill threshold for display
+// ----------------------------------------------------------------
+
+int BsKillsToNextTier(int nTier)
+{
+    if(nTier == BS_TIER_DORMANT)  return BS_KILLS_RESTLESS;
+    if(nTier == BS_TIER_RESTLESS) return BS_KILLS_ACTIVE;
+    if(nTier == BS_TIER_ACTIVE)   return BS_KILLS_MANIFESTED;
+    return -1;
+}
+
+string BsManifestAbilityName(int nClass)
+{
+    if(nClass == BS_CLASS_WARRIOR) return "Ostatnia Wola";
+    if(nClass == BS_CLASS_MAGE)    return "Arcana Uwolniona";
+    if(nClass == BS_CLASS_ROGUE)   return "Cień Śmierci";
+    return "Boskie Wotum";
+}
+
+// ----------------------------------------------------------------
+// Main window layout
+// ----------------------------------------------------------------
+
+json BsBuildMainWindow(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 30.0);
+    float fIconSz= GetNuiScaleDimension(oPC, 56.0);
+    float fLabelH= GetNuiScaleDimension(oPC, 22.0);
+
+    // -- Header: weapon icon + spirit name + close --
+    json jIcon = NuiButtonImage(NuiBind(BS_BIND_WPN_ICON));
+    jIcon = NuiWidth(jIcon, fIconSz);
+    jIcon = NuiHeight(jIcon, fIconSz);
+
+    json jNameLbl = NuiLabel(NuiBind(BS_BIND_SPIRIT_NAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jNameLbl = NuiStyleForegroundColor(jNameLbl, NuiBind(BS_BIND_TIER_COLOR));
+    jNameLbl = NuiHeight(jNameLbl, fLabelH);
+
+    json jWpnLbl = NuiLabel(NuiBind(BS_BIND_WPNNAME_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jWpnLbl = NuiHeight(jWpnLbl, fLabelH);
+
+    json jCloseBtn = NuiButton(JsonString("X"));
+    jCloseBtn = NuiId(jCloseBtn, BS_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, GetNuiScaleDimension(oPC, 30.0));
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jNameCol = JsonArray();
+    jNameCol = JsonArrayInsert(jNameCol, jNameLbl);
+    jNameCol = JsonArrayInsert(jNameCol, jWpnLbl);
+
+    json jHeaderRow = JsonArray();
+    jHeaderRow = JsonArrayInsert(jHeaderRow, jIcon);
+    jHeaderRow = JsonArrayInsert(jHeaderRow, NuiCol(jNameCol));
+    jHeaderRow = JsonArrayInsert(jHeaderRow, NuiSpacer());
+    jHeaderRow = JsonArrayInsert(jHeaderRow, jCloseBtn);
+
+    // -- Tier / class row --
+    json jTierLbl = NuiLabel(NuiBind(BS_BIND_TIER_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTierLbl = NuiStyleForegroundColor(jTierLbl, NuiBind(BS_BIND_TIER_COLOR));
+    jTierLbl = NuiHeight(jTierLbl, fLabelH);
+
+    json jClassLbl = NuiLabel(NuiBind(BS_BIND_CLASS_LBL),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jClassLbl = NuiHeight(jClassLbl, fLabelH);
+    jClassLbl = NuiWidth(jClassLbl, GetNuiScaleDimension(oPC, 120.0));
+
+    json jTierRow = JsonArray();
+    jTierRow = JsonArrayInsert(jTierRow, jTierLbl);
+    jTierRow = JsonArrayInsert(jTierRow, NuiSpacer());
+    jTierRow = JsonArrayInsert(jTierRow, jClassLbl);
+
+    // -- Kill progress row --
+    json jKillsLbl = NuiLabel(NuiBind(BS_BIND_KILLS_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jKillsLbl = NuiHeight(jKillsLbl, fLabelH);
+
+    json jKillsNextLbl = NuiLabel(NuiBind(BS_BIND_KILLS_NEXT),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jKillsNextLbl = NuiHeight(jKillsNextLbl, fLabelH);
+    jKillsNextLbl = NuiWidth(jKillsNextLbl, GetNuiScaleDimension(oPC, 200.0));
+
+    json jKillRow = JsonArray();
+    jKillRow = JsonArrayInsert(jKillRow, jKillsLbl);
+    jKillRow = JsonArrayInsert(jKillRow, NuiSpacer());
+    jKillRow = JsonArrayInsert(jKillRow, jKillsNextLbl);
+
+    // -- Two-column area: bonuses (left) | whispers (right) --
+    float fSectionH = GetNuiScaleDimension(oPC, 160.0);
+    float fColW     = GetNuiScaleDimension(oPC, 280.0);
+
+    json jBonusHdr = NuiLabel(JsonString("Premie ducha"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jBonusHdr = NuiHeight(jBonusHdr, fLabelH);
+    jBonusHdr = NuiStyleForegroundColor(jBonusHdr, GetNuiColorNwnGold());
+
+    json jBonusTxt = NuiGroup(
+        NuiText(NuiBind(BS_BIND_BONUS_LBL), FALSE),
+        TRUE, NUI_SCROLLBARS_NONE);
+    jBonusTxt = NuiHeight(jBonusTxt, GetNuiScaleDimension(oPC, 130.0));
+
+    json jBonusCol = JsonArray();
+    jBonusCol = JsonArrayInsert(jBonusCol, jBonusHdr);
+    jBonusCol = JsonArrayInsert(jBonusCol, jBonusTxt);
+
+    json jWhisperHdr = NuiLabel(JsonString("Szepty ducha"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jWhisperHdr = NuiHeight(jWhisperHdr, fLabelH);
+    jWhisperHdr = NuiStyleForegroundColor(jWhisperHdr, NuiColor(180, 120, 180));
+
+    json jW0 = NuiLabel(NuiBind(BS_BIND_WHISPER_0),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jW0 = NuiHeight(jW0, fLabelH);
+    json jW1 = NuiLabel(NuiBind(BS_BIND_WHISPER_1),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jW1 = NuiHeight(jW1, fLabelH);
+    json jW2 = NuiLabel(NuiBind(BS_BIND_WHISPER_2),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jW2 = NuiHeight(jW2, fLabelH);
+
+    json jWhisperCol = JsonArray();
+    jWhisperCol = JsonArrayInsert(jWhisperCol, jWhisperHdr);
+    jWhisperCol = JsonArrayInsert(jWhisperCol, jW0);
+    jWhisperCol = JsonArrayInsert(jWhisperCol, jW1);
+    jWhisperCol = JsonArrayInsert(jWhisperCol, jW2);
+    jWhisperCol = JsonArrayInsert(jWhisperCol, NuiSpacer());
+
+    json jTwoCol = JsonArray();
+    jTwoCol = JsonArrayInsert(jTwoCol, NuiWidth(NuiCol(jBonusCol), fColW));
+    jTwoCol = JsonArrayInsert(jTwoCol, NuiWidth(NuiCol(jWhisperCol), fColW));
+    json jTwoColRow = NuiHeight(NuiRow(jTwoCol), fSectionH);
+
+    // -- Appease status label --
+    json jAppeasedLbl = NuiLabel(NuiBind(BS_BIND_APPEASED_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jAppeasedLbl = NuiHeight(jAppeasedLbl, fLabelH);
+    jAppeasedLbl = NuiStyleForegroundColor(jAppeasedLbl, NuiColor(100, 220, 100));
+
+    // -- Action buttons row 1: Commune + Appease + Exorcise --
+    json jCommuneBtn = NuiButton(JsonString("Komunikuj się"));
+    jCommuneBtn = NuiId(jCommuneBtn, BS_BTN_COMMUNE);
+    jCommuneBtn = NuiHeight(jCommuneBtn, fBtnH);
+
+    json jAppeaseLbl = NuiBind(BS_BIND_APPEASE_LBL);
+    json jAppeaseBtn = NuiButton(jAppeaseLbl);
+    jAppeaseBtn = NuiId(jAppeaseBtn, BS_BTN_APPEASE);
+    jAppeaseBtn = NuiEnabled(jAppeaseBtn, NuiBind(BS_BIND_APPEASE_ENA));
+    jAppeaseBtn = NuiHeight(jAppeaseBtn, fBtnH);
+
+    json jExorciseBtn = NuiButton(JsonString("Wygnaj ducha"));
+    jExorciseBtn = NuiId(jExorciseBtn, BS_BTN_EXORCISE);
+    jExorciseBtn = NuiEnabled(jExorciseBtn, NuiBind(BS_BIND_EXORCISE_ENA));
+    jExorciseBtn = NuiHeight(jExorciseBtn, fBtnH);
+
+    json jActRow1 = JsonArray();
+    jActRow1 = JsonArrayInsert(jActRow1, jCommuneBtn);
+    jActRow1 = JsonArrayInsert(jActRow1, NuiSpacer());
+    jActRow1 = JsonArrayInsert(jActRow1, jAppeaseBtn);
+    jActRow1 = JsonArrayInsert(jActRow1, NuiSpacer());
+    jActRow1 = JsonArrayInsert(jActRow1, jExorciseBtn);
+
+    // -- Action buttons row 2: Manifest --
+    json jManifestBtn = NuiButton(NuiBind(BS_BIND_MANIFEST_LBL));
+    jManifestBtn = NuiId(jManifestBtn, BS_BTN_MANIFEST);
+    jManifestBtn = NuiEnabled(jManifestBtn, NuiBind(BS_BIND_MANIFEST_ENA));
+    jManifestBtn = NuiHeight(jManifestBtn, fBtnH);
+
+    json jActRow2 = JsonArray();
+    jActRow2 = JsonArrayInsert(jActRow2, jManifestBtn);
+
+    // -- Assemble column --
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(jHeaderRow));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jTierRow));
+    jCol = JsonArrayInsert(jCol, NuiRow(jKillRow));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jTwoColRow);
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jAppeasedLbl)));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jActRow1));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jActRow2));
+
+    json jSide = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    float fContentW = GetNuiScaleDimension(oPC, 640.0);
+    json jMainRow = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiCol(jCol), fContentW));
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    return NuiRow(jMainRow);
+}
+
+// ----------------------------------------------------------------
+// Create / bind window layout
+// ----------------------------------------------------------------
+
+json BsBuildCreateWindow(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 30.0);
+    float fIconSz= GetNuiScaleDimension(oPC, 48.0);
+    float fLabelH= GetNuiScaleDimension(oPC, 22.0);
+
+    // -- Weapon info row --
+    json jWpnIcon = NuiButtonImage(NuiBind(BS_BIND_C_WPN_ICON));
+    jWpnIcon = NuiWidth(jWpnIcon, fIconSz);
+    jWpnIcon = NuiHeight(jWpnIcon, fIconSz);
+
+    json jWpnLbl = NuiLabel(NuiBind(BS_BIND_C_WPN_NAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+
+    json jWpnRow = JsonArray();
+    jWpnRow = JsonArrayInsert(jWpnRow, jWpnIcon);
+    jWpnRow = JsonArrayInsert(jWpnRow, jWpnLbl);
+
+    // -- Spirit name field --
+    json jSnameHdr = NuiLabel(JsonString("Imię ducha:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jSnameHdr = NuiWidth(jSnameHdr, GetNuiScaleDimension(oPC, 90.0));
+    jSnameHdr = NuiHeight(jSnameHdr, fBtnH);
+
+    json jSnameEdit = NuiTextEdit(JsonString(""), NuiBind(BS_BIND_C_SNAME), 40, FALSE);
+    jSnameEdit = NuiHeight(jSnameEdit, fBtnH);
+
+    json jSnameRow = JsonArray();
+    jSnameRow = JsonArrayInsert(jSnameRow, jSnameHdr);
+    jSnameRow = JsonArrayInsert(jSnameRow, jSnameEdit);
+
+    // -- Class selection: 4 toggle buttons --
+    json jClHdr = NuiLabel(JsonString("Klasa ducha:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jClHdr = NuiHeight(jClHdr, fLabelH);
+
+    float fClW = GetNuiScaleDimension(oPC, 90.0);
+
+    json jBtnW = NuiButton(JsonString("Wojownik"));
+    jBtnW = NuiId(jBtnW, BS_BTN_C_W);
+    jBtnW = NuiEncouraged(jBtnW, NuiBind(BS_BIND_C_CLASS_W));
+    jBtnW = NuiWidth(jBtnW, fClW);
+    jBtnW = NuiHeight(jBtnW, fBtnH);
+
+    json jBtnM = NuiButton(JsonString("Czarownik"));
+    jBtnM = NuiId(jBtnM, BS_BTN_C_M);
+    jBtnM = NuiEncouraged(jBtnM, NuiBind(BS_BIND_C_CLASS_M));
+    jBtnM = NuiWidth(jBtnM, fClW);
+    jBtnM = NuiHeight(jBtnM, fBtnH);
+
+    json jBtnR = NuiButton(JsonString("Łotrzyk"));
+    jBtnR = NuiId(jBtnR, BS_BTN_C_R);
+    jBtnR = NuiEncouraged(jBtnR, NuiBind(BS_BIND_C_CLASS_R));
+    jBtnR = NuiWidth(jBtnR, fClW);
+    jBtnR = NuiHeight(jBtnR, fBtnH);
+
+    json jBtnC = NuiButton(JsonString("Kapłan"));
+    jBtnC = NuiId(jBtnC, BS_BTN_C_C);
+    jBtnC = NuiEncouraged(jBtnC, NuiBind(BS_BIND_C_CLASS_C));
+    jBtnC = NuiWidth(jBtnC, fClW);
+    jBtnC = NuiHeight(jBtnC, fBtnH);
+
+    json jClassRow = JsonArray();
+    jClassRow = JsonArrayInsert(jClassRow, jBtnW);
+    jClassRow = JsonArrayInsert(jClassRow, jBtnM);
+    jClassRow = JsonArrayInsert(jClassRow, jBtnR);
+    jClassRow = JsonArrayInsert(jClassRow, jBtnC);
+
+    // -- Status / info label --
+    json jStatusLbl = NuiLabel(NuiBind(BS_BIND_C_STATUS),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jStatusLbl = NuiHeight(jStatusLbl, GetNuiScaleDimension(oPC, 44.0));
+    jStatusLbl = NuiStyleForegroundColor(jStatusLbl, NuiColor(200, 180, 100));
+
+    // -- Bottom buttons: Bind + Cancel --
+    json jBindBtn = NuiButton(JsonString("Związ ducha (" + IntToString(BS_BIND_COST) + " sz)"));
+    jBindBtn = NuiId(jBindBtn, BS_BTN_C_BIND);
+    jBindBtn = NuiEnabled(jBindBtn, NuiBind(BS_BIND_C_BIND_ENA));
+    jBindBtn = NuiHeight(jBindBtn, fBtnH);
+
+    json jCancelBtn = NuiButton(JsonString("Anuluj"));
+    jCancelBtn = NuiId(jCancelBtn, BS_BTN_C_CANCEL);
+    jCancelBtn = NuiHeight(jCancelBtn, fBtnH);
+
+    json jBotRow = JsonArray();
+    jBotRow = JsonArrayInsert(jBotRow, jCancelBtn);
+    jBotRow = JsonArrayInsert(jBotRow, NuiSpacer());
+    jBotRow = JsonArrayInsert(jBotRow, jBindBtn);
+
+    // -- Assemble --
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(jWpnRow));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jSnameRow));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jClHdr);
+    jCol = JsonArrayInsert(jCol, NuiRow(jClassRow));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jStatusLbl);
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+    jCol = JsonArrayInsert(jCol, NuiRow(jBotRow));
+
+    json jSide = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    float fContentW = GetNuiScaleDimension(oPC, 420.0);
+    json jMainRow = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiCol(jCol), fContentW));
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    return NuiRow(jMainRow);
+}
+
+// ----------------------------------------------------------------
+// Window open
+// ----------------------------------------------------------------
+
+void BsOpenWindow(object oPC, string sItemUUID)
+{
+    json jSpirit = BsGetSpirit(sItemUUID);
+    if(JsonGetType(jSpirit) == JSON_TYPE_NULL)
+    {
+        SendMessageToPC(oPC, "[Duch Ostrza] To ostrze nie jest nawiedzone.");
+        return;
+    }
+
+    SetLocalString(oPC, BS_LVAR_ACTIVE_UUID, sItemUUID);
+
+    if(NuiFindWindow(oPC, BS_WIN) != 0)
+    {
+        BsFeedMainWindow(oPC, NuiFindWindow(oPC, BS_WIN));
+        return;
+    }
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))
+                 - GetNuiScaleDimension(oPC, BS_WIN_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT))
+                 - GetNuiScaleDimension(oPC, BS_WIN_H)) / 2.0;
+
+    json jWin = NuiWindow(
+        BsBuildMainWindow(oPC),
+        JsonString("Duch Ostrza"),
+        NuiBind(BS_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    int nToken = NuiCreate(oPC, jWin, BS_WIN, BS_WIN_EV);
+    NuiSetBind(oPC, nToken, BS_WIN_GEOM,
+        NuiRect(fCX, fCY,
+            GetNuiScaleDimension(oPC, BS_WIN_W),
+            GetNuiScaleDimension(oPC, BS_WIN_H)));
+    NuiSetBindWatch(oPC, nToken, BS_BIND_C_SNAME, TRUE);
+
+    BsFeedMainWindow(oPC, nToken);
+}
+
+void BsOpenCreateWindow(object oPC, string sItemUUID, string sWeaponName, string sWeaponIcon)
+{
+    SetLocalString(oPC, BS_LVAR_CREATE_UUID,  sItemUUID);
+    SetLocalInt   (oPC, BS_LVAR_CREATE_CLASS, BS_CLASS_WARRIOR);
+
+    if(NuiFindWindow(oPC, BS_WIN_CREATE) != 0)
+        NuiDestroy(oPC, NuiFindWindow(oPC, BS_WIN_CREATE));
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))
+                 - GetNuiScaleDimension(oPC, BS_CREATE_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT))
+                 - GetNuiScaleDimension(oPC, BS_CREATE_H)) / 2.0;
+
+    json jWin = NuiWindow(
+        BsBuildCreateWindow(oPC),
+        JsonString("Ołtarz Poległych — Związanie Ducha"),
+        NuiBind(BS_WIN_CREATE_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    int nToken = NuiCreate(oPC, jWin, BS_WIN_CREATE, BS_WIN_EV);
+    NuiSetBind(oPC, nToken, BS_WIN_CREATE_GEOM,
+        NuiRect(fCX, fCY,
+            GetNuiScaleDimension(oPC, BS_CREATE_W),
+            GetNuiScaleDimension(oPC, BS_CREATE_H)));
+    NuiSetBindWatch(oPC, nToken, BS_BIND_C_SNAME, TRUE);
+
+    NuiSetBind(oPC, nToken, BS_BIND_C_WPN_ICON, JsonString(sWeaponIcon));
+    NuiSetBind(oPC, nToken, BS_BIND_C_WPN_NAME, JsonString(sWeaponName));
+    NuiSetBind(oPC, nToken, BS_BIND_C_SNAME,    JsonString(""));
+    NuiSetBind(oPC, nToken, BS_BIND_C_BIND_ENA, JsonBool(FALSE));
+
+    BsFeedCreateWindow(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Feed main window
+// ----------------------------------------------------------------
+
+void BsFeedMainWindow(object oPC, int nToken)
+{
+    string sUUID   = GetLocalString(oPC, BS_LVAR_ACTIVE_UUID);
+    json   jSpirit = BsGetSpirit(sUUID);
+    if(JsonGetType(jSpirit) == JSON_TYPE_NULL)
+    {
+        NuiDestroy(oPC, nToken);
+        return;
+    }
+
+    string sSpiritName = JsonGetString(JsonObjectGet(jSpirit, "spirit_name"));
+    int    nClass      = JsonGetInt   (JsonObjectGet(jSpirit, "spirit_class"));
+    int    nKills      = JsonGetInt   (JsonObjectGet(jSpirit, "kill_count"));
+    int    nTier       = BsGetTier(nKills);
+    int    bAppeased   = BsIsAppeased(jSpirit);
+
+    // Weapon info
+    object oRH = GetItemInSlot(INVENTORY_SLOT_RIGHTHAND, oPC);
+    string sWpnIcon = "ir_longsword";
+    string sWpnName = "Nieznana broń";
+    if(GetIsObjectValid(oRH) && GetObjectUUID(oRH) == sUUID)
+    {
+        sWpnIcon = GetStringLowerCase(
+            Get2DAString("baseitems", "DefaultIcon", GetBaseItemType(oRH)));
+        sWpnName = GetName(oRH);
+    }
+
+    NuiSetBind(oPC, nToken, BS_BIND_WPN_ICON,    JsonString(sWpnIcon));
+    NuiSetBind(oPC, nToken, BS_BIND_WPNNAME_LBL, JsonString(sWpnName));
+    NuiSetBind(oPC, nToken, BS_BIND_SPIRIT_NAME, JsonString(sSpiritName));
+    NuiSetBind(oPC, nToken, BS_BIND_TIER_LBL,
+        JsonString("Poziom " + IntToString(nTier + 1) + ": " + BsTierName(nTier)));
+    NuiSetBind(oPC, nToken, BS_BIND_TIER_COLOR,  BsTierColor(nTier));
+    NuiSetBind(oPC, nToken, BS_BIND_CLASS_LBL,   JsonString(BsSpiritClassName(nClass)));
+
+    // Kill progress
+    int nNext = BsKillsToNextTier(nTier);
+    NuiSetBind(oPC, nToken, BS_BIND_KILLS_LBL,
+        JsonString("Pokonani wrogowie: " + IntToString(nKills)));
+    string sNextTxt = nNext >= 0
+        ? "do " + BsTierName(nTier + 1) + ": " + IntToString(nNext - nKills) + " pozostało"
+        : "Szczyt mocy osiągnięty";
+    NuiSetBind(oPC, nToken, BS_BIND_KILLS_NEXT, JsonString(sNextTxt));
+
+    // Bonuses
+    NuiSetBind(oPC, nToken, BS_BIND_BONUS_LBL,
+        JsonString(BsGetBonusDescription(nClass, nTier, bAppeased)));
+
+    // Whispers — 3 cycling whispers based on tier
+    NuiSetBind(oPC, nToken, BS_BIND_WHISPER_0,
+        JsonString("„" + BsGetWhisper(nClass, nTier, nKills)     + """));
+    NuiSetBind(oPC, nToken, BS_BIND_WHISPER_1,
+        JsonString("„" + BsGetWhisper(nClass, nTier, nKills + 1) + """));
+    NuiSetBind(oPC, nToken, BS_BIND_WHISPER_2,
+        JsonString("„" + BsGetWhisper(nClass, nTier, nKills + 2) + """));
+
+    // Appeased status
+    NuiSetBind(oPC, nToken, BS_BIND_APPEASED_LBL,
+        JsonString(bAppeased
+            ? "Duch jest uspokojony — premie wzmocnione."
+            : ""));
+
+    // Appease button
+    NuiSetBind(oPC, nToken, BS_BIND_APPEASE_LBL,
+        JsonString("Ubłagaj (" + IntToString(BS_APPEASE_COST) + " sz)"));
+    NuiSetBind(oPC, nToken, BS_BIND_APPEASE_ENA,
+        JsonBool(!bAppeased));
+
+    // Exorcise — requires cleric level
+    int nClericLevel = GetLevelByClass(CLASS_TYPE_CLERIC, oPC)
+                     + GetLevelByClass(CLASS_TYPE_PALADIN, oPC);
+    NuiSetBind(oPC, nToken, BS_BIND_EXORCISE_ENA,
+        JsonBool(nClericLevel >= BS_EXORCISE_MIN_CLERIC));
+
+    // Manifest
+    int bCanManifest = (nTier == BS_TIER_MANIFESTED && !BsManifestOnCooldown(jSpirit));
+    NuiSetBind(oPC, nToken, BS_BIND_MANIFEST_ENA, JsonBool(bCanManifest));
+    NuiSetBind(oPC, nToken, BS_BIND_MANIFEST_LBL,
+        JsonString(bCanManifest
+            ? "Manifestacja: " + BsManifestAbilityName(nClass)
+            : "Manifestacja — niedostępna"));
+}
+
+// ----------------------------------------------------------------
+// Feed create window
+// ----------------------------------------------------------------
+
+void BsFeedCreateWindow(object oPC, int nToken)
+{
+    int nClass = GetLocalInt(oPC, BS_LVAR_CREATE_CLASS);
+
+    NuiSetBind(oPC, nToken, BS_BIND_C_CLASS_W, JsonBool(nClass == BS_CLASS_WARRIOR));
+    NuiSetBind(oPC, nToken, BS_BIND_C_CLASS_M, JsonBool(nClass == BS_CLASS_MAGE));
+    NuiSetBind(oPC, nToken, BS_BIND_C_CLASS_R, JsonBool(nClass == BS_CLASS_ROGUE));
+    NuiSetBind(oPC, nToken, BS_BIND_C_CLASS_C, JsonBool(nClass == BS_CLASS_CLERIC));
+
+    string sName = JsonGetString(NuiGetBind(oPC, nToken, BS_BIND_C_SNAME));
+    int bHasName = (sName != "");
+    int bHasGold = (GetGold(oPC) >= BS_BIND_COST);
+
+    NuiSetBind(oPC, nToken, BS_BIND_C_BIND_ENA, JsonBool(bHasName && bHasGold));
+    NuiSetBind(oPC, nToken, BS_BIND_C_STATUS,
+        JsonString("Koszt rytuału: " + IntToString(BS_BIND_COST) + " sz. "
+            + (bHasGold ? "" : "Brak środków. ")
+            + "Duch przyjmuje klasę poległego wojownika."));
+}
+
+// ----------------------------------------------------------------
+// Manifest power execution
+// ----------------------------------------------------------------
+
+void BsDoManifest(object oPC, string sUUID, int nClass)
+{
+    location lPC = GetLocation(oPC);
+
+    if(nClass == BS_CLASS_WARRIOR)
+    {
+        // Ostatnia Wola: AoE knockdown + damage
+        ApplyEffectToObject(DURATION_TYPE_INSTANT,
+            EffectVisualEffect(VFX_FNF_SCREEN_SHAKE), oPC);
+        object oTarget = GetFirstObjectInShape(SHAPE_SPHERE, 5.0, lPC, TRUE, OBJECT_TYPE_CREATURE);
+        while(GetIsObjectValid(oTarget))
+        {
+            if(GetIsEnemy(oTarget, oPC))
+            {
+                ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                    EffectKnockdown(), oTarget, 6.0);
+                ApplyEffectToObject(DURATION_TYPE_INSTANT,
+                    EffectDamage(d10(2), DAMAGE_TYPE_BLUDGEONING), oTarget);
+                ApplyEffectToObject(DURATION_TYPE_INSTANT,
+                    EffectVisualEffect(VFX_IMP_STUN), oTarget);
+            }
+            oTarget = GetNextObjectInShape(SHAPE_SPHERE, 5.0, lPC, TRUE, OBJECT_TYPE_CREATURE);
+        }
+        FloatingTextStringOnCreature(
+            "Ostatnia wola ducha eksploduje w obszarze wokół ciebie!", oPC, FALSE);
+    }
+    else if(nClass == BS_CLASS_MAGE)
+    {
+        // Arcana Uwolniona: force damage AoE
+        ApplyEffectToObject(DURATION_TYPE_INSTANT,
+            EffectVisualEffect(VFX_FNF_LOS_NORMAL_10), oPC);
+        object oTarget = GetFirstObjectInShape(SHAPE_SPHERE, 7.0, lPC, TRUE, OBJECT_TYPE_CREATURE);
+        while(GetIsObjectValid(oTarget))
+        {
+            if(GetIsEnemy(oTarget, oPC))
+            {
+                ApplyEffectToObject(DURATION_TYPE_INSTANT,
+                    EffectDamage(d10(3), DAMAGE_TYPE_MAGICAL), oTarget);
+                ApplyEffectToObject(DURATION_TYPE_INSTANT,
+                    EffectVisualEffect(VFX_IMP_MAGBLUE), oTarget);
+            }
+            oTarget = GetNextObjectInShape(SHAPE_SPHERE, 7.0, lPC, TRUE, OBJECT_TYPE_CREATURE);
+        }
+        FloatingTextStringOnCreature(
+            "Skuta magia pęka — fala arkanej energii rozrywa wszystko wokół!", oPC, FALSE);
+    }
+    else if(nClass == BS_CLASS_ROGUE)
+    {
+        // Cień Śmierci: improved invisibility + attack bonus, 3 rounds
+        ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+            EffectInvisibility(INVISIBILITY_TYPE_IMPROVED), oPC, 18.0);
+        ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+            TagEffect(EffectAttackIncrease(4), "BS_MANIFEST_TEMP"), oPC, 18.0);
+        ApplyEffectToObject(DURATION_TYPE_INSTANT,
+            EffectVisualEffect(VFX_IMP_SHADOW_INVISIBILITY), oPC);
+        FloatingTextStringOnCreature(
+            "Cień ducha pochłania cię — stajesz się niewidzialny i śmiertelny.", oPC, FALSE);
+    }
+    else if(nClass == BS_CLASS_CLERIC)
+    {
+        // Boskie Wotum: self heal + divine smite undead
+        int nHeal = d10(3) + 10;
+        ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectHeal(nHeal), oPC);
+        ApplyEffectToObject(DURATION_TYPE_INSTANT,
+            EffectVisualEffect(VFX_IMP_HOLY_AID), oPC);
+
+        object oTarget = GetFirstObjectInShape(SHAPE_SPHERE, 7.0, lPC, TRUE, OBJECT_TYPE_CREATURE);
+        while(GetIsObjectValid(oTarget))
+        {
+            if(GetIsEnemy(oTarget, oPC))
+            {
+                ApplyEffectToObject(DURATION_TYPE_INSTANT,
+                    EffectDamage(d10(3), DAMAGE_TYPE_DIVINE), oTarget);
+                ApplyEffectToObject(DURATION_TYPE_INSTANT,
+                    EffectVisualEffect(VFX_IMP_SUNSTRIKE), oTarget);
+            }
+            oTarget = GetNextObjectInShape(SHAPE_SPHERE, 7.0, lPC, TRUE, OBJECT_TYPE_CREATURE);
+        }
+        FloatingTextStringOnCreature(
+            "Boskie wotum ducha uzdrawia cię i spala wrogów ogniem niebios!", oPC, FALSE);
+    }
+
+    BsSetManifested(sUUID);
+    SendMessageToPC(oPC, "[Duch Ostrza] Manifestacja użyta. Dostępna ponownie za 20 godzin.");
+}

--- a/Blade Spirit/Scripts/lib_bs_def.nss
+++ b/Blade Spirit/Scripts/lib_bs_def.nss
@@ -1,0 +1,343 @@
+#include "lib_nui"
+#include "sql_bs"
+
+// Forward declarations for functions defined in lib_bs.nss
+void BsOpenWindow(object oPC, string sItemUUID);
+void BsOpenCreateWindow(object oPC, string sItemUUID, string sWeaponName, string sWeaponIcon);
+void BsFeedMainWindow(object oPC, int nToken);
+void BsFeedCreateWindow(object oPC, int nToken);
+
+// ----------------------------------------------------------------
+// Window IDs
+// ----------------------------------------------------------------
+
+const string BS_WIN             = "BS_WIN";
+const string BS_WIN_EV          = "lib_bs_ev";
+const string BS_WIN_GEOM        = "bs_win_geom";
+
+const string BS_WIN_CREATE      = "BS_WIN_CREATE";
+const string BS_WIN_CREATE_GEOM = "bs_create_geom";
+
+// ----------------------------------------------------------------
+// Main window binds
+// ----------------------------------------------------------------
+
+const string BS_BIND_WPN_ICON     = "bs_wpn_icon";
+const string BS_BIND_SPIRIT_NAME  = "bs_spirit_name";
+const string BS_BIND_TIER_LBL     = "bs_tier_lbl";
+const string BS_BIND_TIER_COLOR   = "bs_tier_color";
+const string BS_BIND_CLASS_LBL    = "bs_class_lbl";
+const string BS_BIND_KILLS_LBL    = "bs_kills_lbl";
+const string BS_BIND_KILLS_NEXT   = "bs_kills_next";
+const string BS_BIND_BONUS_LBL    = "bs_bonus_lbl";
+const string BS_BIND_WHISPER_0    = "bs_whisper_0";
+const string BS_BIND_WHISPER_1    = "bs_whisper_1";
+const string BS_BIND_WHISPER_2    = "bs_whisper_2";
+const string BS_BIND_MANIFEST_ENA = "bs_manifest_ena";
+const string BS_BIND_MANIFEST_LBL = "bs_manifest_lbl";
+const string BS_BIND_APPEASE_ENA  = "bs_appease_ena";
+const string BS_BIND_APPEASE_LBL  = "bs_appease_lbl";
+const string BS_BIND_EXORCISE_ENA = "bs_exorcise_ena";
+const string BS_BIND_APPEASED_LBL = "bs_appeased_lbl";
+const string BS_BIND_WPNNAME_LBL  = "bs_wpnname_lbl";
+
+// ----------------------------------------------------------------
+// Create window binds
+// ----------------------------------------------------------------
+
+const string BS_BIND_C_WPN_ICON  = "bs_c_icon";
+const string BS_BIND_C_WPN_NAME  = "bs_c_wpnname";
+const string BS_BIND_C_SNAME     = "bs_c_sname";
+const string BS_BIND_C_CLASS_W   = "bs_c_cl_w";
+const string BS_BIND_C_CLASS_M   = "bs_c_cl_m";
+const string BS_BIND_C_CLASS_R   = "bs_c_cl_r";
+const string BS_BIND_C_CLASS_C   = "bs_c_cl_c";
+const string BS_BIND_C_BIND_ENA  = "bs_c_bind_ena";
+const string BS_BIND_C_STATUS    = "bs_c_status";
+
+// ----------------------------------------------------------------
+// Buttons
+// ----------------------------------------------------------------
+
+const string BS_BTN_CLOSE        = "bs_btn_close";
+const string BS_BTN_COMMUNE      = "bs_btn_commune";
+const string BS_BTN_APPEASE      = "bs_btn_appease";
+const string BS_BTN_EXORCISE     = "bs_btn_exorcise";
+const string BS_BTN_MANIFEST     = "bs_btn_manifest";
+const string BS_BTN_C_W          = "bs_btn_cl_w";
+const string BS_BTN_C_M          = "bs_btn_cl_m";
+const string BS_BTN_C_R          = "bs_btn_cl_r";
+const string BS_BTN_C_C          = "bs_btn_cl_c";
+const string BS_BTN_C_BIND       = "bs_btn_bind";
+const string BS_BTN_C_CANCEL     = "bs_btn_cancel";
+
+// ----------------------------------------------------------------
+// LVARs on PC
+// ----------------------------------------------------------------
+
+const string BS_LVAR_ACTIVE_UUID  = "BS_ACTIVE_UUID";
+const string BS_LVAR_CREATE_UUID  = "BS_CREATE_UUID";
+const string BS_LVAR_CREATE_CLASS = "BS_CREATE_CLASS";
+const string BS_LVAR_TARGETING    = "BS_TARGETING";
+
+// ----------------------------------------------------------------
+// Effect tag prefix (+ item UUID = unique per-spirit tag)
+// ----------------------------------------------------------------
+
+const string BS_FX_TAG = "BS_SPIRIT_";
+
+// ----------------------------------------------------------------
+// Costs and limits
+// ----------------------------------------------------------------
+
+const int BS_BIND_COST           = 500;
+const int BS_APPEASE_COST        = 100;
+const int BS_EXORCISE_MIN_CLERIC = 5;
+
+// ----------------------------------------------------------------
+// Layout dimensions
+// ----------------------------------------------------------------
+
+const float BS_WIN_W    = 680.0;
+const float BS_WIN_H    = 460.0;
+const float BS_CREATE_W = 460.0;
+const float BS_CREATE_H = 340.0;
+
+// ----------------------------------------------------------------
+// Bonus application / removal
+// ----------------------------------------------------------------
+
+void BsApplyBonuses(object oPC, string sUUID, int nClass, int nTier, int bAppeased)
+{
+    string sTag  = BS_FX_TAG + sUUID;
+    int    nApp  = bAppeased ? 1 : 0;
+
+    if(nClass == BS_CLASS_WARRIOR)
+    {
+        int nAB = nTier + 1 + nApp;
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+            TagEffect(EffectAttackIncrease(nAB), sTag), oPC);
+        if(nTier >= BS_TIER_ACTIVE)
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAbilityIncrease(ABILITY_STRENGTH,
+                    nTier == BS_TIER_MANIFESTED ? 3 : 2), sTag), oPC);
+    }
+    else if(nClass == BS_CLASS_MAGE)
+    {
+        int nConc   = (nTier + 1) * 2 + nApp;
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+            TagEffect(EffectSkillIncrease(SKILL_CONCENTRATION, nConc), sTag), oPC);
+        if(nTier >= BS_TIER_RESTLESS)
+        {
+            int nScraft = nTier == BS_TIER_RESTLESS ? 2 :
+                          nTier == BS_TIER_ACTIVE   ? 3 : 4 + nApp;
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectSkillIncrease(SKILL_SPELLCRAFT, nScraft), sTag), oPC);
+        }
+        if(nTier == BS_TIER_MANIFESTED)
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAbilityIncrease(ABILITY_INTELLIGENCE, 2), sTag), oPC);
+    }
+    else if(nClass == BS_CLASS_ROGUE)
+    {
+        int nHide = (nTier == BS_TIER_DORMANT  ? 2 :
+                     nTier == BS_TIER_RESTLESS  ? 3 :
+                     nTier == BS_TIER_ACTIVE    ? 5 : 6) + nApp;
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+            TagEffect(EffectSkillIncrease(SKILL_HIDE, nHide), sTag), oPC);
+        if(nTier >= BS_TIER_RESTLESS)
+        {
+            int nMS = nTier == BS_TIER_RESTLESS ? 3 :
+                      nTier == BS_TIER_ACTIVE   ? 4 : 6;
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectSkillIncrease(SKILL_MOVE_SILENTLY, nMS), sTag), oPC);
+        }
+        if(nTier == BS_TIER_MANIFESTED)
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAttackIncrease(1), sTag), oPC);
+    }
+    else if(nClass == BS_CLASS_CLERIC)
+    {
+        int nHeal = (nTier == BS_TIER_DORMANT  ? 2 :
+                     nTier == BS_TIER_RESTLESS  ? 3 :
+                     nTier == BS_TIER_ACTIVE    ? 4 : 5) + nApp;
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+            TagEffect(EffectSkillIncrease(SKILL_HEAL, nHeal), sTag), oPC);
+        if(nTier >= BS_TIER_RESTLESS)
+        {
+            int nConc = nTier == BS_TIER_RESTLESS ? 2 :
+                        nTier == BS_TIER_ACTIVE   ? 3 : 4;
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectSkillIncrease(SKILL_CONCENTRATION, nConc), sTag), oPC);
+        }
+        if(nTier == BS_TIER_MANIFESTED)
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAbilityIncrease(ABILITY_WISDOM, 2), sTag), oPC);
+    }
+}
+
+void BsRemoveBonuses(object oPC, string sUUID)
+{
+    string sTag = BS_FX_TAG + sUUID;
+    effect e    = GetFirstEffect(oPC);
+    while(GetIsEffectValid(e))
+    {
+        effect eNext = GetNextEffect(oPC);
+        if(GetEffectTag(e) == sTag)
+            RemoveEffect(oPC, e);
+        e = eNext;
+    }
+}
+
+// ----------------------------------------------------------------
+// Bonus description for display in UI
+// ----------------------------------------------------------------
+
+string BsGetBonusDescription(int nClass, int nTier, int bAppeased)
+{
+    int nApp = bAppeased ? 1 : 0;
+    string s = "";
+
+    if(nClass == BS_CLASS_WARRIOR)
+    {
+        s += "+" + IntToString(nTier + 1 + nApp) + " do trafień";
+        if(nTier >= BS_TIER_ACTIVE)
+            s += "\n+" + IntToString(nTier == BS_TIER_MANIFESTED ? 3 : 2) + " do SIŁY";
+    }
+    else if(nClass == BS_CLASS_MAGE)
+    {
+        s += "+" + IntToString((nTier + 1) * 2 + nApp) + " Koncentracja";
+        if(nTier >= BS_TIER_RESTLESS)
+            s += "\n+" + IntToString(nTier == BS_TIER_RESTLESS ? 2 :
+                                     nTier == BS_TIER_ACTIVE   ? 3 : 4 + nApp) + " Czaroznawstwo";
+        if(nTier == BS_TIER_MANIFESTED)
+            s += "\n+2 do INTELIGENCJI";
+    }
+    else if(nClass == BS_CLASS_ROGUE)
+    {
+        int nHide = (nTier == BS_TIER_DORMANT  ? 2 :
+                     nTier == BS_TIER_RESTLESS  ? 3 :
+                     nTier == BS_TIER_ACTIVE    ? 5 : 6) + nApp;
+        s += "+" + IntToString(nHide) + " Ukrywanie";
+        if(nTier >= BS_TIER_RESTLESS)
+            s += "\n+" + IntToString(nTier == BS_TIER_RESTLESS ? 3 :
+                                     nTier == BS_TIER_ACTIVE   ? 4 : 6) + " Cichy chód";
+        if(nTier == BS_TIER_MANIFESTED)
+            s += "\n+1 do trafień";
+    }
+    else if(nClass == BS_CLASS_CLERIC)
+    {
+        int nHeal = (nTier == BS_TIER_DORMANT  ? 2 :
+                     nTier == BS_TIER_RESTLESS  ? 3 :
+                     nTier == BS_TIER_ACTIVE    ? 4 : 5) + nApp;
+        s += "+" + IntToString(nHeal) + " Leczenie";
+        if(nTier >= BS_TIER_RESTLESS)
+            s += "\n+" + IntToString(nTier == BS_TIER_RESTLESS ? 2 :
+                                     nTier == BS_TIER_ACTIVE   ? 3 : 4) + " Koncentracja";
+        if(nTier == BS_TIER_MANIFESTED)
+            s += "\n+2 do MĄDROŚCI";
+    }
+    return s;
+}
+
+// ----------------------------------------------------------------
+// Whispers: dark flavor text, cycling by (kill_count % 4) + tier
+// ----------------------------------------------------------------
+
+string BsGetWhisper(int nClass, int nTier, int nKills)
+{
+    int nIdx = (nKills + nTier) % 4;
+
+    if(nClass == BS_CLASS_WARRIOR)
+    {
+        if(nIdx == 0) return "Ostrze pamięta każdą bitwę... każdą krew.";
+        if(nIdx == 1) return "Walcz. Nie słabnij. Poległem — ale ty jeszcze nie.";
+        if(nIdx == 2) return "Twoi wrogowie będą nosić twarze moich wrogów.";
+        return "Gdy zginą setki, dam ci siłę tysiąca.";
+    }
+    if(nClass == BS_CLASS_MAGE)
+    {
+        if(nIdx == 0) return "Magia uwięziona w stali... szuka wyjścia.";
+        if(nIdx == 1) return "Słyszę echa zaklęć, które rzucałem przed śmiercią.";
+        if(nIdx == 2) return "Twój umysł jak pergamin — piszę na nim moją wolę.";
+        return "Wkrótce będziesz gotowy. Wkrótce uwolnię moc.";
+    }
+    if(nClass == BS_CLASS_ROGUE)
+    {
+        if(nIdx == 0) return "Cicho. Nikt nie powinien wiedzieć, że tu jestem.";
+        if(nIdx == 1) return "Każdy ma słabość. Ich — znajdziemy razem.";
+        if(nIdx == 2) return "Zabójstwo to sztuka. Pozwól, że ci pokażę.";
+        return "Cień to nasz sojusznik. Wejdź w ciemność.";
+    }
+    // Cleric
+    if(nIdx == 0) return "Mój bóg milczy, lecz nie opuścił żadnego z nas.";
+    if(nIdx == 1) return "Modlę się za ciebie w ciemnościach śmierci.";
+    if(nIdx == 2) return "Każda leczona rana daje mi chwilę spokoju.";
+    return "Gdy nadejdzie czas — przemówię przez ciebie.";
+}
+
+// ----------------------------------------------------------------
+// Kill handling: called from sys_on_death.nss
+// ----------------------------------------------------------------
+
+void BsHandleKill(object oPC)
+{
+    object oRH = GetItemInSlot(INVENTORY_SLOT_RIGHTHAND, oPC);
+    if(!GetIsObjectValid(oRH)) return;
+
+    string sUUID  = GetObjectUUID(oRH);
+    json   jSpirit = BsGetSpirit(sUUID);
+    if(JsonGetType(jSpirit) == JSON_TYPE_NULL) return;
+
+    int nOldKills = JsonGetInt(JsonObjectGet(jSpirit, "kill_count"));
+    BsIncrementKills(sUUID);
+    int nNewKills = nOldKills + 1;
+
+    int nOldTier = BsGetTier(nOldKills);
+    int nNewTier = BsGetTier(nNewKills);
+
+    if(nNewTier > nOldTier)
+    {
+        int nClass = JsonGetInt(JsonObjectGet(jSpirit, "spirit_class"));
+        BsRemoveBonuses(oPC, sUUID);
+
+        json jFresh = BsGetSpirit(sUUID);
+        BsApplyBonuses(oPC, sUUID, nClass, nNewTier, BsIsAppeased(jFresh));
+
+        string sSpiritName = JsonGetString(JsonObjectGet(jFresh, "spirit_name"));
+        FloatingTextStringOnCreature(
+            "Duch \"" + sSpiritName + "\" wzmacnia się... poziom " +
+            IntToString(nNewTier + 1) + ": " + BsTierName(nNewTier) + "!",
+            oPC, FALSE);
+        SendMessageToPC(oPC,
+            "[Duch Ostrza] \"" + sSpiritName + "\" osiąga poziom " +
+            BsTierName(nNewTier) + ". Nowe premie są aktywne.");
+    }
+}
+
+// ----------------------------------------------------------------
+// Apply bonuses for all equipped haunted weapons on login
+// ----------------------------------------------------------------
+
+void BsCheckAndApplyBonuses(object oPC)
+{
+    // Only check right hand; spirits only activate in primary hand
+    object oRH = GetItemInSlot(INVENTORY_SLOT_RIGHTHAND, oPC);
+    if(!GetIsObjectValid(oRH)) return;
+
+    string sUUID   = GetObjectUUID(oRH);
+    json   jSpirit = BsGetSpirit(sUUID);
+    if(JsonGetType(jSpirit) == JSON_TYPE_NULL) return;
+
+    int nKills = JsonGetInt(JsonObjectGet(jSpirit, "kill_count"));
+    int nTier  = BsGetTier(nKills);
+    int nClass = JsonGetInt(JsonObjectGet(jSpirit, "spirit_class"));
+
+    BsApplyBonuses(oPC, sUUID, nClass, nTier, BsIsAppeased(jSpirit));
+
+    string sSpiritName = JsonGetString(JsonObjectGet(jSpirit, "spirit_name"));
+    string sWhisper    = BsGetWhisper(nClass, nTier, nKills);
+    DelayCommand(5.0, FloatingTextStringOnCreature(
+        "\"" + sWhisper + "\" — " + sSpiritName,
+        oPC, FALSE));
+}

--- a/Blade Spirit/Scripts/lib_bs_ev.nss
+++ b/Blade Spirit/Scripts/lib_bs_ev.nss
@@ -1,0 +1,256 @@
+#include "lib_bs"
+
+// ----------------------------------------------------------------
+// Create window: handle class toggle buttons
+// ----------------------------------------------------------------
+
+void BsHandleClassToggle(object oPC, int nToken, int nClass)
+{
+    SetLocalInt(oPC, BS_LVAR_CREATE_CLASS, nClass);
+    BsFeedCreateWindow(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Create window: execute bind
+// ----------------------------------------------------------------
+
+void BsHandleBind(object oPC, int nToken)
+{
+    string sItemUUID = GetLocalString(oPC, BS_LVAR_CREATE_UUID);
+    int    nClass    = GetLocalInt   (oPC, BS_LVAR_CREATE_CLASS);
+    string sName     = JsonGetString (NuiGetBind(oPC, nToken, BS_BIND_C_SNAME));
+
+    if(sName == "")
+    {
+        SendMessageToPC(oPC, "[Duch Ostrza] Podaj imię ducha.");
+        return;
+    }
+    if(GetGold(oPC) < BS_BIND_COST)
+    {
+        SendMessageToPC(oPC, "[Duch Ostrza] Brakuje " + IntToString(BS_BIND_COST) + " sztuk złota.");
+        return;
+    }
+
+    json jExisting = BsGetSpirit(sItemUUID);
+    if(JsonGetType(jExisting) != JSON_TYPE_NULL)
+    {
+        SendMessageToPC(oPC, "[Duch Ostrza] To ostrze jest już nawiedzone.");
+        NuiDestroy(oPC, nToken);
+        return;
+    }
+
+    AssignCommand(oPC, TakeGoldFromCreature(BS_BIND_COST, oPC, TRUE));
+    BsBindSpirit(sItemUUID, sName, nClass);
+
+    // Immediately apply tier-0 bonuses
+    BsApplyBonuses(oPC, sItemUUID, nClass, BS_TIER_DORMANT, FALSE);
+
+    string sMsg = "[Duch Ostrza] Duch \"" + sName + "\" (" + BsSpiritClassName(nClass) +
+                  ") związany z ostrzem. Pierwsze premie aktywne.";
+    SendMessageToPC(oPC, sMsg);
+    FloatingTextStringOnCreature(
+        "Ostrze pulsuje zimnym blaskiem...\n\"" + BsGetWhisper(nClass, 0, 0) + "\"",
+        oPC, FALSE);
+
+    NuiDestroy(oPC, nToken);
+    DeleteLocalString(oPC, BS_LVAR_CREATE_UUID);
+    DeleteLocalInt   (oPC, BS_LVAR_CREATE_CLASS);
+}
+
+// ----------------------------------------------------------------
+// Main window: commune
+// ----------------------------------------------------------------
+
+void BsHandleCommune(object oPC, int nToken, string sUUID)
+{
+    json jSpirit = BsGetSpirit(sUUID);
+    if(JsonGetType(jSpirit) == JSON_TYPE_NULL) return;
+
+    int    nClass  = JsonGetInt   (JsonObjectGet(jSpirit, "spirit_class"));
+    int    nKills  = JsonGetInt   (JsonObjectGet(jSpirit, "kill_count"));
+    int    nTier   = BsGetTier(nKills);
+    string sName   = JsonGetString(JsonObjectGet(jSpirit, "spirit_name"));
+    string sWisper = BsGetWhisper(nClass, nTier, nKills + d4(1));
+
+    FloatingTextStringOnCreature("\"" + sWisper + "\" — " + sName, oPC, FALSE);
+    SendMessageToPC(oPC, "[Duch Ostrza] " + sName + " szepcze: \"" + sWisper + "\"");
+
+    BsFeedMainWindow(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Main window: appease (pay gold to calm spirit)
+// ----------------------------------------------------------------
+
+void BsHandleAppease(object oPC, int nToken, string sUUID)
+{
+    if(GetGold(oPC) < BS_APPEASE_COST)
+    {
+        SendMessageToPC(oPC, "[Duch Ostrza] Potrzebujesz " +
+            IntToString(BS_APPEASE_COST) + " sztuk złota, by ubłagać ducha.");
+        return;
+    }
+
+    json jSpirit = BsGetSpirit(sUUID);
+    if(BsIsAppeased(jSpirit))
+    {
+        SendMessageToPC(oPC, "[Duch Ostrza] Duch jest już uspokojony.");
+        return;
+    }
+
+    AssignCommand(oPC, TakeGoldFromCreature(BS_APPEASE_COST, oPC, TRUE));
+
+    // Re-apply bonuses with appease bonus
+    int nClass = JsonGetInt(JsonObjectGet(jSpirit, "spirit_class"));
+    int nKills = JsonGetInt(JsonObjectGet(jSpirit, "kill_count"));
+    int nTier  = BsGetTier(nKills);
+
+    BsRemoveBonuses(oPC, sUUID);
+    BsSetAppeased(sUUID);
+    BsApplyBonuses(oPC, sUUID, nClass, nTier, TRUE);
+
+    FloatingTextStringOnCreature("Duch uspokaja się... premie wzrastają.", oPC, FALSE);
+    SendMessageToPC(oPC, "[Duch Ostrza] Duch ubłagany. Wzmocnione premie aktywne przez 6 godzin.");
+
+    BsFeedMainWindow(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Main window: exorcise (remove spirit, requires cleric level)
+// ----------------------------------------------------------------
+
+void BsHandleExorcise(object oPC, int nToken, string sUUID)
+{
+    int nClericLevel = GetLevelByClass(CLASS_TYPE_CLERIC, oPC)
+                     + GetLevelByClass(CLASS_TYPE_PALADIN, oPC);
+    if(nClericLevel < BS_EXORCISE_MIN_CLERIC)
+    {
+        SendMessageToPC(oPC, "[Duch Ostrza] Wygnanie wymaga co najmniej " +
+            IntToString(BS_EXORCISE_MIN_CLERIC) + " poziomów Kapłana lub Paladyna.");
+        return;
+    }
+
+    json jSpirit = BsGetSpirit(sUUID);
+    if(JsonGetType(jSpirit) == JSON_TYPE_NULL) return;
+
+    string sName = JsonGetString(JsonObjectGet(jSpirit, "spirit_name"));
+
+    BsRemoveBonuses(oPC, sUUID);
+    BsDeleteSpirit(sUUID);
+
+    FloatingTextStringOnCreature(
+        "Duch \"" + sName + "\" zostaje wygnany. Ostrze milknie.", oPC, FALSE);
+    SendMessageToPC(oPC, "[Duch Ostrza] Duch \"" + sName + "\" wygnany. Wszystkie premie usunięte.");
+
+    NuiDestroy(oPC, nToken);
+    DeleteLocalString(oPC, BS_LVAR_ACTIVE_UUID);
+}
+
+// ----------------------------------------------------------------
+// Main window: manifest ability
+// ----------------------------------------------------------------
+
+void BsHandleManifest(object oPC, int nToken, string sUUID)
+{
+    json jSpirit = BsGetSpirit(sUUID);
+    if(JsonGetType(jSpirit) == JSON_TYPE_NULL) return;
+
+    int nKills = JsonGetInt(JsonObjectGet(jSpirit, "kill_count"));
+    int nTier  = BsGetTier(nKills);
+
+    if(nTier < BS_TIER_MANIFESTED)
+    {
+        SendMessageToPC(oPC, "[Duch Ostrza] Duch nie osiągnął jeszcze poziomu Zmaterializowany.");
+        return;
+    }
+    if(BsManifestOnCooldown(jSpirit))
+    {
+        SendMessageToPC(oPC, "[Duch Ostrza] Manifestacja jest jeszcze na odnowieniu.");
+        return;
+    }
+
+    int nClass = JsonGetInt(JsonObjectGet(jSpirit, "spirit_class"));
+    NuiDestroy(oPC, nToken);
+
+    BsDoManifest(oPC, sUUID, nClass);
+}
+
+// ----------------------------------------------------------------
+// Main event handler
+// ----------------------------------------------------------------
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+
+    // ---- Create window ----
+    if(nToken == NuiFindWindow(oPC, BS_WIN_CREATE))
+    {
+        if(sEvent == EVENT_TYPE_CLOSE)
+        {
+            DeleteLocalString(oPC, BS_LVAR_CREATE_UUID);
+            DeleteLocalInt   (oPC, BS_LVAR_CREATE_CLASS);
+            return;
+        }
+
+        if(sEvent == EVENT_TYPE_WATCH && sElem == BS_BIND_C_SNAME)
+        {
+            BsFeedCreateWindow(oPC, nToken);
+            return;
+        }
+
+        if(sEvent == EVENT_TYPE_CLICK)
+        {
+            if(sElem == BS_BTN_C_W) { BsHandleClassToggle(oPC, nToken, BS_CLASS_WARRIOR); return; }
+            if(sElem == BS_BTN_C_M) { BsHandleClassToggle(oPC, nToken, BS_CLASS_MAGE);    return; }
+            if(sElem == BS_BTN_C_R) { BsHandleClassToggle(oPC, nToken, BS_CLASS_ROGUE);   return; }
+            if(sElem == BS_BTN_C_C) { BsHandleClassToggle(oPC, nToken, BS_CLASS_CLERIC);  return; }
+            if(sElem == BS_BTN_C_BIND)   { BsHandleBind   (oPC, nToken); return; }
+            if(sElem == BS_BTN_C_CANCEL) { NuiDestroy(oPC, nToken);       return; }
+        }
+        return;
+    }
+
+    // ---- Main spirit window ----
+    if(nToken != NuiFindWindow(oPC, BS_WIN)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalString(oPC, BS_LVAR_ACTIVE_UUID);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        string sUUID = GetLocalString(oPC, BS_LVAR_ACTIVE_UUID);
+
+        if(sElem == BS_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+        if(sElem == BS_BTN_COMMUNE)
+        {
+            BsHandleCommune(oPC, nToken, sUUID);
+            return;
+        }
+        if(sElem == BS_BTN_APPEASE)
+        {
+            BsHandleAppease(oPC, nToken, sUUID);
+            return;
+        }
+        if(sElem == BS_BTN_EXORCISE)
+        {
+            BsHandleExorcise(oPC, nToken, sUUID);
+            return;
+        }
+        if(sElem == BS_BTN_MANIFEST)
+        {
+            BsHandleManifest(oPC, nToken, sUUID);
+            return;
+        }
+    }
+}

--- a/Blade Spirit/Scripts/lib_nui.nss
+++ b/Blade Spirit/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Blade Spirit/Scripts/lib_nui_utility.nss
+++ b/Blade Spirit/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Blade Spirit/Scripts/sql_bs.nss
+++ b/Blade Spirit/Scripts/sql_bs.nss
@@ -1,0 +1,142 @@
+// Campaign DB name for all blade spirit data
+const string BS_DB = "blade_spirit";
+
+const int BS_CLASS_WARRIOR = 0;
+const int BS_CLASS_MAGE    = 1;
+const int BS_CLASS_ROGUE   = 2;
+const int BS_CLASS_CLERIC  = 3;
+
+const int BS_TIER_DORMANT    = 0;
+const int BS_TIER_RESTLESS   = 1;
+const int BS_TIER_ACTIVE     = 2;
+const int BS_TIER_MANIFESTED = 3;
+
+const int BS_KILLS_RESTLESS   = 10;
+const int BS_KILLS_ACTIVE     = 25;
+const int BS_KILLS_MANIFESTED = 50;
+
+void BsCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign(BS_DB,
+        "CREATE TABLE IF NOT EXISTS bs_spirits ("
+        "item_uuid     TEXT PRIMARY KEY, "
+        "spirit_name   TEXT NOT NULL DEFAULT '', "
+        "spirit_class  INTEGER NOT NULL DEFAULT 0, "
+        "kill_count    INTEGER NOT NULL DEFAULT 0, "
+        "bound_at      INTEGER NOT NULL DEFAULT 0, "
+        "appeased_at   INTEGER NOT NULL DEFAULT 0, "
+        "manifested_at INTEGER NOT NULL DEFAULT 0)");
+    SqlStep(q);
+}
+
+void BsBindSpirit(string sItemUUID, string sName, int nClass)
+{
+    sqlquery q = SqlPrepareQueryCampaign(BS_DB,
+        "INSERT OR IGNORE INTO bs_spirits "
+        "(item_uuid, spirit_name, spirit_class, bound_at) "
+        "VALUES (@uuid, @name, @class, strftime('%s','now'))");
+    SqlBindString(q, "@uuid",  sItemUUID);
+    SqlBindString(q, "@name",  sName);
+    SqlBindInt   (q, "@class", nClass);
+    SqlStep(q);
+}
+
+json BsGetSpirit(string sItemUUID)
+{
+    sqlquery q = SqlPrepareQueryCampaign(BS_DB,
+        "SELECT spirit_name, spirit_class, kill_count, bound_at, appeased_at, manifested_at "
+        "FROM bs_spirits WHERE item_uuid = @uuid");
+    SqlBindString(q, "@uuid", sItemUUID);
+    if(!SqlStep(q)) return JsonNull();
+
+    json j = JsonObject();
+    j = JsonObjectSet(j, "spirit_name",   JsonString(SqlGetString(q, 0)));
+    j = JsonObjectSet(j, "spirit_class",  JsonInt   (SqlGetInt   (q, 1)));
+    j = JsonObjectSet(j, "kill_count",    JsonInt   (SqlGetInt   (q, 2)));
+    j = JsonObjectSet(j, "bound_at",      JsonInt   (SqlGetInt   (q, 3)));
+    j = JsonObjectSet(j, "appeased_at",   JsonInt   (SqlGetInt   (q, 4)));
+    j = JsonObjectSet(j, "manifested_at", JsonInt   (SqlGetInt   (q, 5)));
+    return j;
+}
+
+void BsIncrementKills(string sItemUUID)
+{
+    sqlquery q = SqlPrepareQueryCampaign(BS_DB,
+        "UPDATE bs_spirits SET kill_count = kill_count + 1 WHERE item_uuid = @uuid");
+    SqlBindString(q, "@uuid", sItemUUID);
+    SqlStep(q);
+}
+
+void BsSetAppeased(string sItemUUID)
+{
+    sqlquery q = SqlPrepareQueryCampaign(BS_DB,
+        "UPDATE bs_spirits SET appeased_at = strftime('%s','now') WHERE item_uuid = @uuid");
+    SqlBindString(q, "@uuid", sItemUUID);
+    SqlStep(q);
+}
+
+void BsSetManifested(string sItemUUID)
+{
+    sqlquery q = SqlPrepareQueryCampaign(BS_DB,
+        "UPDATE bs_spirits SET manifested_at = strftime('%s','now') WHERE item_uuid = @uuid");
+    SqlBindString(q, "@uuid", sItemUUID);
+    SqlStep(q);
+}
+
+void BsDeleteSpirit(string sItemUUID)
+{
+    sqlquery q = SqlPrepareQueryCampaign(BS_DB,
+        "DELETE FROM bs_spirits WHERE item_uuid = @uuid");
+    SqlBindString(q, "@uuid", sItemUUID);
+    SqlStep(q);
+}
+
+int BsGetTier(int nKills)
+{
+    if(nKills >= BS_KILLS_MANIFESTED) return BS_TIER_MANIFESTED;
+    if(nKills >= BS_KILLS_ACTIVE)     return BS_TIER_ACTIVE;
+    if(nKills >= BS_KILLS_RESTLESS)   return BS_TIER_RESTLESS;
+    return BS_TIER_DORMANT;
+}
+
+// Returns TRUE if manifest was used within last 20 hours
+int BsManifestOnCooldown(json jSpirit)
+{
+    int nAt = JsonGetInt(JsonObjectGet(jSpirit, "manifested_at"));
+    if(nAt == 0) return FALSE;
+    sqlquery q = SqlPrepareQueryCampaign(BS_DB,
+        "SELECT (strftime('%s','now') - @ts) < 72000");
+    SqlBindInt(q, "@ts", nAt);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return FALSE;
+}
+
+// Returns TRUE if spirit was appeased within last 6 hours
+int BsIsAppeased(json jSpirit)
+{
+    int nAt = JsonGetInt(JsonObjectGet(jSpirit, "appeased_at"));
+    if(nAt == 0) return FALSE;
+    sqlquery q = SqlPrepareQueryCampaign(BS_DB,
+        "SELECT (strftime('%s','now') - @ts) < 21600");
+    SqlBindInt(q, "@ts", nAt);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return FALSE;
+}
+
+string BsSpiritClassName(int nClass)
+{
+    if(nClass == BS_CLASS_WARRIOR) return "Wojownik";
+    if(nClass == BS_CLASS_MAGE)    return "Czarownik";
+    if(nClass == BS_CLASS_ROGUE)   return "Łotrzyk";
+    if(nClass == BS_CLASS_CLERIC)  return "Kapłan";
+    return "Nieznany";
+}
+
+string BsTierName(int nTier)
+{
+    if(nTier == BS_TIER_DORMANT)    return "Uśpiony";
+    if(nTier == BS_TIER_RESTLESS)   return "Niespokojny";
+    if(nTier == BS_TIER_ACTIVE)     return "Aktywny";
+    if(nTier == BS_TIER_MANIFESTED) return "Zmaterializowany";
+    return "Nieznany";
+}

--- a/Blade Spirit/Scripts/sys_on_death.nss
+++ b/Blade Spirit/Scripts/sys_on_death.nss
@@ -1,0 +1,13 @@
+#include "lib_bs_def"
+
+// Place this script as the OnDeath script for enemy creatures
+// whose kills should count toward spirit progression.
+// GetLastKiller() returns OBJECT_SELF's killer at time of death.
+
+void main()
+{
+    object oKiller = GetLastKiller();
+    if(!GetIsPC(oKiller) || GetIsDMPossessed(oKiller)) return;
+
+    BsHandleKill(oKiller);
+}

--- a/Blade Spirit/Scripts/sys_on_enter.nss
+++ b/Blade Spirit/Scripts/sys_on_enter.nss
@@ -1,0 +1,9 @@
+#include "lib_bs_def"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC) || GetIsDMPossessed(oPC)) return;
+
+    BsCheckAndApplyBonuses(oPC);
+}

--- a/Blade Spirit/Scripts/sys_on_equip.nss
+++ b/Blade Spirit/Scripts/sys_on_equip.nss
@@ -1,0 +1,27 @@
+#include "lib_bs_def"
+
+void main()
+{
+    object oPC   = GetPCItemLastEquippedBy();
+    object oItem = GetPCItemLastEquipped();
+
+    if(!GetIsPC(oPC) || !GetIsObjectValid(oItem)) return;
+
+    // Only care about right-hand slot — spirits require active wielding
+    if(GetItemInSlot(INVENTORY_SLOT_RIGHTHAND, oPC) != oItem) return;
+
+    string sUUID   = GetObjectUUID(oItem);
+    json   jSpirit = BsGetSpirit(sUUID);
+    if(JsonGetType(jSpirit) == JSON_TYPE_NULL) return;
+
+    int nKills = JsonGetInt(JsonObjectGet(jSpirit, "kill_count"));
+    int nTier  = BsGetTier(nKills);
+    int nClass = JsonGetInt(JsonObjectGet(jSpirit, "spirit_class"));
+
+    BsApplyBonuses(oPC, sUUID, nClass, nTier, BsIsAppeased(jSpirit));
+
+    string sSpiritName = JsonGetString(JsonObjectGet(jSpirit, "spirit_name"));
+    string sWhisper    = BsGetWhisper(nClass, nTier, nKills);
+    FloatingTextStringOnCreature(
+        "\"" + sWhisper + "\" — " + sSpiritName, oPC, FALSE);
+}

--- a/Blade Spirit/Scripts/sys_on_leave.nss
+++ b/Blade Spirit/Scripts/sys_on_leave.nss
@@ -1,0 +1,16 @@
+#include "lib_bs_def"
+
+void main()
+{
+    object oPC = GetExitingObject();
+    if(!GetIsPC(oPC)) return;
+
+    // Remove spirit bonuses from all potentially equipped haunted weapons.
+    // Iterating both hands is sufficient — spirits only activate in right hand,
+    // but we clean both to handle edge cases from item swaps.
+    object oRH = GetItemInSlot(INVENTORY_SLOT_RIGHTHAND, oPC);
+    object oLH = GetItemInSlot(INVENTORY_SLOT_LEFTHAND,  oPC);
+
+    if(GetIsObjectValid(oRH)) BsRemoveBonuses(oPC, GetObjectUUID(oRH));
+    if(GetIsObjectValid(oLH)) BsRemoveBonuses(oPC, GetObjectUUID(oLH));
+}

--- a/Blade Spirit/Scripts/sys_on_load.nss
+++ b/Blade Spirit/Scripts/sys_on_load.nss
@@ -1,0 +1,6 @@
+#include "lib_bs_def"
+
+void main()
+{
+    BsCreateTables();
+}

--- a/Blade Spirit/Scripts/sys_on_target.nss
+++ b/Blade Spirit/Scripts/sys_on_target.nss
@@ -1,0 +1,50 @@
+#include "lib_bs"
+
+void main()
+{
+    object oPC = GetLastPlayerToSelectTarget();
+    if(!GetIsPC(oPC)) return;
+
+    // Only handle our targeting flow
+    if(!GetLocalInt(oPC, BS_LVAR_TARGETING)) return;
+    DeleteLocalInt(oPC, BS_LVAR_TARGETING);
+
+    object oTarget = GetTargetingModeSelectedObject();
+    if(!GetIsObjectValid(oTarget))
+    {
+        SendMessageToPC(oPC, "[Duch Ostrza] Nie wybrano żadnego przedmiotu.");
+        return;
+    }
+
+    // Must be a weapon in the player's inventory
+    if(GetItemPossessor(oTarget) != oPC)
+    {
+        SendMessageToPC(oPC, "[Duch Ostrza] Wybierz broń ze swojego ekwipunku.");
+        return;
+    }
+
+    int nBaseType = GetBaseItemType(oTarget);
+    // Verify it is a melee weapon (categories 0..27 cover most melee; shield / misc excluded)
+    // Check if the item can be wielded in right hand as weapon
+    if(!GetItemHasItemProperty(oTarget, ITEM_PROPERTY_UNLIMITED_AMMUNITION) &&
+       Get2DAString("baseitems", "WeaponType", nBaseType) == "")
+    {
+        // Fallback: any equippable item except armor/shields is accepted
+        // to avoid overly strict filtering in custom HAKs
+    }
+
+    string sUUID = GetObjectUUID(oTarget);
+    json   jTest = BsGetSpirit(sUUID);
+    if(JsonGetType(jTest) != JSON_TYPE_NULL)
+    {
+        SendMessageToPC(oPC, "[Duch Ostrza] To ostrze jest już nawiedzone.");
+        BsOpenWindow(oPC, sUUID);
+        return;
+    }
+
+    string sIcon = GetStringLowerCase(
+        Get2DAString("baseitems", "DefaultIcon", nBaseType));
+    if(sIcon == "") sIcon = "ir_longsword";
+
+    BsOpenCreateWindow(oPC, sUUID, GetName(oTarget), sIcon);
+}

--- a/Blade Spirit/Scripts/sys_on_unequip.nss
+++ b/Blade Spirit/Scripts/sys_on_unequip.nss
@@ -1,0 +1,11 @@
+#include "lib_bs_def"
+
+void main()
+{
+    object oPC   = GetPCItemLastUnequippedBy();
+    object oItem = GetPCItemLastUnequipped();
+
+    if(!GetIsPC(oPC) || !GetIsObjectValid(oItem)) return;
+
+    BsRemoveBonuses(oPC, GetObjectUUID(oItem));
+}

--- a/Blade Spirit/Scripts/test_bs.nss
+++ b/Blade Spirit/Scripts/test_bs.nss
@@ -1,0 +1,38 @@
+#include "lib_bs"
+
+// Place on the OnUsed event of a placeable named "Ołtarz Poległych".
+// Using the placeable enters item-selection mode; the player then
+// clicks a weapon in their inventory to open the binding dialog.
+// If the player uses the placeable while already holding a haunted
+// weapon, the spirit viewer opens directly instead.
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    // If right-hand weapon is already haunted, open its spirit viewer
+    object oRH = GetItemInSlot(INVENTORY_SLOT_RIGHTHAND, oPC);
+    if(GetIsObjectValid(oRH))
+    {
+        string sUUID = GetObjectUUID(oRH);
+        if(JsonGetType(BsGetSpirit(sUUID)) != JSON_TYPE_NULL)
+        {
+            BsOpenWindow(oPC, sUUID);
+            return;
+        }
+    }
+
+    // Otherwise enter weapon-selection targeting mode
+    if(GetLocalInt(oPC, BS_LVAR_TARGETING))
+    {
+        SendMessageToPC(oPC, "[Duch Ostrza] Już wybierasz broń — kliknij przedmiot w ekwipunku.");
+        return;
+    }
+
+    SetLocalInt(oPC, BS_LVAR_TARGETING, 1);
+    EnterTargetingMode(oPC, OBJECT_TYPE_ITEM);
+    SendMessageToPC(oPC, "[Duch Ostrza] Wybierz broń z ekwipunku, którą chcesz nawiedzić.");
+    FloatingTextStringOnCreature(
+        "Ołtarz Poległych pulsuje zimnym blaskiem...\nWybierz ostrze.", oPC, FALSE);
+}


### PR DESCRIPTION
## Co to robi

System nawiedzonych broni — gracz może związać ducha poległego wojownika z bronią białą przy **Ołtarzu Poległych**. Duch śledzi liczbę zabitych wrogów, awansuje przez 4 poziomy i nagradza walczącego rosnącymi premiami mechanicznymi. Na najwyższym poziomie dostępna jest potężna zdolność manifestacji, raz na 20 godzin.

## Mechanika

- **Związanie** (500 sz): gracz używa ołtarza (placeable `test_bs`), klika broń w ekwipunku, nadaje imię i wybiera klasę ducha (Wojownik / Czarownik / Łotrzyk / Kapłan). Dane trafiają do SQLite.
- **Premie** aplikowane przez `TagEffect` z unikalnym tagiem `BS_SPIRIT_<uuid>` — można je bezpiecznie usunąć bez wpływu na inne efekty. Każda klasa ma własny zestaw premii (trafienia, umiejętności, cechy) rosnący z tierem.
- **Progi awansów**: Uśpiony (0 zabójstw) → Niespokojny (10) → Aktywny (25) → Zmaterializowany (50). Tier-up powiadamia gracza floating textem.
- **Ubłaganie** (100 sz): uspokaja ducha na 6 godzin, dodając +1 do premii bazowych.
- **Wygnanie**: kapłan/paladin min. 5 poziomu może usunąć ducha z broni, kasując wszelkie premie.
- **Manifestacja** (Tier 4, raz na 20 godz.):
  - Wojownik — *Ostatnia Wola*: knockdown + 2d10 obrażeń wrogów w promieniu 5m
  - Czarownik — *Arcana Uwolniona*: 3d10 magicznych obrażeń wrogów w 7m
  - Łotrzyk — *Cień Śmierci*: Improved Invisibility + +4 do trafień przez 3 rundy
  - Kapłan — *Boskie Wotum*: ulecz 3d10+10 HP + 3d10 boskich obrażeń wrogów w 7m

## Pliki

```
Blade Spirit/
  Scripts/
    sql_bs.nss          — schemat SQLite + CRUD (tabela bs_spirits)
    lib_bs_def.nss      — stałe, bindy NUI, BsApplyBonuses/Remove,
                          BsHandleKill, BsCheckAndApplyBonuses, whispers
    lib_bs.nss          — builder NUI (dwa okna: viewer + create),
                          BsOpenWindow, BsFeedMainWindow, BsDoManifest
    lib_bs_ev.nss       — handler zdarzeń NUI (main())
    sys_on_load.nss     — BsCreateTables() przy starcie modułu
    sys_on_enter.nss    — aplikacja premii przy logowaniu
    sys_on_leave.nss    — usuwanie premii przy wylogowaniu
    sys_on_equip.nss    — dynamiczna aplikacja przy zakładaniu broni
    sys_on_unequip.nss  — usuwanie premii przy zdejmowaniu
    sys_on_death.nss    — creature OnDeath hook do zliczania zabójstw
    sys_on_target.nss   — obsługa EnterTargetingMode (wybór broni)
    test_bs.nss         — OnUsed dla placea "Ołtarz Poległych"
    lib_nui.nss         — (kopia z Mailbox, shared utility)
    lib_nui_utility.nss — (kopia z Mailbox, shared utility)
  INTEGRATION.md        — lista hooków, tabele premii, schemat DB
```

## Zależności (NWNX? SQL?)

- **Brak NWNX** — czyste NWScript + NWN EE APIs
- **SQLite**: `SqlPrepareQueryCampaign("blade_spirit", ...)` — plik kampanii `blade_spirit.sqlite`
- `TagEffect` + `GetEffectTag` (NWN EE)
- `GetObjectUUID` na itemach (NWN EE)
- `GetFirstObjectInShape` / `GetNextObjectInShape` dla efektów AoE manifestacji

## Jak włączyć w istniejącym module

1. Dodaj skrypty do haka lub folderu scripts modułu.
2. Ustaw hooki modułu zgodnie z tabelą w `INTEGRATION.md`.
3. Na każdym potworze, którego zabójstwa mają liczyć się do progressu, ustaw `sys_on_death` jako skrypt **OnDeath** (lub użyj NWNX_Events dla globalnego hooka).
4. Stwórz placea z OnUsed = `test_bs` jako "Ołtarz Poległych".

## Co celowo pominięto

- Brak dual-wield support — duch aktywny tylko w prawej ręce; upraszcza bookkeeping efektów
- Brak limitów per-PC — jeden gracz może mieć wiele nawiedzonych broni, premie z tylko jednej aktywnej
- Brak transferu ducha między itemami — UUID jest immutable; zniszczenie itemu = utrata ducha (dokumentacja w INTEGRATION.md)
- Brak własnego HAK/grafik — moduł używa ikon z baseitems.2da


---
_Generated by [Claude Code](https://claude.ai/code/session_01UW6hPsxsY8YdHGEiDXrMV8)_