### PR TITLE
feat: Wanted System

### DIFF
--- a/Wanted System/INTEGRATION.md
+++ b/Wanted System/INTEGRATION.md
@@ -1,0 +1,81 @@
+# Wanted System — Integracja
+
+## Hooki modułu
+
+| Zdarzenie modułu | Skrypt / akcja do dołączenia |
+|------------------|------------------------------|
+| OnModuleLoad     | Wywołaj `WantedCreateTables()` z `sys_on_load.nss` |
+| OnClientEnter    | Wywołaj kod z `sys_on_enter.nss` |
+| OnClientExit     | Wywołaj kod z `sys_on_leave.nss` |
+
+Jeśli masz już własne skrypty tych zdarzeń, wklej **ciało `main()`** zamiast
+podmieniać cały plik.
+
+## Dodawanie gorączki (API zewnętrzne)
+
+```nss
+#include "lib_wnt"
+
+// Atak na niewinnego NPC — liczy jako przestępstwo:
+WantedAddHeat(oPC, 20, TRUE);
+
+// Efekt środowiskowy (klątwa obszaru itp.) — nie liczy do przestępstw:
+WantedAddHeat(oPC, 5, FALSE);
+```
+
+Sugerowane wartości gorączki:
+
+| Czyn | Gorączka |
+|------|----------|
+| Kradzież kieszonkowa | 5–10 |
+| Napaść na cywila | 15–20 |
+| Zabójstwo cywila | 30–40 |
+| Atak na strażnika | 40–50 |
+| Zabójstwo strażnika | 60 |
+
+## Reakcja straży
+
+Wklej do skryptu `OnPerception` strażnika (taga np. `city_guard`):
+
+```nss
+#include "lib_wnt"
+
+void main()
+{
+    object oPC = GetLastPerceived();
+    if(!GetLastPerceptionSeen()) return;
+    WantedGuardReact(OBJECT_SELF, oPC);
+}
+```
+
+`WantedGuardReact` działa tylko gdy heat >= `WNT_TH_WANTED` (40). Poniżej tego
+progu straż nie reaguje mechanicznie.
+
+## Tuning — współczynnik zaniku
+
+W `lib_wnt_def.nss`:
+
+```nss
+const float WNT_DECAY_PER_SEC = 0.1;  // TEST: 1 heat na 10 s
+```
+
+Dla serwera produkcyjnego zalecane wartości:
+- `0.016` — 1 heat/min, pełne 100 pkt. znika po ~1 h 40 min
+- `0.008` — 1 heat/min, pełne 100 pkt. znika po ~3 h 20 min
+
+## Zależności
+
+- **NWNX**: Nie wymagany.
+- **SQL**: Własna kampania `wanted` (SQLite). Nie wchodzi w konflikt z innymi
+  modułami używającymi osobnych kampanii.
+- **nw_inc_nui**: Standardowy include NWN:EE (dostępny w każdej instalacji).
+- **Asety**: Skrypty odwołują się do ikonek `wnt_icon_0` … `wnt_icon_4` (TGA 32×32).
+  Podmień je na własne lub użyj dowolnych ikon z zainstalowanego hak-paka.
+
+## Co celowo pominięto
+
+- **Automatyczne śledzenie ataków** — wymaga umieszczenia haka `OnPerception`
+  lub `OnCombatRoundEnd` na każdym NPC-u w module; jest to zadanie dla integratora.
+- **Plakaty i listy gończe jako obiekty** — wymagają osobnego systemu spawnu.
+- **Maskowanie/przebranie** — możliwa integracja z modułem Appearance, poza zakresem.
+- **Streaming danych do innych graczy** — każdy PC ma własny, prywatny rejestr.

--- a/Wanted System/scripts/lib_wnt.nss
+++ b/Wanted System/scripts/lib_wnt.nss
@@ -1,0 +1,459 @@
+// =============================================================================
+// lib_wnt.nss
+// =============================================================================
+// Core logic for the Wanted system:
+//   - HUD  (small, always-on): skull icon-button + level label + heat bar
+//   - Records Panel (opened via HUD click): flavor text + bribe + surrender
+//   - 10-second tick: refreshes HUD, detects threshold transitions
+//   - WantedAddHeat()   — primary API for crime hooks
+//   - WantedBribe()     — pay gold to reduce heat
+//   - WantedSurrender() — pay per-crime fine, clear record
+// =============================================================================
+
+#include "lib_wnt_def"
+
+// Forward declarations so helpers can be called before their definitions.
+void WantedHudTick(object oPC);
+void FeedWantedHud(object oPC, int nToken, int nHeat, int nLvl);
+void FeedWantedPanel(object oPC, int nToken, int nHeat, int nLvl, int nCrimes);
+void WantedDestroyPanel(object oPC);
+
+// ===========================================================================
+// HUD layout
+// ===========================================================================
+
+json BuildWantedHudLayout()
+{
+    // Clickable skull icon — fires "click" event with element WNT_BTN_OPEN.
+    json jBtn = NuiButtonImage(NuiBind(WNT_BIND_ICON));
+    jBtn = NuiId(jBtn, WNT_BTN_OPEN);
+    jBtn = NuiWidth(jBtn,  WNT_HUD_ICON);
+    jBtn = NuiHeight(jBtn, WNT_HUD_ICON);
+    jBtn = NuiTooltip(jBtn, NuiBind(WNT_BIND_TIP));
+
+    // Wanted level name label.
+    json jLbl = NuiLabel(
+        NuiBind(WNT_BIND_LVL_LBL),
+        JsonInt(NUI_HALIGN_LEFT),
+        JsonInt(NUI_VALIGN_MIDDLE));
+    jLbl = NuiWidth(jLbl, 100.0);
+
+    // Heat progress bar — coloured by threshold.
+    json jBar = NuiProgress(NuiBind(WNT_BIND_BAR));
+    jBar = NuiHeight(jBar, 16.0);
+    jBar = NuiStyleForegroundColor(jBar, NuiBind(WNT_BIND_COLOR));
+    jBar = NuiTooltip(jBar, NuiBind(WNT_BIND_TIP));
+
+    json jRow = JsonArray();
+    jRow = JsonArrayInsert(jRow, jBtn);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 6.0));
+    jRow = JsonArrayInsert(jRow, jLbl);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 4.0));
+    jRow = JsonArrayInsert(jRow, jBar);
+
+    return NuiRow(jRow);
+}
+
+// ===========================================================================
+// HUD lifecycle
+// ===========================================================================
+
+void WantedCreateHud(object oPC)
+{
+    if(!GetIsPC(oPC) || GetIsDM(oPC)) return;
+    if(NuiFindWindow(oPC, WNT_HUD_WIN) != 0) return;
+
+    string sUuid = GetObjectUUID(oPC);
+    struct WantedUiPos pos = WantedGetUiPos(sUuid);
+
+    json jGeom = NuiRect(pos.x, pos.y, WNT_HUD_W, WNT_HUD_H);
+    json jWin  = NuiWindow(
+        BuildWantedHudLayout(),
+        JsonString(""),           // no visible title — acts as drag handle only
+        NuiBind(WNT_BIND_GEOM),   // geometry bind (drag updates this)
+        JsonBool(FALSE),          // resizable
+        JsonBool(FALSE),          // collapsed
+        JsonBool(FALSE),          // closable
+        JsonBool(FALSE),          // transparent
+        JsonBool(TRUE));          // border
+
+    int nToken = NuiCreate(oPC, jWin, WNT_HUD_WIN, "lib_wnt_ev");
+    if(nToken == 0) return;
+
+    NuiSetBind(oPC, nToken, WNT_BIND_GEOM, jGeom);
+    NuiSetBindWatch(oPC, nToken, WNT_BIND_GEOM, TRUE);
+    SetLocalInt(oPC, WNT_LVAR_HUD_TOKEN, nToken);
+
+    struct WantedState s = WantedGetState(sUuid);
+    int nHeat = WantedCalcHeat(s);
+    int nLvl  = WantedGetLevel(nHeat);
+    FeedWantedHud(oPC, nToken, nHeat, nLvl);
+
+    // Guard against double-chained ticks on reconnect.
+    if(!GetLocalInt(oPC, WNT_LVAR_TICK_GUARD))
+    {
+        SetLocalInt(oPC, WNT_LVAR_TICK_GUARD, 1);
+        DelayCommand(10.0, WantedHudTick(oPC));
+    }
+}
+
+void WantedDestroyHud(object oPC)
+{
+    int nToken = GetLocalInt(oPC, WNT_LVAR_HUD_TOKEN);
+    if(nToken != 0) NuiDestroy(oPC, nToken);
+    DeleteLocalInt(oPC, WNT_LVAR_HUD_TOKEN);
+    DeleteLocalInt(oPC, WNT_LVAR_GEOM_DELAY);
+    DeleteLocalInt(oPC, WNT_LVAR_TICK_GUARD);
+}
+
+// ===========================================================================
+// HUD data feed
+// ===========================================================================
+
+void FeedWantedHud(object oPC, int nToken, int nHeat, int nLvl)
+{
+    int nRgb = WantedGetColorRGB(nLvl);
+
+    NuiSetBind(oPC, nToken, WNT_BIND_ICON,
+        JsonString(WantedGetIconResref(nLvl)));
+    NuiSetBind(oPC, nToken, WNT_BIND_LVL_LBL,
+        JsonString(WantedGetLevelName(nLvl)));
+    NuiSetBind(oPC, nToken, WNT_BIND_BAR,
+        JsonFloat(IntToFloat(nHeat) / IntToFloat(WNT_MAX_HEAT)));
+    NuiSetBind(oPC, nToken, WNT_BIND_COLOR,
+        NuiColor((nRgb >> 16) & 0xFF, (nRgb >> 8) & 0xFF, nRgb & 0xFF));
+    NuiSetBind(oPC, nToken, WNT_BIND_TIP,
+        JsonString("Goraczka: " + IntToString(nHeat) + "/100 — "
+            + WantedGetLevelName(nLvl)));
+}
+
+// ===========================================================================
+// 10-second tick: refresh UI, detect threshold transitions
+// ===========================================================================
+
+void WantedHudTick(object oPC)
+{
+    if(!GetIsPC(oPC) || !GetIsObjectValid(oPC)) return;
+
+    int nToken = GetLocalInt(oPC, WNT_LVAR_HUD_TOKEN);
+    if(nToken == 0) return;
+
+    if(NuiFindWindow(oPC, WNT_HUD_WIN) == 0)
+    {
+        // Player closed the HUD somehow; stop ticking.
+        DeleteLocalInt(oPC, WNT_LVAR_HUD_TOKEN);
+        return;
+    }
+
+    string sUuid = GetObjectUUID(oPC);
+    struct WantedState s = WantedGetState(sUuid);
+    int nHeat = WantedCalcHeat(s);
+    int nLvl  = WantedGetLevel(nHeat);
+
+    FeedWantedHud(oPC, nToken, nHeat, nLvl);
+
+    if(nLvl != s.last_level)
+    {
+        WantedApplyEffects(oPC, nLvl);
+        WantedWriteLastLevel(sUuid, nLvl);
+
+        if(nLvl < s.last_level)
+            FloatingTextStringOnCreature(
+                "Goraczka opada... " + WantedGetLevelName(nLvl) + ".",
+                oPC, FALSE);
+        else
+            FloatingTextStringOnCreature(
+                "Jestes teraz " + WantedGetLevelName(nLvl) + "!",
+                oPC, FALSE);
+
+        // Keep the open panel in sync.
+        int nPanelToken = GetLocalInt(oPC, WNT_LVAR_PANEL_TOKEN);
+        if(nPanelToken != 0)
+            FeedWantedPanel(oPC, nPanelToken, nHeat, nLvl, s.crimes_committed);
+    }
+
+    DelayCommand(10.0, WantedHudTick(oPC));
+}
+
+// ===========================================================================
+// Records Panel layout
+// ===========================================================================
+
+json BuildWantedPanelLayout()
+{
+    // Large header: level name.
+    json jHdr = NuiLabel(
+        NuiBind(WNT_PANEL_BIND_HDR),
+        JsonInt(NUI_HALIGN_CENTER),
+        JsonInt(NUI_VALIGN_MIDDLE));
+    jHdr = NuiHeight(jHdr, 28.0);
+
+    // Flavor body text (multi-line).
+    json jBody = NuiLabel(
+        NuiBind(WNT_PANEL_BIND_BODY),
+        JsonInt(NUI_HALIGN_LEFT),
+        JsonInt(NUI_VALIGN_TOP));
+    jBody = NuiHeight(jBody, 70.0);
+
+    // Stats line: current heat.
+    json jHeat = NuiLabel(
+        NuiBind(WNT_PANEL_BIND_HEAT),
+        JsonInt(NUI_HALIGN_LEFT),
+        JsonInt(NUI_VALIGN_MIDDLE));
+    jHeat = NuiHeight(jHeat, 20.0);
+
+    // Stats line: crime count.
+    json jCrimes = NuiLabel(
+        NuiBind(WNT_PANEL_BIND_CRIMES),
+        JsonInt(NUI_HALIGN_LEFT),
+        JsonInt(NUI_VALIGN_MIDDLE));
+    jCrimes = NuiHeight(jCrimes, 20.0);
+
+    // Bribe button — label contains dynamic gold cost.
+    json jBtnBribe = NuiButton(NuiBind(WNT_PANEL_BIND_BRIBE));
+    jBtnBribe = NuiId(jBtnBribe, WNT_BTN_BRIBE);
+    jBtnBribe = NuiEnabled(jBtnBribe, NuiBind(WNT_PANEL_BIND_BRIBE_EN));
+    jBtnBribe = NuiHeight(jBtnBribe, 28.0);
+
+    // Surrender button — static label.
+    json jBtnSurr = NuiButton(JsonString("Oddaj sie w rece prawa"));
+    jBtnSurr = NuiId(jBtnSurr, WNT_BTN_SURRENDER);
+    jBtnSurr = NuiEnabled(jBtnSurr, NuiBind(WNT_PANEL_BIND_SURR_EN));
+    jBtnSurr = NuiHeight(jBtnSurr, 28.0);
+
+    // Close button.
+    json jBtnClose = NuiButton(JsonString("Zamknij"));
+    jBtnClose = NuiId(jBtnClose, WNT_BTN_CLOSE);
+    jBtnClose = NuiHeight(jBtnClose, 28.0);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jHdr);
+    jCol = JsonArrayInsert(jCol, NuiHeight(NuiSpacer(), 6.0));
+    jCol = JsonArrayInsert(jCol, jBody);
+    jCol = JsonArrayInsert(jCol, NuiHeight(NuiSpacer(), 4.0));
+    jCol = JsonArrayInsert(jCol, jHeat);
+    jCol = JsonArrayInsert(jCol, jCrimes);
+    jCol = JsonArrayInsert(jCol, NuiHeight(NuiSpacer(), 10.0));
+    jCol = JsonArrayInsert(jCol, jBtnBribe);
+    jCol = JsonArrayInsert(jCol, jBtnSurr);
+    jCol = JsonArrayInsert(jCol, NuiHeight(NuiSpacer(), 4.0));
+    jCol = JsonArrayInsert(jCol, jBtnClose);
+
+    return NuiCol(jCol);
+}
+
+// ===========================================================================
+// Records Panel lifecycle
+// ===========================================================================
+
+void WantedOpenPanel(object oPC)
+{
+    if(NuiFindWindow(oPC, WNT_PANEL_WIN) != 0) return;
+
+    json jGeom = NuiRect(-1.0, -1.0, WNT_PANEL_W, WNT_PANEL_H);
+    json jWin  = NuiWindow(
+        BuildWantedPanelLayout(),
+        JsonString("Rejestr Kryminalny"),
+        NuiBind(WNT_PANEL_BIND_GEOM),
+        JsonBool(FALSE),   // resizable
+        JsonBool(FALSE),   // collapsed
+        JsonBool(TRUE),    // closable — player can X it
+        JsonBool(FALSE),   // transparent
+        JsonBool(TRUE));   // border
+
+    int nToken = NuiCreate(oPC, jWin, WNT_PANEL_WIN, "lib_wnt_ev");
+    if(nToken == 0) return;
+
+    SetLocalInt(oPC, WNT_LVAR_PANEL_TOKEN, nToken);
+
+    string sUuid = GetObjectUUID(oPC);
+    struct WantedState s = WantedGetState(sUuid);
+    int nHeat = WantedCalcHeat(s);
+    int nLvl  = WantedGetLevel(nHeat);
+
+    FeedWantedPanel(oPC, nToken, nHeat, nLvl, s.crimes_committed);
+}
+
+void WantedDestroyPanel(object oPC)
+{
+    int nToken = GetLocalInt(oPC, WNT_LVAR_PANEL_TOKEN);
+    if(nToken != 0) NuiDestroy(oPC, nToken);
+    DeleteLocalInt(oPC, WNT_LVAR_PANEL_TOKEN);
+}
+
+// ===========================================================================
+// Records Panel data feed
+// ===========================================================================
+
+void FeedWantedPanel(object oPC, int nToken, int nHeat, int nLvl, int nCrimes)
+{
+    int nBribeCost = nHeat * WNT_BRIBE_COST_PER_HEAT;
+    int nSurrCost  = nCrimes * WNT_SURRENDER_PER_CRIME;
+    if(nSurrCost < WNT_SURRENDER_MIN_COST) nSurrCost = WNT_SURRENDER_MIN_COST;
+
+    NuiSetBind(oPC, nToken, WNT_PANEL_BIND_HDR,
+        JsonString(WantedGetLevelName(nLvl)));
+    NuiSetBind(oPC, nToken, WNT_PANEL_BIND_BODY,
+        JsonString(WantedGetFlavorText(nLvl)));
+    NuiSetBind(oPC, nToken, WNT_PANEL_BIND_HEAT,
+        JsonString("Goraczka: " + IntToString(nHeat) + " / 100"));
+    NuiSetBind(oPC, nToken, WNT_PANEL_BIND_CRIMES,
+        JsonString("Przestepstwa: " + IntToString(nCrimes)));
+
+    string sBribeLabel = nHeat > 0
+        ? "Oplac kontrybucie (" + IntToString(nBribeCost) + " zl, -30 goraczki)"
+        : "Kontrybucia nieopplacalna";
+    NuiSetBind(oPC, nToken, WNT_PANEL_BIND_BRIBE,  JsonString(sBribeLabel));
+    NuiSetBind(oPC, nToken, WNT_PANEL_BIND_BRIBE_EN,  JsonBool(nHeat > 0));
+    NuiSetBind(oPC, nToken, WNT_PANEL_BIND_SURR_EN,
+        JsonBool(nCrimes > 0));
+}
+
+// ===========================================================================
+// HUD drag-position save (debounced)
+// ===========================================================================
+
+void WantedSaveHudPos(object oPC)
+{
+    DeleteLocalInt(oPC, WNT_LVAR_GEOM_DELAY);
+
+    int nToken = GetLocalInt(oPC, WNT_LVAR_HUD_TOKEN);
+    if(nToken == 0) return;
+
+    json jGeom = NuiGetBind(oPC, nToken, WNT_BIND_GEOM);
+    if(JsonGetType(jGeom) != JSON_TYPE_OBJECT) return;
+
+    float fX = JsonGetFloat(JsonObjectGet(jGeom, "x"));
+    float fY = JsonGetFloat(JsonObjectGet(jGeom, "y"));
+    WantedSetUiPos(GetObjectUUID(oPC), fX, fY);
+}
+
+// ===========================================================================
+// Core gameplay API
+// ===========================================================================
+
+// Add nAmt points of heat. Set bIsCrime = TRUE (default) to increment the
+// crime counter (affects surrender cost). Call this from any crime hook.
+void WantedAddHeat(object oPC, int nAmt, int bIsCrime)
+{
+    if(!GetIsPC(oPC) || GetIsDM(oPC)) return;
+    if(nAmt <= 0) return;
+
+    string sUuid = GetObjectUUID(oPC);
+    struct WantedState s = WantedGetState(sUuid);
+    int nCurrent = WantedCalcHeat(s);
+    int nNew     = nCurrent + nAmt;
+    if(nNew > WNT_MAX_HEAT) nNew = WNT_MAX_HEAT;
+
+    WantedWriteHeat(sUuid, nNew, WantedNowUnix());
+    if(bIsCrime) WantedIncrementCrimes(sUuid);
+
+    int nLvl    = WantedGetLevel(nNew);
+    int nOldLvl = s.last_level;
+    if(nLvl != nOldLvl)
+    {
+        WantedApplyEffects(oPC, nLvl);
+        WantedWriteLastLevel(sUuid, nLvl);
+        FloatingTextStringOnCreature(
+            "Jestes teraz " + WantedGetLevelName(nLvl) + "!",
+            oPC, FALSE);
+    }
+
+    int nHudToken = GetLocalInt(oPC, WNT_LVAR_HUD_TOKEN);
+    if(nHudToken != 0)
+        FeedWantedHud(oPC, nHudToken, nNew, nLvl);
+
+    int nPanelToken = GetLocalInt(oPC, WNT_LVAR_PANEL_TOKEN);
+    if(nPanelToken != 0)
+    {
+        // Re-read state to get updated crime count.
+        struct WantedState sNew = WantedGetState(sUuid);
+        FeedWantedPanel(oPC, nPanelToken, nNew, nLvl, sNew.crimes_committed);
+    }
+}
+
+// Pay gold to reduce heat by WNT_BRIBE_REDUCTION.
+// Cost = current_heat * WNT_BRIBE_COST_PER_HEAT.
+void WantedBribe(object oPC)
+{
+    if(!GetIsPC(oPC)) return;
+
+    string sUuid = GetObjectUUID(oPC);
+    struct WantedState s = WantedGetState(sUuid);
+    int nHeat = WantedCalcHeat(s);
+    if(nHeat <= 0) return;
+
+    int nCost = nHeat * WNT_BRIBE_COST_PER_HEAT;
+    if(GetGold(oPC) < nCost)
+    {
+        FloatingTextStringOnCreature(
+            "Brakuje ci zlota na kontrybucie (" + IntToString(nCost) + " zl).",
+            oPC, FALSE);
+        return;
+    }
+
+    TakeGoldFromCreature(nCost, oPC, TRUE);
+
+    int nNewHeat = nHeat - WNT_BRIBE_REDUCTION;
+    if(nNewHeat < 0) nNewHeat = 0;
+    WantedWriteHeat(sUuid, nNewHeat, WantedNowUnix());
+
+    int nLvl = WantedGetLevel(nNewHeat);
+    if(nLvl != s.last_level)
+    {
+        WantedApplyEffects(oPC, nLvl);
+        WantedWriteLastLevel(sUuid, nLvl);
+    }
+
+    FloatingTextStringOnCreature(
+        "Kontrybucia oplacona. Goraczka: " + IntToString(nNewHeat) + ".",
+        oPC, FALSE);
+
+    int nHudToken = GetLocalInt(oPC, WNT_LVAR_HUD_TOKEN);
+    if(nHudToken != 0)
+        FeedWantedHud(oPC, nHudToken, nNewHeat, nLvl);
+
+    int nPanelToken = GetLocalInt(oPC, WNT_LVAR_PANEL_TOKEN);
+    if(nPanelToken != 0)
+        FeedWantedPanel(oPC, nPanelToken, nNewHeat, nLvl, s.crimes_committed);
+}
+
+// Pay per-crime fine, reset heat to 0 and clear the crime record.
+// Minimum cost: WNT_SURRENDER_MIN_COST gold.
+void WantedSurrender(object oPC)
+{
+    if(!GetIsPC(oPC)) return;
+
+    string sUuid = GetObjectUUID(oPC);
+    struct WantedState s = WantedGetState(sUuid);
+    if(s.crimes_committed <= 0) return;
+
+    int nCost = s.crimes_committed * WNT_SURRENDER_PER_CRIME;
+    if(nCost < WNT_SURRENDER_MIN_COST) nCost = WNT_SURRENDER_MIN_COST;
+
+    if(GetGold(oPC) < nCost)
+    {
+        FloatingTextStringOnCreature(
+            "Nie mozesz pokryc kary (" + IntToString(nCost) + " zl).",
+            oPC, FALSE);
+        return;
+    }
+
+    TakeGoldFromCreature(nCost, oPC, TRUE);
+    WantedWriteHeat(sUuid, 0, WantedNowUnix());
+    WantedResetCrimes(sUuid);
+    WantedWriteLastLevel(sUuid, WNT_LVL_CLEAN);
+    WantedApplyEffects(oPC, WNT_LVL_CLEAN);
+
+    FloatingTextStringOnCreature(
+        "Oddales sie w rece prawa. Karta przestepstw wyczyszczona.",
+        oPC, FALSE);
+
+    int nHudToken = GetLocalInt(oPC, WNT_LVAR_HUD_TOKEN);
+    if(nHudToken != 0)
+        FeedWantedHud(oPC, nHudToken, 0, WNT_LVL_CLEAN);
+
+    int nPanelToken = GetLocalInt(oPC, WNT_LVAR_PANEL_TOKEN);
+    if(nPanelToken != 0)
+        FeedWantedPanel(oPC, nPanelToken, 0, WNT_LVL_CLEAN, 0);
+}

--- a/Wanted System/scripts/lib_wnt_def.nss
+++ b/Wanted System/scripts/lib_wnt_def.nss
@@ -1,0 +1,243 @@
+// =============================================================================
+// lib_wnt_def.nss
+// =============================================================================
+// Constants, pure helpers, and effect helpers for the Wanted system.
+// Exposes the full public API used by lib_wnt.nss and by external callers
+// (e.g., guard OnPerception scripts, crime-detection hooks).
+// =============================================================================
+
+#include "nw_inc_nui"
+#include "sql_wnt"
+
+// ---------------------------------------------------------------------------
+// Thresholds — heat >= value means you are AT LEAST that level
+// ---------------------------------------------------------------------------
+const int WNT_MAX_HEAT    = 100;
+const int WNT_TH_SUSPECT  =  20;   // >= 20  → Podejrzany
+const int WNT_TH_WANTED   =  40;   // >= 40  → Poszukiwany
+const int WNT_TH_OUTLAW   =  60;   // >= 60  → Wyjęty spod prawa
+const int WNT_TH_DEAD     =  80;   // >= 80  → Martwy lub żywy
+
+// ---------------------------------------------------------------------------
+// Level IDs
+// ---------------------------------------------------------------------------
+const int WNT_LVL_CLEAN   = 0;
+const int WNT_LVL_SUSPECT = 1;
+const int WNT_LVL_WANTED  = 2;
+const int WNT_LVL_OUTLAW  = 3;
+const int WNT_LVL_DEAD    = 4;
+
+// ---------------------------------------------------------------------------
+// Decay rate
+// TEST: 0.1 heat/s → full stack clears in ~17 minutes.
+// Production: try 0.010–0.016 (1 heat per ~1 min).
+// ---------------------------------------------------------------------------
+const float WNT_DECAY_PER_SEC = 0.1;
+
+// ---------------------------------------------------------------------------
+// Economy
+// ---------------------------------------------------------------------------
+const int WNT_BRIBE_COST_PER_HEAT  = 15;  // gold per current heat point
+const int WNT_BRIBE_REDUCTION      = 30;  // heat removed per successful bribe
+const int WNT_SURRENDER_PER_CRIME  = 50;  // gold per crime when surrendering
+const int WNT_SURRENDER_MIN_COST   = 100; // minimum gold for surrender
+
+// ---------------------------------------------------------------------------
+// HUD — small always-on bar (draggable, no close button)
+// ---------------------------------------------------------------------------
+const float  WNT_HUD_W = 220.0;
+const float  WNT_HUD_H =  44.0;
+const float  WNT_HUD_ICON = 36.0;
+
+const string WNT_HUD_WIN      = "wnt_hud";
+const string WNT_BIND_GEOM    = "wnt_geom";
+const string WNT_BIND_ICON    = "wnt_icon";
+const string WNT_BIND_LVL_LBL = "wnt_lvl";
+const string WNT_BIND_BAR     = "wnt_bar";
+const string WNT_BIND_COLOR   = "wnt_col";
+const string WNT_BIND_TIP     = "wnt_tip";
+const string WNT_BTN_OPEN     = "wnt_btn_open"; // click skull to open panel
+
+// ---------------------------------------------------------------------------
+// Records Panel — full window with buttons
+// ---------------------------------------------------------------------------
+const float  WNT_PANEL_W = 300.0;
+const float  WNT_PANEL_H = 282.0;
+
+const string WNT_PANEL_WIN          = "wnt_panel";
+const string WNT_PANEL_BIND_GEOM    = "wnt_p_geom";
+const string WNT_PANEL_BIND_HDR     = "wnt_p_hdr";
+const string WNT_PANEL_BIND_BODY    = "wnt_p_body";
+const string WNT_PANEL_BIND_HEAT    = "wnt_p_heat";
+const string WNT_PANEL_BIND_CRIMES  = "wnt_p_crimes";
+const string WNT_PANEL_BIND_BRIBE   = "wnt_p_bribe";  // button label (dynamic cost)
+const string WNT_PANEL_BIND_BRIBE_EN    = "wnt_p_bribe_en";
+const string WNT_PANEL_BIND_SURR_EN     = "wnt_p_surr_en";
+const string WNT_BTN_BRIBE     = "wnt_btn_bribe";
+const string WNT_BTN_SURRENDER = "wnt_btn_surr";
+const string WNT_BTN_CLOSE     = "wnt_btn_close";
+
+// ---------------------------------------------------------------------------
+// Local variables stored on the PC object
+// ---------------------------------------------------------------------------
+const string WNT_LVAR_HUD_TOKEN   = "WNT_HUD_TK";
+const string WNT_LVAR_PANEL_TOKEN = "WNT_PANEL_TK";
+const string WNT_LVAR_GEOM_DELAY  = "WNT_GEOM_DL";
+const string WNT_LVAR_TICK_GUARD  = "WNT_TICK_GD";
+
+// ---------------------------------------------------------------------------
+// Effect tag (all wanted debuffs share this tag for clean removal)
+// ---------------------------------------------------------------------------
+const string WNT_TAG_DBF = "WNT_DEBUFF";
+
+// ===========================================================================
+// Pure helpers
+// ===========================================================================
+
+// Compute effective heat from the stored snapshot + elapsed decay.
+int WantedCalcHeat(struct WantedState s)
+{
+    int nNow     = WantedNowUnix();
+    int nElapsed = nNow - s.last_decay_at;
+    if(nElapsed < 0) nElapsed = 0;
+
+    float fLost = IntToFloat(nElapsed) * WNT_DECAY_PER_SEC;
+    int   nHeat = s.stored_heat - FloatToInt(fLost);
+    if(nHeat < 0)            nHeat = 0;
+    if(nHeat > WNT_MAX_HEAT) nHeat = WNT_MAX_HEAT;
+    return nHeat;
+}
+
+int WantedGetLevel(int nHeat)
+{
+    if(nHeat >= WNT_TH_DEAD)   return WNT_LVL_DEAD;
+    if(nHeat >= WNT_TH_OUTLAW) return WNT_LVL_OUTLAW;
+    if(nHeat >= WNT_TH_WANTED) return WNT_LVL_WANTED;
+    if(nHeat >= WNT_TH_SUSPECT)return WNT_LVL_SUSPECT;
+    return WNT_LVL_CLEAN;
+}
+
+string WantedGetLevelName(int nLvl)
+{
+    switch(nLvl)
+    {
+        case WNT_LVL_CLEAN:   return "Czysto";
+        case WNT_LVL_SUSPECT: return "Podejrzany";
+        case WNT_LVL_WANTED:  return "Poszukiwany";
+        case WNT_LVL_OUTLAW:  return "Wyjety spod prawa";
+        case WNT_LVL_DEAD:    return "Martwy lub zywy";
+    }
+    return "";
+}
+
+string WantedGetFlavorText(int nLvl)
+{
+    switch(nLvl)
+    {
+        case WNT_LVL_CLEAN:
+            return "Nie ciazy na tobie zadna wina w oczach prawa.\nNa razie.";
+        case WNT_LVL_SUSPECT:
+            return "Straz zerka w twoja strone z podejrzliwoscia.\nJeszcze nic pewnego — lecz wiesci sie rozchodza.";
+        case WNT_LVL_WANTED:
+            return "Twoj wizerunek widnieje na bramach i drzwiach karczmy.\nPytania padaja, pieniadze zmieniaja wlascicieli.";
+        case WNT_LVL_OUTLAW:
+            return "Prawa cie nie chronia. Kazdy miecz zbrojnych mierzy\nw twoja strone. Szukaj schronienia wsrod kanalii.";
+        case WNT_LVL_DEAD:
+            return "Wyznaczono nagrode za twoja glowe — i to wysoka.\nLowcy nagrod, kaci i zdrajcy sa w drodze. Uciekaj.";
+    }
+    return "";
+}
+
+string WantedGetIconResref(int nLvl)
+{
+    switch(nLvl)
+    {
+        case WNT_LVL_CLEAN:   return "wnt_icon_0";
+        case WNT_LVL_SUSPECT: return "wnt_icon_1";
+        case WNT_LVL_WANTED:  return "wnt_icon_2";
+        case WNT_LVL_OUTLAW:  return "wnt_icon_3";
+        case WNT_LVL_DEAD:    return "wnt_icon_4";
+    }
+    return "wnt_icon_0";
+}
+
+// Returns packed RGB for NuiColor unpacking.
+int WantedGetColorRGB(int nLvl)
+{
+    switch(nLvl)
+    {
+        case WNT_LVL_CLEAN:   return (120 << 16) | (220 << 8) | 120; // zielony
+        case WNT_LVL_SUSPECT: return (220 << 16) | (200 << 8) |  60; // zolty
+        case WNT_LVL_WANTED:  return (230 << 16) | (130 << 8) |  40; // pomaranczowy
+        case WNT_LVL_OUTLAW:  return (220 << 16) |  (60 << 8) |  40; // czerwony
+        case WNT_LVL_DEAD:    return (160 << 16) |  (20 << 8) | 180; // purpurowy
+    }
+    return (200 << 16) | (200 << 8) | 200;
+}
+
+// ===========================================================================
+// Effect helpers
+// ===========================================================================
+
+void WantedRemoveDebuffs(object oPC)
+{
+    effect e = GetFirstEffect(oPC);
+    while(GetIsEffectValid(e))
+    {
+        if(GetEffectTag(e) == WNT_TAG_DBF) RemoveEffect(oPC, e);
+        e = GetNextEffect(oPC);
+    }
+}
+
+// Debuffs: Clean/Suspect → none.
+// Wanted → -1 CHA (haggard, nervous).
+// Outlaw → -2 CHA, -1 DEX (constantly looking over shoulder).
+// Dead   → -3 CHA, -2 DEX, -1 CON (terror of being hunted).
+void WantedApplyEffects(object oPC, int nLvl)
+{
+    WantedRemoveDebuffs(oPC);
+    if(nLvl < WNT_LVL_WANTED) return;
+
+    effect eDbf;
+    if(nLvl == WNT_LVL_WANTED)
+    {
+        eDbf = EffectAbilityDecrease(ABILITY_CHARISMA, 1);
+    }
+    else if(nLvl == WNT_LVL_OUTLAW)
+    {
+        eDbf = EffectAbilityDecrease(ABILITY_CHARISMA, 2);
+        eDbf = EffectLinkEffects(eDbf, EffectAbilityDecrease(ABILITY_DEXTERITY, 1));
+    }
+    else // WNT_LVL_DEAD
+    {
+        eDbf = EffectAbilityDecrease(ABILITY_CHARISMA, 3);
+        eDbf = EffectLinkEffects(eDbf, EffectAbilityDecrease(ABILITY_DEXTERITY,    2));
+        eDbf = EffectLinkEffects(eDbf, EffectAbilityDecrease(ABILITY_CONSTITUTION, 1));
+    }
+    eDbf = SupernaturalEffect(eDbf);
+    eDbf = TagEffect(eDbf, WNT_TAG_DBF);
+    ApplyEffectToObject(DURATION_TYPE_PERMANENT, eDbf, oPC);
+}
+
+// ===========================================================================
+// Guard helper (can be called from guard OnPerception scripts)
+// ===========================================================================
+
+// Returns TRUE if oPC is wanted at level >= WNT_LVL_WANTED.
+int WantedShouldGuardAttack(object oPC)
+{
+    if(!GetIsPC(oPC) || GetIsDM(oPC)) return FALSE;
+    struct WantedState s = WantedGetState(GetObjectUUID(oPC));
+    return WantedGetLevel(WantedCalcHeat(s)) >= WNT_LVL_WANTED;
+}
+
+// Call from a guard's OnPerception. If the PC is wanted, mark them as a
+// temporary enemy for 2 minutes and shout a warning.
+void WantedGuardReact(object oGuard, object oPC)
+{
+    if(!GetIsPC(oPC) || GetIsDM(oPC)) return;
+    if(!WantedShouldGuardAttack(oPC)) return;
+
+    SetIsTemporaryEnemy(oPC, oGuard, FALSE, 120.0);
+    SpeakString("Zatrzymac! Jestes poszukiwany!", TALKVOLUME_TALK);
+}

--- a/Wanted System/scripts/lib_wnt_ev.nss
+++ b/Wanted System/scripts/lib_wnt_ev.nss
@@ -1,0 +1,97 @@
+// =============================================================================
+// lib_wnt_ev.nss
+// =============================================================================
+// NUI event router for the Wanted system.
+// Wires both the HUD and the Records Panel:
+//
+//   HUD:
+//     WATCH  geometry bind → debounced position save (0.5 s after last drag)
+//     CLOSE                → cleanup locals
+//     CLICK  WNT_BTN_OPEN  → toggle Records Panel
+//
+//   Panel:
+//     CLOSE              → cleanup local
+//     CLICK WNT_BTN_BRIBE     → WantedBribe()
+//     CLICK WNT_BTN_SURRENDER → WantedSurrender()
+//     CLICK WNT_BTN_CLOSE     → WantedDestroyPanel()
+// =============================================================================
+
+#include "lib_wnt"
+
+void main()
+{
+    object oPC      = NuiGetEventPlayer();
+    int    nToken   = NuiGetEventWindow();
+    string sEvent   = NuiGetEventType();
+    string sElement = NuiGetEventElement();
+
+    int nHudToken   = GetLocalInt(oPC, WNT_LVAR_HUD_TOKEN);
+    int nPanelToken = GetLocalInt(oPC, WNT_LVAR_PANEL_TOKEN);
+
+    // -------------------------------------------------------------------------
+    // HUD events
+    // -------------------------------------------------------------------------
+    if(nToken == nHudToken)
+    {
+        if(sEvent == "close")
+        {
+            DeleteLocalInt(oPC, WNT_LVAR_HUD_TOKEN);
+            DeleteLocalInt(oPC, WNT_LVAR_GEOM_DELAY);
+            DeleteLocalInt(oPC, WNT_LVAR_TICK_GUARD);
+            return;
+        }
+
+        if(sEvent == "watch" && sElement == WNT_BIND_GEOM)
+        {
+            // Debounce: 0.5 s after the last drag frame before reading position.
+            if(GetLocalInt(oPC, WNT_LVAR_GEOM_DELAY)) return;
+            SetLocalInt(oPC, WNT_LVAR_GEOM_DELAY, 1);
+            DelayCommand(0.5, WantedSaveHudPos(oPC));
+            return;
+        }
+
+        if(sEvent == "click" && sElement == WNT_BTN_OPEN)
+        {
+            if(NuiFindWindow(oPC, WNT_PANEL_WIN) != 0)
+                WantedDestroyPanel(oPC);
+            else
+                WantedOpenPanel(oPC);
+            return;
+        }
+
+        return;
+    }
+
+    // -------------------------------------------------------------------------
+    // Records Panel events
+    // -------------------------------------------------------------------------
+    if(nToken == nPanelToken)
+    {
+        if(sEvent == "close")
+        {
+            DeleteLocalInt(oPC, WNT_LVAR_PANEL_TOKEN);
+            return;
+        }
+
+        if(sEvent == "click")
+        {
+            if(sElement == WNT_BTN_CLOSE)
+            {
+                WantedDestroyPanel(oPC);
+                return;
+            }
+            if(sElement == WNT_BTN_BRIBE)
+            {
+                WantedBribe(oPC);
+                return;
+            }
+            if(sElement == WNT_BTN_SURRENDER)
+            {
+                WantedSurrender(oPC);
+                return;
+            }
+        }
+
+        return;
+    }
+}

--- a/Wanted System/scripts/sql_wnt.nss
+++ b/Wanted System/scripts/sql_wnt.nss
@@ -1,0 +1,187 @@
+// =============================================================================
+// sql_wnt.nss
+// =============================================================================
+// Campaign SQLite persistence for the Wanted system.
+//
+// Design: timestamp-based decay identical in shape to the Rations module.
+// We store stored_heat (value at last_decay_at) and compute effective heat
+// on demand:
+//
+//     effective = stored_heat - (now - last_decay_at) * WNT_DECAY_PER_SEC
+//
+// On any crime or payment, we snapshot the current effective value as the new
+// stored_heat and update last_decay_at = now. This avoids per-tick writes.
+//
+// Tables:
+//   wnt_state(uuid, stored_heat, last_decay_at, last_level, crimes_committed)
+//   wnt_ui   (uuid, x, y)
+// =============================================================================
+
+const string WNT_DB        = "wanted";
+const string WNT_TBL_STATE = "wnt_state";
+const string WNT_TBL_UI    = "wnt_ui";
+
+// ---------------------------------------------------------------------------
+// Time helper
+// ---------------------------------------------------------------------------
+int WantedNowUnix()
+{
+    sqlquery sql = SqlPrepareQueryCampaign(WNT_DB, "SELECT strftime('%s', 'now');");
+    SqlStep(sql);
+    return SqlGetInt(sql, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Table creation (idempotent)
+// ---------------------------------------------------------------------------
+void WantedCreateTables()
+{
+    sqlquery sql = SqlPrepareQueryCampaign(WNT_DB,
+        "CREATE TABLE IF NOT EXISTS " + WNT_TBL_STATE + " ("
+        + "uuid             TEXT    PRIMARY KEY, "
+        + "stored_heat      INTEGER DEFAULT 0, "
+        + "last_decay_at    INTEGER NOT NULL, "
+        + "last_level       INTEGER DEFAULT 0, "
+        + "crimes_committed INTEGER DEFAULT 0);");
+    SqlStep(sql);
+
+    sql = SqlPrepareQueryCampaign(WNT_DB,
+        "CREATE TABLE IF NOT EXISTS " + WNT_TBL_UI + " ("
+        + "uuid TEXT PRIMARY KEY, "
+        + "x    REAL DEFAULT -1.0, "
+        + "y    REAL DEFAULT -1.0);");
+    SqlStep(sql);
+}
+
+// ---------------------------------------------------------------------------
+// Row bootstrap
+// ---------------------------------------------------------------------------
+void WantedEnsureRow(object oPC)
+{
+    string sUuid = GetObjectUUID(oPC);
+    int    nNow  = WantedNowUnix();
+
+    sqlquery sql = SqlPrepareQueryCampaign(WNT_DB,
+        "INSERT OR IGNORE INTO " + WNT_TBL_STATE
+        + " (uuid, stored_heat, last_decay_at) VALUES (@u, 0, @t);");
+    SqlBindString(sql, "@u", sUuid);
+    SqlBindInt(sql,    "@t", nNow);
+    SqlStep(sql);
+
+    sql = SqlPrepareQueryCampaign(WNT_DB,
+        "INSERT OR IGNORE INTO " + WNT_TBL_UI + " (uuid) VALUES (@u);");
+    SqlBindString(sql, "@u", sUuid);
+    SqlStep(sql);
+}
+
+// ---------------------------------------------------------------------------
+// State struct
+// ---------------------------------------------------------------------------
+struct WantedState
+{
+    int stored_heat;
+    int last_decay_at;
+    int last_level;
+    int crimes_committed;
+};
+
+struct WantedState WantedGetState(string sUuid)
+{
+    struct WantedState r;
+    r.stored_heat      = 0;
+    r.last_decay_at    = WantedNowUnix();
+    r.last_level       = 0;
+    r.crimes_committed = 0;
+
+    sqlquery sql = SqlPrepareQueryCampaign(WNT_DB,
+        "SELECT stored_heat, last_decay_at, last_level, crimes_committed "
+        + "FROM " + WNT_TBL_STATE + " WHERE uuid = @u;");
+    SqlBindString(sql, "@u", sUuid);
+    if(SqlStep(sql))
+    {
+        r.stored_heat      = SqlGetInt(sql, 0);
+        r.last_decay_at    = SqlGetInt(sql, 1);
+        r.last_level       = SqlGetInt(sql, 2);
+        r.crimes_committed = SqlGetInt(sql, 3);
+    }
+    return r;
+}
+
+// ---------------------------------------------------------------------------
+// Heat writes
+// ---------------------------------------------------------------------------
+void WantedWriteHeat(string sUuid, int nHeat, int nNow)
+{
+    sqlquery sql = SqlPrepareQueryCampaign(WNT_DB,
+        "UPDATE " + WNT_TBL_STATE
+        + " SET stored_heat = @h, last_decay_at = @t WHERE uuid = @u;");
+    SqlBindString(sql, "@u", sUuid);
+    SqlBindInt(sql,    "@h", nHeat);
+    SqlBindInt(sql,    "@t", nNow);
+    SqlStep(sql);
+}
+
+void WantedWriteLastLevel(string sUuid, int nLvl)
+{
+    sqlquery sql = SqlPrepareQueryCampaign(WNT_DB,
+        "UPDATE " + WNT_TBL_STATE + " SET last_level = @v WHERE uuid = @u;");
+    SqlBindString(sql, "@u", sUuid);
+    SqlBindInt(sql,    "@v", nLvl);
+    SqlStep(sql);
+}
+
+// ---------------------------------------------------------------------------
+// Crime counter
+// ---------------------------------------------------------------------------
+void WantedIncrementCrimes(string sUuid)
+{
+    sqlquery sql = SqlPrepareQueryCampaign(WNT_DB,
+        "UPDATE " + WNT_TBL_STATE
+        + " SET crimes_committed = crimes_committed + 1 WHERE uuid = @u;");
+    SqlBindString(sql, "@u", sUuid);
+    SqlStep(sql);
+}
+
+void WantedResetCrimes(string sUuid)
+{
+    sqlquery sql = SqlPrepareQueryCampaign(WNT_DB,
+        "UPDATE " + WNT_TBL_STATE + " SET crimes_committed = 0 WHERE uuid = @u;");
+    SqlBindString(sql, "@u", sUuid);
+    SqlStep(sql);
+}
+
+// ---------------------------------------------------------------------------
+// UI position
+// ---------------------------------------------------------------------------
+struct WantedUiPos
+{
+    float x;
+    float y;
+};
+
+struct WantedUiPos WantedGetUiPos(string sUuid)
+{
+    struct WantedUiPos r;
+    r.x = -1.0;
+    r.y = -1.0;
+
+    sqlquery sql = SqlPrepareQueryCampaign(WNT_DB,
+        "SELECT x, y FROM " + WNT_TBL_UI + " WHERE uuid = @u;");
+    SqlBindString(sql, "@u", sUuid);
+    if(SqlStep(sql))
+    {
+        r.x = SqlGetFloat(sql, 0);
+        r.y = SqlGetFloat(sql, 1);
+    }
+    return r;
+}
+
+void WantedSetUiPos(string sUuid, float fX, float fY)
+{
+    sqlquery sql = SqlPrepareQueryCampaign(WNT_DB,
+        "UPDATE " + WNT_TBL_UI + " SET x = @x, y = @y WHERE uuid = @u;");
+    SqlBindString(sql, "@u", sUuid);
+    SqlBindFloat(sql,  "@x", fX);
+    SqlBindFloat(sql,  "@y", fY);
+    SqlStep(sql);
+}

--- a/Wanted System/scripts/sys_on_enter.nss
+++ b/Wanted System/scripts/sys_on_enter.nss
@@ -1,0 +1,31 @@
+// =============================================================================
+// sys_on_enter.nss
+// =============================================================================
+// Module OnClientEnter event.
+// Ensures the player has a Wanted row in the campaign DB, re-applies the
+// correct debuffs for their current heat, and spawns the HUD after a 1-second
+// delay (NUI created immediately on enter can race the client settling).
+// =============================================================================
+
+#include "lib_wnt"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC) || GetIsDM(oPC)) return;
+
+    WantedEnsureRow(oPC);
+
+    // Align cached last_level with the true current heat on login
+    // (heat may have decayed while the player was offline).
+    string sUuid = GetObjectUUID(oPC);
+    struct WantedState s = WantedGetState(sUuid);
+    int nHeat = WantedCalcHeat(s);
+    int nLvl  = WantedGetLevel(nHeat);
+
+    WantedApplyEffects(oPC, nLvl);
+    WantedWriteLastLevel(sUuid, nLvl);
+
+    // 1-second delay: NUI requires the player's area to be fully loaded.
+    DelayCommand(1.0, WantedCreateHud(oPC));
+}

--- a/Wanted System/scripts/sys_on_leave.nss
+++ b/Wanted System/scripts/sys_on_leave.nss
@@ -1,0 +1,17 @@
+// =============================================================================
+// sys_on_leave.nss
+// =============================================================================
+// Module OnClientExit event. Tears down NUI windows.
+// Heat state persists in the campaign DB via timestamps — no extra writes needed.
+// =============================================================================
+
+#include "lib_wnt"
+
+void main()
+{
+    object oPC = GetExitingObject();
+    if(!GetIsPC(oPC)) return;
+
+    WantedDestroyPanel(oPC);
+    WantedDestroyHud(oPC);
+}

--- a/Wanted System/scripts/sys_on_load.nss
+++ b/Wanted System/scripts/sys_on_load.nss
@@ -1,0 +1,13 @@
+// =============================================================================
+// sys_on_load.nss
+// =============================================================================
+// Module OnModuleLoad event. Creates Wanted system campaign tables.
+// Merge into your existing OnModuleLoad handler if you have one.
+// =============================================================================
+
+#include "lib_wnt"
+
+void main()
+{
+    WantedCreateTables();
+}

--- a/Wanted System/scripts/test_wnt.nss
+++ b/Wanted System/scripts/test_wnt.nss
@@ -1,0 +1,44 @@
+// =============================================================================
+// test_wnt.nss
+// =============================================================================
+// Demonstration script — place on a Placeable's OnUsed event.
+//
+// Each use adds 25 heat points (counts as one crime), then opens the Records
+// Panel so you can observe the threshold system and test the bribe/surrender
+// buttons. Use repeatedly to climb through all five wanted levels.
+//
+// To reset: log out and wait for decay (at test rate ~4 minutes for full drain),
+// or trigger WantedSurrender() directly from a DM conversation script.
+// =============================================================================
+
+#include "lib_wnt"
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC) || GetIsDM(oPC)) return;
+
+    // Simulate one crime: add 25 heat.
+    WantedAddHeat(oPC, 25, TRUE);
+
+    string sUuid = GetObjectUUID(oPC);
+    struct WantedState s = WantedGetState(sUuid);
+    int nHeat = WantedCalcHeat(s);
+    int nLvl  = WantedGetLevel(nHeat);
+
+    SendMessageToPC(oPC,
+        "[Wanted] Popelniles przestepstwo! "
+        + "Goraczka: " + IntToString(nHeat) + "/100. "
+        + "Status: " + WantedGetLevelName(nLvl) + ". "
+        + "Przestepstw lacznie: " + IntToString(s.crimes_committed));
+
+    // Ensure the HUD is visible.
+    if(NuiFindWindow(oPC, WNT_HUD_WIN) == 0)
+        WantedCreateHud(oPC);
+
+    // Open the Records Panel (toggle: second use while panel is open closes it).
+    if(NuiFindWindow(oPC, WNT_PANEL_WIN) != 0)
+        WantedDestroyPanel(oPC);
+    else
+        WantedOpenPanel(oPC);
+}


### PR DESCRIPTION
## Co to robi

System reputacji kryminalnej per-gracza. Gracz popełnia przestępstwa → akumuluje "gorączkę" (0–100), która topnieje z czasem rzeczywistym (podejście timestamp-based, identyczne z modułem Rations). HUD zawsze widoczny na ekranie; klik na ikonę otwiera panel z rejestrem i opcjami płatności.

## Mechanika

**Pięć progów gorączki:**

| Próg | Gorączka | Debuff |
|------|----------|--------|
| Czysto | 0–19 | brak |
| Podejrzany | 20–39 | brak (tylko flavor) |
| Poszukiwany | 40–59 | –1 CHA |
| Wyjęty spod prawa | 60–79 | –2 CHA, –1 DEX |
| Martwy lub żywy | 80–100 | –3 CHA, –2 DEX, –1 CON |

**Zanik:** timestamp-based — żadnych zapisów do DB co tick; gorączka obliczana na żądanie z `stored_heat - elapsed * decay_rate`. Zanik działa też w trybie offline.

**Opcje grającego (panel "Rejestr Kryminalny"):**
- **Opłać kontrybucję** — koszt `heat × 15` zł, usuwa 30 pkt. gorączki
- **Oddaj się w ręce prawa** — koszt `przestępstwa × 50` zł (min. 100), zeruje gorączkę i licznik przestępstw

**Straż:** helper `WantedGuardReact(oGuard, oPC)` do podpięcia w OnPerception — przy gorączce ≥ 40 strażnik zostaje tymczasowym wrogiem na 2 min.

## Pliki

```
Wanted System/
  scripts/
    sql_wnt.nss          — SQLite schema + CRUD (2 tabele: wnt_state, wnt_ui)
    lib_wnt_def.nss      — stałe, pure helpers, efekty, helper straży
    lib_wnt.nss          — HUD, panel, WantedAddHeat / Bribe / Surrender
    lib_wnt_ev.nss       — router zdarzeń NUI (HUD + panel)
    sys_on_load.nss      — OnModuleLoad: CREATE TABLE IF NOT EXISTS
    sys_on_enter.nss     — OnClientEnter: init wiersza DB + HUD po 1 s
    sys_on_leave.nss     — OnClientExit: destroy HUD + panel
    test_wnt.nss         — placeable OnUsed: +25 heat, otwiera panel
  INTEGRATION.md         — hooki, API, tuning, zależności
```

## Zależności (NWNX? SQL?)

- **NWNX**: nie wymagany.
- **SQL**: kampania SQLite `wanted` (izolowana od innych modułów).
- **nw_inc_nui**: standardowy include NWN:EE.
- **Asety**: ikony `wnt_icon_0`…`wnt_icon_4` (TGA 32×32) — do dostarczenia w hak-paku.

## Jak włączyć w istniejącym module

1. Skopiuj folder `Wanted System/scripts/` do skryptów modułu.
2. Podepnij hooki jak w tabeli w `INTEGRATION.md`.
3. W skryptach combat/pickpocket wołaj `WantedAddHeat(oPC, nAmt, TRUE)`.
4. Na strażnikach (OnPerception): `WantedGuardReact(OBJECT_SELF, oPerceived)`.
5. Opcjonalnie: ustaw `WNT_DECAY_PER_SEC = 0.016` dla wolniejszego zaniku na produkcji.

## Co celowo pominięto

- Automatyczne wykrywanie ataków (wymaga hooka na każdym NPC — decyzja integratora).
- Plakaty gończe jako obiekty w świecie.
- Maskowanie/przebranie (integracja z modułem Appearance możliwa ale poza zakresem).
- Streaming stanu do innych graczy (rejestr jest prywatny per-PC).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KF9Hgtcd9PKjaUHmWxj2GH)_