### PR TITLE
feat: Soul Bond (Więź Duszy)

### DIFF
--- a/Soul Bond/INTEGRATION.md
+++ b/Soul Bond/INTEGRATION.md
@@ -1,0 +1,46 @@
+# Soul Bond — Integracja
+
+## Co to robi
+
+Broń gromadzi zabójstwa przez pięć rang (`Uśpiona → Przebudzona → Skuta Krwią → Spragniona → Wściekła → Wykuta z Duszy`). Każda ranga przyznaje trwałe premie (wzmocnienie, obrażenia zimnem, zastraszanie, regeneracja) przez `TagItemProperty`. Więź należy do **broni**, nie postaci — może zmienić właściciela i nadal nieść mroczny dorobek. Gracze przeglądają postęp przez okno NUI.
+
+## Wymagania
+
+- **NWN:EE** (engine ≥ 8193) — wymaga `TagItemProperty`, `GetItemPropertyTag`, `NuiCreate`, `GetObjectUUID`.
+- **NWNX**: Niewymagany.
+- **Kampania SQL**: `soulbond` (tworzona przez `sys_on_load.nss`).
+
+## Hooki modułu
+
+| Zdarzenie modułu      | Skrypt              |
+|-----------------------|---------------------|
+| OnModuleLoad          | `sys_on_load`       |
+| OnClientEnter         | `sys_on_enter`      |
+| OnCreatureDeath       | `sys_on_death`      |
+
+Jeśli w module już istnieją skrypty dla tych zdarzeń, dodaj wywołanie (`ExecuteScript("sys_on_load", GetModule())` itp.) w odpowiednim miejscu, lub wstaw `#include "lib_sb"` i wywołaj funkcje bezpośrednio.
+
+## Placeable testowy
+
+Ustaw `test_sb` jako skrypt `OnUsed` dowolnego placeable. Gracze klikają obiekt, by otworzyć okno Więzi Duszy.
+
+## Progi rang
+
+| Ranga | Min. zabójstw | Premia                                              |
+|-------|--------------|-----------------------------------------------------|
+| 1     | 10           | Wzmocnienie +1                                      |
+| 2     | 50           | Wzmocnienie +1, obrażenia zimnem +1k4               |
+| 3     | 200          | Wzmocnienie +2, obrażenia zimnem +1k4               |
+| 4     | 500          | Wzmocnienie +2, obrażenia zimnem +1k6, Zastr. +2    |
+| 5     | 1000         | Wzmocnienie +3, obrażenia zimnem +1k6, Zastr. +4, Reg. +1 |
+
+## Zerwanie więzi
+
+Kosztuje 500 zk. Usuwa wszystkie premie, czyści wpis w bazie. Broń wraca do stanu „Uśpionej".
+
+## Co celowo pominięto
+
+- Limit broni per postać (nie ma — system jest weapon-centric).
+- Animacje / efekty cząsteczkowe przy rankupie (byłyby miłe, lecz wymagają assets w HAK).
+- Obraz broni w oknie NUI (brak ikony per-weapon w vanilla; można rozszerzyć przez `Get2DAString("baseitems","DefaultIcon",nBaseType)`).
+- Tryb DM do ręcznego ustawiania zabójstw (można dodać konsolą przez `SqlPrepareQueryCampaign`).

--- a/Soul Bond/Scripts/lib_sb.nss
+++ b/Soul Bond/Scripts/lib_sb.nss
@@ -1,0 +1,505 @@
+#include "lib_sb_def"
+
+void SbOpenWindow(object oPC);
+void SbFeedWindow(object oPC, int nToken, json jWeapon);
+void SbApplyBonuses(object oWeapon, int nRank);
+void SbRemoveBonuses(object oWeapon);
+void SbRestoreAllBonds(object oPC);
+void SbInspectMainHand(object oPC);
+void SbShowConfirmBreak(object oPC, string sUuid, string sWpName);
+
+// ----------------------------------------------------------------
+// Item property management
+// ----------------------------------------------------------------
+
+void SbRemoveBonuses(object oWeapon)
+{
+    itemproperty ip = GetFirstItemProperty(oWeapon);
+    while(GetIsItemPropertyValid(ip))
+    {
+        if(GetItemPropertyTag(ip) == SB_TAG)
+            RemoveItemProperty(oWeapon, ip);
+        ip = GetNextItemProperty(oWeapon);
+    }
+}
+
+void SbApplyBonuses(object oWeapon, int nRank)
+{
+    SbRemoveBonuses(oWeapon);
+    if(nRank <= 0) return;
+
+    itemproperty ip;
+
+    // Enhancement bonus scales: 1,1,2,2,3
+    int nEnh = 1;
+    if(nRank >= 3) nEnh = 2;
+    if(nRank >= 5) nEnh = 3;
+    ip = TagItemProperty(ItemPropertyEnhancementBonus(nEnh), SB_TAG);
+    AddItemProperty(DURATION_TYPE_PERMANENT, ip, oWeapon);
+
+    // Cold damage from rank 2 onward
+    if(nRank >= 2)
+    {
+        int nDmgType = (nRank >= 4) ? IP_CONST_DAMAGEBONUS_1D6 : IP_CONST_DAMAGEBONUS_1D4;
+        ip = TagItemProperty(
+            ItemPropertyDamageBonus(IP_CONST_DAMAGETYPE_COLD, nDmgType), SB_TAG);
+        AddItemProperty(DURATION_TYPE_PERMANENT, ip, oWeapon);
+    }
+
+    // Intimidate bonus from rank 4
+    if(nRank >= 4)
+    {
+        int nSkillBonus = (nRank >= 5) ? 4 : 2;
+        ip = TagItemProperty(ItemPropertySkillBonus(SKILL_INTIMIDATE, nSkillBonus), SB_TAG);
+        AddItemProperty(DURATION_TYPE_PERMANENT, ip, oWeapon);
+    }
+
+    // Regeneration at rank 5
+    if(nRank >= 5)
+    {
+        ip = TagItemProperty(ItemPropertyRegeneration(1), SB_TAG);
+        AddItemProperty(DURATION_TYPE_PERMANENT, ip, oWeapon);
+    }
+}
+
+// Scans all inventory slots and equipped slots, re-applies bonuses for bonded weapons
+void SbRestoreAllBonds(object oPC)
+{
+    // Check equipped main hand
+    object oEquipped = GetItemInSlot(INVENTORY_SLOT_RIGHTHAND, oPC);
+    if(GetIsObjectValid(oEquipped))
+    {
+        string sUuid = GetObjectUUID(oEquipped);
+        json jData = SbGetWeapon(sUuid);
+        if(JsonGetType(jData) != JSON_TYPE_NULL)
+        {
+            int nRank = JsonGetInt(JsonObjectGet(jData, "rank"));
+            SbApplyBonuses(oEquipped, nRank);
+        }
+    }
+
+    // Scan inventory
+    object oItem = GetFirstItemInInventory(oPC);
+    while(GetIsObjectValid(oItem))
+    {
+        string sUuid = GetObjectUUID(oItem);
+        json jData = SbGetWeapon(sUuid);
+        if(JsonGetType(jData) != JSON_TYPE_NULL)
+        {
+            int nRank = JsonGetInt(JsonObjectGet(jData, "rank"));
+            SbApplyBonuses(oItem, nRank);
+        }
+        oItem = GetNextItemInInventory(oPC);
+    }
+}
+
+// ----------------------------------------------------------------
+// NUI layout
+// ----------------------------------------------------------------
+
+json SbBuildDetailView(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 28.0);
+    float fProgH = GetNuiScaleDimension(oPC, 18.0);
+    float fLabelW= GetNuiScaleDimension(oPC, 120.0);
+
+    // Weapon name (large)
+    json jWpName = NuiLabel(NuiBind(SB_BIND_WPNAME),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jWpName = NuiHeight(jWpName, GetNuiScaleDimension(oPC, 32.0));
+    jWpName = NuiStyleForegroundColor(jWpName, NuiColor(220, 200, 120));
+
+    // Bond epithet
+    json jBondName = NuiLabel(NuiBind(SB_BIND_BONDNAME),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jBondName = NuiHeight(jBondName, GetNuiScaleDimension(oPC, 24.0));
+    jBondName = NuiStyleForegroundColor(jBondName, NuiColor(180, 100, 100));
+
+    // Rank label
+    json jRankLbl = NuiLabel(NuiBind(SB_BIND_RANK_LBL),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jRankLbl = NuiHeight(jRankLbl, GetNuiScaleDimension(oPC, 22.0));
+
+    // Kill count label
+    json jKillsLbl = NuiLabel(NuiBind(SB_BIND_KILLS_LBL),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jKillsLbl = NuiHeight(jKillsLbl, GetNuiScaleDimension(oPC, 20.0));
+
+    // Progress bar
+    json jProg = NuiProgressBar(NuiBind(SB_BIND_PROGRESS));
+    jProg = NuiHeight(jProg, fProgH);
+
+    // Next rank label
+    json jNextLbl = NuiLabel(NuiBind(SB_BIND_NEXT_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jNextLbl = NuiHeight(jNextLbl, GetNuiScaleDimension(oPC, 20.0));
+    jNextLbl = NuiStyleForegroundColor(jNextLbl, NuiColor(160, 160, 160));
+
+    // Current bonuses section header
+    json jBonusHdr = NuiLabel(JsonString("Aktywne premie:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jBonusHdr = NuiHeight(jBonusHdr, GetNuiScaleDimension(oPC, 20.0));
+    jBonusHdr = NuiStyleForegroundColor(jBonusHdr, NuiColor(140, 200, 140));
+
+    json jBonusTxt = NuiText(NuiBind(SB_BIND_BONUS_TXT), FALSE);
+    jBonusTxt = NuiHeight(jBonusTxt, GetNuiScaleDimension(oPC, 64.0));
+
+    // Next bonus section header
+    json jNextBonusHdr = NuiLabel(JsonString("Premie po awansie:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jNextBonusHdr = NuiHeight(jNextBonusHdr, GetNuiScaleDimension(oPC, 20.0));
+    jNextBonusHdr = NuiStyleForegroundColor(jNextBonusHdr, NuiColor(140, 140, 200));
+
+    json jNextBonusTxt = NuiText(NuiBind(SB_BIND_NEXT_BONUS), FALSE);
+    jNextBonusTxt = NuiHeight(jNextBonusTxt, GetNuiScaleDimension(oPC, 64.0));
+
+    // Bonder name
+    json jBonderLbl = NuiLabel(NuiBind(SB_BIND_BONDER_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jBonderLbl = NuiHeight(jBonderLbl, GetNuiScaleDimension(oPC, 20.0));
+    jBonderLbl = NuiStyleForegroundColor(jBonderLbl, NuiColor(140, 140, 140));
+
+    // Status (shown when no weapon inspected)
+    json jStatusLbl = NuiLabel(NuiBind(SB_BIND_STATUS_LBL),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jStatusLbl = NuiHeight(jStatusLbl, GetNuiScaleDimension(oPC, 22.0));
+    jStatusLbl = NuiStyleForegroundColor(jStatusLbl, NuiColor(160, 100, 80));
+
+    // Inspect button
+    json jInspectBtn = NuiButton(JsonString("Zbadaj prawą rękę"));
+    jInspectBtn = NuiId(jInspectBtn, SB_BTN_INSPECT);
+    jInspectBtn = NuiWidth(jInspectBtn, GetNuiScaleDimension(oPC, 180.0));
+    jInspectBtn = NuiHeight(jInspectBtn, fBtnH);
+
+    // Break bond button
+    json jBreakBtn = NuiButton(JsonString("Zerw więź (" + IntToString(SB_BREAK_COST) + " zk)"));
+    jBreakBtn = NuiId(jBreakBtn, SB_BTN_BREAK);
+    jBreakBtn = NuiEnabled(jBreakBtn, NuiBind(SB_BIND_BREAK_ENA));
+    jBreakBtn = NuiWidth(jBreakBtn, GetNuiScaleDimension(oPC, 200.0));
+    jBreakBtn = NuiHeight(jBreakBtn, fBtnH);
+
+    // Bottom row
+    json jBotRow = JsonArray();
+    jBotRow = JsonArrayInsert(jBotRow, jInspectBtn);
+    jBotRow = JsonArrayInsert(jBotRow, NuiSpacer());
+    jBotRow = JsonArrayInsert(jBotRow, jBreakBtn);
+
+    // Separator spacer
+    json jSep = CreateEmptyRow(oPC, 6.0);
+
+    // Assemble column
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jWpName);
+    jCol = JsonArrayInsert(jCol, jBondName);
+    jCol = JsonArrayInsert(jCol, jRankLbl);
+    jCol = JsonArrayInsert(jCol, jKillsLbl);
+    jCol = JsonArrayInsert(jCol, jProg);
+    jCol = JsonArrayInsert(jCol, jNextLbl);
+    jCol = JsonArrayInsert(jCol, jSep);
+    jCol = JsonArrayInsert(jCol, jBonusHdr);
+    jCol = JsonArrayInsert(jCol, NuiGroup(jBonusTxt, TRUE, NUI_SCROLLBARS_NONE));
+    jCol = JsonArrayInsert(jCol, jNextBonusHdr);
+    jCol = JsonArrayInsert(jCol, NuiGroup(jNextBonusTxt, TRUE, NUI_SCROLLBARS_NONE));
+    jCol = JsonArrayInsert(jCol, jSep);
+    jCol = JsonArrayInsert(jCol, jStatusLbl);
+    jCol = JsonArrayInsert(jCol, jBonderLbl);
+    jCol = JsonArrayInsert(jCol, NuiRow(jBotRow));
+
+    float fContentW = GetNuiScaleDimension(oPC, 480.0);
+    json jSide = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    json jMainRow = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiCol(jCol), fContentW));
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    return NuiRow(jMainRow);
+}
+
+// ----------------------------------------------------------------
+// Window open / feed
+// ----------------------------------------------------------------
+
+void SbOpenWindow(object oPC)
+{
+    if(NuiFindWindow(oPC, SB_WINDOW) != 0)
+    {
+        SbInspectMainHand(oPC);
+        return;
+    }
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))
+                 - GetNuiScaleDimension(oPC, SB_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT))
+                 - GetNuiScaleDimension(oPC, SB_H)) / 2.0;
+    json jGeom = NuiRect(fCX, fCY,
+        GetNuiScaleDimension(oPC, SB_W),
+        GetNuiScaleDimension(oPC, SB_H));
+
+    float fBtnH = GetNuiScaleDimension(oPC, 28.0);
+    json jCloseBtn = NuiButton(JsonString("X"));
+    jCloseBtn = NuiId(jCloseBtn, SB_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, GetNuiScaleDimension(oPC, 28.0));
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jTitleLbl = NuiLabel(JsonString("Więź Duszy"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitleLbl = NuiStyleForegroundColor(jTitleLbl, NuiColor(200, 160, 80));
+
+    json jTopRow = JsonArray();
+    jTopRow = JsonArrayInsert(jTopRow, jTitleLbl);
+    jTopRow = JsonArrayInsert(jTopRow, NuiSpacer());
+    jTopRow = JsonArrayInsert(jTopRow, jCloseBtn);
+
+    json jDetailGrp = NuiGroup(SbBuildDetailView(oPC), FALSE, NUI_SCROLLBARS_AUTO);
+    jDetailGrp = NuiId(jDetailGrp, SB_GRP_DETAIL);
+
+    json jRoot = JsonArray();
+    jRoot = JsonArrayInsert(jRoot, NuiRow(jTopRow));
+    jRoot = JsonArrayInsert(jRoot, jDetailGrp);
+
+    json jWin = NuiWindow(NuiCol(jRoot),
+        JsonBool(FALSE),
+        NuiBind(SB_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    int nToken = NuiCreate(oPC, jWin, SB_WINDOW, SB_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, SB_WIN_GEOM, jGeom);
+
+    SbInspectMainHand(oPC);
+}
+
+void SbFeedWindow(object oPC, int nToken, json jWeapon)
+{
+    if(JsonGetType(jWeapon) == JSON_TYPE_NULL)
+    {
+        NuiSetBind(oPC, nToken, SB_BIND_WPNAME,     JsonString("— brak broni —"));
+        NuiSetBind(oPC, nToken, SB_BIND_BONDNAME,   JsonString(""));
+        NuiSetBind(oPC, nToken, SB_BIND_RANK_LBL,   JsonString("Ranga: Uśpiona [0/5]"));
+        NuiSetBind(oPC, nToken, SB_BIND_KILLS_LBL,  JsonString("Nie wykryto więzi."));
+        NuiSetBind(oPC, nToken, SB_BIND_PROGRESS,   JsonFloat(0.0));
+        NuiSetBind(oPC, nToken, SB_BIND_NEXT_LBL,   JsonString("Zdobądź 10 zabójstw, by przebudzić ostrze."));
+        NuiSetBind(oPC, nToken, SB_BIND_BONUS_TXT,  JsonString("—"));
+        NuiSetBind(oPC, nToken, SB_BIND_NEXT_BONUS, JsonString("—"));
+        NuiSetBind(oPC, nToken, SB_BIND_BONDER_LBL, JsonString(""));
+        NuiSetBind(oPC, nToken, SB_BIND_STATUS_LBL, JsonString("Ekwipuj broń w prawą rękę i kliknij [Zbadaj]."));
+        NuiSetBind(oPC, nToken, SB_BIND_BREAK_ENA,  JsonBool(FALSE));
+        return;
+    }
+
+    string sWpName    = JsonGetString(JsonObjectGet(jWeapon, "weapon_name"));
+    string sBondName  = JsonGetString(JsonObjectGet(jWeapon, "bond_name"));
+    string sBonder    = JsonGetString(JsonObjectGet(jWeapon, "bonder_name"));
+    int    nKills     = JsonGetInt   (JsonObjectGet(jWeapon, "kills"));
+    int    nRank      = JsonGetInt   (JsonObjectGet(jWeapon, "rank"));
+
+    string sRankLbl = "Ranga: " + SbRankLabel(nRank) + " [" + IntToString(nRank) + "/" + IntToString(SB_MAX_RANK) + "]";
+
+    string sKillsLbl;
+    if(nRank >= SB_MAX_RANK)
+        sKillsLbl = "Zabójstwa: " + IntToString(nKills) + " (maks. ranga osiągnięta)";
+    else
+    {
+        int nNext = SbRankThreshold(nRank + 1);
+        sKillsLbl = "Zabójstwa: " + IntToString(nKills) + " / " + IntToString(nNext);
+    }
+
+    string sNextLbl;
+    if(nRank >= SB_MAX_RANK)
+        sNextLbl = "Pieczęć krwi pulsuje słabo — ostrze jest pełne.";
+    else
+    {
+        int nLeft = SbRankThreshold(nRank + 1) - nKills;
+        sNextLbl = "Do rangi " + SbRankLabel(nRank + 1) + ": " + IntToString(nLeft) + " zabójstw.";
+    }
+
+    string sBonderLbl = sBonder != "" ? "Pierwsze krople: " + sBonder : "";
+
+    NuiSetBind(oPC, nToken, SB_BIND_WPNAME,     JsonString(sWpName));
+    NuiSetBind(oPC, nToken, SB_BIND_BONDNAME,   JsonString(sBondName != "" ? "\"" + sBondName + "\"" : ""));
+    NuiSetBind(oPC, nToken, SB_BIND_RANK_LBL,   JsonString(sRankLbl));
+    NuiSetBind(oPC, nToken, SB_BIND_KILLS_LBL,  JsonString(sKillsLbl));
+    NuiSetBind(oPC, nToken, SB_BIND_PROGRESS,   JsonFloat(SbCalcProgress(nKills, nRank)));
+    NuiSetBind(oPC, nToken, SB_BIND_NEXT_LBL,   JsonString(sNextLbl));
+    NuiSetBind(oPC, nToken, SB_BIND_BONUS_TXT,  JsonString(SbBonusDescription(nRank)));
+    NuiSetBind(oPC, nToken, SB_BIND_NEXT_BONUS, JsonString(SbNextBonusDescription(nRank)));
+    NuiSetBind(oPC, nToken, SB_BIND_BONDER_LBL, JsonString(sBonderLbl));
+    NuiSetBind(oPC, nToken, SB_BIND_STATUS_LBL, JsonString(""));
+    NuiSetBind(oPC, nToken, SB_BIND_BREAK_ENA,  JsonBool(nRank > 0));
+}
+
+// ----------------------------------------------------------------
+// Inspect / kill counting
+// ----------------------------------------------------------------
+
+void SbInspectMainHand(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, SB_WINDOW);
+    if(nToken == 0) return;
+
+    object oWeapon = GetItemInSlot(INVENTORY_SLOT_RIGHTHAND, oPC);
+    if(!GetIsObjectValid(oWeapon))
+    {
+        DeleteLocalString(oPC, SB_LVAR_INSPECTED);
+        SbFeedWindow(oPC, nToken, JsonNull());
+        return;
+    }
+
+    string sUuid = GetObjectUUID(oWeapon);
+    SetLocalString(oPC, SB_LVAR_INSPECTED, sUuid);
+
+    json jData = SbGetWeapon(sUuid);
+    SbFeedWindow(oPC, nToken, jData);
+}
+
+// Called from sys_on_death to credit a kill to the wielded weapon
+void SbCreditKill(object oKiller)
+{
+    if(!GetIsPC(oKiller)) return;
+
+    object oWeapon = GetItemInSlot(INVENTORY_SLOT_RIGHTHAND, oKiller);
+    if(!GetIsObjectValid(oWeapon)) return;
+
+    // Ignore gloves (unarmed combat stand-in)
+    int nBaseType = GetBaseItemType(oWeapon);
+    if(nBaseType == BASE_ITEM_GLOVES) return;
+
+    string sUuid = GetObjectUUID(oWeapon);
+
+    // Register on first kill
+    json jData = SbGetWeapon(sUuid);
+    if(JsonGetType(jData) == JSON_TYPE_NULL)
+        SbRegisterWeapon(sUuid, GetName(oWeapon), GetName(oKiller));
+
+    int nNewKills = SbIncrementKills(sUuid);
+
+    // Re-fetch for current rank
+    jData = SbGetWeapon(sUuid);
+    int nRank = JsonGetInt(JsonObjectGet(jData, "rank"));
+
+    // Check rank advancement
+    int nNewRank = nRank;
+    int r;
+    for(r = nRank + 1; r <= SB_MAX_RANK; r++)
+    {
+        if(nNewKills >= SbRankThreshold(r))
+            nNewRank = r;
+        else
+            break;
+    }
+
+    if(nNewRank > nRank)
+    {
+        string sEpithet = SbPickEpithet(nNewRank, nNewKills);
+        SbSetRank(sUuid, nNewRank, sEpithet);
+        SbApplyBonuses(oWeapon, nNewRank);
+
+        string sMsg = "Pieczęć krwi pulsuje — " + GetName(oWeapon) +
+                      " osiąga rangę " + SbRankLabel(nNewRank) +
+                      " [\"" + sEpithet + "\"].";
+        SendMessageToPC(oKiller, sMsg);
+        FloatingTextStringOnCreature(sMsg, oKiller, FALSE);
+    }
+
+    // Refresh open window if inspecting this weapon
+    int nToken = NuiFindWindow(oKiller, SB_WINDOW);
+    if(nToken != 0 && GetLocalString(oKiller, SB_LVAR_INSPECTED) == sUuid)
+    {
+        jData = SbGetWeapon(sUuid);
+        SbFeedWindow(oKiller, nToken, jData);
+    }
+}
+
+// ----------------------------------------------------------------
+// Break bond
+// ----------------------------------------------------------------
+
+void SbShowConfirmBreak(object oPC, string sUuid, string sWpName)
+{
+    if(NuiFindWindow(oPC, SB_WIN_CONFIRM) != 0)
+        NuiDestroy(oPC, NuiFindWindow(oPC, SB_WIN_CONFIRM));
+
+    SetLocalString(oPC, "SB_BREAK_UUID", sUuid);
+
+    float fW = GetNuiScaleDimension(oPC, 420.0);
+    float fH = GetNuiScaleDimension(oPC, 180.0);
+    float fX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - fW) / 2.0;
+    float fY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - fH) / 2.0;
+
+    string sMsg = "Zerwać więź z \"" + sWpName + "\"?\n\n" +
+                  "Kosztuje " + IntToString(SB_BREAK_COST) + " złotych kruszczynów.\n" +
+                  "Broń straci wszystkie premie rezonansowe.";
+
+    json jMsgLbl = NuiLabel(JsonString(sMsg),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+
+    float fBtnH = GetNuiScaleDimension(oPC, 28.0);
+    json jYes = NuiButton(JsonString("Zerw więź"));
+    jYes = NuiId(jYes, SB_BTN_CONF_YES);
+    jYes = NuiWidth(jYes, GetNuiScaleDimension(oPC, 120.0));
+    jYes = NuiHeight(jYes, fBtnH);
+
+    json jNo = NuiButton(JsonString("Anuluj"));
+    jNo = NuiId(jNo, SB_BTN_CONF_NO);
+    jNo = NuiWidth(jNo, GetNuiScaleDimension(oPC, 120.0));
+    jNo = NuiHeight(jNo, fBtnH);
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jYes);
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jNo);
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jMsgLbl);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+
+    json jWin = NuiWindow(NuiCol(jCol),
+        JsonString("Potwierdzenie"),
+        NuiRect(fX, fY, fW, fH),
+        JsonBool(FALSE), JsonBool(FALSE), JsonBool(TRUE),
+        JsonBool(FALSE), JsonBool(TRUE));
+
+    NuiCreate(oPC, jWin, SB_WIN_CONFIRM, SB_EV_SCRIPT);
+}
+
+void SbExecuteBreak(object oPC, string sUuid)
+{
+    if(GetGold(oPC) < SB_BREAK_COST)
+    {
+        SendMessageToPC(oPC, "[Więź Duszy] Za mało złota. Potrzebujesz " + IntToString(SB_BREAK_COST) + " kruszczynów.");
+        return;
+    }
+
+    AssignCommand(oPC, TakeGoldFromCreature(SB_BREAK_COST, oPC, TRUE));
+
+    // Find the weapon object in PC's possession
+    object oItem = GetItemInSlot(INVENTORY_SLOT_RIGHTHAND, oPC);
+    if(GetIsObjectValid(oItem) && GetObjectUUID(oItem) == sUuid)
+        SbRemoveBonuses(oItem);
+    else
+    {
+        oItem = GetFirstItemInInventory(oPC);
+        while(GetIsObjectValid(oItem))
+        {
+            if(GetObjectUUID(oItem) == sUuid)
+            {
+                SbRemoveBonuses(oItem);
+                break;
+            }
+            oItem = GetNextItemInInventory(oPC);
+        }
+    }
+
+    SbDeleteWeapon(sUuid);
+    DeleteLocalString(oPC, SB_LVAR_INSPECTED);
+
+    SendMessageToPC(oPC, "[Więź Duszy] Więź zerwana. Ostrze milczy.");
+
+    int nToken = NuiFindWindow(oPC, SB_WINDOW);
+    if(nToken != 0) SbFeedWindow(oPC, nToken, JsonNull());
+}

--- a/Soul Bond/Scripts/lib_sb_def.nss
+++ b/Soul Bond/Scripts/lib_sb_def.nss
@@ -1,0 +1,157 @@
+#include "lib_nui"
+#include "sql_sb"
+
+// ----------------------------------------------------------------
+// Window / event IDs
+// ----------------------------------------------------------------
+
+const string SB_WINDOW       = "SB_WINDOW";
+const string SB_EV_SCRIPT    = "lib_sb_ev";
+const string SB_GRP_DETAIL   = "SB_GRP_DETAIL";
+const string SB_WIN_GEOM     = "sb_win_geom";
+const string SB_WIN_CONFIRM  = "SB_WIN_CONFIRM";
+
+// ----------------------------------------------------------------
+// Bind IDs
+// ----------------------------------------------------------------
+
+const string SB_BIND_WPNAME     = "sb_wpname";
+const string SB_BIND_BONDNAME   = "sb_bondname";
+const string SB_BIND_RANK_LBL   = "sb_rank_lbl";
+const string SB_BIND_KILLS_LBL  = "sb_kills_lbl";
+const string SB_BIND_PROGRESS   = "sb_progress";
+const string SB_BIND_NEXT_LBL   = "sb_next_lbl";
+const string SB_BIND_BONUS_TXT  = "sb_bonus_txt";
+const string SB_BIND_NEXT_BONUS = "sb_next_bonus";
+const string SB_BIND_BONDER_LBL = "sb_bonder_lbl";
+const string SB_BIND_BREAK_ENA  = "sb_break_ena";
+const string SB_BIND_STATUS_LBL = "sb_status_lbl";
+
+// ----------------------------------------------------------------
+// Button IDs
+// ----------------------------------------------------------------
+
+const string SB_BTN_CLOSE       = "sb_btn_close";
+const string SB_BTN_INSPECT     = "sb_btn_inspect";
+const string SB_BTN_BREAK       = "sb_btn_break";
+const string SB_BTN_CONF_YES    = "sb_btn_conf_yes";
+const string SB_BTN_CONF_NO     = "sb_btn_conf_no";
+
+// ----------------------------------------------------------------
+// LVARs on PC
+// ----------------------------------------------------------------
+
+const string SB_LVAR_INSPECTED  = "SB_INSPECTED_UUID";
+
+// ----------------------------------------------------------------
+// Mechanics
+// ----------------------------------------------------------------
+
+const string SB_TAG             = "SB_RES";
+const int    SB_MAX_RANK        = 5;
+const int    SB_KILLS_RANK_1    = 10;
+const int    SB_KILLS_RANK_2    = 50;
+const int    SB_KILLS_RANK_3    = 200;
+const int    SB_KILLS_RANK_4    = 500;
+const int    SB_KILLS_RANK_5    = 1000;
+const int    SB_BREAK_COST      = 500;
+
+const float  SB_W               = 520.0;
+const float  SB_H               = 420.0;
+
+// ----------------------------------------------------------------
+// Rank helpers
+// ----------------------------------------------------------------
+
+string SbRankLabel(int nRank)
+{
+    if(nRank == 1) return "Przebudzona";
+    if(nRank == 2) return "Skuta Krwią";
+    if(nRank == 3) return "Spragniona";
+    if(nRank == 4) return "Wściekła";
+    if(nRank == 5) return "Wykuta z Duszy";
+    return "Uśpiona";
+}
+
+int SbRankThreshold(int nRank)
+{
+    if(nRank <= 0) return 0;
+    if(nRank == 1) return SB_KILLS_RANK_1;
+    if(nRank == 2) return SB_KILLS_RANK_2;
+    if(nRank == 3) return SB_KILLS_RANK_3;
+    if(nRank == 4) return SB_KILLS_RANK_4;
+    return SB_KILLS_RANK_5;
+}
+
+// Picks an epithet by rank and a small index derived from kills count
+string SbPickEpithet(int nRank, int nKills)
+{
+    int nIdx = nKills % 5;
+    if(nRank == 1)
+    {
+        if(nIdx == 0) return "Wdowica";
+        if(nIdx == 1) return "Bladaczka";
+        if(nIdx == 2) return "Cicha";
+        if(nIdx == 3) return "Gorzka";
+        return "Łaknąca";
+    }
+    if(nRank == 2)
+    {
+        if(nIdx == 0) return "Krwiopijca";
+        if(nIdx == 1) return "Bólodrca";
+        if(nIdx == 2) return "Szkieletnica";
+        if(nIdx == 3) return "Mroczna";
+        return "Gorączkowa";
+    }
+    if(nRank == 3)
+    {
+        if(nIdx == 0) return "Duszogryz";
+        if(nIdx == 1) return "Pożeraczka";
+        if(nIdx == 2) return "Nienasycona";
+        if(nIdx == 3) return "Wyjąca";
+        return "Bezlitosna";
+    }
+    if(nRank == 4)
+    {
+        if(nIdx == 0) return "Rozszarpywaczka";
+        if(nIdx == 1) return "Siewca Grozy";
+        if(nIdx == 2) return "Mrozodajna";
+        if(nIdx == 3) return "Zatruta";
+        return "Wściekła";
+    }
+    // rank 5
+    if(nIdx == 0) return "Wieczna Żniwiarka";
+    if(nIdx == 1) return "Karmicielka Cienia";
+    if(nIdx == 2) return "Strażniczka Popiołów";
+    if(nIdx == 3) return "Trójca Zguby";
+    return "Wykuta z Duszy";
+}
+
+string SbBonusDescription(int nRank)
+{
+    if(nRank <= 0) return "Ostrze nie zaznało krwi — żadnych premii.";
+    if(nRank == 1) return "Wzmocnienie +1.";
+    if(nRank == 2) return "Wzmocnienie +1\nObrażenia zimnem +1k4.";
+    if(nRank == 3) return "Wzmocnienie +2\nObrażenia zimnem +1k4.";
+    if(nRank == 4) return "Wzmocnienie +2\nObrażenia zimnem +1k6\nZastraszanie +2.";
+    return "Wzmocnienie +3\nObrażenia zimnem +1k6\nZastraszanie +4\nRegeneracja +1.";
+}
+
+string SbNextBonusDescription(int nCurrentRank)
+{
+    if(nCurrentRank >= SB_MAX_RANK)
+        return "Ostrze osiągnęło pełnię mrocznej chwały.";
+    return SbBonusDescription(nCurrentRank + 1);
+}
+
+float SbCalcProgress(int nKills, int nRank)
+{
+    if(nRank >= SB_MAX_RANK) return 1.0;
+    int nPrev = SbRankThreshold(nRank);
+    int nNext = SbRankThreshold(nRank + 1);
+    if(nNext <= nPrev) return 1.0;
+    float fP = IntToFloat(nKills - nPrev) / IntToFloat(nNext - nPrev);
+    if(fP < 0.0) return 0.0;
+    if(fP > 1.0) return 1.0;
+    return fP;
+}

--- a/Soul Bond/Scripts/lib_sb_ev.nss
+++ b/Soul Bond/Scripts/lib_sb_ev.nss
@@ -1,0 +1,76 @@
+#include "lib_sb"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+
+    // ---- Confirm popup ----
+    if(nToken == NuiFindWindow(oPC, SB_WIN_CONFIRM))
+    {
+        if(sEvent == EVENT_TYPE_CLICK)
+        {
+            if(sElem == SB_BTN_CONF_YES)
+            {
+                string sUuid = GetLocalString(oPC, "SB_BREAK_UUID");
+                NuiDestroy(oPC, nToken);
+                SbExecuteBreak(oPC, sUuid);
+            }
+            else if(sElem == SB_BTN_CONF_NO)
+            {
+                NuiDestroy(oPC, nToken);
+            }
+        }
+        return;
+    }
+
+    if(nToken != NuiFindWindow(oPC, SB_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalString(oPC, SB_LVAR_INSPECTED);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == SB_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        if(sElem == SB_BTN_INSPECT)
+        {
+            SbInspectMainHand(oPC);
+            return;
+        }
+
+        if(sElem == SB_BTN_BREAK)
+        {
+            string sUuid = GetLocalString(oPC, SB_LVAR_INSPECTED);
+            if(sUuid == "")
+            {
+                SendMessageToPC(oPC, "[Więź Duszy] Nie wybrano żadnej broni do zbadania.");
+                return;
+            }
+            json jData = SbGetWeapon(sUuid);
+            if(JsonGetType(jData) == JSON_TYPE_NULL)
+            {
+                SendMessageToPC(oPC, "[Więź Duszy] Ta broń nie ma żadnej więzi.");
+                return;
+            }
+            int nRank = JsonGetInt(JsonObjectGet(jData, "rank"));
+            if(nRank <= 0)
+            {
+                SendMessageToPC(oPC, "[Więź Duszy] Nie ma jeszcze nic do zerwania.");
+                return;
+            }
+            string sWpName = JsonGetString(JsonObjectGet(jData, "weapon_name"));
+            SbShowConfirmBreak(oPC, sUuid, sWpName);
+            return;
+        }
+    }
+}

--- a/Soul Bond/Scripts/sql_sb.nss
+++ b/Soul Bond/Scripts/sql_sb.nss
@@ -1,0 +1,98 @@
+void SbCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("soulbond",
+        "CREATE TABLE IF NOT EXISTS sb_weapons ("
+        "  weapon_uuid  TEXT PRIMARY KEY,"
+        "  weapon_name  TEXT DEFAULT '',"
+        "  bond_name    TEXT DEFAULT '',"
+        "  bonder_name  TEXT DEFAULT '',"
+        "  kills        INTEGER DEFAULT 0,"
+        "  rank         INTEGER DEFAULT 0"
+        ")");
+    SqlStep(q);
+}
+
+// Returns JsonObject {weapon_uuid, weapon_name, bond_name, bonder_name, kills, rank} or JsonNull
+json SbGetWeapon(string sUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign("soulbond",
+        "SELECT weapon_name, bond_name, bonder_name, kills, rank "
+        "FROM sb_weapons WHERE weapon_uuid = @uuid");
+    SqlBindString(q, "@uuid", sUuid);
+    if(!SqlStep(q)) return JsonNull();
+
+    json j = JsonObject();
+    j = JsonObjectSet(j, "weapon_uuid",  JsonString(sUuid));
+    j = JsonObjectSet(j, "weapon_name",  JsonString(SqlGetString(q, 0)));
+    j = JsonObjectSet(j, "bond_name",    JsonString(SqlGetString(q, 1)));
+    j = JsonObjectSet(j, "bonder_name",  JsonString(SqlGetString(q, 2)));
+    j = JsonObjectSet(j, "kills",        JsonInt   (SqlGetInt   (q, 3)));
+    j = JsonObjectSet(j, "rank",         JsonInt   (SqlGetInt   (q, 4)));
+    return j;
+}
+
+void SbRegisterWeapon(string sUuid, string sWeaponName, string sBonderName)
+{
+    sqlquery q = SqlPrepareQueryCampaign("soulbond",
+        "INSERT OR IGNORE INTO sb_weapons (weapon_uuid, weapon_name, bonder_name) "
+        "VALUES (@uuid, @wname, @bname)");
+    SqlBindString(q, "@uuid",  sUuid);
+    SqlBindString(q, "@wname", sWeaponName);
+    SqlBindString(q, "@bname", sBonderName);
+    SqlStep(q);
+}
+
+// Returns new kill count after increment
+int SbIncrementKills(string sUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign("soulbond",
+        "UPDATE sb_weapons SET kills = kills + 1 WHERE weapon_uuid = @uuid");
+    SqlBindString(q, "@uuid", sUuid);
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("soulbond",
+        "SELECT kills FROM sb_weapons WHERE weapon_uuid = @uuid");
+    SqlBindString(q, "@uuid", sUuid);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+void SbSetRank(string sUuid, int nRank, string sBondName)
+{
+    sqlquery q = SqlPrepareQueryCampaign("soulbond",
+        "UPDATE sb_weapons SET rank = @rank, bond_name = @bname "
+        "WHERE weapon_uuid = @uuid");
+    SqlBindInt   (q, "@rank",  nRank);
+    SqlBindString(q, "@bname", sBondName);
+    SqlBindString(q, "@uuid",  sUuid);
+    SqlStep(q);
+}
+
+void SbDeleteWeapon(string sUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign("soulbond",
+        "DELETE FROM sb_weapons WHERE weapon_uuid = @uuid");
+    SqlBindString(q, "@uuid", sUuid);
+    SqlStep(q);
+}
+
+// Returns JsonArray of all weapons for display (no PC filter — weapon-centric)
+json SbGetAllBonded()
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("soulbond",
+        "SELECT weapon_uuid, weapon_name, bond_name, bonder_name, kills, rank "
+        "FROM sb_weapons ORDER BY kills DESC LIMIT 50");
+    while(SqlStep(q))
+    {
+        json j = JsonObject();
+        j = JsonObjectSet(j, "weapon_uuid",  JsonString(SqlGetString(q, 0)));
+        j = JsonObjectSet(j, "weapon_name",  JsonString(SqlGetString(q, 1)));
+        j = JsonObjectSet(j, "bond_name",    JsonString(SqlGetString(q, 2)));
+        j = JsonObjectSet(j, "bonder_name",  JsonString(SqlGetString(q, 3)));
+        j = JsonObjectSet(j, "kills",        JsonInt   (SqlGetInt   (q, 4)));
+        j = JsonObjectSet(j, "rank",         JsonInt   (SqlGetInt   (q, 5)));
+        jRows = JsonArrayInsert(jRows, j);
+    }
+    return jRows;
+}

--- a/Soul Bond/Scripts/sys_on_death.nss
+++ b/Soul Bond/Scripts/sys_on_death.nss
@@ -1,0 +1,17 @@
+#include "lib_sb"
+
+void main()
+{
+    object oDead   = OBJECT_SELF;
+    object oKiller = GetLastKiller();
+
+    if(GetIsPC(oDead)) return;
+    if(!GetIsObjectValid(oKiller)) return;
+
+    // If killed by an associate (henchman/familiar/summoned), credit the master
+    object oMaster = GetMaster(oKiller);
+    if(GetIsObjectValid(oMaster) && GetIsPC(oMaster))
+        oKiller = oMaster;
+
+    SbCreditKill(oKiller);
+}

--- a/Soul Bond/Scripts/sys_on_enter.nss
+++ b/Soul Bond/Scripts/sys_on_enter.nss
@@ -1,0 +1,10 @@
+#include "lib_sb"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC) || GetIsDMPossessed(oPC)) return;
+
+    // Small delay so inventory is fully loaded before scanning
+    DelayCommand(2.0, SbRestoreAllBonds(oPC));
+}

--- a/Soul Bond/Scripts/sys_on_load.nss
+++ b/Soul Bond/Scripts/sys_on_load.nss
@@ -1,0 +1,6 @@
+#include "lib_sb_def"
+
+void main()
+{
+    SbCreateTables();
+}

--- a/Soul Bond/Scripts/test_sb.nss
+++ b/Soul Bond/Scripts/test_sb.nss
@@ -1,0 +1,11 @@
+#include "lib_sb"
+
+// OnUsed script for a placeable. Drag-and-drop onto any container or statue
+// in the toolset to let players open the Soul Bond inspector.
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    SbOpenWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

Broń gromadzi zabójstwa i rośnie w mroczną siłę przez pięć rang. Każda ranga przyznaje trwałe premie jako `ItemProperty` otagowane przez `TagItemProperty("SB_RES")`, dzięki czemu można je precyzyjnie usuwać bez niszczenia oryginalnych właściwości broni. Gracz otwiera okno NUI, by sprawdzić postęp inspektowanej broni i (za opłatą) zerwać więź.

## Mechanika

- **Ranga 1 — Przebudzona** (10 zabójstw): Wzmocnienie +1
- **Ranga 2 — Skuta Krwią** (50): Wzmocnienie +1, obrażenia zimnem +1k4
- **Ranga 3 — Spragniona** (200): Wzmocnienie +2, obrażenia zimnem +1k4
- **Ranga 4 — Wściekła** (500): Wzmocnienie +2, obrażenia zimnem +1k6, Zastraszanie +2
- **Ranga 5 — Wykuta z Duszy** (1000): Wzmocnienie +3, obrażenia zimnem +1k6, Zastraszanie +4, Regeneracja +1

Więź należy do **broni**, nie postaci — miecz zmieniający właściciela zachowuje swój mroczny dorobek. Zerwanie więzi kosztuje 500 zk i czyści wszystkie premie oraz wpis w bazie.

## Pliki

| Plik | Rola |
|------|------|
| `sql_sb.nss` | Schemat SQLite + zapytania CRUD |
| `lib_sb_def.nss` | Stałe, ID bindów, progi rang, etykiety, opis premii |
| `lib_sb.nss` | Rdzeń: NUI layout, kredytowanie zabójstw, aplikowanie `ItemProperty` |
| `lib_sb_ev.nss` | Handler zdarzeń NUI (click, close, confirm popup) |
| `sys_on_load.nss` | `CREATE TABLE IF NOT EXISTS` przy starcie modułu |
| `sys_on_enter.nss` | Przywracanie premii przy wejściu gracza |
| `sys_on_death.nss` | `OnCreatureDeath` — kredytowanie zabójstwa |
| `test_sb.nss` | `OnUsed` na placeable — otwiera okno NUI |
| `INTEGRATION.md` | Instrukcja integracji, tabela progów, co pominięto |

## Zależności

- **NWNX**: Niewymagany.
- **NWN:EE** ≥ 8193 (wymaga `TagItemProperty`, `GetItemPropertyTag`, `NuiCreate`, `GetObjectUUID`).
- **Kampania SQL**: `soulbond` (auto-tworzona).

## Jak włączyć w istniejącym module

1. Skopiuj folder `Soul Bond/Scripts/` do HAK lub folderu skryptów modułu.
2. Ustaw hooki modułu: `OnModuleLoad → sys_on_load`, `OnClientEnter → sys_on_enter`, `OnCreatureDeath → sys_on_death`.
3. Ustaw `test_sb` jako `OnUsed` dowolnego placeable.
4. Jeśli moduł ma już własne hooki, wywołaj odpowiednie funkcje biblioteczne (`SbCreateTables()`, `SbRestoreAllBonds(oPC)`, `SbCreditKill(oKiller)`) z istniejących skryptów.

## Co celowo pominięto

- Animacje/VFX przy rankupie (wymagałyby assets w HAK).
- Ikona broni w oknie NUI (brak per-weapon icon w vanilla; prostej rozbudowy przez `Get2DAString`).
- Tryb DM do ręcznego ustawiania zabójstw.
- Historia zabójstw / log ostatnich ofiar (łatwa rozbudowa przez dodatkową tabelę SQL).


---
_Generated by [Claude Code](https://claude.ai/code/session_018fgo8VuPhBjfmBevFuBHpm)_