### PR TITLE
feat: Sigil Wards

### DIFF
--- a/Sigil Wards/INTEGRATION.md
+++ b/Sigil Wards/INTEGRATION.md
@@ -1,0 +1,94 @@
+# Sigil Wards — Integracja z modułem
+
+## Wymagania
+
+- NWN:EE 8193.36+ (NUI, SqlPrepareQueryCampaign)
+- Brak zależności NWNX
+- Brak niestandardowych zasobów HAK (wizualne efekty używają stockowych VFX)
+
+## Hooki do podłączenia
+
+| Zdarzenie modułu | Skrypt         |
+|------------------|----------------|
+| OnModuleLoad     | `sys_on_load`  |
+| OnClientEnter    | `sys_on_enter` |
+| OnHeartbeat      | `sys_on_hb`    |
+
+> Jeśli inne systemy używają tych zdarzeń, wywołaj funkcje `SglXxx` z istniejącego hooka
+> zamiast nadpisywać skrypt. Wszystkie pliki `sys_on_*.nss` są cienkie i jednolinijkowe.
+
+## Otwieranie panelu gracza
+
+Umieść placeable w module (np. „Tablica Znaków Ochronnych"), ustaw jego skrypt
+`OnUsed = test_sgl`. Alternatywnie wywołaj `CreateSglWindow(oPC)` z dowolnego miejsca
+w kodzie — np. komendy czatu, zdarzenia itemu, rozmowy z NPC.
+
+```nss
+#include "lib_sgl"
+
+void main()
+{
+    CreateSglWindow(GetPCSpeaker());
+}
+```
+
+## Baza danych
+
+Dane są przechowywane w Campaign DB o nazwie `sigil_wards`. Skrypt `sys_on_load`
+tworzy tabele idempotentnie (`CREATE TABLE IF NOT EXISTS`). Nie trzeba
+nic robić ręcznie — pierwsze uruchomienie modułu zakłada schemat.
+
+Tabele:
+- `sgl_sigils` — aktywne znaki (właściciel, obszar, współrzędne, typ, ładunki)
+- `sgl_attuned` — uprawnienia dostępu per znak
+- `sgl_players` — rejestr graczy (do wyszukiwania w panelu dostępu)
+
+## Mechanika sprawdzania bliskości
+
+`sys_on_hb` uruchamia `SglCheckProximity()` co ~18 sekund (co 3. tik
+heartbeat = co 3 × 6 s). Funkcja zapytuje SQL o wszystkie aktywne znaki,
+iteruje graczy online i porównuje dystans. Jeśli gracz jest bliżej niż
+`SGL_TRIGGER_RADIUS` (domyślnie 4,5 m) i nie jest właścicielem ani
+uprawnionym, znak wyzwala efekt i traci jeden ładunek.
+
+Cooldown 30 sekund (local int na graczu) zapobiega wielokrotnemu
+wyzwalaniu tego samego znaku przy staniu w miejscu.
+
+## Konfiguracja
+
+Stałe dostępne do zmiany w `lib_sgl_def.nss`:
+
+| Stała                 | Domyślnie | Opis                                    |
+|-----------------------|-----------|-----------------------------------------|
+| `SGL_MAX_SIGILS`      | 5         | Maks. aktywnych znaków na gracza        |
+| `SGL_TRIGGER_RADIUS`  | 4.5       | Promień wyzwalania (metry)              |
+| `SGL_HB_MODULO`       | 3         | Sprawdzenie co N heartbeatów (~18 s)   |
+| `SGL_COOLDOWN_SECONDS`| 30        | Cooldown retrigera dla tej samej pary  |
+| `SGL_MAX_ATTUNED`     | 10        | Maks. uprawnionych na znak              |
+
+Ładunki per typ (w `sql_sgl.nss`):
+
+| Typ            | Ładunki | Efekt                              |
+|----------------|---------|------------------------------------|
+| Alarm          | 10      | Powiadomienie; brak obrażeń        |
+| Porażenie      | 5       | 1k8 obrażeń elektrycznych          |
+| Unieruchomienie| 3       | Paraliż 6 sekund                   |
+| Trwoga         | 5       | Przerażenie 8 sekund               |
+
+## Efekty wizualne lokalizacji
+
+Przy umieszczeniu znaku i po restarcie serwera (`SglRestoreVisuals`) skrypt
+aplikuje `VFX_DUR_PROT_PREMONITION` jako tymczasową poświatę (1 godzina).
+Efekty nie są persystentne między restartami — są odtwarzane przy każdym
+załadowaniu modułu. Przy dużej liczbie aktywnych znaków i częstych
+restartach można wyłączyć `SglRestoreVisuals()` z `sys_on_load` bez utraty
+danych (znaki w SQL nadal działają).
+
+## Celowo pominięto
+
+- HAK / nowe assety — brak własnych ikon i tekstur; moduł działa na stockowych VFX
+- DM-panel do podglądu wszystkich znaków na mapie
+- Wyszukiwarka offline-graczy w panelu dostępu (widoczni tylko zalogowani gracze)
+- Item „kreda sygilów" jako wymóg użycia (prosty do dodania: sprawdzenie inventarza
+  w `SglPlaceAtLocation` przed insertem do SQL)
+- Ograniczenie do konkretnych ras/klas (można sprawdzić `GetRacialType` w `SglPlaceAtLocation`)

--- a/Sigil Wards/Scripts/lib_nui.nss
+++ b/Sigil Wards/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Sigil Wards/Scripts/lib_nui_utility.nss
+++ b/Sigil Wards/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Sigil Wards/Scripts/lib_sgl.nss
+++ b/Sigil Wards/Scripts/lib_sgl.nss
@@ -1,0 +1,743 @@
+#include "lib_sgl_def"
+
+// ----------------------------------------------------------------
+// Sigil type metadata
+// ----------------------------------------------------------------
+
+string SglGetTypeName(int nType)
+{
+    switch(nType)
+    {
+        case SGL_TYPE_ALARM: return "Alarm";
+        case SGL_TYPE_SHOCK: return "Porażenie";
+        case SGL_TYPE_HOLD:  return "Unieruchomienie";
+        case SGL_TYPE_FEAR:  return "Trwoga";
+    }
+    return "Nieznany";
+}
+
+string SglGetTypeDesc(int nType)
+{
+    switch(nType)
+    {
+        case SGL_TYPE_ALARM:
+            return "Kamień pulsuje bladym blaskiem. Kiedy intruz wkroczy w krąg znaku, "
+                 + "właściciel zostaje powiadomiony — cichy strażnik, co nie atakuje, "
+                 + "lecz nigdy nie śpi.";
+        case SGL_TYPE_SHOCK:
+            return "Runa iskrzy mroczną elektrycznością, wyryta krwią i solą. Każdy, kto "
+                 + "przekroczy granicę znaku bez klucza dostępu, przyjmie na siebie "
+                 + "uderzenie piorunu.";
+        case SGL_TYPE_HOLD:
+            return "Symbol więzi, wyryta w kamieniu bladym ogniem. Intruz zastyga w miejscu, "
+                 + "skuty niewidzialnym kajdanem przez kilka okrutnych sekund.";
+        case SGL_TYPE_FEAR:
+            return "Pieczęć strachu przemawia do pierwotnych lęków. Intruz traci odwagę "
+                 + "i ucieka, ogarnięty paniką, której nie potrafi wyjaśnić.";
+    }
+    return "";
+}
+
+json SglGetTypeColor(int nType)
+{
+    switch(nType)
+    {
+        case SGL_TYPE_ALARM: return NuiColor(220, 220, 160);
+        case SGL_TYPE_SHOCK: return NuiColor(100, 160, 255);
+        case SGL_TYPE_HOLD:  return NuiColor(100, 220, 140);
+        case SGL_TYPE_FEAR:  return NuiColor(200,  80, 200);
+    }
+    return NuiColor(200, 200, 200);
+}
+
+int SglGetDefaultCharges(int nType)
+{
+    switch(nType)
+    {
+        case SGL_TYPE_ALARM: return SGL_CHARGES_ALARM;
+        case SGL_TYPE_SHOCK: return SGL_CHARGES_SHOCK;
+        case SGL_TYPE_HOLD:  return SGL_CHARGES_HOLD;
+        case SGL_TYPE_FEAR:  return SGL_CHARGES_FEAR;
+    }
+    return 5;
+}
+
+// Returns "3/5" style string for display
+string SglChargesLabel(int nCurrent, int nType)
+{
+    return IntToString(nCurrent) + "/" + IntToString(SglGetDefaultCharges(nType));
+}
+
+// ----------------------------------------------------------------
+// Notify owner if online
+// ----------------------------------------------------------------
+
+void SglNotifyOwner(string sOwnerUuid, int nSigilId, int nType,
+                    string sAreaName, int nChargesLeft)
+{
+    string sTypeName = SglGetTypeName(nType);
+    string sMsg;
+
+    if(nChargesLeft <= 0)
+        sMsg = "[Znak Ochronny] " + sTypeName + " w strefie „" + sAreaName
+             + "" wyczerpał ładunki i zgasł.";
+    else
+        sMsg = "[Znak Ochronny] " + sTypeName + " wyzwolony w strefie „" + sAreaName
+             + "" — pozostało " + IntToString(nChargesLeft) + " ładunków.";
+
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        if(GetObjectUUID(oPC) == sOwnerUuid)
+        {
+            SendMessageToPC(oPC, sMsg);
+            int nToken = NuiFindWindow(oPC, SGL_WINDOW);
+            if(nToken != 0)
+                FeedSglList(oPC, nToken);
+            return;
+        }
+        oPC = GetNextPC();
+    }
+}
+
+// ----------------------------------------------------------------
+// Apply sigil trigger effect on oVictim
+// ----------------------------------------------------------------
+
+void SglFireEffect(object oVictim, int nType, int nSigilId,
+                   string sOwnerUuid, location lSigil, string sAreaName)
+{
+    // Sigil-location visual pulse
+    int nLocVfx = VFX_IMP_SONIC;
+    switch(nType)
+    {
+        case SGL_TYPE_ALARM: nLocVfx = VFX_IMP_SONIC;       break;
+        case SGL_TYPE_SHOCK: nLocVfx = VFX_IMP_LIGHTNING_S; break;
+        case SGL_TYPE_HOLD:  nLocVfx = VFX_IMP_HOLD;        break;
+        case SGL_TYPE_FEAR:  nLocVfx = VFX_IMP_FEAR_S;      break;
+    }
+    ApplyEffectAtLocation(DURATION_TYPE_INSTANT, EffectVisualEffect(nLocVfx), lSigil);
+
+    // Victim effect
+    switch(nType)
+    {
+        case SGL_TYPE_ALARM:
+            // No combat effect — only notification
+            FloatingTextStringOnCreature(
+                "Signum Custodis!", oVictim, FALSE);
+            SendMessageToPC(oVictim,
+                "[Znak Ochronny] Alarm! Naruszasz chroniony krąg — właściciel zostaje powiadomiony.");
+            break;
+
+        case SGL_TYPE_SHOCK:
+            ApplyEffectToObject(DURATION_TYPE_INSTANT,
+                EffectVisualEffect(VFX_COM_HIT_ELECTRICAL), oVictim);
+            ApplyEffectToObject(DURATION_TYPE_INSTANT,
+                EffectDamage(d8(1), DAMAGE_TYPE_ELECTRICAL, DAMAGE_POWER_NORMAL), oVictim);
+            SendMessageToPC(oVictim,
+                "[Znak Ochronny] Runa porażenia uderza cię elektryczną mocą!");
+            break;
+
+        case SGL_TYPE_HOLD:
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                EffectParalyze(), oVictim, 6.0);
+            ApplyEffectToObject(DURATION_TYPE_INSTANT,
+                EffectVisualEffect(VFX_DUR_PARALYZED), oVictim);
+            SendMessageToPC(oVictim,
+                "[Znak Ochronny] Znak więzi zaciska się na tobie — nie możesz się ruszyć!");
+            break;
+
+        case SGL_TYPE_FEAR:
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                EffectFrightened(), oVictim, 8.0);
+            ApplyEffectToObject(DURATION_TYPE_INSTANT,
+                EffectVisualEffect(VFX_IMP_FEAR_S), oVictim);
+            SendMessageToPC(oVictim,
+                "[Znak Ochronny] Pieczęć trwogi wypełnia twój umysł pierwotnym strachem!");
+            break;
+    }
+
+    int nRemaining = SglDecrementCharges(nSigilId);
+    SglNotifyOwner(sOwnerUuid, nSigilId, nType, sAreaName, nRemaining);
+
+    if(nRemaining <= 0)
+        SglRemoveSigil(nSigilId);
+}
+
+// ----------------------------------------------------------------
+// Heartbeat proximity check — called from sys_on_hb.nss
+// ----------------------------------------------------------------
+
+void SglCheckProximity()
+{
+    json jSigils = SglGetAllActiveSigils();
+    int nSigilCount = JsonGetLength(jSigils);
+    if(nSigilCount == 0) return;
+
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        if(!GetIsPC(oPC) || GetIsDMPossessed(oPC))
+        {
+            oPC = GetNextPC();
+            continue;
+        }
+
+        object oArea    = GetArea(oPC);
+        string sPCArea  = GetTag(oArea);
+        location lPC    = GetLocation(oPC);
+
+        int i;
+        for(i = 0; i < nSigilCount; i++)
+        {
+            json jSig = JsonArrayGet(jSigils, i);
+
+            if(JsonGetString(JsonObjectGet(jSig, "area_tag")) != sPCArea) continue;
+
+            int    nId        = JsonGetInt   (JsonObjectGet(jSig, "id"));
+            string sOwnerUuid = JsonGetString(JsonObjectGet(jSig, "owner_uuid"));
+
+            if(GetObjectUUID(oPC) == sOwnerUuid) continue;
+
+            // Cooldown prevents re-triggering the same sigil within SGL_COOLDOWN_SECONDS
+            string sCool = "SGL_COOL_" + IntToString(nId);
+            if(GetLocalInt(oPC, sCool)) continue;
+
+            float fX = JsonGetFloat(JsonObjectGet(jSig, "pos_x"));
+            float fY = JsonGetFloat(JsonObjectGet(jSig, "pos_y"));
+            float fZ = JsonGetFloat(JsonObjectGet(jSig, "pos_z"));
+
+            location lSig = Location(oArea, Vector(fX, fY, fZ), 0.0);
+            float fDist   = GetDistanceBetweenLocations(lPC, lSig);
+
+            if(fDist < 0.0 || fDist > SGL_TRIGGER_RADIUS) continue;
+
+            if(SglIsAttuned(nId, GetObjectUUID(oPC))) continue;
+
+            // Arm cooldown before firing so re-entrant calls during effect don't double-fire
+            SetLocalInt(oPC, sCool, 1);
+            DelayCommand(IntToFloat(SGL_COOLDOWN_SECONDS), DeleteLocalInt(oPC, sCool));
+
+            int    nType     = JsonGetInt   (JsonObjectGet(jSig, "sigil_type"));
+            string sAreaName = JsonGetString(JsonObjectGet(jSig, "area_name"));
+            SglFireEffect(oPC, nType, nId, sOwnerUuid, lSig, sAreaName);
+        }
+
+        oPC = GetNextPC();
+    }
+}
+
+// ----------------------------------------------------------------
+// Place a new sigil at caller's location
+// ----------------------------------------------------------------
+
+void SglPlaceAtLocation(object oPC, int nType)
+{
+    if(SglGetPlayerSigilCount(oPC) >= SGL_MAX_SIGILS)
+    {
+        SendMessageToPC(oPC, "[Znak Ochronny] Nie możesz utrzymać więcej niż "
+            + IntToString(SGL_MAX_SIGILS) + " aktywnych znaków.");
+        return;
+    }
+
+    object oArea    = GetArea(oPC);
+    vector vPos     = GetPosition(oPC);
+    string sAreaTag = GetTag(oArea);
+    string sAreaName= GetName(oArea);
+    int    nCharges = SglGetDefaultCharges(nType);
+
+    int nId = SglPlaceSigil(oPC, sAreaTag, sAreaName,
+                             vPos.x, vPos.y, vPos.z, nType, nCharges);
+    if(nId <= 0)
+    {
+        SendMessageToPC(oPC, "[Znak Ochronny] Nie udało się wpisać znaku w kamień.");
+        return;
+    }
+
+    // Temporary glow at placement site (1 hour; cleared on restart, restored by sys_on_load)
+    location lPlace = Location(oArea, vPos, 0.0);
+    ApplyEffectAtLocation(DURATION_TYPE_TEMPORARY,
+        EffectVisualEffect(VFX_DUR_PROT_PREMONITION), lPlace, 3600.0);
+
+    SendMessageToPC(oPC, "[Znak Ochronny] " + SglGetTypeName(nType)
+        + " wpisany w kamień. Ładunki: " + IntToString(nCharges) + ".");
+}
+
+// ----------------------------------------------------------------
+// Build — List View
+// ----------------------------------------------------------------
+
+json BuildSglListView(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 28.0);
+    float fRowH  = GetNuiScaleDimension(oPC, 26.0);
+    float fListH = GetNuiScaleDimension(oPC, 280.0);
+    float fTypeW = GetNuiScaleDimension(oPC, 130.0);
+    float fChgW  = GetNuiScaleDimension(oPC, 70.0);
+
+    // Header label
+    json jHeader = NuiLabel(NuiBind(SGL_BIND_HEADER),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jHeader = NuiHeight(jHeader, fBtnH);
+
+    json jPlaceBtn = NuiButton(JsonString("Nowy Znak"));
+    jPlaceBtn = NuiId(jPlaceBtn, SGL_BTN_PLACE_OPEN);
+    jPlaceBtn = NuiWidth(jPlaceBtn, GetNuiScaleDimension(oPC, 110.0));
+    jPlaceBtn = NuiHeight(jPlaceBtn, fBtnH);
+
+    json jTopRow = JsonArray();
+    jTopRow = JsonArrayInsert(jTopRow, jHeader);
+    jTopRow = JsonArrayInsert(jTopRow, NuiSpacer());
+    jTopRow = JsonArrayInsert(jTopRow, jPlaceBtn);
+
+    // Row template: [Typ | Strefa (elastic) | Ładunki]
+    json jTypeLbl = NuiLabel(NuiBind(SGL_BIND_ROW_TYPE),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTypeLbl = NuiStyleForegroundColor(jTypeLbl, NuiBind(SGL_BIND_ROW_COLOR));
+    jTypeLbl = NuiWidth(jTypeLbl, fTypeW);
+
+    json jAreaLbl = NuiLabel(NuiBind(SGL_BIND_ROW_AREA),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jAreaLbl = NuiStyleForegroundColor(jAreaLbl, NuiBind(SGL_BIND_ROW_COLOR));
+
+    json jChgLbl = NuiLabel(NuiBind(SGL_BIND_ROW_CHARGES),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jChgLbl = NuiStyleForegroundColor(jChgLbl, NuiBind(SGL_BIND_ROW_COLOR));
+    jChgLbl = NuiWidth(jChgLbl, fChgW);
+
+    json jCellCols = JsonArray();
+    jCellCols = JsonArrayInsert(jCellCols, jTypeLbl);
+    jCellCols = JsonArrayInsert(jCellCols, jAreaLbl);
+    jCellCols = JsonArrayInsert(jCellCols, jChgLbl);
+
+    json jCell = NuiGroup(NuiRow(jCellCols), TRUE, NUI_SCROLLBARS_NONE);
+    jCell = NuiId(jCell, SGL_BTN_ROW);
+    jCell = NuiEncouraged(jCell, NuiBind(SGL_BIND_ROW_ENC));
+
+    json jTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jCell, 0.0, TRUE));
+    json jList = NuiList(jTmpl, NuiBind(SGL_BIND_LIST_COUNT), fRowH);
+    jList = NuiHeight(jList, fListH);
+
+    // Bottom action bar
+    json jDisarmBtn = NuiButton(JsonString("Rozbrój"));
+    jDisarmBtn = NuiId(jDisarmBtn, SGL_BTN_DISARM);
+    jDisarmBtn = NuiEnabled(jDisarmBtn, NuiBind(SGL_BIND_DISARM_ENA));
+    jDisarmBtn = NuiWidth(jDisarmBtn, GetNuiScaleDimension(oPC, 100.0));
+    jDisarmBtn = NuiHeight(jDisarmBtn, fBtnH);
+    jDisarmBtn = NuiTooltip(jDisarmBtn, JsonString("Usuń wybrany znak i odzyskaj kamień."));
+
+    json jAttBtn = NuiButton(JsonString("Dostęp"));
+    jAttBtn = NuiId(jAttBtn, SGL_BTN_ATT_OPEN);
+    jAttBtn = NuiEnabled(jAttBtn, NuiBind(SGL_BIND_ATT_ENA));
+    jAttBtn = NuiWidth(jAttBtn, GetNuiScaleDimension(oPC, 100.0));
+    jAttBtn = NuiHeight(jAttBtn, fBtnH);
+    jAttBtn = NuiTooltip(jAttBtn, JsonString("Zarządzaj kto może przejść przez wybrany znak."));
+
+    json jBotRow = JsonArray();
+    jBotRow = JsonArrayInsert(jBotRow, jDisarmBtn);
+    jBotRow = JsonArrayInsert(jBotRow, NuiSpacer());
+    jBotRow = JsonArrayInsert(jBotRow, jAttBtn);
+
+    // Column assembly
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(jTopRow));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, jList);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBotRow));
+
+    float fContentW = GetNuiScaleDimension(oPC, SGL_W - 40.0);
+    json jSide      = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    json jMainRow   = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiCol(jCol), fContentW));
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    return NuiRow(jMainRow);
+}
+
+// ----------------------------------------------------------------
+// Build — Place View
+// ----------------------------------------------------------------
+
+json BuildSglPlaceView(object oPC)
+{
+    float fBtnH    = GetNuiScaleDimension(oPC, 28.0);
+    float fDescH   = GetNuiScaleDimension(oPC, 130.0);
+    float fArrowW  = GetNuiScaleDimension(oPC, 36.0);
+
+    // Type picker row: [◄] Type Name [►]
+    json jPrev = NuiButton(JsonString("◄"));
+    jPrev = NuiId(jPrev, SGL_BTN_TYPE_PREV);
+    jPrev = NuiWidth(jPrev, fArrowW);
+    jPrev = NuiHeight(jPrev, fBtnH);
+
+    json jTypeLbl = NuiLabel(NuiBind(SGL_BIND_PLACE_TYPE_LBL),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    json jNext = NuiButton(JsonString("►"));
+    jNext = NuiId(jNext, SGL_BTN_TYPE_NEXT);
+    jNext = NuiWidth(jNext, fArrowW);
+    jNext = NuiHeight(jNext, fBtnH);
+
+    json jPickerRow = JsonArray();
+    jPickerRow = JsonArrayInsert(jPickerRow, jPrev);
+    jPickerRow = JsonArrayInsert(jPickerRow, jTypeLbl);
+    jPickerRow = JsonArrayInsert(jPickerRow, jNext);
+
+    // Description text
+    json jDesc = NuiGroup(NuiText(NuiBind(SGL_BIND_PLACE_TYPE_DESC), FALSE),
+        TRUE, NUI_SCROLLBARS_NONE);
+    jDesc = NuiHeight(jDesc, fDescH);
+
+    // Charges info
+    json jChgLbl = NuiLabel(NuiBind(SGL_BIND_PLACE_CHARGES),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jChgLbl = NuiHeight(jChgLbl, GetNuiScaleDimension(oPC, 22.0));
+
+    // Confirm / Back
+    json jConfBtn = NuiButton(JsonString("Wpisz Znak Tutaj"));
+    jConfBtn = NuiId(jConfBtn, SGL_BTN_PLACE_CONF);
+    jConfBtn = NuiWidth(jConfBtn, GetNuiScaleDimension(oPC, 170.0));
+    jConfBtn = NuiHeight(jConfBtn, fBtnH);
+
+    json jBackBtn = NuiButton(JsonString("Anuluj"));
+    jBackBtn = NuiId(jBackBtn, SGL_BTN_BACK);
+    jBackBtn = NuiWidth(jBackBtn, GetNuiScaleDimension(oPC, 90.0));
+    jBackBtn = NuiHeight(jBackBtn, fBtnH);
+
+    json jBotRow = JsonArray();
+    jBotRow = JsonArrayInsert(jBotRow, jBackBtn);
+    jBotRow = JsonArrayInsert(jBotRow, NuiSpacer());
+    jBotRow = JsonArrayInsert(jBotRow, jConfBtn);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jPickerRow));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jDesc);
+    jCol = JsonArrayInsert(jCol, jChgLbl);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBotRow));
+
+    float fContentW = GetNuiScaleDimension(oPC, SGL_W - 40.0);
+    json jSide      = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    json jMainRow   = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiCol(jCol), fContentW));
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    return NuiRow(jMainRow);
+}
+
+// ----------------------------------------------------------------
+// Build — Attune View
+// ----------------------------------------------------------------
+
+json BuildSglAttuneView(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 28.0);
+    float fRowH  = GetNuiScaleDimension(oPC, 24.0);
+    float fListH = GetNuiScaleDimension(oPC, 130.0);
+
+    // Sigil info header
+    json jHeader = NuiLabel(NuiBind(SGL_BIND_ATT_HEADER),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jHeader = NuiHeight(jHeader, fBtnH);
+
+    // Attuned player list
+    json jAttLbl = NuiLabel(NuiBind(SGL_BIND_ATT_NAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    json jAttCell = NuiGroup(NuiRow(JsonArrayInsert(JsonArray(), jAttLbl)),
+        TRUE, NUI_SCROLLBARS_NONE);
+    jAttCell = NuiId(jAttCell, SGL_BTN_ATT_ROW);
+    jAttCell = NuiEncouraged(jAttCell, NuiBind(SGL_BIND_ATT_ENC));
+
+    json jAttTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jAttCell, 0.0, TRUE));
+    json jAttList = NuiList(jAttTmpl, NuiBind(SGL_BIND_ATT_COUNT), fRowH);
+    jAttList = NuiHeight(jAttList, fListH);
+
+    json jRevoke = NuiButton(JsonString("Usuń dostęp"));
+    jRevoke = NuiId(jRevoke, SGL_BTN_REVOKE);
+    jRevoke = NuiEnabled(jRevoke, NuiBind(SGL_BIND_REVOKE_ENA));
+    jRevoke = NuiWidth(jRevoke, GetNuiScaleDimension(oPC, 130.0));
+    jRevoke = NuiHeight(jRevoke, fBtnH);
+
+    // Online player list to grant access
+    json jOnlineLbl = NuiLabel(JsonString("Gracze online (kliknij by nadać dostęp):"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jOnlineLbl = NuiHeight(jOnlineLbl, GetNuiScaleDimension(oPC, 20.0));
+
+    json jOLbl = NuiLabel(NuiBind(SGL_BIND_ONLINE_NAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    json jOCell = NuiGroup(NuiRow(JsonArrayInsert(JsonArray(), jOLbl)),
+        TRUE, NUI_SCROLLBARS_NONE);
+    jOCell = NuiId(jOCell, SGL_BTN_ONLINE_ROW);
+    jOCell = NuiEncouraged(jOCell, NuiBind(SGL_BIND_ONLINE_ENC));
+
+    json jOTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jOCell, 0.0, TRUE));
+    json jOList = NuiList(jOTmpl, NuiBind(SGL_BIND_ONLINE_CNT), fRowH);
+    jOList = NuiHeight(jOList, fListH);
+
+    // Back
+    json jBackBtn = NuiButton(JsonString("Wstecz"));
+    jBackBtn = NuiId(jBackBtn, SGL_BTN_BACK);
+    jBackBtn = NuiWidth(jBackBtn, GetNuiScaleDimension(oPC, 90.0));
+    jBackBtn = NuiHeight(jBackBtn, fBtnH);
+
+    json jRevRow = JsonArray();
+    jRevRow = JsonArrayInsert(jRevRow, NuiSpacer());
+    jRevRow = JsonArrayInsert(jRevRow, jRevoke);
+
+    json jBotRow = JsonArray();
+    jBotRow = JsonArrayInsert(jBotRow, jBackBtn);
+    jBotRow = JsonArrayInsert(jBotRow, NuiSpacer());
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jHeader);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, jAttList);
+    jCol = JsonArrayInsert(jCol, NuiRow(jRevRow));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jOnlineLbl);
+    jCol = JsonArrayInsert(jCol, jOList);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBotRow));
+
+    float fContentW = GetNuiScaleDimension(oPC, SGL_W - 40.0);
+    json jSide      = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    json jMainRow   = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiCol(jCol), fContentW));
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    return NuiRow(jMainRow);
+}
+
+// ----------------------------------------------------------------
+// Window create / swap
+// ----------------------------------------------------------------
+
+void CreateSglWindow(object oPC)
+{
+    if(NuiFindWindow(oPC, SGL_WINDOW) != 0)
+    {
+        NuiSetGroupLayout(oPC, NuiFindWindow(oPC, SGL_WINDOW),
+            SGL_GRP_SWAP, BuildSglListView(oPC));
+        FeedSglList(oPC, NuiFindWindow(oPC, SGL_WINDOW));
+        return;
+    }
+
+    float fW = GetNuiScaleDimension(oPC, SGL_W);
+    float fH = GetNuiScaleDimension(oPC, SGL_H);
+    float fX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - fW) / 2.0;
+    float fY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - fH) / 2.0;
+    json jGeom = NuiRect(fX, fY, fW, fH);
+
+    float fBtnH = GetNuiScaleDimension(oPC, 28.0);
+    json jCloseBtn = NuiButton(JsonString("X"));
+    jCloseBtn = NuiId(jCloseBtn, SGL_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, GetNuiScaleDimension(oPC, 28.0));
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jTitleRow = JsonArray();
+    jTitleRow = JsonArrayInsert(jTitleRow, NuiSpacer());
+    jTitleRow = JsonArrayInsert(jTitleRow, jCloseBtn);
+
+    json jSwapGrp = NuiGroup(BuildSglListView(oPC), FALSE, NUI_SCROLLBARS_NONE);
+    jSwapGrp = NuiId(jSwapGrp, SGL_GRP_SWAP);
+
+    json jRootCols = JsonArray();
+    jRootCols = JsonArrayInsert(jRootCols, NuiRow(jTitleRow));
+    jRootCols = JsonArrayInsert(jRootCols, jSwapGrp);
+    json jRoot = NuiCol(jRootCols);
+
+    json jWin = NuiWindow(jRoot,
+        JsonString("Znaki Ochronne"),
+        NuiBind(SGL_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    int nToken = NuiCreate(oPC, jWin, SGL_WINDOW, SGL_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, SGL_WIN_GEOM, jGeom);
+
+    FeedSglList(oPC, nToken);
+}
+
+void SwapToListView(object oPC, int nToken)
+{
+    SetLocalInt(oPC, SGL_LVAR_SEL_ID, 0);
+    DeleteLocalString(oPC, SGL_LVAR_SEL_ATT);
+    NuiSetGroupLayout(oPC, nToken, SGL_GRP_SWAP, BuildSglListView(oPC));
+    FeedSglList(oPC, nToken);
+}
+
+void SwapToPlaceView(object oPC, int nToken)
+{
+    SetLocalInt(oPC, SGL_LVAR_TYPE_IDX, SGL_TYPE_ALARM);
+    NuiSetGroupLayout(oPC, nToken, SGL_GRP_SWAP, BuildSglPlaceView(oPC));
+    FeedSglPlace(oPC, nToken);
+}
+
+void SwapToAttuneView(object oPC, int nToken)
+{
+    DeleteLocalString(oPC, SGL_LVAR_SEL_ATT);
+    NuiSetGroupLayout(oPC, nToken, SGL_GRP_SWAP, BuildSglAttuneView(oPC));
+    FeedSglAttune(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Feed — List View
+// ----------------------------------------------------------------
+
+void FeedSglList(object oPC, int nToken)
+{
+    json jSigils = SglGetPlayerSigils(oPC);
+    int  nCount  = JsonGetLength(jSigils);
+    int  nMax    = SGL_MAX_SIGILS;
+
+    NuiSetBind(oPC, nToken, SGL_BIND_HEADER,
+        JsonString("Aktywne znaki: " + IntToString(nCount) + "/" + IntToString(nMax)));
+
+    json jTypes   = JsonArray();
+    json jAreas   = JsonArray();
+    json jCharges = JsonArray();
+    json jEncs    = JsonArray();
+    json jColors  = JsonArray();
+
+    int nSelId = GetLocalInt(oPC, SGL_LVAR_SEL_ID);
+
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json   jSig    = JsonArrayGet(jSigils, i);
+        int    nId     = JsonGetInt   (JsonObjectGet(jSig, "id"));
+        int    nType   = JsonGetInt   (JsonObjectGet(jSig, "sigil_type"));
+        int    nChg    = JsonGetInt   (JsonObjectGet(jSig, "charges"));
+        string sArea   = JsonGetString(JsonObjectGet(jSig, "area_name"));
+
+        jTypes   = JsonArrayInsert(jTypes,   JsonString(SglGetTypeName(nType)));
+        jAreas   = JsonArrayInsert(jAreas,   JsonString(sArea));
+        jCharges = JsonArrayInsert(jCharges, JsonString(SglChargesLabel(nChg, nType)));
+        jEncs    = JsonArrayInsert(jEncs,    JsonBool(nSelId > 0 && nId == nSelId));
+        jColors  = JsonArrayInsert(jColors,  SglGetTypeColor(nType));
+    }
+
+    NuiSetBind(oPC, nToken, SGL_BIND_ROW_TYPE,    jTypes);
+    NuiSetBind(oPC, nToken, SGL_BIND_ROW_AREA,    jAreas);
+    NuiSetBind(oPC, nToken, SGL_BIND_ROW_CHARGES, jCharges);
+    NuiSetBind(oPC, nToken, SGL_BIND_ROW_ENC,     jEncs);
+    NuiSetBind(oPC, nToken, SGL_BIND_ROW_COLOR,   jColors);
+    NuiSetBind(oPC, nToken, SGL_BIND_LIST_COUNT,  JsonInt(nCount));
+
+    int bSel = (nSelId > 0);
+    NuiSetBind(oPC, nToken, SGL_BIND_DISARM_ENA, JsonBool(bSel));
+    NuiSetBind(oPC, nToken, SGL_BIND_ATT_ENA,    JsonBool(bSel));
+}
+
+// ----------------------------------------------------------------
+// Feed — Place View
+// ----------------------------------------------------------------
+
+void FeedSglPlace(object oPC, int nToken)
+{
+    int nType = GetLocalInt(oPC, SGL_LVAR_TYPE_IDX);
+    NuiSetBind(oPC, nToken, SGL_BIND_PLACE_TYPE_LBL,
+        JsonString(SglGetTypeName(nType)));
+    NuiSetBind(oPC, nToken, SGL_BIND_PLACE_TYPE_DESC,
+        JsonString(SglGetTypeDesc(nType)));
+    NuiSetBind(oPC, nToken, SGL_BIND_PLACE_CHARGES,
+        JsonString("Ładunki: " + IntToString(SglGetDefaultCharges(nType))));
+}
+
+// ----------------------------------------------------------------
+// Feed — Attune View
+// ----------------------------------------------------------------
+
+void FeedSglAttune(object oPC, int nToken)
+{
+    int nSigilId = GetLocalInt(oPC, SGL_LVAR_SEL_ID);
+
+    // Header
+    json jSig = SglGetSigilById(nSigilId);
+    string sHeader = "Brak wybranego znaku";
+    if(JsonGetType(jSig) != JSON_TYPE_NULL)
+    {
+        int    nType  = JsonGetInt   (JsonObjectGet(jSig, "sigil_type"));
+        string sArea  = JsonGetString(JsonObjectGet(jSig, "area_name"));
+        sHeader = "Dostęp do znaku: " + SglGetTypeName(nType) + " [" + sArea + "]";
+    }
+    NuiSetBind(oPC, nToken, SGL_BIND_ATT_HEADER, JsonString(sHeader));
+
+    // Attuned list
+    json jAttuned = SglGetAttuned(nSigilId);
+    int  nAttCount = JsonGetLength(jAttuned);
+    json jAttNames = JsonArray();
+    json jAttEncs  = JsonArray();
+    string sSelAtt = GetLocalString(oPC, SGL_LVAR_SEL_ATT);
+
+    int i;
+    for(i = 0; i < nAttCount; i++)
+    {
+        json   jA    = JsonArrayGet(jAttuned, i);
+        string sUuid = JsonGetString(JsonObjectGet(jA, "uuid"));
+        string sName = JsonGetString(JsonObjectGet(jA, "name"));
+        jAttNames = JsonArrayInsert(jAttNames, JsonString(sName));
+        jAttEncs  = JsonArrayInsert(jAttEncs,  JsonBool(sUuid == sSelAtt && sSelAtt != ""));
+    }
+    NuiSetBind(oPC, nToken, SGL_BIND_ATT_NAME,  jAttNames);
+    NuiSetBind(oPC, nToken, SGL_BIND_ATT_ENC,   jAttEncs);
+    NuiSetBind(oPC, nToken, SGL_BIND_ATT_COUNT, JsonInt(nAttCount));
+    NuiSetBind(oPC, nToken, SGL_BIND_REVOKE_ENA, JsonBool(sSelAtt != ""));
+
+    // Online players list (excluding self and already-attuned)
+    json jOnlineNames = JsonArray();
+    json jOnlineEncs  = JsonArray();
+    int  nOnlineCnt   = 0;
+    string sSelfUuid  = GetObjectUUID(oPC);
+
+    object oOther = GetFirstPC();
+    while(GetIsObjectValid(oOther))
+    {
+        if(oOther != oPC && !GetIsDMPossessed(oOther))
+        {
+            string sOtherUuid = GetObjectUUID(oOther);
+            if(!SglIsAttuned(nSigilId, sOtherUuid))
+            {
+                jOnlineNames = JsonArrayInsert(jOnlineNames, JsonString(GetName(oOther)));
+                jOnlineEncs  = JsonArrayInsert(jOnlineEncs,  JsonBool(FALSE));
+                nOnlineCnt++;
+            }
+        }
+        oOther = GetNextPC();
+    }
+    NuiSetBind(oPC, nToken, SGL_BIND_ONLINE_NAME, jOnlineNames);
+    NuiSetBind(oPC, nToken, SGL_BIND_ONLINE_ENC,  jOnlineEncs);
+    NuiSetBind(oPC, nToken, SGL_BIND_ONLINE_CNT,  JsonInt(nOnlineCnt));
+}
+
+// ----------------------------------------------------------------
+// Restore visual glows for all active sigils after server restart
+// ----------------------------------------------------------------
+
+void SglRestoreVisuals()
+{
+    json jSigils = SglGetAllActiveSigils();
+    int nCount   = JsonGetLength(jSigils);
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json   jSig   = JsonArrayGet(jSigils, i);
+        string sArea  = JsonGetString(JsonObjectGet(jSig, "area_tag"));
+        float  fX     = JsonGetFloat (JsonObjectGet(jSig, "pos_x"));
+        float  fY     = JsonGetFloat (JsonObjectGet(jSig, "pos_y"));
+        float  fZ     = JsonGetFloat (JsonObjectGet(jSig, "pos_z"));
+
+        // GetObjectByTag finds the first area with this tag
+        object oArea = GetObjectByTag(sArea);
+        if(!GetIsObjectValid(oArea)) continue;
+
+        location lSig = Location(oArea, Vector(fX, fY, fZ), 0.0);
+        ApplyEffectAtLocation(DURATION_TYPE_TEMPORARY,
+            EffectVisualEffect(VFX_DUR_PROT_PREMONITION), lSig, 3600.0);
+    }
+}

--- a/Sigil Wards/Scripts/lib_sgl_def.nss
+++ b/Sigil Wards/Scripts/lib_sgl_def.nss
@@ -1,0 +1,111 @@
+#include "lib_nui"
+#include "sql_sgl"
+
+// ----------------------------------------------------------------
+// Sigil type IDs
+// ----------------------------------------------------------------
+
+const int SGL_TYPE_ALARM = 0;  // powiadamia właściciela, brak obrażeń
+const int SGL_TYPE_SHOCK = 1;  // błyskawica, 1k8 obrażeń od elektryczności
+const int SGL_TYPE_HOLD  = 2;  // paraliż na 6 sekund
+const int SGL_TYPE_FEAR  = 3;  // przerażenie na 8 sekund
+
+const int SGL_TYPE_COUNT = 4;
+
+// ----------------------------------------------------------------
+// Limits and tuning
+// ----------------------------------------------------------------
+
+const int   SGL_MAX_SIGILS        = 5;     // max active sigils per player
+const float SGL_TRIGGER_RADIUS    = 4.5;   // metres — trigger if closer than this
+const int   SGL_HB_MODULO         = 3;     // check proximity every N heartbeats (~18 s)
+const int   SGL_COOLDOWN_SECONDS  = 30;    // seconds before same creature can retrigger same sigil
+const int   SGL_MAX_ATTUNED       = 10;    // max attuned players per sigil
+
+// ----------------------------------------------------------------
+// Window / group IDs
+// ----------------------------------------------------------------
+
+const string SGL_WINDOW     = "SGL_WINDOW";
+const string SGL_EV_SCRIPT  = "lib_sgl_ev";
+const string SGL_WIN_GEOM   = "sgl_win_geom";
+const string SGL_GRP_SWAP   = "SGL_GRP_SWAP";
+
+// ----------------------------------------------------------------
+// Bind names — list view
+// ----------------------------------------------------------------
+
+const string SGL_BIND_ROW_TYPE    = "sgl_row_type";
+const string SGL_BIND_ROW_AREA    = "sgl_row_area";
+const string SGL_BIND_ROW_CHARGES = "sgl_row_charges";
+const string SGL_BIND_ROW_ENC     = "sgl_row_enc";
+const string SGL_BIND_ROW_COLOR   = "sgl_row_color";
+const string SGL_BIND_LIST_COUNT  = "sgl_list_count";
+const string SGL_BIND_HEADER      = "sgl_header";
+const string SGL_BIND_DISARM_ENA  = "sgl_disarm_ena";
+const string SGL_BIND_ATT_ENA     = "sgl_att_ena";
+
+// ----------------------------------------------------------------
+// Bind names — place view
+// ----------------------------------------------------------------
+
+const string SGL_BIND_PLACE_TYPE_LBL  = "sgl_place_type";
+const string SGL_BIND_PLACE_TYPE_DESC = "sgl_place_desc";
+const string SGL_BIND_PLACE_CHARGES   = "sgl_place_chg";
+
+// ----------------------------------------------------------------
+// Bind names — attune view
+// ----------------------------------------------------------------
+
+const string SGL_BIND_ATT_HEADER  = "sgl_att_header";
+const string SGL_BIND_ATT_NAME    = "sgl_att_name";
+const string SGL_BIND_ATT_ENC     = "sgl_att_enc";
+const string SGL_BIND_ATT_COUNT   = "sgl_att_count";
+const string SGL_BIND_REVOKE_ENA  = "sgl_revoke_ena";
+const string SGL_BIND_SEARCH_TXT  = "sgl_search_txt";
+const string SGL_BIND_ONLINE_NAME = "sgl_online_name";
+const string SGL_BIND_ONLINE_ENC  = "sgl_online_enc";
+const string SGL_BIND_ONLINE_CNT  = "sgl_online_count";
+
+// ----------------------------------------------------------------
+// Button IDs
+// ----------------------------------------------------------------
+
+const string SGL_BTN_CLOSE       = "sgl_btn_close";
+const string SGL_BTN_PLACE_OPEN  = "sgl_btn_place_open";
+const string SGL_BTN_DISARM      = "sgl_btn_disarm";
+const string SGL_BTN_ATT_OPEN    = "sgl_btn_att_open";
+const string SGL_BTN_ROW         = "sgl_btn_row";
+const string SGL_BTN_TYPE_PREV   = "sgl_btn_type_prev";
+const string SGL_BTN_TYPE_NEXT   = "sgl_btn_type_next";
+const string SGL_BTN_PLACE_CONF  = "sgl_btn_place_conf";
+const string SGL_BTN_BACK        = "sgl_btn_back";
+const string SGL_BTN_ATT_ROW     = "sgl_btn_att_row";
+const string SGL_BTN_ONLINE_ROW  = "sgl_btn_online_row";
+const string SGL_BTN_REVOKE      = "sgl_btn_revoke";
+const string SGL_BTN_SEARCH      = "sgl_btn_search";
+
+// ----------------------------------------------------------------
+// LVARs on PC
+// ----------------------------------------------------------------
+
+const string SGL_LVAR_SEL_ID     = "SGL_SEL_ID";       // selected sigil id in list view
+const string SGL_LVAR_TYPE_IDX   = "SGL_TYPE_IDX";     // current type in place view
+const string SGL_LVAR_SEL_ATT    = "SGL_SEL_ATT";      // selected attuned uuid in attune view
+const string SGL_LVAR_SEARCH_RES = "SGL_SEARCH_RES";   // json array of search results
+
+// ----------------------------------------------------------------
+// Layout dimensions (pre-scale)
+// ----------------------------------------------------------------
+
+const float SGL_W = 660.0;
+const float SGL_H = 460.0;
+
+// ----------------------------------------------------------------
+// Forward declarations for cross-referencing
+// ----------------------------------------------------------------
+
+void FeedSglList(object oPC, int nToken);
+void FeedSglPlace(object oPC, int nToken);
+void FeedSglAttune(object oPC, int nToken);
+string SglGetTypeName(int nType);

--- a/Sigil Wards/Scripts/lib_sgl_ev.nss
+++ b/Sigil Wards/Scripts/lib_sgl_ev.nss
@@ -1,0 +1,243 @@
+#include "lib_sgl"
+
+// ----------------------------------------------------------------
+// Main NUI event handler — assigned to SGL_EV_SCRIPT
+// ----------------------------------------------------------------
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    if(nToken != NuiFindWindow(oPC, SGL_WINDOW)) return;
+
+    // ---- Window close: cleanup LVAR state ----
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalInt   (oPC, SGL_LVAR_SEL_ID);
+        DeleteLocalInt   (oPC, SGL_LVAR_TYPE_IDX);
+        DeleteLocalString(oPC, SGL_LVAR_SEL_ATT);
+        DeleteLocalJson  (oPC, SGL_LVAR_SEARCH_RES);
+        return;
+    }
+
+    // ----------------------------------------------------------------
+    // Click events
+    // ----------------------------------------------------------------
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        // ---- Global close button ----
+        if(sElem == SGL_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        // ----------------------------------------------------------------
+        // List view buttons
+        // ----------------------------------------------------------------
+
+        if(sElem == SGL_BTN_PLACE_OPEN)
+        {
+            if(SglGetPlayerSigilCount(oPC) >= SGL_MAX_SIGILS)
+            {
+                SendMessageToPC(oPC, "[Znak Ochronny] Masz już maksymalną liczbę aktywnych znaków ("
+                    + IntToString(SGL_MAX_SIGILS) + ").");
+                return;
+            }
+            SwapToPlaceView(oPC, nToken);
+            return;
+        }
+
+        if(sElem == SGL_BTN_DISARM)
+        {
+            int nSelId = GetLocalInt(oPC, SGL_LVAR_SEL_ID);
+            if(nSelId <= 0) return;
+
+            json jSig = SglGetSigilById(nSelId);
+            if(JsonGetType(jSig) == JSON_TYPE_NULL)
+            {
+                SendMessageToPC(oPC, "[Znak Ochronny] Znak już nie istnieje.");
+                SetLocalInt(oPC, SGL_LVAR_SEL_ID, 0);
+                FeedSglList(oPC, nToken);
+                return;
+            }
+            // Verify ownership
+            if(JsonGetString(JsonObjectGet(jSig, "owner_uuid")) != GetObjectUUID(oPC))
+            {
+                SendMessageToPC(oPC, "[Znak Ochronny] To nie jest twój znak.");
+                return;
+            }
+            SglRemoveSigil(nSelId);
+            SetLocalInt(oPC, SGL_LVAR_SEL_ID, 0);
+            SendMessageToPC(oPC, "[Znak Ochronny] Znak rozbrojony.");
+            FeedSglList(oPC, nToken);
+            return;
+        }
+
+        if(sElem == SGL_BTN_ATT_OPEN)
+        {
+            int nSelId = GetLocalInt(oPC, SGL_LVAR_SEL_ID);
+            if(nSelId <= 0) return;
+            SwapToAttuneView(oPC, nToken);
+            return;
+        }
+
+        // ----------------------------------------------------------------
+        // Place view buttons
+        // ----------------------------------------------------------------
+
+        if(sElem == SGL_BTN_TYPE_PREV)
+        {
+            int nIdx2 = GetLocalInt(oPC, SGL_LVAR_TYPE_IDX);
+            nIdx2--;
+            if(nIdx2 < 0) nIdx2 = SGL_TYPE_COUNT - 1;
+            SetLocalInt(oPC, SGL_LVAR_TYPE_IDX, nIdx2);
+            FeedSglPlace(oPC, nToken);
+            return;
+        }
+
+        if(sElem == SGL_BTN_TYPE_NEXT)
+        {
+            int nIdx2 = GetLocalInt(oPC, SGL_LVAR_TYPE_IDX);
+            nIdx2 = (nIdx2 + 1) % SGL_TYPE_COUNT;
+            SetLocalInt(oPC, SGL_LVAR_TYPE_IDX, nIdx2);
+            FeedSglPlace(oPC, nToken);
+            return;
+        }
+
+        if(sElem == SGL_BTN_PLACE_CONF)
+        {
+            int nType = GetLocalInt(oPC, SGL_LVAR_TYPE_IDX);
+            SglPlaceAtLocation(oPC, nType);
+            SwapToListView(oPC, nToken);
+            return;
+        }
+
+        // ----------------------------------------------------------------
+        // Attune view buttons
+        // ----------------------------------------------------------------
+
+        if(sElem == SGL_BTN_REVOKE)
+        {
+            int    nSelId   = GetLocalInt   (oPC, SGL_LVAR_SEL_ID);
+            string sSelAtt  = GetLocalString(oPC, SGL_LVAR_SEL_ATT);
+            if(nSelId <= 0 || sSelAtt == "") return;
+            SglRevokeAttunement(nSelId, sSelAtt);
+            DeleteLocalString(oPC, SGL_LVAR_SEL_ATT);
+            FeedSglAttune(oPC, nToken);
+            return;
+        }
+
+        // ---- Back button (shared between place and attune views) ----
+        if(sElem == SGL_BTN_BACK)
+        {
+            SwapToListView(oPC, nToken);
+            return;
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // Mousedown events (list row selection)
+    // ----------------------------------------------------------------
+
+    if(sEvent == EVENT_TYPE_MOUSEDOWN)
+    {
+        // ---- Main sigil list row ----
+        if(sElem == SGL_BTN_ROW)
+        {
+            json jSigils = SglGetPlayerSigils(oPC);
+            if(nIdx < 0 || nIdx >= JsonGetLength(jSigils)) return;
+
+            json   jSig  = JsonArrayGet(jSigils, nIdx);
+            int    nId   = JsonGetInt(JsonObjectGet(jSig, "id"));
+            int    nCount = JsonGetLength(jSigils);
+
+            // Toggle selection: click same row to deselect
+            int nPrev = GetLocalInt(oPC, SGL_LVAR_SEL_ID);
+            SetLocalInt(oPC, SGL_LVAR_SEL_ID, (nPrev == nId) ? 0 : nId);
+            FeedSglList(oPC, nToken);
+            return;
+        }
+
+        // ---- Attuned player row (select for revoke) ----
+        if(sElem == SGL_BTN_ATT_ROW)
+        {
+            int  nSigilId = GetLocalInt(oPC, SGL_LVAR_SEL_ID);
+            json jAttuned = SglGetAttuned(nSigilId);
+            if(nIdx < 0 || nIdx >= JsonGetLength(jAttuned)) return;
+
+            json   jA       = JsonArrayGet(jAttuned, nIdx);
+            string sUuid    = JsonGetString(JsonObjectGet(jA, "uuid"));
+            string sPrevAtt = GetLocalString(oPC, SGL_LVAR_SEL_ATT);
+
+            // Toggle selection
+            SetLocalString(oPC, SGL_LVAR_SEL_ATT,
+                (sPrevAtt == sUuid) ? "" : sUuid);
+            FeedSglAttune(oPC, nToken);
+            return;
+        }
+
+        // ---- Online player row (grant attunement) ----
+        if(sElem == SGL_BTN_ONLINE_ROW)
+        {
+            int nSigilId = GetLocalInt(oPC, SGL_LVAR_SEL_ID);
+            if(nSigilId <= 0) return;
+
+            // Rebuild online list the same way FeedSglAttune does
+            json jAttuned = SglGetAttuned(nSigilId);
+            json jOnline  = JsonArray();
+            object oOther = GetFirstPC();
+            while(GetIsObjectValid(oOther))
+            {
+                if(oOther != oPC && !GetIsDMPossessed(oOther))
+                {
+                    string sOtherUuid = GetObjectUUID(oOther);
+                    if(!SglIsAttuned(nSigilId, sOtherUuid))
+                    {
+                        json jEntry = JsonObject();
+                        jEntry = JsonObjectSet(jEntry, "uuid", JsonString(sOtherUuid));
+                        jEntry = JsonObjectSet(jEntry, "name", JsonString(GetName(oOther)));
+                        jOnline = JsonArrayInsert(jOnline, jEntry);
+                    }
+                }
+                oOther = GetNextPC();
+            }
+
+            if(nIdx < 0 || nIdx >= JsonGetLength(jOnline)) return;
+            json   jTarget = JsonArrayGet(jOnline, nIdx);
+            string sUuid   = JsonGetString(JsonObjectGet(jTarget, "uuid"));
+            string sName   = JsonGetString(JsonObjectGet(jTarget, "name"));
+
+            if(JsonGetLength(jAttuned) >= SGL_MAX_ATTUNED)
+            {
+                SendMessageToPC(oPC, "[Znak Ochronny] Osiągnięto limit dostępu ("
+                    + IntToString(SGL_MAX_ATTUNED) + " graczy).");
+                return;
+            }
+
+            SglAttunePlayer(nSigilId, sUuid, sName);
+            SendMessageToPC(oPC, "[Znak Ochronny] " + sName + " ma teraz dostęp do znaku.");
+
+            // Notify the newly attuned player if online
+            object oGranted = GetFirstPC();
+            while(GetIsObjectValid(oGranted))
+            {
+                if(GetObjectUUID(oGranted) == sUuid)
+                {
+                    SendMessageToPC(oGranted, "[Znak Ochronny] " + GetName(oPC)
+                        + " nadał ci dostęp przez jeden ze swych znaków ochronnych.");
+                    break;
+                }
+                oGranted = GetNextPC();
+            }
+
+            FeedSglAttune(oPC, nToken);
+            return;
+        }
+    }
+}

--- a/Sigil Wards/Scripts/sql_sgl.nss
+++ b/Sigil Wards/Scripts/sql_sgl.nss
@@ -1,0 +1,247 @@
+// Campaign DB identifier
+const string SGL_DB = "sigil_wards";
+
+// Default charge counts per sigil type
+const int SGL_CHARGES_ALARM = 10;
+const int SGL_CHARGES_SHOCK = 5;
+const int SGL_CHARGES_HOLD  = 3;
+const int SGL_CHARGES_FEAR  = 5;
+
+void SglCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign(SGL_DB,
+        "CREATE TABLE IF NOT EXISTS sgl_sigils ("
+        "  id         INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "  owner_uuid TEXT    NOT NULL,"
+        "  owner_name TEXT    NOT NULL DEFAULT '',"
+        "  area_tag   TEXT    NOT NULL DEFAULT '',"
+        "  area_name  TEXT    NOT NULL DEFAULT '',"
+        "  pos_x      REAL    NOT NULL DEFAULT 0.0,"
+        "  pos_y      REAL    NOT NULL DEFAULT 0.0,"
+        "  pos_z      REAL    NOT NULL DEFAULT 0.0,"
+        "  sigil_type INTEGER NOT NULL DEFAULT 0,"
+        "  charges    INTEGER NOT NULL DEFAULT 5,"
+        "  placed_at  INTEGER NOT NULL DEFAULT 0"
+        ")");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign(SGL_DB,
+        "CREATE TABLE IF NOT EXISTS sgl_attuned ("
+        "  sigil_id      INTEGER NOT NULL,"
+        "  attuned_uuid  TEXT    NOT NULL,"
+        "  attuned_name  TEXT    NOT NULL DEFAULT '',"
+        "  PRIMARY KEY (sigil_id, attuned_uuid)"
+        ")");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign(SGL_DB,
+        "CREATE TABLE IF NOT EXISTS sgl_players ("
+        "  uuid TEXT PRIMARY KEY,"
+        "  name TEXT NOT NULL DEFAULT ''"
+        ")");
+    SqlStep(q);
+}
+
+void SglRegisterPlayer(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign(SGL_DB,
+        "INSERT OR REPLACE INTO sgl_players (uuid, name) VALUES (@uuid, @name)");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindString(q, "@name", GetName(oPC));
+    SqlStep(q);
+}
+
+// Returns id of inserted sigil or 0 on failure
+int SglPlaceSigil(object oPC, string sAreaTag, string sAreaName,
+                  float fX, float fY, float fZ, int nType, int nCharges)
+{
+    sqlquery q = SqlPrepareQueryCampaign(SGL_DB,
+        "INSERT INTO sgl_sigils (owner_uuid, owner_name, area_tag, area_name, "
+        "  pos_x, pos_y, pos_z, sigil_type, charges, placed_at) "
+        "VALUES (@ouuid, @oname, @atag, @aname, @x, @y, @z, @type, @chg, strftime('%s','now'))");
+    SqlBindString(q, "@ouuid",  GetObjectUUID(oPC));
+    SqlBindString(q, "@oname",  GetName(oPC));
+    SqlBindString(q, "@atag",   sAreaTag);
+    SqlBindString(q, "@aname",  sAreaName);
+    SqlBindFloat (q, "@x",      fX);
+    SqlBindFloat (q, "@y",      fY);
+    SqlBindFloat (q, "@z",      fZ);
+    SqlBindInt   (q, "@type",   nType);
+    SqlBindInt   (q, "@chg",    nCharges);
+    SqlStep(q);
+
+    sqlquery qId = SqlPrepareQueryCampaign(SGL_DB, "SELECT last_insert_rowid()");
+    if(SqlStep(qId)) return SqlGetInt(qId, 0);
+    return 0;
+}
+
+// Returns JsonArray [{id, area_tag, area_name, sigil_type, charges, placed_at}]
+json SglGetPlayerSigils(object oPC)
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign(SGL_DB,
+        "SELECT id, area_tag, area_name, sigil_type, charges, placed_at "
+        "FROM sgl_sigils WHERE owner_uuid = @uuid AND charges > 0 ORDER BY placed_at ASC");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    while(SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "id",         JsonInt   (SqlGetInt   (q, 0)));
+        jRow = JsonObjectSet(jRow, "area_tag",   JsonString(SqlGetString(q, 1)));
+        jRow = JsonObjectSet(jRow, "area_name",  JsonString(SqlGetString(q, 2)));
+        jRow = JsonObjectSet(jRow, "sigil_type", JsonInt   (SqlGetInt   (q, 3)));
+        jRow = JsonObjectSet(jRow, "charges",    JsonInt   (SqlGetInt   (q, 4)));
+        jRow = JsonObjectSet(jRow, "placed_at",  JsonInt   (SqlGetInt   (q, 5)));
+        jRows = JsonArrayInsert(jRows, jRow);
+    }
+    return jRows;
+}
+
+// Returns JsonArray of ALL active sigils for heartbeat proximity check
+// [{id, owner_uuid, area_tag, area_name, pos_x, pos_y, pos_z, sigil_type, charges}]
+json SglGetAllActiveSigils()
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign(SGL_DB,
+        "SELECT id, owner_uuid, area_tag, area_name, pos_x, pos_y, pos_z, sigil_type, charges "
+        "FROM sgl_sigils WHERE charges > 0");
+    while(SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "id",         JsonInt   (SqlGetInt   (q, 0)));
+        jRow = JsonObjectSet(jRow, "owner_uuid", JsonString(SqlGetString(q, 1)));
+        jRow = JsonObjectSet(jRow, "area_tag",   JsonString(SqlGetString(q, 2)));
+        jRow = JsonObjectSet(jRow, "area_name",  JsonString(SqlGetString(q, 3)));
+        jRow = JsonObjectSet(jRow, "pos_x",      JsonFloat (SqlGetFloat (q, 4)));
+        jRow = JsonObjectSet(jRow, "pos_y",      JsonFloat (SqlGetFloat (q, 5)));
+        jRow = JsonObjectSet(jRow, "pos_z",      JsonFloat (SqlGetFloat (q, 6)));
+        jRow = JsonObjectSet(jRow, "sigil_type", JsonInt   (SqlGetInt   (q, 7)));
+        jRow = JsonObjectSet(jRow, "charges",    JsonInt   (SqlGetInt   (q, 8)));
+        jRows = JsonArrayInsert(jRows, jRow);
+    }
+    return jRows;
+}
+
+// Returns remaining charges after decrement, or 0
+int SglDecrementCharges(int nSigilId)
+{
+    sqlquery q = SqlPrepareQueryCampaign(SGL_DB,
+        "UPDATE sgl_sigils SET charges = MAX(0, charges - 1) WHERE id = @id");
+    SqlBindInt(q, "@id", nSigilId);
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign(SGL_DB,
+        "SELECT charges FROM sgl_sigils WHERE id = @id");
+    SqlBindInt(q, "@id", nSigilId);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+void SglRemoveSigil(int nSigilId)
+{
+    sqlquery q = SqlPrepareQueryCampaign(SGL_DB,
+        "DELETE FROM sgl_sigils WHERE id = @id");
+    SqlBindInt(q, "@id", nSigilId);
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign(SGL_DB,
+        "DELETE FROM sgl_attuned WHERE sigil_id = @id");
+    SqlBindInt(q, "@id", nSigilId);
+    SqlStep(q);
+}
+
+int SglGetPlayerSigilCount(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign(SGL_DB,
+        "SELECT COUNT(*) FROM sgl_sigils WHERE owner_uuid = @uuid AND charges > 0");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+void SglAttunePlayer(int nSigilId, string sUuid, string sName)
+{
+    sqlquery q = SqlPrepareQueryCampaign(SGL_DB,
+        "INSERT OR IGNORE INTO sgl_attuned (sigil_id, attuned_uuid, attuned_name) "
+        "VALUES (@sid, @uuid, @name)");
+    SqlBindInt   (q, "@sid",  nSigilId);
+    SqlBindString(q, "@uuid", sUuid);
+    SqlBindString(q, "@name", sName);
+    SqlStep(q);
+}
+
+void SglRevokeAttunement(int nSigilId, string sUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign(SGL_DB,
+        "DELETE FROM sgl_attuned WHERE sigil_id = @sid AND attuned_uuid = @uuid");
+    SqlBindInt   (q, "@sid",  nSigilId);
+    SqlBindString(q, "@uuid", sUuid);
+    SqlStep(q);
+}
+
+// Returns JsonArray [{uuid, name}]
+json SglGetAttuned(int nSigilId)
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign(SGL_DB,
+        "SELECT attuned_uuid, attuned_name FROM sgl_attuned WHERE sigil_id = @sid");
+    SqlBindInt(q, "@sid", nSigilId);
+    while(SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "uuid", JsonString(SqlGetString(q, 0)));
+        jRow = JsonObjectSet(jRow, "name", JsonString(SqlGetString(q, 1)));
+        jRows = JsonArrayInsert(jRows, jRow);
+    }
+    return jRows;
+}
+
+int SglIsAttuned(int nSigilId, string sUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign(SGL_DB,
+        "SELECT COUNT(*) FROM sgl_attuned WHERE sigil_id = @sid AND attuned_uuid = @uuid");
+    SqlBindInt   (q, "@sid",  nSigilId);
+    SqlBindString(q, "@uuid", sUuid);
+    if(SqlStep(q)) return SqlGetInt(q, 0) > 0;
+    return FALSE;
+}
+
+// Returns sigil row or JsonNull
+json SglGetSigilById(int nSigilId)
+{
+    sqlquery q = SqlPrepareQueryCampaign(SGL_DB,
+        "SELECT id, owner_uuid, area_tag, area_name, pos_x, pos_y, pos_z, sigil_type, charges "
+        "FROM sgl_sigils WHERE id = @id");
+    SqlBindInt(q, "@id", nSigilId);
+    if(!SqlStep(q)) return JsonNull();
+    json jRow = JsonObject();
+    jRow = JsonObjectSet(jRow, "id",         JsonInt   (SqlGetInt   (q, 0)));
+    jRow = JsonObjectSet(jRow, "owner_uuid", JsonString(SqlGetString(q, 1)));
+    jRow = JsonObjectSet(jRow, "area_tag",   JsonString(SqlGetString(q, 2)));
+    jRow = JsonObjectSet(jRow, "area_name",  JsonString(SqlGetString(q, 3)));
+    jRow = JsonObjectSet(jRow, "pos_x",      JsonFloat (SqlGetFloat (q, 4)));
+    jRow = JsonObjectSet(jRow, "pos_y",      JsonFloat (SqlGetFloat (q, 5)));
+    jRow = JsonObjectSet(jRow, "pos_z",      JsonFloat (SqlGetFloat (q, 6)));
+    jRow = JsonObjectSet(jRow, "sigil_type", JsonInt   (SqlGetInt   (q, 7)));
+    jRow = JsonObjectSet(jRow, "charges",    JsonInt   (SqlGetInt   (q, 8)));
+    return jRow;
+}
+
+// Returns JsonArray of registered players matching name fragment, excluding self
+json SglSearchPlayers(string sQuery, object oExclude)
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign(SGL_DB,
+        "SELECT uuid, name FROM sgl_players "
+        "WHERE LOWER(name) LIKE LOWER('%' || @q || '%') AND uuid != @excl LIMIT 10");
+    SqlBindString(q, "@q",    sQuery);
+    SqlBindString(q, "@excl", GetObjectUUID(oExclude));
+    while(SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "uuid", JsonString(SqlGetString(q, 0)));
+        jRow = JsonObjectSet(jRow, "name", JsonString(SqlGetString(q, 1)));
+        jRows = JsonArrayInsert(jRows, jRow);
+    }
+    return jRows;
+}

--- a/Sigil Wards/Scripts/sys_on_enter.nss
+++ b/Sigil Wards/Scripts/sys_on_enter.nss
@@ -1,0 +1,17 @@
+#include "lib_sgl"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC) || GetIsDMPossessed(oPC)) return;
+
+    SglRegisterPlayer(oPC);
+
+    int nCount = SglGetPlayerSigilCount(oPC);
+    if(nCount > 0)
+    {
+        string sMsg = "[Znak Ochronny] Masz " + IntToString(nCount)
+            + " aktywnych znaków ochronnych.";
+        DelayCommand(3.0, SendMessageToPC(oPC, sMsg));
+    }
+}

--- a/Sigil Wards/Scripts/sys_on_hb.nss
+++ b/Sigil Wards/Scripts/sys_on_hb.nss
@@ -1,0 +1,14 @@
+#include "lib_sgl"
+
+// Module OnHeartbeat — staggered proximity check every SGL_HB_MODULO heartbeats.
+// Heartbeat fires every 6 seconds; with modulo 3 this checks every ~18 seconds.
+
+void main()
+{
+    int nCount = GetLocalInt(GetModule(), "SGL_HB_COUNT");
+    nCount     = (nCount + 1) % SGL_HB_MODULO;
+    SetLocalInt(GetModule(), "SGL_HB_COUNT", nCount);
+    if(nCount != 0) return;
+
+    SglCheckProximity();
+}

--- a/Sigil Wards/Scripts/sys_on_load.nss
+++ b/Sigil Wards/Scripts/sys_on_load.nss
@@ -1,0 +1,9 @@
+#include "lib_sgl"
+
+void main()
+{
+    SglCreateTables();
+    // Re-apply ground visual effects for all persistent sigils so they glow
+    // after a server restart. Effects last 1 hour; they're re-applied each restart.
+    SglRestoreVisuals();
+}

--- a/Sigil Wards/Scripts/test_sgl.nss
+++ b/Sigil Wards/Scripts/test_sgl.nss
@@ -1,0 +1,13 @@
+#include "lib_sgl"
+
+// OnUsed script for the Sigil Wards demo placeable.
+// Place a "Tablica Znaków Ochronnych" placeable in the toolset,
+// set its OnUsed script to "test_sgl", then activate it in-game.
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    CreateSglWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

System magicznych znaków ochronnych, które gracze mogą wpisywać w miejscach
świata i które wyzwalają efekty obronne lub alarmowe gdy nieuprawiona osoba
wkroczy w ich zasięg. Dane persystują przez restarty serwera w campaign DB
`sigil_wards`.

## Mechanika

Gracz otwiera panel NUI (OnUsed na placeable `test_sgl` lub wywołanie
`CreateSglWindow(oPC)` z dowolnego miejsca). Może umieścić do 5 aktywnych
znaków — każdy w swoim bieżącym położeniu. Cztery typy znaków:

| Typ                | Ładunki | Efekt                                       |
|--------------------|---------|---------------------------------------------|
| Alarm              | 10      | Powiadomienie właściciela; brak obrażeń     |
| Porażenie          | 5       | 1k8 obrażeń elektrycznych na intruza        |
| Unieruchomienie    | 3       | Paraliż 6 sekund                            |
| Trwoga             | 5       | Przerażenie 8 sekund                        |

`sys_on_hb` sprawdza co ~18 sekund (co 3. tik heartbeat) dystans wszystkich
online-graczy do wszystkich aktywnych znaków (kampania DB, bez NWNX).
Właściciel nigdy nie wyzwala własnych znaków; gracze z nadanym dostępem
(`sgl_attuned`) również przechodzą bezpiecznie. Cooldown 30 s per
(gracz × znak) zapobiega wielokrotnemu wyzwalaniu przy staniu w miejscu.

Panel pozwala też zdalnie rozbroić znak i zarządzać listą uprawnionych —
widoczni są gracze aktualnie online, których właściciel może dodać jednym
kliknięciem.

## Pliki

```
Sigil Wards/
  Scripts/
    lib_nui.nss             — współdzielone helpery NUI (z Mailbox)
    lib_nui_utility.nss     — j.w.
    sql_sgl.nss             — schemat SQLite i wszystkie zapytania CRUD
    lib_sgl_def.nss         — stałe, ID bindów, przyciski, forward decl
    lib_sgl.nss             — typ znaku, efekty, UI Build*/Feed*, heartbeat
    lib_sgl_ev.nss          — handler NUI zdarzeń (main())
    sys_on_load.nss         — CREATE TABLE IF NOT EXISTS + restore visuals
    sys_on_enter.nss        — rejestracja gracza, powiadomienie o znakach
    sys_on_hb.nss           — staggered proximity scan
    test_sgl.nss            — OnUsed demo: otwiera panel gracza
  INTEGRATION.md            — tabela hooków, konfiguracja, ograniczenia
```

## Zależności (NWNX? SQL?)

- **Brak NWNX** — tylko natywne NWN:EE API (NUI, SqlPrepareQueryCampaign)
- **Campaign DB** `sigil_wards` — tworzony automatycznie przez `sys_on_load`
- Minimalna wersja: NWN:EE 8193.36 (NUI + SQLite)

## Jak włączyć w istniejącym module

1. Skopiuj folder `Sigil Wards/Scripts/` do katalogu skryptów modułu.
2. Podepnij hooki w ustawieniach modułu:
   - `OnModuleLoad` → `sys_on_load`
   - `OnClientEnter` → `sys_on_enter`
   - `OnHeartbeat` → `sys_on_hb`
3. Umieść placeable z `OnUsed = test_sgl` lub wywołaj
   `CreateSglWindow(oPC)` z dowolnego NPC/dialogi/komendy.
4. Gotowe — tabele SQL tworzone są przy pierwszym załadowaniu.

Jeśli moduł ma już własne skrypty hooków, wywołaj funkcje z `lib_sgl.nss`
wewnątrz istniejących hooków zamiast nadpisywać skrypt.

## Co celowo pominięto

- **HAK / nowe assety** — brak własnych ikon, tylko stockowe VFX (`VFX_IMP_LIGHTNING_S` itp.)
- **Panel DM** do podglądu wszystkich znaków na mapie serwera
- **Item wymagany** do umieszczenia znaku (np. kreda sygilów) — logika jest
  trywialna do dodania jako sprawdzenie inventarza w `SglPlaceAtLocation`
  przed insertem do SQL
- **Wyszukiwarka offline-graczy** w panelu dostępu — widoczni są tylko gracze
  aktualnie online (offline można dodać przez rozszerzenie o `SglSearchPlayers` z sql_sgl.nss)
- **Ograniczenia rasa/klasa** — trivial do dodania w `SglPlaceAtLocation`


---
_Generated by [Claude Code](https://claude.ai/code/session_01TFRN3ibSGLdeBYuqr8DZ4F)_