### PR TITLE
feat: Tatuaże Magiczne

### DIFF
--- a/Magical Tattoos/INTEGRATION.md
+++ b/Magical Tattoos/INTEGRATION.md
@@ -1,0 +1,92 @@
+# Magical Tattoos — Integracja z Modułem
+
+## Opis
+
+System magicznych tatuaży pozwala graczom nanosić trwałe pieczęcie na 5 miejsc
+ciała (Głowa, Szyja, Piersi, Lewe Ramię, Prawe Ramię). Każdy tatuaż daje
+mechaniczny bonus (AB, AC, umiejętności, rzuty, odporność na ogień). Niektóre
+wzory są przeklęte — silniejszy efekt kosztem kary. Efekty są persistentne przez
+bazę SQLite i re-aplikowane przy każdym wejściu do modułu.
+
+## Hooki do podpięcia
+
+| Zdarzenie                | Skrypt                         |
+|--------------------------|--------------------------------|
+| OnModuleLoad             | `sys_on_load`                  |
+| OnClientEnter            | `sys_on_enter`                 |
+| Placeable OnUsed         | `test_tatu` (pracownia)        |
+
+Jeśli masz już własne `OnModuleLoad` / `OnClientEnter`, wywołaj funkcje z tych
+skryptów na końcu istniejącego handlera:
+
+```nwscript
+// W OnModuleLoad:
+#include "lib_tatu_def"
+// ...
+TatuCreateTables();
+TatuSeedDesigns();
+
+// W OnClientEnter:
+#include "lib_tatu"
+// ...
+object oPC = GetEnteringObject();
+if(GetIsPC(oPC)) TatuApplyEffectsForPC(oPC);
+```
+
+## Skrypty do skopiowania do modułu / haka
+
+Wszystkie pliki z folderu `Scripts/`:
+- `lib_nui.nss`, `lib_nui_utility.nss` — narzędzia NUI (mogą już istnieć)
+- `sql_tatu.nss` — schemat SQL i zapytania
+- `lib_tatu_def.nss` — stałe, helpery, forward deklaracje
+- `lib_tatu.nss` — logika, UI, efekty
+- `lib_tatu_ev.nss` — handler zdarzeń NUI (wpisać jako Event Script przy NuiCreate)
+- `sys_on_load.nss`, `sys_on_enter.nss`, `test_tatu.nss` — hooki
+
+## Placeable — Pracownia Tatuaży
+
+Utwórz dowolny Placeable z OnUsed = `test_tatu`. Rekomendowany tag: `pracownia_tatu`.
+Umieść przy NPC Tatuażysty lub w osobnym pomieszczeniu.
+
+## Atrament — wymagane itemy
+
+Każdy wzór wymaga specjalnego attramentu (itemu po tagu). Utwórz w palecie
+modułu następujące Misc Small Itemy:
+
+| Tag           | Nazwa wyświetlana       | Użycie w projektach          |
+|---------------|-------------------------|------------------------------|
+| `ink_crow`    | Atrament Kruczy         | Szpon Wrony (HEAD +2 AB)     |
+| `ink_sight`   | Atrament Wizji          | Oko Proroka (HEAD +3 Spot)   |
+| `ink_bile`    | Atrament Żółciowy       | Pieczęć Zarazy (NECK)        |
+| `ink_bone`    | Atrament Kostny         | Kość Milczenia (NECK)        |
+| `ink_stone`   | Atrament Kamienny       | Serce Kamienia (CHEST)       |
+| `ink_iron`    | Atrament Żelazny        | Łańcuch Obrońcy (CHEST)      |
+| `ink_ash`     | Atrament Popielny       | Blizna Ognia (CHEST)         |
+| `ink_shadow`  | Atrament Cienia         | Skrzydła Nocy / Znak Złodzieja |
+| `ink_blood`   | Atrament Krwawy         | Pięść Tyranta (RIGHT)        |
+
+Możesz rozdawać atrament jako loot z potworów, drop w skrzynkach lub sprzedawać
+go przez NPC-handlarza.
+
+## Zależności NWNX
+
+Brak. Moduł używa wyłącznie standardowego API NWScript (NUI, SQL Campaign, Effects).
+
+## Dostosowanie — dodawanie wzorów
+
+Wywołaj `TatuSeedOne(...)` w `sys_on_load.nss` po istniejących 10 wpisach.
+Tabela `tatu_designs` używa `INSERT OR IGNORE`, więc ponowne uruchomienie
+modułu nie nadpisze istniejących danych.
+
+## Usuwanie tatuażu
+
+Koszt: 150 zł + 5 obrażeń magicznych (parametry `TATU_REMOVE_GOLD` i
+`TATU_REMOVE_DMG` w `lib_tatu_def.nss`). Kliknięcie miejsca na mapie ciała
+(jeśli ma tatuaż) aktywuje przycisk „Wypal Tatuaż".
+
+## Co celowo pominięto
+
+- Własne obrazki/ikony tatuaży (brak zasobów graficznych w repozytorium)
+- Animator wizualny (efekt VFX nakładany na PC przy nanoszeniu)
+- Ograniczenie wzorów do klas postaci
+- GM-narzędzie do dodawania wzorów przez UI (GM musi edytować SQL ręcznie)

--- a/Magical Tattoos/Scripts/lib_nui.nss
+++ b/Magical Tattoos/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Magical Tattoos/Scripts/lib_nui_utility.nss
+++ b/Magical Tattoos/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Magical Tattoos/Scripts/lib_tatu.nss
+++ b/Magical Tattoos/Scripts/lib_tatu.nss
@@ -1,0 +1,676 @@
+#include "lib_tatu_def"
+
+// ----------------------------------------------------------------
+// Effect application helpers
+// ----------------------------------------------------------------
+
+void TatuRemoveEffectsForSlot(object oPC, int nSlotIdx)
+{
+    int nTag = TATU_EFFECT_TAG_BASE + nSlotIdx;
+    effect eEff  = GetFirstEffect(oPC);
+    effect eNext;
+    while(GetIsEffectValid(eEff))
+    {
+        eNext = GetNextEffect(oPC);
+        if(GetEffectTag(eEff) == nTag)
+            RemoveEffect(oPC, eEff);
+        eEff = eNext;
+    }
+}
+
+void TatuApplyDesignEffects(object oPC, json jDesign, int nSlotIdx)
+{
+    int nTag = TATU_EFFECT_TAG_BASE + nSlotIdx;
+
+    int nBonAb  = JsonGetInt(JsonObjectGet(jDesign, "bon_ab"));
+    int nBonAc  = JsonGetInt(JsonObjectGet(jDesign, "bon_ac"));
+    int nBonSk  = JsonGetInt(JsonObjectGet(jDesign, "bon_skill"));
+    int nBonSkV = JsonGetInt(JsonObjectGet(jDesign, "bon_skill_v"));
+    int nBonSv  = JsonGetInt(JsonObjectGet(jDesign, "bon_save"));
+    int nBonSvV = JsonGetInt(JsonObjectGet(jDesign, "bon_save_v"));
+    int nBonRs  = JsonGetInt(JsonObjectGet(jDesign, "bon_resist"));
+    int bCursed = JsonGetInt(JsonObjectGet(jDesign, "is_cursed"));
+    int nCurAb  = JsonGetInt(JsonObjectGet(jDesign, "curse_ab"));
+    int nCurSv  = JsonGetInt(JsonObjectGet(jDesign, "curse_saves"));
+    int nCurCha = JsonGetInt(JsonObjectGet(jDesign, "curse_cha"));
+
+    if(nBonAb > 0)
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+            TagEffect(EffectAttackIncrease(nBonAb), nTag), oPC);
+
+    if(nBonAc > 0)
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+            TagEffect(EffectACIncrease(nBonAc, AC_DODGE_BONUS), nTag), oPC);
+
+    if(nBonSk >= 0 && nBonSkV > 0)
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+            TagEffect(EffectSkillIncrease(nBonSk, nBonSkV), nTag), oPC);
+
+    if(nBonSv >= 0 && nBonSvV > 0)
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+            TagEffect(EffectSavingThrowIncrease(nBonSv, nBonSvV), nTag), oPC);
+
+    if(nBonRs > 0)
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+            TagEffect(EffectDamageResistance(DAMAGE_TYPE_FIRE, nBonRs, 0), nTag), oPC);
+
+    if(bCursed)
+    {
+        if(nCurAb > 0)
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAttackDecrease(nCurAb), nTag), oPC);
+
+        if(nCurSv > 0)
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectSavingThrowDecrease(SAVING_THROW_ALL, nCurSv), nTag), oPC);
+
+        if(nCurCha > 0)
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT,
+                TagEffect(EffectAbilityDecrease(ABILITY_CHARISMA, nCurCha), nTag), oPC);
+    }
+}
+
+void TatuApplyEffectsForPC(object oPC)
+{
+    json jTattoos = TatuGetPCTattoos(oPC);
+    int nCount    = JsonGetLength(jTattoos);
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jT     = JsonArrayGet(jTattoos, i);
+        int nDesId  = JsonGetInt   (JsonObjectGet(jT, "design_id"));
+        string sSlot= JsonGetString(JsonObjectGet(jT, "slot"));
+        int nSlotIdx= TatuGetSlotIndex(sSlot);
+        if(nSlotIdx < 0) continue;
+
+        json jDesign = TatuGetDesignById(nDesId);
+        if(JsonGetType(jDesign) == JSON_TYPE_NULL) continue;
+
+        TatuRemoveEffectsForSlot(oPC, nSlotIdx);
+        TatuApplyDesignEffects(oPC, jDesign, nSlotIdx);
+    }
+}
+
+// ----------------------------------------------------------------
+// NUI — slot button helper
+// ----------------------------------------------------------------
+
+json TatuMakeSlotButton(object oPC, int nIdx, float fWidth)
+{
+    float fH  = GetNuiScaleDimension(oPC, TATU_BTN_H);
+    float fW  = GetNuiScaleDimension(oPC, fWidth);
+    string sId  = TATU_BTN_SLOT + "_" + IntToString(nIdx);
+    string sLbl = TATU_BIND_SLOT_LBL + "_" + IntToString(nIdx);
+    string sEnc = TATU_BIND_SLOT_ENC + "_" + IntToString(nIdx);
+
+    json jBtn = NuiButton(NuiBind(sLbl));
+    jBtn = NuiId(jBtn, sId);
+    jBtn = NuiEncouraged(jBtn, NuiBind(sEnc));
+    jBtn = NuiWidth(jBtn, fW);
+    jBtn = NuiHeight(jBtn, fH);
+    return jBtn;
+}
+
+// ----------------------------------------------------------------
+// NUI — Body map panel
+// ----------------------------------------------------------------
+
+json BuildTatuBodyMap(object oPC)
+{
+    float fH = GetNuiScaleDimension(oPC, TATU_MAP_H);
+
+    // Header
+    json jHdr = NuiLabel(JsonString("— Mapa Ciała —"),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jHdr = NuiHeight(jHdr, GetNuiScaleDimension(oPC, 22.0));
+
+    // HEAD (centered row)
+    json jRowHead = JsonArray();
+    jRowHead = JsonArrayInsert(jRowHead, NuiSpacer());
+    jRowHead = JsonArrayInsert(jRowHead, TatuMakeSlotButton(oPC, 0, TATU_SLOT_BTN_W));
+    jRowHead = JsonArrayInsert(jRowHead, NuiSpacer());
+
+    // NECK (centered row)
+    json jRowNeck = JsonArray();
+    jRowNeck = JsonArrayInsert(jRowNeck, NuiSpacer());
+    jRowNeck = JsonArrayInsert(jRowNeck, TatuMakeSlotButton(oPC, 1, TATU_SLOT_BTN_W));
+    jRowNeck = JsonArrayInsert(jRowNeck, NuiSpacer());
+
+    // CHEST (centered row)
+    json jRowChest = JsonArray();
+    jRowChest = JsonArrayInsert(jRowChest, NuiSpacer());
+    jRowChest = JsonArrayInsert(jRowChest, TatuMakeSlotButton(oPC, 2, TATU_SLOT_BTN_W));
+    jRowChest = JsonArrayInsert(jRowChest, NuiSpacer());
+
+    // LEFT + RIGHT arms (side by side)
+    json jRowArms = JsonArray();
+    jRowArms = JsonArrayInsert(jRowArms, TatuMakeSlotButton(oPC, 3, TATU_SLOT_ARM_W));
+    jRowArms = JsonArrayInsert(jRowArms, NuiSpacer());
+    jRowArms = JsonArrayInsert(jRowArms, TatuMakeSlotButton(oPC, 4, TATU_SLOT_ARM_W));
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jHdr);
+    jCol = JsonArrayInsert(jCol, NuiRow(jRowHead));
+    jCol = JsonArrayInsert(jCol, NuiRow(jRowNeck));
+    jCol = JsonArrayInsert(jCol, NuiRow(jRowChest));
+    jCol = JsonArrayInsert(jCol, NuiRow(jRowArms));
+
+    json jGrp = NuiGroup(NuiCol(jCol), TRUE, NUI_SCROLLBARS_NONE);
+    jGrp = NuiHeight(jGrp, fH);
+    return jGrp;
+}
+
+// ----------------------------------------------------------------
+// NUI — Design list panel
+// ----------------------------------------------------------------
+
+json BuildTatuDesignList(object oPC)
+{
+    float fRowH  = GetNuiScaleDimension(oPC, TATU_ROW_H);
+    float fSlotW = GetNuiScaleDimension(oPC, 80.0);
+
+    json jNameLbl = NuiLabel(NuiBind(TATU_BIND_LIST_NAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jNameLbl = NuiStyleForegroundColor(jNameLbl, NuiBind(TATU_BIND_LIST_COLOR));
+
+    json jSlotLbl = NuiLabel(NuiBind(TATU_BIND_LIST_SLOT),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jSlotLbl = NuiStyleForegroundColor(jSlotLbl, NuiBind(TATU_BIND_LIST_COLOR));
+    jSlotLbl = NuiWidth(jSlotLbl, fSlotW);
+
+    json jCellRow = JsonArray();
+    jCellRow = JsonArrayInsert(jCellRow, jNameLbl);
+    jCellRow = JsonArrayInsert(jCellRow, jSlotLbl);
+
+    json jCell = NuiGroup(NuiRow(jCellRow), TRUE, NUI_SCROLLBARS_NONE);
+    jCell = NuiId(jCell, TATU_BTN_ROW);
+    jCell = NuiEncouraged(jCell, NuiBind(TATU_BIND_LIST_ENC));
+
+    json jTmpl = JsonArrayInsert(JsonArray(),
+        NuiListTemplateCell(jCell, 0.0, TRUE));
+
+    json jList = NuiList(jTmpl, NuiBind(TATU_BIND_LIST_COUNT), fRowH);
+    return jList;
+}
+
+// ----------------------------------------------------------------
+// NUI — Detail panel
+// ----------------------------------------------------------------
+
+json BuildTatuDetailPanel(object oPC)
+{
+    float fH      = GetNuiScaleDimension(oPC, TATU_DETAIL_H);
+    float fBtnH   = GetNuiScaleDimension(oPC, TATU_BTN_H);
+    float fBtnW   = GetNuiScaleDimension(oPC, 160.0);
+    float fDescH  = GetNuiScaleDimension(oPC, 60.0);
+
+    json jName = NuiLabel(NuiBind(TATU_BIND_DET_NAME),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jName = NuiHeight(jName, GetNuiScaleDimension(oPC, 24.0));
+
+    json jDesc = NuiGroup(NuiText(NuiBind(TATU_BIND_DET_DESC), FALSE),
+        FALSE, NUI_SCROLLBARS_NONE);
+    jDesc = NuiHeight(jDesc, fDescH);
+
+    json jEffect = NuiLabel(NuiBind(TATU_BIND_DET_EFFECT),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jEffect = NuiHeight(jEffect, GetNuiScaleDimension(oPC, 22.0));
+    jEffect = NuiStyleForegroundColor(jEffect, NuiColor(160, 220, 160));
+
+    json jReq = NuiLabel(NuiBind(TATU_BIND_DET_REQ),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jReq = NuiHeight(jReq, GetNuiScaleDimension(oPC, 22.0));
+    jReq = NuiStyleForegroundColor(jReq, NuiColor(220, 200, 120));
+
+    json jCurse = NuiLabel(NuiBind(TATU_BIND_DET_CURSE),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jCurse = NuiHeight(jCurse, GetNuiScaleDimension(oPC, 22.0));
+    jCurse = NuiStyleForegroundColor(jCurse, NuiColor(220, 100, 100));
+
+    json jApplyBtn = NuiButton(NuiBind(TATU_BIND_APPLY_LBL));
+    jApplyBtn = NuiId(jApplyBtn, TATU_BTN_APPLY);
+    jApplyBtn = NuiEnabled(jApplyBtn, NuiBind(TATU_BIND_APPLY_ENA));
+    jApplyBtn = NuiWidth(jApplyBtn, fBtnW);
+    jApplyBtn = NuiHeight(jApplyBtn, fBtnH);
+
+    json jRemoveBtn = NuiButton(JsonString("Wypal Tatuaż"));
+    jRemoveBtn = NuiId(jRemoveBtn, TATU_BTN_REMOVE);
+    jRemoveBtn = NuiEnabled(jRemoveBtn, NuiBind(TATU_BIND_REMOVE_ENA));
+    jRemoveBtn = NuiWidth(jRemoveBtn, fBtnW);
+    jRemoveBtn = NuiHeight(jRemoveBtn, fBtnH);
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jApplyBtn);
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jRemoveBtn);
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jName);
+    jCol = JsonArrayInsert(jCol, jDesc);
+    jCol = JsonArrayInsert(jCol, jEffect);
+    jCol = JsonArrayInsert(jCol, jReq);
+    jCol = JsonArrayInsert(jCol, jCurse);
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+
+    json jGrp = NuiGroup(NuiCol(jCol), TRUE, NUI_SCROLLBARS_NONE);
+    jGrp = NuiHeight(jGrp, fH);
+    return jGrp;
+}
+
+// ----------------------------------------------------------------
+// NUI — Window creation
+// ----------------------------------------------------------------
+
+void TatuOpenWindow(object oPC)
+{
+    if(NuiFindWindow(oPC, TATU_WINDOW) != 0)
+    {
+        TatuRefreshAll(oPC, NuiFindWindow(oPC, TATU_WINDOW));
+        return;
+    }
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))
+        - GetNuiScaleDimension(oPC, TATU_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT))
+        - GetNuiScaleDimension(oPC, TATU_H)) / 2.0;
+    json jGeom = NuiRect(fCX, fCY,
+        GetNuiScaleDimension(oPC, TATU_W),
+        GetNuiScaleDimension(oPC, TATU_H));
+
+    // Top bar: title label + close button
+    float fBtnH = GetNuiScaleDimension(oPC, TATU_BTN_H);
+
+    json jTitleLbl = NuiLabel(JsonString("Pracownia Tatuaży Magicznych"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitleLbl = NuiStyleForegroundColor(jTitleLbl, NuiColor(200, 170, 100));
+
+    json jCloseBtn = NuiButton(JsonString("X"));
+    jCloseBtn = NuiId(jCloseBtn, TATU_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, GetNuiScaleDimension(oPC, 30.0));
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jTopRow = JsonArray();
+    jTopRow = JsonArrayInsert(jTopRow, jTitleLbl);
+    jTopRow = JsonArrayInsert(jTopRow, NuiSpacer());
+    jTopRow = JsonArrayInsert(jTopRow, jCloseBtn);
+
+    // Left column: design list
+    float fListW = GetNuiScaleDimension(oPC, TATU_LIST_W);
+    json jListHdr = NuiLabel(JsonString("Dostępne Wzory"),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jListHdr = NuiHeight(jListHdr, GetNuiScaleDimension(oPC, 22.0));
+    jListHdr = NuiStyleForegroundColor(jListHdr, NuiColor(200, 170, 100));
+
+    json jLeftCol = JsonArray();
+    jLeftCol = JsonArrayInsert(jLeftCol, jListHdr);
+    jLeftCol = JsonArrayInsert(jLeftCol, BuildTatuDesignList(oPC));
+
+    json jLeft = NuiWidth(NuiCol(jLeftCol), fListW);
+
+    // Right column: body map + detail panel
+    json jRightCol = JsonArray();
+    jRightCol = JsonArrayInsert(jRightCol, BuildTatuBodyMap(oPC));
+    jRightCol = JsonArrayInsert(jRightCol, BuildTatuDetailPanel(oPC));
+
+    json jRight = NuiCol(jRightCol);
+
+    // Main content row
+    json jContentRow = JsonArray();
+    jContentRow = JsonArrayInsert(jContentRow, jLeft);
+    jContentRow = JsonArrayInsert(jContentRow, NuiSpacer());
+    jContentRow = JsonArrayInsert(jContentRow, jRight);
+
+    // Root
+    json jRoot = JsonArray();
+    jRoot = JsonArrayInsert(jRoot, NuiRow(jTopRow));
+    jRoot = JsonArrayInsert(jRoot, NuiRow(jContentRow));
+
+    json jWin = NuiWindow(NuiCol(jRoot),
+        JsonBool(FALSE),
+        NuiBind(TATU_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    // Initialize selection state
+    SetLocalInt(oPC, TATU_LVAR_SEL_DESIGN, 0);
+    SetLocalInt(oPC, TATU_LVAR_SEL_SLOT,   -1);
+
+    int nToken = NuiCreate(oPC, jWin, TATU_WINDOW, TATU_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, TATU_WIN_GEOM, jGeom);
+
+    json jDesigns = TatuGetAllDesigns();
+    json jTattoos = TatuGetPCTattoos(oPC);
+    FeedTatuDesignList(oPC, nToken, jDesigns, jTattoos);
+    FeedTatuBodyMap(oPC, nToken, jTattoos);
+    FeedTatuDetail(oPC, nToken, jDesigns, jTattoos);
+}
+
+// ----------------------------------------------------------------
+// Feed — Design list
+// ----------------------------------------------------------------
+
+void FeedTatuDesignList(object oPC, int nToken, json jDesigns, json jTattoos)
+{
+    int nCount = JsonGetLength(jDesigns);
+    int nSelId = GetLocalInt(oPC, TATU_LVAR_SEL_DESIGN);
+
+    json jNames  = JsonArray();
+    json jSlots  = JsonArray();
+    json jColors = JsonArray();
+    json jEncs   = JsonArray();
+
+    json jWhite   = NuiColor(255, 255, 255);
+    json jCursed  = NuiColor(220, 120, 120);  // cursed designs in red tint
+    json jApplied = NuiColor(160, 220, 160);  // already applied in green tint
+
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jD      = JsonArrayGet(jDesigns, i);
+        int nId      = JsonGetInt   (JsonObjectGet(jD, "id"));
+        string sName = JsonGetString(JsonObjectGet(jD, "name"));
+        string sSlot = JsonGetString(JsonObjectGet(jD, "slot"));
+        int bCursed  = JsonGetInt   (JsonObjectGet(jD, "is_cursed"));
+        int nSlotIdx = TatuGetSlotIndex(sSlot);
+
+        int bApplied = (TatuFindTattooInSlot(jTattoos, sSlot) == nId);
+
+        json jColor = jWhite;
+        if(bApplied) jColor = jApplied;
+        else if(bCursed) jColor = jCursed;
+
+        string sSlotLbl = TatuGetSlotLabel(nSlotIdx);
+        if(bApplied) sSlotLbl = "[noszony]";
+
+        jNames  = JsonArrayInsert(jNames,  JsonString(sName));
+        jSlots  = JsonArrayInsert(jSlots,  JsonString(sSlotLbl));
+        jColors = JsonArrayInsert(jColors, jColor);
+        jEncs   = JsonArrayInsert(jEncs,   JsonBool(nSelId == nId));
+    }
+
+    NuiSetBind(oPC, nToken, TATU_BIND_LIST_NAME,  jNames);
+    NuiSetBind(oPC, nToken, TATU_BIND_LIST_SLOT,  jSlots);
+    NuiSetBind(oPC, nToken, TATU_BIND_LIST_COLOR, jColors);
+    NuiSetBind(oPC, nToken, TATU_BIND_LIST_ENC,   jEncs);
+    NuiSetBind(oPC, nToken, TATU_BIND_LIST_COUNT, JsonInt(nCount));
+}
+
+// ----------------------------------------------------------------
+// Feed — Body map
+// ----------------------------------------------------------------
+
+void FeedTatuBodyMap(object oPC, int nToken, json jTattoos)
+{
+    int nSelSlot = GetLocalInt(oPC, TATU_LVAR_SEL_SLOT);
+    int i;
+    for(i = 0; i < TATU_SLOT_COUNT; i++)
+    {
+        string sSlot    = TatuGetSlotName(i);
+        string sSlotLbl = TatuGetSlotLabel(i);
+        int nDesignId   = TatuFindTattooInSlot(jTattoos, sSlot);
+
+        string sLbl;
+        if(nDesignId > 0)
+        {
+            json jD   = TatuGetDesignById(nDesignId);
+            string sN = JsonGetString(JsonObjectGet(jD, "name"));
+            sLbl = sN;
+        }
+        else
+        {
+            sLbl = "— " + sSlotLbl + " —";
+        }
+
+        NuiSetBind(oPC, nToken,
+            TATU_BIND_SLOT_LBL + "_" + IntToString(i),
+            JsonString(sLbl));
+        NuiSetBind(oPC, nToken,
+            TATU_BIND_SLOT_ENC + "_" + IntToString(i),
+            JsonBool(nSelSlot == i));
+    }
+}
+
+// ----------------------------------------------------------------
+// Feed — Detail panel
+// ----------------------------------------------------------------
+
+void FeedTatuDetailEmpty(object oPC, int nToken, string sMsg)
+{
+    NuiSetBind(oPC, nToken, TATU_BIND_DET_NAME,   JsonString(sMsg));
+    NuiSetBind(oPC, nToken, TATU_BIND_DET_DESC,   JsonString(""));
+    NuiSetBind(oPC, nToken, TATU_BIND_DET_EFFECT, JsonString(""));
+    NuiSetBind(oPC, nToken, TATU_BIND_DET_REQ,    JsonString(""));
+    NuiSetBind(oPC, nToken, TATU_BIND_DET_CURSE,  JsonString(""));
+    NuiSetBind(oPC, nToken, TATU_BIND_APPLY_ENA,  JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, TATU_BIND_APPLY_LBL,  JsonString("Natnij"));
+    NuiSetBind(oPC, nToken, TATU_BIND_REMOVE_ENA, JsonBool(FALSE));
+}
+
+void FeedTatuDetailDesign(object oPC, int nToken, json jDesign, int bSlotMode)
+{
+    string sName    = JsonGetString(JsonObjectGet(jDesign, "name"));
+    string sDesc    = JsonGetString(JsonObjectGet(jDesign, "description"));
+    string sSlot    = JsonGetString(JsonObjectGet(jDesign, "slot"));
+    int nCostGold   = JsonGetInt   (JsonObjectGet(jDesign, "cost_gold"));
+    string sCostItem= JsonGetString(JsonObjectGet(jDesign, "cost_item"));
+    int nIsCursed   = JsonGetInt   (JsonObjectGet(jDesign, "is_cursed"));
+
+    string sEffect  = TatuBuildEffectText(jDesign);
+    string sCurse   = TatuBuildCurseText(jDesign);
+
+    string sReq = IntToString(nCostGold) + " zł";
+    if(sCostItem != "")
+        sReq = sReq + " + " + TatuInkName(sCostItem);
+
+    string sCurseLabel = "";
+    if(nIsCursed && sCurse != "")
+        sCurseLabel = "Przekleństwo: " + sCurse;
+
+    NuiSetBind(oPC, nToken, TATU_BIND_DET_NAME,   JsonString(sName));
+    NuiSetBind(oPC, nToken, TATU_BIND_DET_DESC,   JsonString(sDesc));
+    NuiSetBind(oPC, nToken, TATU_BIND_DET_EFFECT, JsonString("Efekt: " + sEffect));
+    NuiSetBind(oPC, nToken, TATU_BIND_DET_CURSE,  JsonString(sCurseLabel));
+
+    if(bSlotMode)
+    {
+        // Viewing the applied tattoo from body map slot click → show Remove
+        string sRemoveHint = "Usunięcie: " + IntToString(TATU_REMOVE_GOLD)
+            + " zł + " + IntToString(TATU_REMOVE_DMG) + " obrażeń";
+        NuiSetBind(oPC, nToken, TATU_BIND_DET_REQ,    JsonString(sRemoveHint));
+        NuiSetBind(oPC, nToken, TATU_BIND_APPLY_ENA,  JsonBool(FALSE));
+        NuiSetBind(oPC, nToken, TATU_BIND_APPLY_LBL,  JsonString("Natnij"));
+        NuiSetBind(oPC, nToken, TATU_BIND_REMOVE_ENA, JsonBool(TRUE));
+        return;
+    }
+
+    // Viewing from design list → check whether we can apply
+    NuiSetBind(oPC, nToken, TATU_BIND_DET_REQ, JsonString("Koszt: " + sReq));
+
+    int nCurrentInSlot = TatuGetPCTattooDesignInSlot(oPC, sSlot);
+    int bSlotEmpty     = (nCurrentInSlot == 0);
+    int bHasGold       = (GetGold(oPC) >= nCostGold);
+    int bHasItem       = TRUE;
+    if(sCostItem != "")
+        bHasItem = GetIsObjectValid(GetItemPossessedBy(oPC, sCostItem));
+
+    int bCanApply = bSlotEmpty && bHasGold && bHasItem;
+
+    string sApplyLbl = "Natnij";
+    if(!bSlotEmpty)
+        sApplyLbl = "Miejsce zajęte";
+    else if(!bHasGold)
+        sApplyLbl = "Brak złota";
+    else if(!bHasItem)
+        sApplyLbl = "Brak atrtamentu";
+
+    NuiSetBind(oPC, nToken, TATU_BIND_APPLY_ENA,  JsonBool(bCanApply));
+    NuiSetBind(oPC, nToken, TATU_BIND_APPLY_LBL,  JsonString(sApplyLbl));
+    NuiSetBind(oPC, nToken, TATU_BIND_REMOVE_ENA, JsonBool(FALSE));
+}
+
+void FeedTatuDetail(object oPC, int nToken, json jDesigns, json jTattoos)
+{
+    int nSelDesign = GetLocalInt(oPC, TATU_LVAR_SEL_DESIGN);
+    int nSelSlot   = GetLocalInt(oPC, TATU_LVAR_SEL_SLOT);
+
+    if(nSelDesign <= 0 && nSelSlot < 0)
+    {
+        FeedTatuDetailEmpty(oPC, nToken, "Wybierz wzór lub miejsce na ciele.");
+        return;
+    }
+
+    if(nSelDesign > 0)
+    {
+        json jD = TatuFindDesignById(jDesigns, nSelDesign);
+        if(JsonGetType(jD) == JSON_TYPE_NULL)
+        {
+            FeedTatuDetailEmpty(oPC, nToken, "Nieznany wzór.");
+            return;
+        }
+        FeedTatuDetailDesign(oPC, nToken, jD, FALSE);
+        return;
+    }
+
+    // Slot selected from body map
+    if(nSelSlot >= 0)
+    {
+        string sSlot  = TatuGetSlotName(nSelSlot);
+        int nDesignId = TatuFindTattooInSlot(jTattoos, sSlot);
+
+        if(nDesignId == 0)
+        {
+            FeedTatuDetailEmpty(oPC, nToken,
+                "— " + TatuGetSlotLabel(nSelSlot) + " —  (puste)");
+            return;
+        }
+
+        json jD = TatuFindDesignById(jDesigns, nDesignId);
+        if(JsonGetType(jD) == JSON_TYPE_NULL)
+        {
+            FeedTatuDetailEmpty(oPC, nToken, "Błąd danych tatuażu.");
+            return;
+        }
+        FeedTatuDetailDesign(oPC, nToken, jD, TRUE);
+    }
+}
+
+// ----------------------------------------------------------------
+// Refresh helper
+// ----------------------------------------------------------------
+
+void TatuRefreshAll(object oPC, int nToken)
+{
+    json jDesigns = TatuGetAllDesigns();
+    json jTattoos = TatuGetPCTattoos(oPC);
+    FeedTatuDesignList(oPC, nToken, jDesigns, jTattoos);
+    FeedTatuBodyMap(oPC, nToken, jTattoos);
+    FeedTatuDetail(oPC, nToken, jDesigns, jTattoos);
+}
+
+// ----------------------------------------------------------------
+// Apply / Remove logic
+// ----------------------------------------------------------------
+
+void TatuDoApply(object oPC, int nToken)
+{
+    int nSelDesign = GetLocalInt(oPC, TATU_LVAR_SEL_DESIGN);
+    if(nSelDesign <= 0) return;
+
+    json jDesigns = TatuGetAllDesigns();
+    json jDesign  = TatuFindDesignById(jDesigns, nSelDesign);
+    if(JsonGetType(jDesign) == JSON_TYPE_NULL) return;
+
+    string sSlot     = JsonGetString(JsonObjectGet(jDesign, "slot"));
+    int nCostGold    = JsonGetInt   (JsonObjectGet(jDesign, "cost_gold"));
+    string sCostItem = JsonGetString(JsonObjectGet(jDesign, "cost_item"));
+    int nSlotIdx     = TatuGetSlotIndex(sSlot);
+    string sName     = JsonGetString(JsonObjectGet(jDesign, "name"));
+    int nIsCursed    = JsonGetInt   (JsonObjectGet(jDesign, "is_cursed"));
+
+    if(TatuGetPCTattooDesignInSlot(oPC, sSlot) != 0)
+    {
+        SendMessageToPC(oPC, "[Tatuaże] To miejsce jest już zajęte innym tatuażem.");
+        return;
+    }
+
+    if(GetGold(oPC) < nCostGold)
+    {
+        SendMessageToPC(oPC, "[Tatuaże] Potrzebujesz " + IntToString(nCostGold) + " złota.");
+        return;
+    }
+
+    object oInk = OBJECT_INVALID;
+    if(sCostItem != "")
+    {
+        oInk = GetItemPossessedBy(oPC, sCostItem);
+        if(!GetIsObjectValid(oInk))
+        {
+            SendMessageToPC(oPC, "[Tatuaże] Brakuje składnika: "
+                + TatuInkName(sCostItem) + ".");
+            return;
+        }
+    }
+
+    AssignCommand(oPC, TakeGoldFromCreature(nCostGold, oPC, TRUE));
+    if(GetIsObjectValid(oInk))
+        DestroyObject(oInk);
+
+    TatuApplyTattoo(oPC, nSelDesign, sSlot);
+    TatuRemoveEffectsForSlot(oPC, nSlotIdx);
+    TatuApplyDesignEffects(oPC, jDesign, nSlotIdx);
+
+    SetLocalInt(oPC, TATU_LVAR_SEL_DESIGN, 0);
+
+    SendMessageToPC(oPC, "[Tatuaże] Tatuaż \"" + sName
+        + "\" wyryty w twoją skórę. Pieczęć pulsuje.");
+    if(nIsCursed)
+        SendMessageToPC(oPC,
+            "[Tatuaże] Poczułeś ciemną moc przekleństwa wnikającą w krew — "
+            "lecz moc sama w sobie jest niepodzielna.");
+
+    TatuRefreshAll(oPC, nToken);
+}
+
+void TatuDoRemove(object oPC, int nToken)
+{
+    int nSelSlot = GetLocalInt(oPC, TATU_LVAR_SEL_SLOT);
+    if(nSelSlot < 0) return;
+
+    string sSlot  = TatuGetSlotName(nSelSlot);
+    int nDesignId = TatuGetPCTattooDesignInSlot(oPC, sSlot);
+    if(nDesignId == 0)
+    {
+        SendMessageToPC(oPC, "[Tatuaże] To miejsce nie ma tatuażu.");
+        return;
+    }
+
+    if(GetGold(oPC) < TATU_REMOVE_GOLD)
+    {
+        SendMessageToPC(oPC,
+            "[Tatuaże] Wypalenie tatuażu kosztuje "
+            + IntToString(TATU_REMOVE_GOLD) + " złota.");
+        return;
+    }
+
+    AssignCommand(oPC, TakeGoldFromCreature(TATU_REMOVE_GOLD, oPC, TRUE));
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectDamage(TATU_REMOVE_DMG, DAMAGE_TYPE_MAGICAL), oPC);
+
+    TatuRemoveTattoo(oPC, sSlot);
+    TatuRemoveEffectsForSlot(oPC, nSelSlot);
+
+    SetLocalInt(oPC, TATU_LVAR_SEL_SLOT, -1);
+
+    SendMessageToPC(oPC,
+        "[Tatuaże] Tatuaż z " + TatuGetSlotLabel(nSelSlot)
+        + " boleśnie wypalony rozżarzonym żelazem. "
+        + "Smród spalonej skóry unosi się w powietrzu.");
+
+    TatuRefreshAll(oPC, nToken);
+}

--- a/Magical Tattoos/Scripts/lib_tatu_def.nss
+++ b/Magical Tattoos/Scripts/lib_tatu_def.nss
@@ -1,0 +1,272 @@
+#include "lib_nui"
+#include "sql_tatu"
+
+// Forward declarations for functions defined in lib_tatu.nss
+void TatuOpenWindow(object oPC);
+void FeedTatuDesignList(object oPC, int nToken, json jDesigns, json jTattoos);
+void FeedTatuBodyMap(object oPC, int nToken, json jTattoos);
+void FeedTatuDetail(object oPC, int nToken, json jDesigns, json jTattoos);
+void TatuApplyEffectsForPC(object oPC);
+void TatuRemoveEffectsForSlot(object oPC, int nSlotIdx);
+void TatuDoApply(object oPC, int nToken);
+void TatuDoRemove(object oPC, int nToken);
+void TatuRefreshAll(object oPC, int nToken);
+
+// ----------------------------------------------------------------
+// Window IDs
+// ----------------------------------------------------------------
+
+const string TATU_WINDOW    = "TATU_WINDOW";
+const string TATU_EV_SCRIPT = "lib_tatu_ev";
+const string TATU_WIN_GEOM  = "tatu_win_geom";
+
+// ----------------------------------------------------------------
+// Bind IDs — Design list
+// ----------------------------------------------------------------
+
+const string TATU_BIND_LIST_NAME  = "tatu_list_name";
+const string TATU_BIND_LIST_SLOT  = "tatu_list_slot";
+const string TATU_BIND_LIST_ENC   = "tatu_list_enc";
+const string TATU_BIND_LIST_COLOR = "tatu_list_color";
+const string TATU_BIND_LIST_COUNT = "tatu_list_count";
+
+// ----------------------------------------------------------------
+// Bind IDs — Body map (one per slot, append "_0" … "_4")
+// ----------------------------------------------------------------
+
+const string TATU_BIND_SLOT_LBL = "tatu_slot_lbl";
+const string TATU_BIND_SLOT_ENC = "tatu_slot_enc";
+
+// ----------------------------------------------------------------
+// Bind IDs — Detail panel
+// ----------------------------------------------------------------
+
+const string TATU_BIND_DET_NAME   = "tatu_det_name";
+const string TATU_BIND_DET_DESC   = "tatu_det_desc";
+const string TATU_BIND_DET_EFFECT = "tatu_det_effect";
+const string TATU_BIND_DET_REQ    = "tatu_det_req";
+const string TATU_BIND_DET_CURSE  = "tatu_det_curse";
+const string TATU_BIND_APPLY_ENA  = "tatu_apply_ena";
+const string TATU_BIND_APPLY_LBL  = "tatu_apply_lbl";
+const string TATU_BIND_REMOVE_ENA = "tatu_remove_ena";
+
+// ----------------------------------------------------------------
+// Button IDs
+// ----------------------------------------------------------------
+
+const string TATU_BTN_CLOSE  = "tatu_btn_close";
+const string TATU_BTN_ROW    = "tatu_btn_row";
+const string TATU_BTN_SLOT   = "tatu_btn_slot";  // + "_0" … "_4"
+const string TATU_BTN_APPLY  = "tatu_btn_apply";
+const string TATU_BTN_REMOVE = "tatu_btn_remove";
+
+// ----------------------------------------------------------------
+// LVARs on PC
+// ----------------------------------------------------------------
+
+const string TATU_LVAR_SEL_DESIGN = "TATU_SEL_DESIGN";    // int: 0 = none
+const string TATU_LVAR_SEL_SLOT   = "TATU_SEL_SLOT_IDX";  // int: -1 = none, 0-4 = slot
+
+// ----------------------------------------------------------------
+// Slot definitions
+// ----------------------------------------------------------------
+
+const int    TATU_SLOT_COUNT = 5;
+// Slot name strings stored in SQL
+const string TATU_SLOT_HEAD  = "GLOWA";
+const string TATU_SLOT_NECK  = "SZYJA";
+const string TATU_SLOT_CHEST = "PIERSI";
+const string TATU_SLOT_LEFT  = "LEWE_RAMIE";
+const string TATU_SLOT_RIGHT = "PRAWE_RAMIE";
+
+// ----------------------------------------------------------------
+// Effect tagging (TATU_EFFECT_TAG_BASE + slot_idx per slot)
+// ----------------------------------------------------------------
+
+const int TATU_EFFECT_TAG_BASE = 7000;
+
+// ----------------------------------------------------------------
+// Layout dimensions (unscaled)
+// ----------------------------------------------------------------
+
+const float TATU_W        = 740.0;
+const float TATU_H        = 520.0;
+const float TATU_LIST_W   = 270.0;
+const float TATU_ROW_H    = 28.0;
+const float TATU_BTN_H    = 30.0;
+const float TATU_MAP_H    = 200.0;
+const float TATU_SLOT_BTN_W = 160.0;
+const float TATU_SLOT_ARM_W = 120.0;
+const float TATU_DETAIL_H = 195.0;
+
+// ----------------------------------------------------------------
+// Remove ritual cost
+// ----------------------------------------------------------------
+
+const int TATU_REMOVE_GOLD = 150;
+const int TATU_REMOVE_DMG  = 5;
+
+// ----------------------------------------------------------------
+// Slot helpers
+// ----------------------------------------------------------------
+
+string TatuGetSlotName(int nIdx)
+{
+    if(nIdx == 0) return TATU_SLOT_HEAD;
+    if(nIdx == 1) return TATU_SLOT_NECK;
+    if(nIdx == 2) return TATU_SLOT_CHEST;
+    if(nIdx == 3) return TATU_SLOT_LEFT;
+    if(nIdx == 4) return TATU_SLOT_RIGHT;
+    return "";
+}
+
+string TatuGetSlotLabel(int nIdx)
+{
+    if(nIdx == 0) return "Głowa";
+    if(nIdx == 1) return "Szyja";
+    if(nIdx == 2) return "Piersi";
+    if(nIdx == 3) return "Lewe Ramię";
+    if(nIdx == 4) return "Prawe Ramię";
+    return "";
+}
+
+int TatuGetSlotIndex(string sSlot)
+{
+    if(sSlot == TATU_SLOT_HEAD)  return 0;
+    if(sSlot == TATU_SLOT_NECK)  return 1;
+    if(sSlot == TATU_SLOT_CHEST) return 2;
+    if(sSlot == TATU_SLOT_LEFT)  return 3;
+    if(sSlot == TATU_SLOT_RIGHT) return 4;
+    return -1;
+}
+
+// ----------------------------------------------------------------
+// Ink name mapping (tag → display name)
+// ----------------------------------------------------------------
+
+string TatuInkName(string sTag)
+{
+    if(sTag == "ink_crow")   return "Atrament Kruczy";
+    if(sTag == "ink_sight")  return "Atrament Wizji";
+    if(sTag == "ink_bile")   return "Atrament Żółciowy";
+    if(sTag == "ink_bone")   return "Atrament Kostny";
+    if(sTag == "ink_stone")  return "Atrament Kamienny";
+    if(sTag == "ink_iron")   return "Atrament Żelazny";
+    if(sTag == "ink_ash")    return "Atrament Popielny";
+    if(sTag == "ink_shadow") return "Atrament Cienia";
+    if(sTag == "ink_blood")  return "Atrament Krwawy";
+    return sTag;
+}
+
+// ----------------------------------------------------------------
+// Effect text builders
+// ----------------------------------------------------------------
+
+string TatuSkillName(int nSkillId)
+{
+    if(nSkillId == 0)  return "Oswajanie Zwierząt";
+    if(nSkillId == 1)  return "Skupienie";
+    if(nSkillId == 2)  return "Rozbrajanie Pułapek";
+    if(nSkillId == 3)  return "Dyscyplina";
+    if(nSkillId == 4)  return "Leczenie";
+    if(nSkillId == 5)  return "Ukrywanie";
+    if(nSkillId == 6)  return "Nasłuchiwanie";
+    if(nSkillId == 7)  return "Wiedza";
+    if(nSkillId == 8)  return "Skradanie";
+    if(nSkillId == 9)  return "Otwieranie Zamków";
+    if(nSkillId == 10) return "Parowanie";
+    if(nSkillId == 11) return "Występy";
+    if(nSkillId == 12) return "Przekonywanie";
+    if(nSkillId == 13) return "Kieszonkowstwo";
+    if(nSkillId == 14) return "Szukanie";
+    if(nSkillId == 15) return "Stawianie Pułapek";
+    if(nSkillId == 16) return "Magia Zaklęć";
+    if(nSkillId == 17) return "Spostrzegawczość";
+    if(nSkillId == 18) return "Drwiny";
+    if(nSkillId == 19) return "Akrobatyka";
+    if(nSkillId == 20) return "Użycie Magii";
+    return "Umiejętność";
+}
+
+string TatuSaveName(int nSaveType)
+{
+    if(nSaveType == 0) return "Wszystkie Rzuty";
+    if(nSaveType == 1) return "Tężyzna";
+    if(nSaveType == 2) return "Refleks";
+    if(nSaveType == 3) return "Wola";
+    return "Rzut Obronny";
+}
+
+string TatuBuildEffectText(json jDesign)
+{
+    string sParts = "";
+
+    int nBonAb  = JsonGetInt(JsonObjectGet(jDesign, "bon_ab"));
+    int nBonAc  = JsonGetInt(JsonObjectGet(jDesign, "bon_ac"));
+    int nBonSk  = JsonGetInt(JsonObjectGet(jDesign, "bon_skill"));
+    int nBonSkV = JsonGetInt(JsonObjectGet(jDesign, "bon_skill_v"));
+    int nBonSv  = JsonGetInt(JsonObjectGet(jDesign, "bon_save"));
+    int nBonSvV = JsonGetInt(JsonObjectGet(jDesign, "bon_save_v"));
+    int nBonRs  = JsonGetInt(JsonObjectGet(jDesign, "bon_resist"));
+
+    if(nBonAb > 0)
+        sParts = sParts + "Atak +" + IntToString(nBonAb) + "   ";
+    if(nBonAc > 0)
+        sParts = sParts + "Zbroja +" + IntToString(nBonAc) + "   ";
+    if(nBonSk >= 0 && nBonSkV > 0)
+        sParts = sParts + TatuSkillName(nBonSk) + " +" + IntToString(nBonSkV) + "   ";
+    if(nBonSv >= 0 && nBonSvV > 0)
+        sParts = sParts + TatuSaveName(nBonSv) + " +" + IntToString(nBonSvV) + "   ";
+    if(nBonRs > 0)
+        sParts = sParts + "Odp. Ogień " + IntToString(nBonRs) + "   ";
+
+    if(sParts == "") return "(brak efektu)";
+    return sParts;
+}
+
+string TatuBuildCurseText(json jDesign)
+{
+    if(!JsonGetInt(JsonObjectGet(jDesign, "is_cursed"))) return "";
+
+    string sCurse = "";
+    int nCurAb   = JsonGetInt(JsonObjectGet(jDesign, "curse_ab"));
+    int nCurSv   = JsonGetInt(JsonObjectGet(jDesign, "curse_saves"));
+    int nCurCha  = JsonGetInt(JsonObjectGet(jDesign, "curse_cha"));
+
+    if(nCurAb > 0)  sCurse = sCurse + "Atak –" + IntToString(nCurAb) + "   ";
+    if(nCurSv > 0)  sCurse = sCurse + "Rzuty Obronne –" + IntToString(nCurSv) + "   ";
+    if(nCurCha > 0) sCurse = sCurse + "Charyzma –" + IntToString(nCurCha) + "   ";
+
+    return sCurse;
+}
+
+// ----------------------------------------------------------------
+// JSON cache helper
+// ----------------------------------------------------------------
+
+json TatuFindDesignById(json jDesigns, int nId)
+{
+    int nCount = JsonGetLength(jDesigns);
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jD = JsonArrayGet(jDesigns, i);
+        if(JsonGetInt(JsonObjectGet(jD, "id")) == nId)
+            return jD;
+    }
+    return JsonNull();
+}
+
+// Returns design_id for a given slot from the PC tattoos array, or 0.
+int TatuFindTattooInSlot(json jTattoos, string sSlot)
+{
+    int nCount = JsonGetLength(jTattoos);
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jT = JsonArrayGet(jTattoos, i);
+        if(JsonGetString(JsonObjectGet(jT, "slot")) == sSlot)
+            return JsonGetInt(JsonObjectGet(jT, "design_id"));
+    }
+    return 0;
+}

--- a/Magical Tattoos/Scripts/lib_tatu_ev.nss
+++ b/Magical Tattoos/Scripts/lib_tatu_ev.nss
@@ -1,0 +1,88 @@
+#include "lib_tatu"
+
+// ----------------------------------------------------------------
+// NUI event handler — called by NWN for all TATU_WINDOW events.
+// ----------------------------------------------------------------
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    if(nToken != NuiFindWindow(oPC, TATU_WINDOW)) return;
+
+    // -- Window closed by system (ESC / title X if closable) --
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        SetLocalInt(oPC, TATU_LVAR_SEL_DESIGN, 0);
+        SetLocalInt(oPC, TATU_LVAR_SEL_SLOT,   -1);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == TATU_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        if(sElem == TATU_BTN_APPLY)
+        {
+            TatuDoApply(oPC, nToken);
+            return;
+        }
+
+        if(sElem == TATU_BTN_REMOVE)
+        {
+            TatuDoRemove(oPC, nToken);
+            return;
+        }
+    }
+
+    if(sEvent == EVENT_TYPE_MOUSEDOWN)
+    {
+        // Design list row clicked
+        if(sElem == TATU_BTN_ROW)
+        {
+            json jDesigns = TatuGetAllDesigns();
+            if(nIdx < 0 || nIdx >= JsonGetLength(jDesigns)) return;
+
+            json jD   = JsonArrayGet(jDesigns, nIdx);
+            int nId   = JsonGetInt(JsonObjectGet(jD, "id"));
+
+            SetLocalInt(oPC, TATU_LVAR_SEL_DESIGN, nId);
+            SetLocalInt(oPC, TATU_LVAR_SEL_SLOT,   -1);
+
+            json jTattoos = TatuGetPCTattoos(oPC);
+            FeedTatuDesignList(oPC, nToken, jDesigns, jTattoos);
+            FeedTatuBodyMap(oPC, nToken, jTattoos);
+            FeedTatuDetail(oPC, nToken, jDesigns, jTattoos);
+            return;
+        }
+
+        // Body map slot button clicked: ID = TATU_BTN_SLOT + "_N"
+        string sSlotPrefix = TATU_BTN_SLOT + "_";
+        int nPrefixLen     = GetStringLength(sSlotPrefix);
+        if(GetStringLeft(sElem, nPrefixLen) == sSlotPrefix)
+        {
+            int nSlotIdx = StringToInt(
+                GetStringRight(sElem, GetStringLength(sElem) - nPrefixLen));
+
+            if(nSlotIdx < 0 || nSlotIdx >= TATU_SLOT_COUNT) return;
+
+            SetLocalInt(oPC, TATU_LVAR_SEL_SLOT,   nSlotIdx);
+            SetLocalInt(oPC, TATU_LVAR_SEL_DESIGN, 0);
+
+            json jDesigns = TatuGetAllDesigns();
+            json jTattoos = TatuGetPCTattoos(oPC);
+            FeedTatuDesignList(oPC, nToken, jDesigns, jTattoos);
+            FeedTatuBodyMap(oPC, nToken, jTattoos);
+            FeedTatuDetail(oPC, nToken, jDesigns, jTattoos);
+            return;
+        }
+    }
+}

--- a/Magical Tattoos/Scripts/sql_tatu.nss
+++ b/Magical Tattoos/Scripts/sql_tatu.nss
@@ -1,0 +1,285 @@
+// SQL schema and queries for the Magical Tattoos module.
+// Campaign DB name: "tatu"
+
+const string TATU_DB = "tatu";
+
+// ----------------------------------------------------------------
+// Schema
+// ----------------------------------------------------------------
+
+void TatuCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign(TATU_DB,
+        "CREATE TABLE IF NOT EXISTS tatu_designs ("
+        "id INTEGER PRIMARY KEY,"
+        "name TEXT NOT NULL DEFAULT '',"
+        "description TEXT DEFAULT '',"
+        "slot TEXT NOT NULL DEFAULT '',"
+        "cost_gold INTEGER DEFAULT 0,"
+        "cost_item TEXT DEFAULT '',"
+        "bon_ab INTEGER DEFAULT 0,"
+        "bon_ac INTEGER DEFAULT 0,"
+        "bon_skill INTEGER DEFAULT -1,"
+        "bon_skill_v INTEGER DEFAULT 0,"
+        "bon_save INTEGER DEFAULT -1,"
+        "bon_save_v INTEGER DEFAULT 0,"
+        "bon_resist INTEGER DEFAULT 0,"
+        "is_cursed INTEGER DEFAULT 0,"
+        "curse_desc TEXT DEFAULT '',"
+        "curse_ab INTEGER DEFAULT 0,"
+        "curse_saves INTEGER DEFAULT 0,"
+        "curse_cha INTEGER DEFAULT 0"
+        ")");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign(TATU_DB,
+        "CREATE TABLE IF NOT EXISTS tatu_pc ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "pc_uuid TEXT NOT NULL,"
+        "design_id INTEGER NOT NULL,"
+        "slot TEXT NOT NULL,"
+        "applied_at INTEGER DEFAULT 0,"
+        "UNIQUE(pc_uuid, slot)"
+        ")");
+    SqlStep(q);
+}
+
+// ----------------------------------------------------------------
+// Design seeding
+// ----------------------------------------------------------------
+
+void TatuSeedOne(int nId, string sName, string sDesc, string sSlot,
+                 int nGold, string sItem,
+                 int nBonAb, int nBonAc, int nBonSk, int nBonSkV,
+                 int nBonSv, int nBonSvV, int nBonRs,
+                 int bCursed, string sCurseDesc,
+                 int nCurAb, int nCurSv, int nCurCha)
+{
+    sqlquery q = SqlPrepareQueryCampaign(TATU_DB,
+        "INSERT OR IGNORE INTO tatu_designs "
+        "(id,name,description,slot,cost_gold,cost_item,"
+        " bon_ab,bon_ac,bon_skill,bon_skill_v,bon_save,bon_save_v,bon_resist,"
+        " is_cursed,curse_desc,curse_ab,curse_saves,curse_cha) "
+        "VALUES (@id,@nm,@ds,@sl,@cg,@ci,"
+        " @ba,@bc,@bsk,@bskv,@bsv,@bsvv,@br,"
+        " @ic,@cd,@cab,@csv,@ccha)");
+    SqlBindInt   (q, "@id",   nId);
+    SqlBindString(q, "@nm",   sName);
+    SqlBindString(q, "@ds",   sDesc);
+    SqlBindString(q, "@sl",   sSlot);
+    SqlBindInt   (q, "@cg",   nGold);
+    SqlBindString(q, "@ci",   sItem);
+    SqlBindInt   (q, "@ba",   nBonAb);
+    SqlBindInt   (q, "@bc",   nBonAc);
+    SqlBindInt   (q, "@bsk",  nBonSk);
+    SqlBindInt   (q, "@bskv", nBonSkV);
+    SqlBindInt   (q, "@bsv",  nBonSv);
+    SqlBindInt   (q, "@bsvv", nBonSvV);
+    SqlBindInt   (q, "@br",   nBonRs);
+    SqlBindInt   (q, "@ic",   bCursed);
+    SqlBindString(q, "@cd",   sCurseDesc);
+    SqlBindInt   (q, "@cab",  nCurAb);
+    SqlBindInt   (q, "@csv",  nCurSv);
+    SqlBindInt   (q, "@ccha", nCurCha);
+    SqlStep(q);
+}
+
+void TatuSeedDesigns()
+{
+    // Slot GLOWA — 2 designs
+    TatuSeedOne(1,
+        "Szpon Wrona",
+        "Symbol kruczego szponu wyryty na czole igłą maczaną w atramencie "
+        "z piór nocnych ptaków. Kto nosi ten znak, atakuje z chyżością "
+        "i precyzją drapieżnika.",
+        "GLOWA", 80, "ink_crow",
+        2, 0, -1, 0, -1, 0, 0,
+        0, "", 0, 0, 0);
+
+    TatuSeedOne(2,
+        "Oko Proroka",
+        "Spirala wokół lewego oka wytrawiona atramentem wizji ze źrenicy "
+        "widziadłowego ptaka. Obdarza noszącego ponadnaturalną "
+        "spostrzegawczością — każdy cień staje się czytelny.",
+        "GLOWA", 60, "ink_sight",
+        0, 0, 17, 3, -1, 0, 0,
+        0, "", 0, 0, 0);
+
+    // Slot SZYJA — 2 designs
+    TatuSeedOne(3,
+        "Pieczęć Zarazy",
+        "Czarny krąg na szyi otoczony wzorem robaków toczących trupią skórę. "
+        "Trucizny i choroby omijają ciało noszącego jak wodę omija rynna — "
+        "lecz ci, którzy go widzą, odwracają wzrok z odrazą.",
+        "SZYJA", 80, "ink_bile",
+        0, 0, -1, 0, 1, 3, 0,
+        1, "Widok pieczęci budzi wstręt — Charyzma –2.",
+        0, 0, 2);
+
+    TatuSeedOne(4,
+        "Kość Milczenia",
+        "Wzór wyryty z proszku kości pokruszonych pod księżycem w pełni. "
+        "Skupia umysł noszącego jak ostrze skalpela — pozwala zachować "
+        "zimną krew nawet gdy piekło kipi wokół.",
+        "SZYJA", 70, "ink_bone",
+        0, 0, 1, 3, -1, 0, 0,
+        0, "", 0, 0, 0);
+
+    // Slot PIERSI — 3 designs
+    TatuSeedOne(5,
+        "Serce Kamienia",
+        "Pełna klatka piersiowa pokryta geometrycznym wzorem skały wulkanicznej. "
+        "Ciało staje się twardą powłoką odporną na ciosy — lecz twarz "
+        "zastyga w chłodnym, kamiennym bezruchu.",
+        "PIERSI", 120, "ink_stone",
+        0, 2, -1, 0, -1, 0, 0,
+        1, "Kamienna twarz odpycha ludzi — Charyzma –2.",
+        0, 0, 2);
+
+    TatuSeedOne(6,
+        "Łańcuch Obrońcy",
+        "Splot łańcuchów wijący się od obojczyka po żebra wzmacnia skórę "
+        "jak zbroję z ciemnego żelaza. Żaden wzór nie oferuje tak "
+        "skutecznej ochrony bez przekleństwa.",
+        "PIERSI", 100, "ink_iron",
+        0, 3, -1, 0, -1, 0, 0,
+        0, "", 0, 0, 0);
+
+    TatuSeedOne(7,
+        "Blizna Ognia",
+        "Fraktalne blizny po ogniu odnowione atramentem z popiołu salamandry. "
+        "Skóra noszącego twardnieje na podmuch płomieni jak hartowana "
+        "stal — ogień staje się jedynie ciepłym tchnieniem.",
+        "PIERSI", 90, "ink_ash",
+        0, 0, -1, 0, -1, 0, 10,
+        0, "", 0, 0, 0);
+
+    // Slot LEWE_RAMIE — 2 designs
+    TatuSeedOne(8,
+        "Skrzydła Nocy",
+        "Para czarnych skrzydeł na lewym ramieniu — atrament ze smoły "
+        "i skropionego cienia. Każdy krok noszącego staje się cichy "
+        "jak lot sowy polującej w mrok.",
+        "LEWE_RAMIE", 50, "ink_shadow",
+        0, 0, 8, 4, -1, 0, 0,
+        0, "", 0, 0, 0);
+
+    TatuSeedOne(9,
+        "Znak Złodzieja",
+        "Sześć linii przecinających się w gwiezdny wzór wygnieciony "
+        "na lewym nadgarstku. Dłoń staje się zwinna i niezauważalna — "
+        "idealna do pracy w cudzej kieszeni.",
+        "LEWE_RAMIE", 45, "ink_shadow",
+        0, 0, 13, 3, -1, 0, 0,
+        0, "", 0, 0, 0);
+
+    // Slot PRAWE_RAMIE — 1 design
+    TatuSeedOne(10,
+        "Pięść Tyranta",
+        "Wzór czarnych kolców spiralujących od łokcia po knykcie prawej ręki. "
+        "Uderzenia stają się mordercze — lecz ciało żyje w permanentnym "
+        "napięciu, drżąco reagując na każdą groźbę.",
+        "PRAWE_RAMIE", 110, "ink_blood",
+        2, 0, -1, 0, -1, 0, 0,
+        1, "Nerwy w gotowości bojowej — wszystkie rzuty obronne –2.",
+        0, 2, 0);
+}
+
+// ----------------------------------------------------------------
+// Queries
+// ----------------------------------------------------------------
+
+json TatuRowToJson(sqlquery q)
+{
+    json j = JsonObject();
+    j = JsonObjectSet(j, "id",          JsonInt   (SqlGetInt   (q, 0)));
+    j = JsonObjectSet(j, "name",        JsonString(SqlGetString(q, 1)));
+    j = JsonObjectSet(j, "description", JsonString(SqlGetString(q, 2)));
+    j = JsonObjectSet(j, "slot",        JsonString(SqlGetString(q, 3)));
+    j = JsonObjectSet(j, "cost_gold",   JsonInt   (SqlGetInt   (q, 4)));
+    j = JsonObjectSet(j, "cost_item",   JsonString(SqlGetString(q, 5)));
+    j = JsonObjectSet(j, "bon_ab",      JsonInt   (SqlGetInt   (q, 6)));
+    j = JsonObjectSet(j, "bon_ac",      JsonInt   (SqlGetInt   (q, 7)));
+    j = JsonObjectSet(j, "bon_skill",   JsonInt   (SqlGetInt   (q, 8)));
+    j = JsonObjectSet(j, "bon_skill_v", JsonInt   (SqlGetInt   (q, 9)));
+    j = JsonObjectSet(j, "bon_save",    JsonInt   (SqlGetInt   (q, 10)));
+    j = JsonObjectSet(j, "bon_save_v",  JsonInt   (SqlGetInt   (q, 11)));
+    j = JsonObjectSet(j, "bon_resist",  JsonInt   (SqlGetInt   (q, 12)));
+    j = JsonObjectSet(j, "is_cursed",   JsonInt   (SqlGetInt   (q, 13)));
+    j = JsonObjectSet(j, "curse_desc",  JsonString(SqlGetString(q, 14)));
+    j = JsonObjectSet(j, "curse_ab",    JsonInt   (SqlGetInt   (q, 15)));
+    j = JsonObjectSet(j, "curse_saves", JsonInt   (SqlGetInt   (q, 16)));
+    j = JsonObjectSet(j, "curse_cha",   JsonInt   (SqlGetInt   (q, 17)));
+    return j;
+}
+
+const string TATU_SELECT_COLS =
+    "SELECT id,name,description,slot,cost_gold,cost_item,"
+    " bon_ab,bon_ac,bon_skill,bon_skill_v,bon_save,bon_save_v,bon_resist,"
+    " is_cursed,curse_desc,curse_ab,curse_saves,curse_cha"
+    " FROM tatu_designs";
+
+json TatuGetAllDesigns()
+{
+    json jArr = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign(TATU_DB,
+        TATU_SELECT_COLS + " ORDER BY slot, id");
+    while(SqlStep(q))
+        jArr = JsonArrayInsert(jArr, TatuRowToJson(q));
+    return jArr;
+}
+
+json TatuGetDesignById(int nId)
+{
+    sqlquery q = SqlPrepareQueryCampaign(TATU_DB,
+        TATU_SELECT_COLS + " WHERE id = @id");
+    SqlBindInt(q, "@id", nId);
+    if(SqlStep(q)) return TatuRowToJson(q);
+    return JsonNull();
+}
+
+json TatuGetPCTattoos(object oPC)
+{
+    json jArr = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign(TATU_DB,
+        "SELECT design_id, slot FROM tatu_pc WHERE pc_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    while(SqlStep(q))
+    {
+        json j = JsonObject();
+        j = JsonObjectSet(j, "design_id", JsonInt   (SqlGetInt   (q, 0)));
+        j = JsonObjectSet(j, "slot",      JsonString(SqlGetString(q, 1)));
+        jArr = JsonArrayInsert(jArr, j);
+    }
+    return jArr;
+}
+
+int TatuGetPCTattooDesignInSlot(object oPC, string sSlot)
+{
+    sqlquery q = SqlPrepareQueryCampaign(TATU_DB,
+        "SELECT design_id FROM tatu_pc WHERE pc_uuid = @uuid AND slot = @slot");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindString(q, "@slot", sSlot);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+void TatuApplyTattoo(object oPC, int nDesignId, string sSlot)
+{
+    sqlquery q = SqlPrepareQueryCampaign(TATU_DB,
+        "INSERT OR REPLACE INTO tatu_pc (pc_uuid, design_id, slot, applied_at)"
+        " VALUES (@uuid, @did, @slot, strftime('%s','now'))");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@did",  nDesignId);
+    SqlBindString(q, "@slot", sSlot);
+    SqlStep(q);
+}
+
+void TatuRemoveTattoo(object oPC, string sSlot)
+{
+    sqlquery q = SqlPrepareQueryCampaign(TATU_DB,
+        "DELETE FROM tatu_pc WHERE pc_uuid = @uuid AND slot = @slot");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindString(q, "@slot", sSlot);
+    SqlStep(q);
+}

--- a/Magical Tattoos/Scripts/sys_on_enter.nss
+++ b/Magical Tattoos/Scripts/sys_on_enter.nss
@@ -1,0 +1,18 @@
+#include "lib_tatu"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC)) return;
+
+    // Re-apply all tattoo effects after login/module restart.
+    // Permanent effects are not persisted across sessions in NWN.
+    TatuApplyEffectsForPC(oPC);
+
+    int nCount = JsonGetLength(TatuGetPCTattoos(oPC));
+    if(nCount > 0)
+        SendMessageToPC(oPC,
+            "[Tatuaże] Nosisz " + IntToString(nCount)
+            + " magiczn" + (nCount == 1 ? "y tatuaż" : "e tatuaże")
+            + ". Pieczęcie pulsują na twojej skórze.");
+}

--- a/Magical Tattoos/Scripts/sys_on_load.nss
+++ b/Magical Tattoos/Scripts/sys_on_load.nss
@@ -1,0 +1,7 @@
+#include "lib_tatu_def"
+
+void main()
+{
+    TatuCreateTables();
+    TatuSeedDesigns();
+}

--- a/Magical Tattoos/Scripts/test_tatu.nss
+++ b/Magical Tattoos/Scripts/test_tatu.nss
@@ -1,0 +1,11 @@
+// OnUsed script for a "Pracownia Tatuaży" placeable.
+// Place on any NWN placeable to open the tattoo studio UI.
+#include "lib_tatu"
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    TatuOpenWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

System magicznych tatuaży pozwala graczom trwale modyfikować postać przez nanoszenie zapieczętowanych wzorów na 5 miejsc ciała. UI otwiera się przez placeable tatuażysty, wyświetla listę 10 dostępnych wzorów oraz anatomiczną „mapę ciała" z aktualnymi tatuażami.

## Mechanika

- **5 miejsc ciała** (Głowa, Szyja, Piersi, Lewe Ramię, Prawe Ramię) — każde może mieć co najwyżej jeden tatuaż.
- **10 wzorów** o różnych efektach mechanicznych: bonus do ataku, AC, umiejętności (Spostrzegawczość, Skupienie, Skradanie, Kieszonkowstwo), rzutów obronnych (Tężyzna), odporności na ogień.
- **Przeklęte tatuaże** (3 z 10): silniejszy bonus kosztem kary (–CHA lub –rzuty obronne). Przekleństwo nakłada się jako osobny tagged effect.
- **Wymagania do nałożenia**: określona kwota złota + item attramentu o konkretnym tagu (np. `ink_crow`). Atrament jest niszczony po użyciu.
- **Usunięcie**: 150 zł + 5 obrażeń magicznych (wypalanie żelazem).
- **Persystencja**: dane w SQLite (`tatu_designs`, `tatu_pc`). Efekty są re-aplikowane przy każdym logowaniu (`sys_on_enter`), bo NWN nie przechowuje DURATION_TYPE_PERMANENT między sesjami.
- **Tagowanie efektów**: każdy slot używa unikalnego tagu efektu (`TATU_EFFECT_TAG_BASE + slot_idx = 7000..7004`) — usuwa tylko własne efekty przy podmianie.

## Pliki

```
Magical Tattoos/
├── Scripts/
│   ├── sql_tatu.nss          — schemat SQL, seed 10 wzorów, zapytania CRUD
│   ├── lib_tatu_def.nss      — stałe NUI, helpery slotów, forward deklaracje
│   ├── lib_tatu.nss          — logika UI (window builder, feed, Apply/Remove)
│   ├── lib_tatu_ev.nss       — handler zdarzeń NUI
│   ├── sys_on_load.nss       — init tabel + seed przy starcie modułu
│   ├── sys_on_enter.nss      — re-aplikacja efektów przy wejściu gracza
│   ├── test_tatu.nss         — OnUsed dla placeable pracowni
│   ├── lib_nui.nss           — wspólne narzędzia NUI (kopia)
│   └── lib_nui_utility.nss   — wspólne utility NUI (kopia)
└── INTEGRATION.md            — instrukcja podpięcia, tabela atramentów
```

## Zależności (NWNX? SQL?)

- **SQL**: `SqlPrepareQueryCampaign("tatu", ...)` — standard NWN campaign DB, bez NWNX.
- **NWNX**: brak. Moduł używa wyłącznie standardowego NWScript API.
- **NUI**: standardowe nw_inc_nui (dołączone przez lib_nui.nss).

## Jak włączyć w istniejącym module

1. Skopiować wszystkie pliki z `Scripts/` do skryptów modułu / haka.
2. W `OnModuleLoad` wywołać `TatuCreateTables(); TatuSeedDesigns();`.
3. W `OnClientEnter` wywołać `TatuApplyEffectsForPC(GetEnteringObject());`.
4. Stworzyć placeable z `OnUsed = test_tatu`.
5. Dodać do loot/sklepów itemy tagami `ink_crow`, `ink_sight`, itd. (szczegóły w INTEGRATION.md).

## Co celowo pominięto

- Własne ikony/grafiki tatuaży (brak zasobów graficznych w repozytorium).
- Efekty VFX przy nanoszeniu (łatwo dodać `ApplyEffectToObject(INSTANT, EffectVisualEffect(...), oPC)`).
- Ograniczenia wzorów do klas postaci (rozszerzalne przez dodanie kolumny `req_class` w `tatu_designs`).
- GM-narzędzie do dodawania wzorów w locie przez UI.


---
_Generated by [Claude Code](https://claude.ai/code/session_017GHYbUvy8RKTn8Ngt66Q9f)_