### PR TITLE
feat: Głos Kamienia (Voice of Stone)

### DIFF
--- a/Voice of Stone/INTEGRATION.md
+++ b/Voice of Stone/INTEGRATION.md
@@ -1,0 +1,59 @@
+# Voice of Stone – Głos Kamienia
+
+Dark-fantasy inscription system. Players carve messages on Stone Tablets,
+bless others' writing, and absorb esoteric knowledge from blood-written texts.
+
+## Hooks to wire
+
+| Hook | Script |
+|------|--------|
+| Module OnLoad | `sys_on_load` |
+| Module OnClientEnter | `sys_on_enter` |
+| Tablet placeable OnUsed | `test_ins` |
+
+## Tablet placeable setup
+
+1. Place any placeable in the toolset.
+2. Set its **Tag** to a unique string, e.g. `ins_tablet_crypt`.
+3. Set its **OnUsed** script to `test_ins`.
+4. Repeat for each tablet location; inscriptions are isolated per-tag.
+
+The `sys_on_enter` script auto-detects placeables tagged `ins_tablet` or
+`INS_TABLET` (first match in area). Give them a more specific tag
+(e.g. `ins_tablet_market`) and the system will still work because
+`InsOpenWindow` always reads the tablet's actual tag at call time.
+
+## NWNX dependencies
+
+None. Pure NWN:EE NWScript and NUI.
+Requires NWN:EE build **8193+** for `TagEffect` / `GetEffectTag`.
+
+## SQL
+
+Campaign database: `stone_inscriptions`
+Tables: `inscriptions`, `ins_votes`, `ins_reads`
+
+Created automatically on first module load via `InsCreateTables()`.
+Migrations are idempotent (`CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`).
+
+## Expiry
+
+* Normal inscription: 72 hours.
+* Blood inscription: 216 hours (3×).
+* 10+ blessings: permanent (`expires_at = 0`).
+* Each blessing extends life by +1 hour (and grants permanence at threshold).
+* `InsExpireOld()` is called on module load and every client enter.
+
+## Blood inscription bonus
+
+Reading a blood inscription you did not write grants **+1 Lore (Wiedza)**
+for 1 hour (supernatural, tagged `INS_BLOOD_LORE`).
+Stacks up to **+3**; the stack cap is defined in `INS_BLOOD_BONUS_MAX`.
+
+## Deliberately omitted
+
+* Inscription images / icons in HAK (purely text-based, no asset dependencies).
+* Per-area listing (tablets are tag-namespaced, not area-namespaced).
+* Inscription deletion by author (intended to feel permanent and weighty).
+* Server-side rate limiting per player (one inscription per session would need
+  a heartbeat check; left for server owner to add via `InsGetCount` filter).

--- a/Voice of Stone/Scripts/lib_ins.nss
+++ b/Voice of Stone/Scripts/lib_ins.nss
@@ -1,0 +1,507 @@
+#include "lib_ins_def"
+
+// ----------------------------------------------------------------
+// Read view layout
+// ----------------------------------------------------------------
+
+json BuildInsReadView(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 28.0);
+    float fRowH  = GetNuiScaleDimension(oPC, 26.0);
+    float fTypeW = GetNuiScaleDimension(oPC, 96.0);
+    float fAuthW = GetNuiScaleDimension(oPC, 110.0);
+    float fAgeW  = GetNuiScaleDimension(oPC, 40.0);
+
+    // Row template: type | author | preview (elastic) | age | select button
+    json jTypeLbl = NuiLabel(NuiBind(INS_BIND_LST_TYPE),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jTypeLbl = NuiStyleForegroundColor(jTypeLbl, NuiBind(INS_BIND_LST_TCOL));
+    jTypeLbl = NuiWidth(jTypeLbl, fTypeW);
+
+    json jAuthLbl = NuiLabel(NuiBind(INS_BIND_LST_AUTH),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jAuthLbl = NuiWidth(jAuthLbl, fAuthW);
+
+    json jPrevLbl = NuiLabel(NuiBind(INS_BIND_LST_PREV),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+
+    json jAgeLbl = NuiLabel(NuiBind(INS_BIND_LST_AGE),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jAgeLbl = NuiWidth(jAgeLbl, fAgeW);
+
+    json jRowCells = JsonArray();
+    jRowCells = JsonArrayInsert(jRowCells, jTypeLbl);
+    jRowCells = JsonArrayInsert(jRowCells, jAuthLbl);
+    jRowCells = JsonArrayInsert(jRowCells, jPrevLbl);
+    jRowCells = JsonArrayInsert(jRowCells, jAgeLbl);
+
+    json jRowGrp = NuiGroup(NuiRow(jRowCells), FALSE, NUI_SCROLLBARS_NONE);
+    jRowGrp = NuiId(jRowGrp, INS_BTN_ROW);
+    jRowGrp = NuiEncouraged(jRowGrp, NuiBind(INS_BIND_LST_ENC));
+
+    json jTmpl = JsonArrayInsert(JsonArray(),
+        NuiListTemplateCell(jRowGrp, 0.0, TRUE));
+
+    float fListH = GetNuiScaleDimension(oPC, 218.0);
+    json jList = NuiList(jTmpl, NuiBind(INS_BIND_LST_CNT), fRowH);
+    jList = NuiHeight(jList, fListH);
+
+    // Pagination row
+    json jPrevBtn = NuiButton(JsonString("< Poprzednia"));
+    jPrevBtn = NuiId(jPrevBtn, INS_BTN_PREV_PAGE);
+    jPrevBtn = NuiEnabled(jPrevBtn, NuiBind(INS_BIND_PREV_ENA));
+    jPrevBtn = NuiWidth(jPrevBtn, GetNuiScaleDimension(oPC, 110.0));
+    jPrevBtn = NuiHeight(jPrevBtn, fBtnH);
+
+    json jNextBtn = NuiButton(JsonString("Nastepna >"));
+    jNextBtn = NuiId(jNextBtn, INS_BTN_NEXT_PAGE);
+    jNextBtn = NuiEnabled(jNextBtn, NuiBind(INS_BIND_NEXT_ENA));
+    jNextBtn = NuiWidth(jNextBtn, GetNuiScaleDimension(oPC, 110.0));
+    jNextBtn = NuiHeight(jNextBtn, fBtnH);
+
+    json jPageLbl = NuiLabel(NuiBind(INS_BIND_PAGE_LBL),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+
+    json jPagRow = JsonArray();
+    jPagRow = JsonArrayInsert(jPagRow, jPrevBtn);
+    jPagRow = JsonArrayInsert(jPagRow, jPageLbl);
+    jPagRow = JsonArrayInsert(jPagRow, jNextBtn);
+
+    // Detail section: always present, content changes on row selection
+    float fDetTextH = GetNuiScaleDimension(oPC, 80.0);
+
+    json jDetHdr = NuiLabel(NuiBind(INS_BIND_DET_HDR),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jDetHdr = NuiHeight(jDetHdr, GetNuiScaleDimension(oPC, 22.0));
+
+    json jDetTextGrp = NuiGroup(NuiText(NuiBind(INS_BIND_DET_TEXT), FALSE),
+        TRUE, NUI_SCROLLBARS_AUTO);
+    jDetTextGrp = NuiHeight(jDetTextGrp, fDetTextH);
+
+    json jDetRate = NuiLabel(NuiBind(INS_BIND_DET_RATE),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jDetRate = NuiHeight(jDetRate, GetNuiScaleDimension(oPC, 22.0));
+
+    json jBlessBtn = NuiButton(JsonString("Poblogoslaw"));
+    jBlessBtn = NuiId(jBlessBtn, INS_BTN_BLESS);
+    jBlessBtn = NuiEnabled(jBlessBtn, NuiBind(INS_BIND_BLESS_ENA));
+    jBlessBtn = NuiWidth(jBlessBtn, GetNuiScaleDimension(oPC, 120.0));
+    jBlessBtn = NuiHeight(jBlessBtn, fBtnH);
+
+    json jBackBtn = NuiButton(JsonString("Wróc do listy"));
+    jBackBtn = NuiId(jBackBtn, INS_BTN_BACK_LIST);
+    jBackBtn = NuiWidth(jBackBtn, GetNuiScaleDimension(oPC, 120.0));
+    jBackBtn = NuiHeight(jBackBtn, fBtnH);
+
+    json jDetBtnRow = JsonArray();
+    jDetBtnRow = JsonArrayInsert(jDetBtnRow, jBlessBtn);
+    jDetBtnRow = JsonArrayInsert(jDetBtnRow, NuiSpacer());
+    jDetBtnRow = JsonArrayInsert(jDetBtnRow, jBackBtn);
+
+    json jDetCol = JsonArray();
+    jDetCol = JsonArrayInsert(jDetCol, jDetHdr);
+    jDetCol = JsonArrayInsert(jDetCol, jDetTextGrp);
+    jDetCol = JsonArrayInsert(jDetCol, jDetRate);
+    jDetCol = JsonArrayInsert(jDetCol, NuiRow(jDetBtnRow));
+
+    json jDetGrp = NuiGroup(NuiCol(jDetCol), TRUE, NUI_SCROLLBARS_NONE);
+    jDetGrp = NuiHeight(jDetGrp, GetNuiScaleDimension(oPC, 166.0));
+
+    // Assemble read column
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jList);
+    jCol = JsonArrayInsert(jCol, NuiRow(jPagRow));
+    jCol = JsonArrayInsert(jCol, jDetGrp);
+    return NuiCol(jCol);
+}
+
+// ----------------------------------------------------------------
+// Write view layout
+// ----------------------------------------------------------------
+
+json BuildInsWriteView(object oPC)
+{
+    float fBtnH = GetNuiScaleDimension(oPC, 28.0);
+
+    json jTypeLbl = NuiLabel(JsonString("Typ inskrypcji:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTypeLbl = NuiHeight(jTypeLbl, GetNuiScaleDimension(oPC, 22.0));
+
+    json jTypeBtns = JsonArray();
+    int i;
+    for(i = 0; i < INS_TYPE_COUNT; i++)
+    {
+        json jBtn = NuiButton(JsonString(InsTypeName(i)));
+        jBtn = NuiId(jBtn, INS_BTN_TYPE_PFX + IntToString(i));
+        jBtn = NuiEncouraged(jBtn, NuiBind(INS_BIND_TYPE_ENC + IntToString(i)));
+        jBtn = NuiHeight(jBtn, fBtnH);
+        jTypeBtns = JsonArrayInsert(jTypeBtns, jBtn);
+    }
+
+    json jTxtLbl = NuiLabel(JsonString("Tresc:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTxtLbl = NuiHeight(jTxtLbl, GetNuiScaleDimension(oPC, 22.0));
+
+    json jTxtEdit = NuiTextEdit(
+        JsonString("Wyryj tu slowa, które przetrwaja próbe czasu..."),
+        NuiBind(INS_BIND_WRITE_TXT), INS_TEXT_MAX, TRUE);
+    jTxtEdit = NuiHeight(jTxtEdit, GetNuiScaleDimension(oPC, 200.0));
+
+    json jBloodChk = NuiCheck(
+        JsonString("Krwawa Inskrypcja (koszt: 10% HP; trwa 3x dluzej; daje czytelnikom +1 Wiedze)"),
+        NuiBind(INS_BIND_BLOOD_CHK));
+    jBloodChk = NuiHeight(jBloodChk, GetNuiScaleDimension(oPC, 28.0));
+
+    json jCharsLbl = NuiLabel(NuiBind(INS_BIND_CHARS_LBL),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jCharsLbl = NuiHeight(jCharsLbl, GetNuiScaleDimension(oPC, 20.0));
+
+    json jInsBtn = NuiButton(JsonString("Zapisz inskrypcje"));
+    jInsBtn = NuiId(jInsBtn, INS_BTN_INSCRIBE);
+    jInsBtn = NuiEnabled(jInsBtn, NuiBind(INS_BIND_WRITE_ENA));
+    jInsBtn = NuiWidth(jInsBtn, GetNuiScaleDimension(oPC, 180.0));
+    jInsBtn = NuiHeight(jInsBtn, GetNuiScaleDimension(oPC, 34.0));
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jInsBtn);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jTypeLbl);
+    jCol = JsonArrayInsert(jCol, NuiRow(jTypeBtns));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jTxtLbl);
+    jCol = JsonArrayInsert(jCol, jTxtEdit);
+    jCol = JsonArrayInsert(jCol, jBloodChk);
+    jCol = JsonArrayInsert(jCol, jCharsLbl);
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+    return NuiCol(jCol);
+}
+
+// ----------------------------------------------------------------
+// Window create / swap
+// ----------------------------------------------------------------
+
+void InsOpenWindow(object oPC, object oTablet)
+{
+    SetLocalString(oPC, INS_LVAR_TABLET,   GetTag(oTablet));
+    SetLocalInt   (oPC, INS_LVAR_PAGE,     0);
+    SetLocalInt   (oPC, INS_LVAR_SEL_ID,   0);
+    SetLocalInt   (oPC, INS_LVAR_SEL_TYPE, INS_TYPE_WARNING);
+
+    if(NuiFindWindow(oPC, INS_WINDOW) != 0)
+    {
+        int nToken = NuiFindWindow(oPC, INS_WINDOW);
+        NuiSetGroupLayout(oPC, nToken, INS_GRP_SWAP, BuildInsReadView(oPC));
+        SwapToReadView(oPC, nToken);
+        return;
+    }
+
+    float fGX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))
+                 - GetNuiScaleDimension(oPC, INS_W)) / 2.0;
+    float fGY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT))
+                 - GetNuiScaleDimension(oPC, INS_H)) / 2.0;
+    json jGeom = NuiRect(fGX, fGY,
+        GetNuiScaleDimension(oPC, INS_W),
+        GetNuiScaleDimension(oPC, INS_H));
+
+    float fBtnH = GetNuiScaleDimension(oPC, 28.0);
+
+    json jReadTab = NuiButton(JsonString("Czytaj"));
+    jReadTab = NuiId(jReadTab, INS_BTN_TAB_READ);
+    jReadTab = NuiWidth(jReadTab, GetNuiScaleDimension(oPC, 90.0));
+    jReadTab = NuiHeight(jReadTab, fBtnH);
+
+    json jWriteTab = NuiButton(JsonString("Zapisz"));
+    jWriteTab = NuiId(jWriteTab, INS_BTN_TAB_WRITE);
+    jWriteTab = NuiWidth(jWriteTab, GetNuiScaleDimension(oPC, 90.0));
+    jWriteTab = NuiHeight(jWriteTab, fBtnH);
+
+    json jCloseBtn = NuiButton(JsonString("X"));
+    jCloseBtn = NuiId(jCloseBtn, INS_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, GetNuiScaleDimension(oPC, 30.0));
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jTopRow = JsonArray();
+    jTopRow = JsonArrayInsert(jTopRow, jReadTab);
+    jTopRow = JsonArrayInsert(jTopRow, jWriteTab);
+    jTopRow = JsonArrayInsert(jTopRow, NuiSpacer());
+    jTopRow = JsonArrayInsert(jTopRow, jCloseBtn);
+
+    json jSwapGrp = NuiGroup(BuildInsReadView(oPC), FALSE, NUI_SCROLLBARS_NONE);
+    jSwapGrp = NuiId(jSwapGrp, INS_GRP_SWAP);
+
+    json jRootCol = JsonArray();
+    jRootCol = JsonArrayInsert(jRootCol, NuiRow(jTopRow));
+    jRootCol = JsonArrayInsert(jRootCol, jSwapGrp);
+
+    json jWin = NuiWindow(NuiCol(jRootCol),
+        JsonBool(FALSE),
+        NuiBind(INS_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    int nToken = NuiCreate(oPC, jWin, INS_WINDOW, INS_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, INS_WIN_GEOM, jGeom);
+    SwapToReadView(oPC, nToken);
+}
+
+void SwapToReadView(object oPC, int nToken)
+{
+    NuiSetGroupLayout(oPC, nToken, INS_GRP_SWAP, BuildInsReadView(oPC));
+    SetLocalInt(oPC, INS_LVAR_SEL_ID, 0);
+    FeedInsList  (oPC, nToken);
+    FeedInsDetail(oPC, nToken, 0);
+    NuiSetBindWatch(oPC, nToken, INS_BIND_WRITE_TXT, FALSE);
+}
+
+void SwapToWriteView(object oPC, int nToken)
+{
+    NuiSetGroupLayout(oPC, nToken, INS_GRP_SWAP, BuildInsWriteView(oPC));
+    SetLocalInt(oPC, INS_LVAR_SEL_TYPE, INS_TYPE_WARNING);
+
+    int i;
+    for(i = 0; i < INS_TYPE_COUNT; i++)
+        NuiSetBind(oPC, nToken, INS_BIND_TYPE_ENC + IntToString(i), JsonBool(i == 0));
+
+    NuiSetBind(oPC, nToken, INS_BIND_WRITE_TXT,  JsonString(""));
+    NuiSetBind(oPC, nToken, INS_BIND_BLOOD_CHK,  JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, INS_BIND_CHARS_LBL,
+        JsonString(IntToString(INS_TEXT_MAX) + "/" + IntToString(INS_TEXT_MAX) + " znaków"));
+    NuiSetBind(oPC, nToken, INS_BIND_WRITE_ENA,  JsonBool(FALSE));
+    NuiSetBindWatch(oPC, nToken, INS_BIND_WRITE_TXT, TRUE);
+}
+
+// ----------------------------------------------------------------
+// Feed – list
+// ----------------------------------------------------------------
+
+void FeedInsList(object oPC, int nToken)
+{
+    string sTag  = GetLocalString(oPC, INS_LVAR_TABLET);
+    int nPage    = GetLocalInt   (oPC, INS_LVAR_PAGE);
+    int nTotal   = InsGetCount(sTag);
+    int nPages   = (nTotal + INS_PAGE_SIZE - 1) / INS_PAGE_SIZE;
+    if(nPages < 1) nPages = 1;
+    if(nPage >= nPages) nPage = nPages - 1;
+    if(nPage < 0)       nPage = 0;
+    SetLocalInt(oPC, INS_LVAR_PAGE, nPage);
+
+    json jRows  = InsGetPage(sTag, nPage * INS_PAGE_SIZE, INS_PAGE_SIZE);
+    int  nCount = JsonGetLength(jRows);
+    SetLocalJson(oPC, INS_LVAR_LIST_JSON, jRows);
+
+    json jTypes = JsonArray();
+    json jTCols = JsonArray();
+    json jAuths = JsonArray();
+    json jPrevs = JsonArray();
+    json jAges  = JsonArray();
+    json jEncs  = JsonArray();
+
+    int nSelId = GetLocalInt(oPC, INS_LVAR_SEL_ID);
+
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json   jRow   = JsonArrayGet(jRows, i);
+        int    nId    = JsonGetInt   (JsonObjectGet(jRow, "id"));
+        string sAuth  = JsonGetString(JsonObjectGet(jRow, "author_name"));
+        string sBody  = JsonGetString(JsonObjectGet(jRow, "body"));
+        int    nType  = JsonGetInt   (JsonObjectGet(jRow, "type"));
+        int    bBlood = JsonGetInt   (JsonObjectGet(jRow, "is_blood"));
+        int    nAt    = JsonGetInt   (JsonObjectGet(jRow, "created_at"));
+
+        string sTypeMark = InsTypeName(nType) + (bBlood ? " [K]" : "");
+        jTypes = JsonArrayInsert(jTypes, JsonString(sTypeMark));
+        jTCols = JsonArrayInsert(jTCols, InsTypeColor(nType));
+        jAuths = JsonArrayInsert(jAuths, JsonString(sAuth));
+        jPrevs = JsonArrayInsert(jPrevs, JsonString(InsTruncate(sBody, 38)));
+        jAges  = JsonArrayInsert(jAges,  JsonString(InsFormatAge(nAt)));
+        jEncs  = JsonArrayInsert(jEncs,  JsonBool(nSelId > 0 && nId == nSelId));
+    }
+
+    NuiSetBind(oPC, nToken, INS_BIND_LST_TYPE, jTypes);
+    NuiSetBind(oPC, nToken, INS_BIND_LST_TCOL, jTCols);
+    NuiSetBind(oPC, nToken, INS_BIND_LST_AUTH, jAuths);
+    NuiSetBind(oPC, nToken, INS_BIND_LST_PREV, jPrevs);
+    NuiSetBind(oPC, nToken, INS_BIND_LST_AGE,  jAges);
+    NuiSetBind(oPC, nToken, INS_BIND_LST_ENC,  jEncs);
+    NuiSetBind(oPC, nToken, INS_BIND_LST_CNT,  JsonInt(nCount));
+
+    string sPageLbl = nTotal > 0
+        ? "Strona " + IntToString(nPage + 1) + "/" + IntToString(nPages)
+        : "Brak inskrypcji na tej tablicy";
+    NuiSetBind(oPC, nToken, INS_BIND_PAGE_LBL, JsonString(sPageLbl));
+    NuiSetBind(oPC, nToken, INS_BIND_PREV_ENA, JsonBool(nPage > 0));
+    NuiSetBind(oPC, nToken, INS_BIND_NEXT_ENA, JsonBool(nPage < nPages - 1 && nTotal > 0));
+}
+
+// ----------------------------------------------------------------
+// Feed – detail
+// ----------------------------------------------------------------
+
+void FeedInsDetail(object oPC, int nToken, int nId)
+{
+    SetLocalInt(oPC, INS_LVAR_SEL_ID, nId);
+
+    if(nId <= 0)
+    {
+        NuiSetBind(oPC, nToken, INS_BIND_DET_HDR,   JsonString("Wybierz inskrypcje z listy powyzej."));
+        NuiSetBind(oPC, nToken, INS_BIND_DET_TEXT,  JsonString(""));
+        NuiSetBind(oPC, nToken, INS_BIND_DET_RATE,  JsonString(""));
+        NuiSetBind(oPC, nToken, INS_BIND_BLESS_ENA, JsonBool(FALSE));
+        return;
+    }
+
+    json jIns = InsGetById(nId);
+    if(JsonGetType(jIns) == JSON_TYPE_NULL) return;
+
+    string sAuthorUuid = JsonGetString(JsonObjectGet(jIns, "author_uuid"));
+    string sAuthorName = JsonGetString(JsonObjectGet(jIns, "author_name"));
+    string sBody       = JsonGetString(JsonObjectGet(jIns, "body"));
+    int    nType       = JsonGetInt   (JsonObjectGet(jIns, "type"));
+    int    bBlood      = JsonGetInt   (JsonObjectGet(jIns, "is_blood"));
+    int    nBless      = JsonGetInt   (JsonObjectGet(jIns, "blessings"));
+
+    string sUuid      = GetObjectUUID(oPC);
+    int    bOwn       = (sAuthorUuid == sUuid);
+    int    bVoted     = InsHasVoted(nId, sUuid);
+    int    bCanBless  = (!bOwn && !bVoted);
+
+    string sBloodTag = bBlood ? "  [Krwawa]" : "";
+    string sHdr = InsTypeName(nType) + "  |  " + sAuthorName + sBloodTag;
+
+    NuiSetBind(oPC, nToken, INS_BIND_DET_HDR,   JsonString(sHdr));
+    NuiSetBind(oPC, nToken, INS_BIND_DET_TEXT,  JsonString(sBody));
+    NuiSetBind(oPC, nToken, INS_BIND_DET_RATE,  JsonString(InsFormatBlessings(nBless)));
+    NuiSetBind(oPC, nToken, INS_BIND_BLESS_ENA, JsonBool(bCanBless));
+
+    // Blood inscription bonus: +1 Lore for 1h, stacks up to INS_BLOOD_BONUS_MAX
+    if(bBlood && !bOwn && !InsHasReadBonus(nId, sUuid))
+    {
+        InsMarkReadBonus(nId, sUuid);
+        InsApplyBloodBonus(oPC);
+    }
+}
+
+// ----------------------------------------------------------------
+// Actions
+// ----------------------------------------------------------------
+
+void InsDoInscribe(object oPC, int nToken)
+{
+    string sBody = JsonGetString(NuiGetBind(oPC, nToken, INS_BIND_WRITE_TXT));
+    if(GetStringLength(sBody) < 3)
+    {
+        SendMessageToPC(oPC, "[Glos Kamienia] Tresc jest zbyt krótka.");
+        return;
+    }
+    if(GetStringLength(sBody) > INS_TEXT_MAX)
+    {
+        SendMessageToPC(oPC, "[Glos Kamienia] Tresc przekracza dozwolona dlugosc.");
+        return;
+    }
+
+    int bBlood = JsonGetInt(NuiGetBind(oPC, nToken, INS_BIND_BLOOD_CHK));
+    if(bBlood)
+    {
+        int nCurHP = GetCurrentHitPoints(oPC);
+        int nCost  = (nCurHP * INS_BLOOD_HP_PCT) / 100;
+        if(nCost < 1) nCost = 1;
+        if(nCurHP <= nCost)
+        {
+            SendMessageToPC(oPC,
+                "[Glos Kamienia] Jestes zbyt ranny, by pisac krwia.");
+            return;
+        }
+        ApplyEffectToObject(DURATION_TYPE_INSTANT,
+            EffectDamage(nCost, DAMAGE_TYPE_MAGICAL), oPC);
+        ApplyEffectToObject(DURATION_TYPE_INSTANT,
+            EffectVisualEffect(VFX_COM_BLOOD_CRT_RED), oPC);
+        SendMessageToPC(oPC,
+            "[Glos Kamienia] Wyryzujesz slowa wlasna krwia. (" +
+            IntToString(nCost) + " HP)");
+    }
+
+    int    nType = GetLocalInt   (oPC, INS_LVAR_SEL_TYPE);
+    string sTag  = GetLocalString(oPC, INS_LVAR_TABLET);
+
+    InsAdd(sTag, GetObjectUUID(oPC), GetName(oPC), sBody, nType, bBlood);
+
+    string sFlavor;
+    switch(nType)
+    {
+        case INS_TYPE_WARNING:   sFlavor = "Ostrzezenie wyryto w kamieniu. Niechaj zyje wiecznie."; break;
+        case INS_TYPE_DISCOVERY: sFlavor = "Odkrycie uwiecznione. Moze inni tez skorzystaja.";       break;
+        case INS_TYPE_GUIDANCE:  sFlavor = "Porada wyryta. Wiedza dzielona to wiedza podwojna.";     break;
+        case INS_TYPE_MOCKERY:   sFlavor = "Szpila wyryta. Slowa tnac moga ostrze jak miecz.";       break;
+        case INS_TYPE_TRIBUTE:   sFlavor = "Hold oddany. Pamiec trwa w kamieniu dluzej niz w sercach."; break;
+        default:                 sFlavor = "Inskrypcja wyryta."; break;
+    }
+    SendMessageToPC(oPC, "[Glos Kamienia] " + sFlavor);
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectVisualEffect(VFX_IMP_MAGIC_PROTECTION), oPC);
+
+    SetLocalInt(oPC, INS_LVAR_PAGE, 0);
+    SwapToReadView(oPC, nToken);
+}
+
+void InsDoBless(object oPC, int nToken)
+{
+    int nId = GetLocalInt(oPC, INS_LVAR_SEL_ID);
+    if(nId <= 0) return;
+
+    string sUuid = GetObjectUUID(oPC);
+    if(InsHasVoted(nId, sUuid))
+    {
+        SendMessageToPC(oPC, "[Glos Kamienia] Juz poblogoslawiłes te inskrypcje.");
+        return;
+    }
+
+    json jIns = InsGetById(nId);
+    if(JsonGetType(jIns) != JSON_TYPE_NULL &&
+       JsonGetString(JsonObjectGet(jIns, "author_uuid")) == sUuid)
+    {
+        SendMessageToPC(oPC,
+            "[Glos Kamienia] Nie mozesz blogoslawic wlasnej inskrypcji.");
+        return;
+    }
+
+    InsBless(nId, sUuid);
+
+    int nBless = JsonGetInt(JsonObjectGet(InsGetById(nId), "blessings"));
+    string sFlavor = (nBless >= INS_BLESS_PERMANENT)
+        ? "[Glos Kamienia] Inskrypcja osiagnela Pieczen Wieczna. Trwa na zawsze."
+        : "[Glos Kamienia] Twoje blogoslawienstwo wzmacnia inskrypcje.";
+    SendMessageToPC(oPC, sFlavor);
+
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectVisualEffect(VFX_IMP_HEAD_HOLY), oPC);
+
+    FeedInsList  (oPC, nToken);
+    FeedInsDetail(oPC, nToken, nId);
+}
+
+// Grants +1 Lore for INS_BLOOD_BONUS_DUR seconds, up to INS_BLOOD_BONUS_MAX stacks.
+void InsApplyBloodBonus(object oPC)
+{
+    int nStacks = 0;
+    effect eChk = GetFirstEffect(oPC);
+    while(GetIsEffectValid(eChk))
+    {
+        if(GetEffectTag(eChk) == "INS_BLOOD_LORE") nStacks++;
+        eChk = GetNextEffect(oPC);
+    }
+    if(nStacks >= INS_BLOOD_BONUS_MAX) return;
+
+    effect eBonus = TagEffect(EffectSkillIncrease(SKILL_LORE, 1), "INS_BLOOD_LORE");
+    eBonus = SupernaturalEffect(eBonus);
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eBonus, oPC, INS_BLOOD_BONUS_DUR);
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectVisualEffect(VFX_IMP_HEAD_ODD), oPC);
+    SendMessageToPC(oPC,
+        "[Glos Kamienia] Krwawa inskrypcja przekazuje ci wiedze. (+1 Wiedza, 1h)");
+}

--- a/Voice of Stone/Scripts/lib_ins_def.nss
+++ b/Voice of Stone/Scripts/lib_ins_def.nss
@@ -1,0 +1,132 @@
+#include "lib_nui"
+#include "sql_ins"
+
+// Forward declarations
+void FeedInsList(object oPC, int nToken);
+void FeedInsDetail(object oPC, int nToken, int nId);
+void InsOpenWindow(object oPC, object oTablet);
+void SwapToReadView(object oPC, int nToken);
+void SwapToWriteView(object oPC, int nToken);
+void InsApplyBloodBonus(object oPC);
+
+// ----------------------------------------------------------------
+// Window / bind constants
+// ----------------------------------------------------------------
+
+const string INS_WINDOW        = "INS_WINDOW";
+const string INS_EV_SCRIPT     = "lib_ins_ev";
+const string INS_GRP_SWAP      = "INS_GRP_SWAP";
+const string INS_WIN_GEOM      = "ins_win_geom";
+
+// Top bar buttons
+const string INS_BTN_TAB_READ  = "ins_tab_read";
+const string INS_BTN_TAB_WRITE = "ins_tab_write";
+const string INS_BTN_CLOSE     = "ins_btn_close";
+
+// List array binds (one value per visible row)
+const string INS_BIND_LST_TYPE = "ins_lst_type";   // type name string
+const string INS_BIND_LST_TCOL = "ins_lst_tcol";   // NuiColor per type
+const string INS_BIND_LST_AUTH = "ins_lst_auth";
+const string INS_BIND_LST_PREV = "ins_lst_prev";   // truncated preview
+const string INS_BIND_LST_AGE  = "ins_lst_age";
+const string INS_BIND_LST_ENC  = "ins_lst_enc";    // encouraged = selected
+const string INS_BIND_LST_CNT  = "ins_lst_cnt";    // row count integer bind
+const string INS_BTN_ROW       = "ins_btn_row";
+
+// Pagination
+const string INS_BTN_PREV_PAGE = "ins_btn_prev";
+const string INS_BTN_NEXT_PAGE = "ins_btn_next";
+const string INS_BIND_PAGE_LBL = "ins_page_lbl";
+const string INS_BIND_PREV_ENA = "ins_prev_ena";
+const string INS_BIND_NEXT_ENA = "ins_next_ena";
+
+// Detail panel
+const string INS_BIND_DET_HDR  = "ins_det_hdr";    // "TYPE | Author [Krwawa]"
+const string INS_BIND_DET_TEXT = "ins_det_text";
+const string INS_BIND_DET_RATE = "ins_det_rate";   // formatted blessing count
+const string INS_BIND_BLESS_ENA= "ins_bless_ena";
+const string INS_BTN_BLESS     = "ins_btn_bless";
+const string INS_BTN_BACK_LIST = "ins_btn_back";
+
+// Write panel
+const string INS_BTN_TYPE_PFX  = "ins_type_";      // + "0".."4"
+const string INS_BIND_TYPE_ENC = "ins_type_enc";   // + "0".."4" (bool, radio emulation)
+const string INS_BIND_WRITE_TXT= "ins_write_txt";
+const string INS_BIND_BLOOD_CHK= "ins_blood_chk";
+const string INS_BIND_CHARS_LBL= "ins_chars_lbl";
+const string INS_BIND_WRITE_ENA= "ins_write_ena";
+const string INS_BTN_INSCRIBE  = "ins_btn_inscribe";
+
+// LVARs on PC
+const string INS_LVAR_TABLET   = "INS_TABLET_TAG";
+const string INS_LVAR_PAGE     = "INS_PAGE";
+const string INS_LVAR_SEL_ID   = "INS_SEL_ID";
+const string INS_LVAR_SEL_TYPE = "INS_SEL_TYPE";   // currently selected write type
+const string INS_LVAR_LIST_JSON= "INS_LIST_JSON";  // cached page rows for row-click lookup
+
+// Layout dimensions (pre-scale)
+const float  INS_W             = 700.0;
+const float  INS_H             = 540.0;
+const int    INS_PAGE_SIZE     = 8;
+const int    INS_TEXT_MAX      = 200;
+const int    INS_BLOOD_HP_PCT  = 10;   // % of current HP consumed by blood inscription
+
+// Inscription types
+const int INS_TYPE_WARNING     = 0;
+const int INS_TYPE_DISCOVERY   = 1;
+const int INS_TYPE_GUIDANCE    = 2;
+const int INS_TYPE_MOCKERY     = 3;
+const int INS_TYPE_TRIBUTE     = 4;
+const int INS_TYPE_COUNT       = 5;
+
+// Blood bonus caps
+const int   INS_BLOOD_BONUS_MAX= 3;      // max stacks of Lore bonus
+const float INS_BLOOD_BONUS_DUR= 3600.0; // 1 hour per stack
+
+// ----------------------------------------------------------------
+// Type helpers
+// ----------------------------------------------------------------
+
+string InsTypeName(int nType)
+{
+    switch(nType)
+    {
+        case INS_TYPE_WARNING:   return "OSTRZEZENIE";
+        case INS_TYPE_DISCOVERY: return "ODKRYCIE";
+        case INS_TYPE_GUIDANCE:  return "PORADA";
+        case INS_TYPE_MOCKERY:   return "SZPILA";
+        case INS_TYPE_TRIBUTE:   return "HOLD";
+    }
+    return "?";
+}
+
+json InsTypeColor(int nType)
+{
+    switch(nType)
+    {
+        case INS_TYPE_WARNING:   return NuiColor(220, 60,  60);
+        case INS_TYPE_DISCOVERY: return NuiColor(220, 180, 50);
+        case INS_TYPE_GUIDANCE:  return NuiColor(80,  160, 220);
+        case INS_TYPE_MOCKERY:   return NuiColor(100, 210, 100);
+        case INS_TYPE_TRIBUTE:   return NuiColor(200, 130, 220);
+    }
+    return NuiColor(200, 200, 200);
+}
+
+// Returns at most nMax chars, appending ellipsis if truncated
+string InsTruncate(string sText, int nMax)
+{
+    if(GetStringLength(sText) <= nMax) return sText;
+    return GetStringLeft(sText, nMax - 1) + "~";
+}
+
+string InsFormatBlessings(int nCount)
+{
+    if(nCount == 0) return "Brak blogoslawien";
+    if(nCount >= INS_BLESS_PERMANENT)
+        return "Pieczen Wieczna (" + IntToString(nCount) + ")";
+    string sStar = "";
+    int i;
+    for(i = 0; i < nCount && i < 5; i++) sStar = sStar + "*";
+    return sStar + " (" + IntToString(nCount) + ")";
+}

--- a/Voice of Stone/Scripts/lib_ins_ev.nss
+++ b/Voice of Stone/Scripts/lib_ins_ev.nss
@@ -1,0 +1,129 @@
+#include "lib_ins"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    if(nToken != NuiFindWindow(oPC, INS_WINDOW)) return;
+
+    // ---- Window closed (native X or NuiDestroy) ----
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalString(oPC, INS_LVAR_TABLET);
+        DeleteLocalInt   (oPC, INS_LVAR_PAGE);
+        DeleteLocalInt   (oPC, INS_LVAR_SEL_ID);
+        DeleteLocalInt   (oPC, INS_LVAR_SEL_TYPE);
+        DeleteLocalJson  (oPC, INS_LVAR_LIST_JSON);
+        return;
+    }
+
+    // ---- Watch: text field changes ----
+    if(sEvent == EVENT_TYPE_WATCH && sElem == INS_BIND_WRITE_TXT)
+    {
+        string sTxt = JsonGetString(NuiGetBind(oPC, nToken, INS_BIND_WRITE_TXT));
+        int    nLen = GetStringLength(sTxt);
+        int    nLeft = INS_TEXT_MAX - nLen;
+        NuiSetBind(oPC, nToken, INS_BIND_CHARS_LBL,
+            JsonString(IntToString(nLeft < 0 ? 0 : nLeft) + "/" +
+                       IntToString(INS_TEXT_MAX) + " znaków"));
+        NuiSetBind(oPC, nToken, INS_BIND_WRITE_ENA,
+            JsonBool(nLen >= 3 && nLen <= INS_TEXT_MAX));
+        return;
+    }
+
+    // ---- Click: top-bar and detail buttons ----
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == INS_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+        if(sElem == INS_BTN_TAB_READ)
+        {
+            SwapToReadView(oPC, nToken);
+            return;
+        }
+        if(sElem == INS_BTN_TAB_WRITE)
+        {
+            SwapToWriteView(oPC, nToken);
+            return;
+        }
+
+        // Pagination
+        if(sElem == INS_BTN_PREV_PAGE)
+        {
+            int nPage = GetLocalInt(oPC, INS_LVAR_PAGE);
+            if(nPage > 0)
+            {
+                SetLocalInt(oPC, INS_LVAR_PAGE, nPage - 1);
+                SetLocalInt(oPC, INS_LVAR_SEL_ID, 0);
+                FeedInsList  (oPC, nToken);
+                FeedInsDetail(oPC, nToken, 0);
+            }
+            return;
+        }
+        if(sElem == INS_BTN_NEXT_PAGE)
+        {
+            SetLocalInt(oPC, INS_LVAR_PAGE, GetLocalInt(oPC, INS_LVAR_PAGE) + 1);
+            SetLocalInt(oPC, INS_LVAR_SEL_ID, 0);
+            FeedInsList  (oPC, nToken);
+            FeedInsDetail(oPC, nToken, 0);
+            return;
+        }
+
+        // Detail actions
+        if(sElem == INS_BTN_BLESS)
+        {
+            InsDoBless(oPC, nToken);
+            return;
+        }
+        if(sElem == INS_BTN_BACK_LIST)
+        {
+            SetLocalInt(oPC, INS_LVAR_SEL_ID, 0);
+            FeedInsList  (oPC, nToken);
+            FeedInsDetail(oPC, nToken, 0);
+            return;
+        }
+
+        // Write: type selector buttons (ins_type_0 … ins_type_4)
+        if(GetStringLeft(sElem, GetStringLength(INS_BTN_TYPE_PFX)) == INS_BTN_TYPE_PFX)
+        {
+            string sSuffix = GetStringRight(sElem,
+                GetStringLength(sElem) - GetStringLength(INS_BTN_TYPE_PFX));
+            int nType = StringToInt(sSuffix);
+            if(nType >= 0 && nType < INS_TYPE_COUNT)
+            {
+                SetLocalInt(oPC, INS_LVAR_SEL_TYPE, nType);
+                int i;
+                for(i = 0; i < INS_TYPE_COUNT; i++)
+                    NuiSetBind(oPC, nToken,
+                        INS_BIND_TYPE_ENC + IntToString(i), JsonBool(i == nType));
+            }
+            return;
+        }
+
+        // Write: inscribe
+        if(sElem == INS_BTN_INSCRIBE)
+        {
+            InsDoInscribe(oPC, nToken);
+            return;
+        }
+    }
+
+    // ---- MouseDown: list row click ----
+    if(sEvent == EVENT_TYPE_MOUSEDOWN && sElem == INS_BTN_ROW)
+    {
+        json jList = GetLocalJson(oPC, INS_LVAR_LIST_JSON);
+        if(nIdx < 0 || nIdx >= JsonGetLength(jList)) return;
+        json jRow = JsonArrayGet(jList, nIdx);
+        int  nId  = JsonGetInt(JsonObjectGet(jRow, "id"));
+        SetLocalInt(oPC, INS_LVAR_SEL_ID, nId);
+        FeedInsList  (oPC, nToken);
+        FeedInsDetail(oPC, nToken, nId);
+    }
+}

--- a/Voice of Stone/Scripts/lib_nui.nss
+++ b/Voice of Stone/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Voice of Stone/Scripts/lib_nui_utility.nss
+++ b/Voice of Stone/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Voice of Stone/Scripts/sql_ins.nss
+++ b/Voice of Stone/Scripts/sql_ins.nss
@@ -1,0 +1,212 @@
+const int INS_EXPIRY_HOURS    = 72;
+const int INS_BLOOD_MULT      = 3;
+const int INS_BLESS_PERMANENT = 10;
+
+void InsCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("stone_inscriptions",
+        "CREATE TABLE IF NOT EXISTS inscriptions ("
+        "  id          INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "  tablet_tag  TEXT    NOT NULL DEFAULT '',"
+        "  author_uuid TEXT    NOT NULL DEFAULT '',"
+        "  author_name TEXT    NOT NULL DEFAULT '',"
+        "  body        TEXT    NOT NULL DEFAULT '',"
+        "  type        INTEGER NOT NULL DEFAULT 0,"
+        "  is_blood    INTEGER NOT NULL DEFAULT 0,"
+        "  blessings   INTEGER NOT NULL DEFAULT 0,"
+        "  created_at  INTEGER NOT NULL DEFAULT 0,"
+        "  expires_at  INTEGER NOT NULL DEFAULT 0"
+        ")");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("stone_inscriptions",
+        "CREATE TABLE IF NOT EXISTS ins_votes ("
+        "  inscription_id INTEGER NOT NULL,"
+        "  voter_uuid     TEXT    NOT NULL,"
+        "  PRIMARY KEY (inscription_id, voter_uuid)"
+        ")");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("stone_inscriptions",
+        "CREATE TABLE IF NOT EXISTS ins_reads ("
+        "  inscription_id INTEGER NOT NULL,"
+        "  reader_uuid    TEXT    NOT NULL,"
+        "  PRIMARY KEY (inscription_id, reader_uuid)"
+        ")");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("stone_inscriptions",
+        "CREATE INDEX IF NOT EXISTS idx_ins_tablet"
+        " ON inscriptions (tablet_tag, expires_at)");
+    SqlStep(q);
+}
+
+void InsExpireOld()
+{
+    sqlquery q = SqlPrepareQueryCampaign("stone_inscriptions",
+        "DELETE FROM inscriptions"
+        " WHERE expires_at > 0 AND expires_at < strftime('%s','now')");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("stone_inscriptions",
+        "DELETE FROM ins_votes"
+        " WHERE inscription_id NOT IN (SELECT id FROM inscriptions)");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("stone_inscriptions",
+        "DELETE FROM ins_reads"
+        " WHERE inscription_id NOT IN (SELECT id FROM inscriptions)");
+    SqlStep(q);
+}
+
+int InsAdd(string sTabletTag, string sAuthorUuid, string sAuthorName,
+           string sBody, int nType, int bBlood)
+{
+    int nHours = bBlood ? INS_EXPIRY_HOURS * INS_BLOOD_MULT : INS_EXPIRY_HOURS;
+
+    sqlquery q = SqlPrepareQueryCampaign("stone_inscriptions",
+        "INSERT INTO inscriptions"
+        " (tablet_tag, author_uuid, author_name, body, type, is_blood,"
+        "  blessings, created_at, expires_at)"
+        " VALUES (@tag, @auuid, @aname, @body, @type, @blood, 0,"
+        " strftime('%s','now'), strftime('%s','now') + @hours * 3600)");
+    SqlBindString(q, "@tag",   sTabletTag);
+    SqlBindString(q, "@auuid", sAuthorUuid);
+    SqlBindString(q, "@aname", sAuthorName);
+    SqlBindString(q, "@body",  sBody);
+    SqlBindInt   (q, "@type",  nType);
+    SqlBindInt   (q, "@blood", bBlood);
+    SqlBindInt   (q, "@hours", nHours);
+    SqlStep(q);
+
+    sqlquery qId = SqlPrepareQueryCampaign("stone_inscriptions",
+        "SELECT last_insert_rowid()");
+    if(SqlStep(qId)) return SqlGetInt(qId, 0);
+    return 0;
+}
+
+int InsGetCount(string sTabletTag)
+{
+    sqlquery q = SqlPrepareQueryCampaign("stone_inscriptions",
+        "SELECT COUNT(*) FROM inscriptions"
+        " WHERE tablet_tag = @tag"
+        " AND (expires_at = 0 OR expires_at > strftime('%s','now'))");
+    SqlBindString(q, "@tag", sTabletTag);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// Returns JsonArray of rows sorted by blessings DESC then newest first
+json InsGetPage(string sTabletTag, int nOffset, int nLimit)
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("stone_inscriptions",
+        "SELECT id, author_uuid, author_name, body, type, is_blood, blessings, created_at"
+        " FROM inscriptions"
+        " WHERE tablet_tag = @tag"
+        " AND (expires_at = 0 OR expires_at > strftime('%s','now'))"
+        " ORDER BY blessings DESC, created_at DESC"
+        " LIMIT @lim OFFSET @off");
+    SqlBindString(q, "@tag", sTabletTag);
+    SqlBindInt   (q, "@lim", nLimit);
+    SqlBindInt   (q, "@off", nOffset);
+    while(SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "id",          JsonInt   (SqlGetInt   (q, 0)));
+        jRow = JsonObjectSet(jRow, "author_uuid", JsonString(SqlGetString(q, 1)));
+        jRow = JsonObjectSet(jRow, "author_name", JsonString(SqlGetString(q, 2)));
+        jRow = JsonObjectSet(jRow, "body",        JsonString(SqlGetString(q, 3)));
+        jRow = JsonObjectSet(jRow, "type",        JsonInt   (SqlGetInt   (q, 4)));
+        jRow = JsonObjectSet(jRow, "is_blood",    JsonInt   (SqlGetInt   (q, 5)));
+        jRow = JsonObjectSet(jRow, "blessings",   JsonInt   (SqlGetInt   (q, 6)));
+        jRow = JsonObjectSet(jRow, "created_at",  JsonInt   (SqlGetInt   (q, 7)));
+        jRows = JsonArrayInsert(jRows, jRow);
+    }
+    return jRows;
+}
+
+json InsGetById(int nId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("stone_inscriptions",
+        "SELECT id, author_uuid, author_name, body, type, is_blood, blessings, created_at"
+        " FROM inscriptions WHERE id = @id");
+    SqlBindInt(q, "@id", nId);
+    if(!SqlStep(q)) return JsonNull();
+    json jRow = JsonObject();
+    jRow = JsonObjectSet(jRow, "id",          JsonInt   (SqlGetInt   (q, 0)));
+    jRow = JsonObjectSet(jRow, "author_uuid", JsonString(SqlGetString(q, 1)));
+    jRow = JsonObjectSet(jRow, "author_name", JsonString(SqlGetString(q, 2)));
+    jRow = JsonObjectSet(jRow, "body",        JsonString(SqlGetString(q, 3)));
+    jRow = JsonObjectSet(jRow, "type",        JsonInt   (SqlGetInt   (q, 4)));
+    jRow = JsonObjectSet(jRow, "is_blood",    JsonInt   (SqlGetInt   (q, 5)));
+    jRow = JsonObjectSet(jRow, "blessings",   JsonInt   (SqlGetInt   (q, 6)));
+    jRow = JsonObjectSet(jRow, "created_at",  JsonInt   (SqlGetInt   (q, 7)));
+    return jRow;
+}
+
+int InsHasVoted(int nId, string sVoterUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign("stone_inscriptions",
+        "SELECT 1 FROM ins_votes"
+        " WHERE inscription_id = @id AND voter_uuid = @uuid");
+    SqlBindInt   (q, "@id",   nId);
+    SqlBindString(q, "@uuid", sVoterUuid);
+    return SqlStep(q);
+}
+
+void InsBless(int nId, string sVoterUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign("stone_inscriptions",
+        "INSERT OR IGNORE INTO ins_votes (inscription_id, voter_uuid)"
+        " VALUES (@id, @uuid)");
+    SqlBindInt   (q, "@id",   nId);
+    SqlBindString(q, "@uuid", sVoterUuid);
+    SqlStep(q);
+
+    // Each blessing extends life by 1h; at threshold make permanent (expires_at=0)
+    q = SqlPrepareQueryCampaign("stone_inscriptions",
+        "UPDATE inscriptions"
+        " SET blessings = blessings + 1,"
+        "     expires_at = CASE WHEN blessings + 1 >= @perm THEN 0"
+        "                       ELSE expires_at + 3600 END"
+        " WHERE id = @id");
+    SqlBindInt(q, "@perm", INS_BLESS_PERMANENT);
+    SqlBindInt(q, "@id",   nId);
+    SqlStep(q);
+}
+
+int InsHasReadBonus(int nId, string sUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign("stone_inscriptions",
+        "SELECT 1 FROM ins_reads"
+        " WHERE inscription_id = @id AND reader_uuid = @uuid");
+    SqlBindInt   (q, "@id",   nId);
+    SqlBindString(q, "@uuid", sUuid);
+    return SqlStep(q);
+}
+
+void InsMarkReadBonus(int nId, string sUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign("stone_inscriptions",
+        "INSERT OR IGNORE INTO ins_reads (inscription_id, reader_uuid)"
+        " VALUES (@id, @uuid)");
+    SqlBindInt   (q, "@id",   nId);
+    SqlBindString(q, "@uuid", sUuid);
+    SqlStep(q);
+}
+
+// Returns age as "Xh" / "Xd" / "dawno" using SQLite arithmetic
+string InsFormatAge(int nCreatedAt)
+{
+    sqlquery q = SqlPrepareQueryCampaign("stone_inscriptions",
+        "SELECT CAST((strftime('%s','now') - @ts) / 3600 AS INTEGER)");
+    SqlBindInt(q, "@ts", nCreatedAt);
+    if(!SqlStep(q)) return "?";
+    int nHours = SqlGetInt(q, 0);
+    if(nHours < 1)  return "<1h";
+    if(nHours < 24) return IntToString(nHours) + "h";
+    int nDays = nHours / 24;
+    if(nDays < 30)  return IntToString(nDays) + "d";
+    return "dawno";
+}

--- a/Voice of Stone/Scripts/sys_on_enter.nss
+++ b/Voice of Stone/Scripts/sys_on_enter.nss
@@ -1,0 +1,26 @@
+#include "lib_ins_def"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC)) return;
+
+    // Run expiry cleanup once per enter to keep the DB lean
+    InsExpireOld();
+
+    // Notify the player if there's a stone tablet in this area
+    object oTablet = GetNearestObjectByTag("ins_tablet", oPC, 1);
+    if(!GetIsObjectValid(oTablet))
+        oTablet = GetNearestObjectByTag("INS_TABLET", oPC, 1);
+
+    if(GetIsObjectValid(oTablet) && GetArea(oTablet) == GetArea(oPC))
+    {
+        int nCount = InsGetCount(GetTag(oTablet));
+        string sMsg = nCount > 0
+            ? "[Glos Kamienia] Widzisz Kamienna Tablice. Zawiera " +
+              IntToString(nCount) + " inskrypcj" +
+              (nCount == 1 ? "e" : (nCount < 5 ? "e" : "i")) + "."
+            : "[Glos Kamienia] Widzisz Kamienna Tablice. Jeszcze nikt tu nie pisał.";
+        DelayCommand(2.0, SendMessageToPC(oPC, sMsg));
+    }
+}

--- a/Voice of Stone/Scripts/sys_on_load.nss
+++ b/Voice of Stone/Scripts/sys_on_load.nss
@@ -1,0 +1,7 @@
+#include "lib_ins_def"
+
+void main()
+{
+    InsCreateTables();
+    InsExpireOld();
+}

--- a/Voice of Stone/Scripts/test_ins.nss
+++ b/Voice of Stone/Scripts/test_ins.nss
@@ -1,0 +1,16 @@
+#include "lib_ins"
+
+// Place this script in the OnUsed event of a placeable with tag "ins_tablet".
+// The placeable's tag is used as the inscription namespace, so tablets in
+// different locations should have distinct tags (e.g. "ins_tablet_tavern",
+// "ins_tablet_graveyard").
+
+void main()
+{
+    object oPC     = GetLastUsedBy();
+    object oTablet = OBJECT_SELF;
+
+    if(!GetIsPC(oPC)) return;
+
+    InsOpenWindow(oPC, oTablet);
+}


### PR DESCRIPTION
## Co to robi

System inskrypcji na Kamiennych Tablicach — gracze wypisują krótkie wiadomości (maks. 200 znaków) w 5 typach (Ostrzeżenie, Odkrycie, Porada, Szpila, Hołd), czytają je przez NUI, błogosławią ulubione (10+ błogosławień = Pieczęć Wieczna, inskrypcja nigdy nie wygasa) i pochłaniają wiedzę z krwawych inskrypcji.

## Mechanika

| Element | Opis |
|---------|------|
| **Inskrypcje** | Tekst + typ (5 rodzajów) + opcja krwawa. Domyślny czas życia: 72h. |
| **Krwawa Inskrypcja** | Kosztuje 10% bieżących HP. Trwa 3× dłużej (216h). Czytelnicy (nie autor) dostają +1 Wiedza (SKILL_LORE) na 1h, max +3 stacki; efekt tagowany `INS_BLOOD_LORE`, supernatural. |
| **Błogosławieństwa** | Każde +1h do wygaśnięcia inskrypcji. Przy ≥10 staje się Pieczęcią Wieczną (`expires_at = 0`). Własnej inskrypcji nie można błogosławić. |
| **Ekspiracja** | `InsExpireOld()` usuwa przeterminowane wpisy kaskadowo (votes, reads). Wywoływana przy OnLoad i OnClientEnter. |
| **Paginacja** | 8 wpisów na stronę, sortowanie: blessings DESC, then newest. |
| **NUI** | Swap grup (jak Mailbox): zakładka Czytaj ↔ Zapisz przez `NuiSetGroupLayout`. Lista z kolorowaniem per typ, panel detali, radio-style selektor typów. |

## Pliki

```
Voice of Stone/
  Scripts/
    sql_ins.nss        — warstwa SQL (campaign DB "stone_inscriptions")
    lib_ins_def.nss    — stałe, kolory typów, helpery tekstowe
    lib_ins.nss        — budowanie NUI, feeds, InsDoInscribe, InsDoBless, InsApplyBloodBonus
    lib_ins_ev.nss     — handler NUI (switch po sEvent/sElem)
    lib_nui.nss        — shared NUI utility (kopia z Mailbox)
    lib_nui_utility.nss
    sys_on_load.nss    — CreateTables + ExpireOld
    sys_on_enter.nss   — hint o tablicy w obszarze + ExpireOld
    test_ins.nss       — OnUsed handler dla placeabla tablicy
  INTEGRATION.md       — instrukcja podpięcia hooków i setupu tablicy
```

## Zależności (NWNX? SQL?)

- **NWNX**: brak.
- **NWN:EE**: wymaga buildu ≥ 8193 dla `TagEffect` / `GetEffectTag` (krew-bonus).
- **SQL**: campaign database `stone_inscriptions`; tabele tworzone automatycznie przy OnLoad.

## Jak włączyć w istniejącym module

1. Skopiuj folder `Voice of Stone/Scripts/` do skryptów modułu (lub HAK).
2. Podepnij `sys_on_load` pod `OnModuleLoad` (lub wywołaj z istniejącego skryptu).
3. Podepnij `sys_on_enter` pod `OnClientEnter`.
4. Postaw placeable z tagiem `ins_tablet` (lub dowolnym unikalnym tagiem) i skryptem `test_ins` na `OnUsed`.
5. Różne tablice w różnych lokacjach — różne tagi = osobne przestrzenie inskrypcji.

## Co celowo pominięto

- Pliki graficzne / ikony w HAK — system czysto tekstowy, zero zależności od zasobów.
- Usuwanie własnych inskrypcji — wpisana trwałość jest klimatycznym wyborem projektowym.
- Rate-limiting (max X inskrypcji per gracz per dzień) — pozostawiono do konfiguracji przez serwer.
- Osobny licznik per-obszar (tablice są namespace'owane tagiem, nie area_tag).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LqWGdhSDFDMsDsNzgwJdbW)_