### PR TITLE
feat: Homunculus

### DIFF
--- a/Homunculus/INTEGRATION.md
+++ b/Homunculus/INTEGRATION.md
@@ -1,0 +1,62 @@
+# Homunculus — Integracja z modułem NWN
+
+## Co to robi
+
+System alchemicznego towarzysza. Gracz zbiera 3 reagenty alchemiczne i wytwarza
+homunkulus — małą istotę, która towarzyszy mu w podróży (manifestuje się jako
+orbita VFX wokół postaci). Więź rośnie z każdym karmieniem i odblokowuje kolejne
+zdolności dobowe. Niekarmiony homunkulus traci więź; jej zanik do 0 permanentnie
+go zabija. Przy więzi 10 gracz może dokonać Poświęcenia — zniszczyć towarzysza
+w zamian za jednorazowy, potężny efekt.
+
+## Skrypty do podpięcia
+
+| Zdarzenie modułu      | Skrypt              |
+|-----------------------|---------------------|
+| OnModuleLoad          | `sys_on_load.nss`   |
+| OnClientEnter         | `sys_on_enter.nss`  |
+
+Panel otwierany jest przez umieszczony w świecie **Placeable** (np. stół alchemiczny)
+z podpiętym skryptem `test_hom.nss` jako OnUsed.
+
+## Wymagania — NWNX
+
+Brak. Moduł działa wyłącznie w oparciu o NWScript + NUI + wbudowaną bazę danych
+SQLite (SqlPrepareQueryCampaign z nazwą kampanii `"homunculus"`).
+
+## Wymagania — Hak
+
+Brak. Wszystkie VFX i resrefy to standardowe assety NWN:EE.
+
+Jeśli chcesz podmienić VFX towarzysza (domyślnie `VFX_DUR_IOUNSTONE_BLUE`),
+zmień stałą `HOM_VFX` w `lib_hom_def.nss`.
+
+## Przedmioty testowe (do dodania ręcznie lub przez skrypt)
+
+| Tag                | Rola                                                         |
+|--------------------|--------------------------------------------------------------|
+| `hom_reagent`      | Reagent do stworzenia homunkulus (potrzeba 3 sztuk)          |
+| `hom_feed`         | Pokarm — 1 sztuka zużywana przy każdym karmieniu             |
+
+W środowisku testowym możesz użyć dowolnych istniejących itemów i tymczasowo
+zmienić ich tagi na powyższe w Toolset, lub rozdać graczowi przez konsolę DM.
+
+## Szybki test
+
+1. Dodaj `sys_on_load.nss` do zdarzenia OnModuleLoad.
+2. Dodaj `sys_on_enter.nss` do zdarzenia OnClientEnter.
+3. Umieść placeable z `test_hom.nss` na mapie.
+4. Wejdź do modułu, dodaj sobie 3 itemy z tagiem `hom_reagent`.
+5. Użyj placeable — otwórz panel, kliknij „Stwórz Homunkulus".
+6. Dodaj item z tagiem `hom_feed` i kliknij „Nakarm".
+7. Sprawdź VFX, zdolności i dziennik.
+
+## Celowo pominięto
+
+- Fizyczne stworzenie poruszające się po mapie — wymaga NWNX Creature lub
+  dedykowanego skryptu AI heartbeat; pominięto, by moduł był standalone.
+- Wiele rodzajów homunkulus (ziemny, ognisty itp.) — rozszerzenie możliwe przez
+  dodanie kolumny `type` do tabeli i wariantów VFX/zdolności.
+- Śmierć homunkulus w walce (aktualnie tylko przez głód lub poświęcenie) —
+  można dodać przez hook OnCreatureDeath jeśli dodano fizycznego NPC.
+- Limit 1 homunkulus na gracza jest zamierzony (klimat mroczny — wyjątkowa więź).

--- a/Homunculus/Scripts/lib_hom.nss
+++ b/Homunculus/Scripts/lib_hom.nss
@@ -1,0 +1,713 @@
+// lib_hom.nss — UI construction, game logic, and maintenance for the Homunculus module
+#include "lib_hom_def"
+
+// ----------------------------------------------------------------
+// VFX presence management
+// ----------------------------------------------------------------
+
+void HomApplyPresenceVFX(object oPC)
+{
+    // Apply a persistent iounstone orbit to signal the companion is active.
+    // The effect is re-applied on every module enter so no slot tracking is needed.
+    effect eVFX = EffectVisualEffect(HOM_VFX);
+    ApplyEffectToObject(DURATION_TYPE_PERMANENT, eVFX, oPC);
+}
+
+void HomRemovePresenceVFX(object oPC)
+{
+    effect eCheck = GetFirstEffect(oPC);
+    while(GetIsEffectValid(eCheck))
+    {
+        if(GetEffectType(eCheck) == EFFECT_TYPE_VISUALEFFECT)
+        {
+            int nVfxId = GetEffectInteger(eCheck, 0);
+            if(nVfxId == HOM_VFX)
+            {
+                RemoveEffect(oPC, eCheck);
+                return;
+            }
+        }
+        eCheck = GetNextEffect(oPC);
+    }
+}
+
+// ----------------------------------------------------------------
+// Maintenance check — called on module enter and heartbeat
+// ----------------------------------------------------------------
+
+void HomCheckMaintenance(object oPC)
+{
+    if(!HomExists(oPC)) return;
+
+    int nSecs = HomSecondsSinceFed(oPC);
+
+    if(nSecs > HOM_STARVE_TIMEOUT)
+    {
+        // Apply one bond point of decay per login session while starving.
+        // This avoids double-penalising if the player logs in and out quickly.
+        HomLowerBond(oPC);
+
+        if(!HomExists(oPC))
+        {
+            HomAddLog(oPC, "Twój homunkulus skonał z głodu. Więź pękła bezpowrotnie.");
+            HomRemovePresenceVFX(oPC);
+            SendMessageToPC(oPC, "[Homunkulus] Twój homunkulus umarł z głodu. Więź dobiegła końca.");
+            FloatingTextStringOnCreature(
+                "Homunkulus nie żyje… Pieczęć krwi wygasła.", oPC, FALSE);
+            return;
+        }
+
+        int nBond = HomGetBondLevel(oPC);
+        HomAddLog(oPC, "Homunkulus jest osłabiony z głodu. Więź: " + IntToString(nBond));
+        SendMessageToPC(oPC,
+            "[Homunkulus] Homunkulus jest głodny od ponad 48 godzin! Więź spada do "
+            + IntToString(nBond) + " / 10. Nakarm go!");
+    }
+}
+
+// ----------------------------------------------------------------
+// Ability execution
+// ----------------------------------------------------------------
+
+void HomUseAbilityDetect(object oPC)
+{
+    int nEnemies = 0;
+    int nTraps   = 0;
+    object oNear = GetNearestCreature(CREATURE_TYPE_IS_ALIVE, TRUE, oPC, 1,
+                                      CREATURE_TYPE_REPUTATION, REPUTATION_TYPE_ENEMY);
+    while(GetIsObjectValid(oNear) && GetDistanceToObject(oNear) <= 15.0)
+    {
+        nEnemies++;
+        oNear = GetNearestCreature(CREATURE_TYPE_IS_ALIVE, TRUE, oPC, nEnemies + 1,
+                                   CREATURE_TYPE_REPUTATION, REPUTATION_TYPE_ENEMY);
+    }
+
+    object oTrap = GetNearestTrapToObject(oPC);
+    if(GetIsObjectValid(oTrap) && GetDistanceBetween(oTrap, oPC) <= 15.0)
+        nTraps = 1;
+
+    string sMsg;
+    if(nEnemies == 0 && nTraps == 0)
+        sMsg = "Homunkulus mruczy spokojnie — w pobliżu nie wyczuwa żadnego zagrożenia.";
+    else
+    {
+        sMsg = "Homunkulus szepcze ostrzegawczo!";
+        if(nEnemies > 0)
+            sMsg = sMsg + " Wrogów w zasięgu: " + IntToString(nEnemies) + ".";
+        if(nTraps > 0)
+            sMsg = sMsg + " Wyczuwa pułapkę w pobliżu!";
+    }
+
+    SendMessageToPC(oPC, "[Homunkulus] " + sMsg);
+    FloatingTextStringOnCreature(sMsg, oPC, FALSE);
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+        EffectVisualEffect(VFX_IMP_BLIND_DEAF_M), oPC, 1.5);
+}
+
+void HomUseAbilityScavenge(object oPC)
+{
+    string sResRef = HomRandomIngredientResref();
+    object oItem   = CreateItemOnObject(sResRef, oPC);
+    if(GetIsObjectValid(oItem))
+    {
+        string sMsg = "Homunkulus wraca z małą zdobyczą: " + GetName(oItem) + "!";
+        SendMessageToPC(oPC, "[Homunkulus] " + sMsg);
+        FloatingTextStringOnCreature("Homunkulus coś przyniósł!", oPC, FALSE);
+    }
+    else
+    {
+        SendMessageToPC(oPC, "[Homunkulus] Homunkulus wraca z pustymi rękami tym razem.");
+    }
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+        EffectVisualEffect(VFX_IMP_MAGIC_PROTECTION), oPC, 1.5);
+}
+
+void HomUseAbilityShield(object oPC)
+{
+    effect eTHP = EffectTemporaryHitpoints(10);
+    effect eAC  = EffectACIncrease(2, AC_DODGE_BONUS);
+    effect eVFX = EffectVisualEffect(VFX_IMP_MAGIC_PROTECTION);
+
+    float fDur = 3600.0; // 1 hour
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eTHP, oPC, fDur);
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eAC,  oPC, fDur);
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eVFX, oPC, 2.0);
+
+    SendMessageToPC(oPC,
+        "[Homunkulus] Alchemiczna substancja oplata twoje ciało. +10 HP, +2 AC przez godzinę.");
+    FloatingTextStringOnCreature(
+        "Pieczęć alchemiczna aktywna!", oPC, FALSE);
+}
+
+void HomUseAbilitySurge(object oPC)
+{
+    float fDur   = 1800.0; // 30 minutes
+    effect eSave = EffectSavingThrowIncrease(SAVING_THROW_ALL, 4, SAVING_THROW_TYPE_ALL);
+    effect eVFX  = EffectVisualEffect(VFX_IMP_PULSE_WIND);
+
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eSave, oPC, fDur);
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eVFX,  oPC, 2.0);
+
+    SendMessageToPC(oPC,
+        "[Homunkulus] Esencja przepływa przez ciebie. +4 do wszystkich rzutów obronnych przez 30 minut.");
+    FloatingTextStringOnCreature(
+        "Wzmocnienie Duszy aktywne!", oPC, FALSE);
+}
+
+void HomUseAbility(object oPC)
+{
+    if(!HomExists(oPC))
+    {
+        SendMessageToPC(oPC, "[Homunkulus] Nie posiadasz żywego homunkulus.");
+        return;
+    }
+    if(HomAbilityOnCooldown(oPC))
+    {
+        SendMessageToPC(oPC, "[Homunkulus] Homunkulus jest wyczerpany. Wróć jutro.");
+        return;
+    }
+
+    int nBond = HomGetBondLevel(oPC);
+    HomMarkAbilityUsed(oPC);
+
+    if(nBond <= 2)
+    {
+        HomAddLog(oPC, "Percepcja Zagrożeń — homunkulus skontrolował otoczenie.");
+        HomUseAbilityDetect(oPC);
+    }
+    else if(nBond <= 5)
+    {
+        HomAddLog(oPC, "Zbieraczka Składników — homunkulus przyniósł reagent.");
+        HomUseAbilityScavenge(oPC);
+    }
+    else if(nBond <= 8)
+    {
+        HomAddLog(oPC, "Tarcza Alchemiczna — aktywowano osłonę.");
+        HomUseAbilityShield(oPC);
+    }
+    else
+    {
+        HomAddLog(oPC, "Wzmocnienie Duszy — esencja wzmocniła ciało.");
+        HomUseAbilitySurge(oPC);
+    }
+}
+
+// ----------------------------------------------------------------
+// Feed logic
+// ----------------------------------------------------------------
+
+int HomCountFeedItems(object oPC)
+{
+    int nCount = 0;
+    object oItem = GetFirstItemInInventory(oPC);
+    while(GetIsObjectValid(oItem))
+    {
+        if(GetTag(oItem) == HOM_FEED_ITEM_TAG)
+            nCount++;
+        oItem = GetNextItemInInventory(oPC);
+    }
+    return nCount;
+}
+
+void HomConsumeOneFeedItem(object oPC)
+{
+    object oItem = GetFirstItemInInventory(oPC);
+    while(GetIsObjectValid(oItem))
+    {
+        if(GetTag(oItem) == HOM_FEED_ITEM_TAG)
+        {
+            int nStack = GetItemStackSize(oItem);
+            if(nStack > 1)
+                SetItemStackSize(oItem, nStack - 1);
+            else
+                DestroyObject(oItem);
+            return;
+        }
+        oItem = GetNextItemInInventory(oPC);
+    }
+}
+
+void HomFeedCompanion(object oPC)
+{
+    if(!HomExists(oPC))
+    {
+        SendMessageToPC(oPC, "[Homunkulus] Nie posiadasz żywego homunkulus.");
+        return;
+    }
+    if(HomCountFeedItems(oPC) < 1)
+    {
+        SendMessageToPC(oPC, "[Homunkulus] Potrzebujesz reagentu karmienia (tag: " + HOM_FEED_ITEM_TAG + ").");
+        return;
+    }
+
+    int nSecsFed = HomSecondsSinceFed(oPC);
+    HomConsumeOneFeedItem(oPC);
+    HomFeed(oPC);
+
+    // Bond grows if fed on time (within the normal window)
+    if(nSecsFed >= HOM_FEED_INTERVAL)
+    {
+        HomRaiseBond(oPC);
+        int nBond = HomGetBondLevel(oPC);
+        HomAddLog(oPC, "Nakarmiony — więź wzrosła do " + IntToString(nBond) + ".");
+        SendMessageToPC(oPC,
+            "[Homunkulus] Homunkulus zjada porcję z apetytem. Więź wzrasta do "
+            + IntToString(nBond) + " / 10.");
+        FloatingTextStringOnCreature("Więź się wzmocniła!", oPC, FALSE);
+    }
+    else
+    {
+        HomAddLog(oPC, "Nakarmiony — więź stabilna.");
+        SendMessageToPC(oPC, "[Homunkulus] Homunkulus przyjmuje pożywienie. Więź stabilna.");
+    }
+}
+
+// ----------------------------------------------------------------
+// Sacrifice
+// ----------------------------------------------------------------
+
+void HomSacrifice(object oPC)
+{
+    if(!HomExists(oPC))
+    {
+        SendMessageToPC(oPC, "[Homunkulus] Nie posiadasz homunkulus, który można poświęcić.");
+        return;
+    }
+    if(HomGetBondLevel(oPC) < 10)
+    {
+        SendMessageToPC(oPC, "[Homunkulus] Więź musi osiągnąć poziom 10, aby móc dokonać poświęcenia.");
+        return;
+    }
+
+    HomAddLog(oPC, "POŚWIĘCENIE — homunkulus złożony w ofierze.");
+    HomKill(oPC);
+    HomRemovePresenceVFX(oPC);
+
+    // Powerful one-time boon: full HP restore + powerful regen for 10 minutes
+    effect eHP  = EffectHeal(GetMaxHitPoints(oPC));
+    effect eReg = EffectRegenerate(5, 6.0); // 5 HP every 6 seconds
+    effect eVFX = EffectVisualEffect(VFX_IMP_PULSE_HOLY);
+
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,   eHP,  oPC);
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eReg, oPC, 600.0);
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eVFX, oPC, 3.0);
+
+    SendMessageToPC(oPC,
+        "[Homunkulus] Homunkulus roztopił się w potoku gorącej esencji, wypełniając twoje ciało życiem."
+        " Pełne HP przywrócone. Regeneracja 5 HP/6s przez 10 minut.");
+    FloatingTextStringOnCreature(
+        "Homunkulus poświęcony… jego siła stała się twoją.", oPC, FALSE);
+}
+
+// ----------------------------------------------------------------
+// Crafting
+// ----------------------------------------------------------------
+
+int HomCountReagents(object oPC)
+{
+    int nCount = 0;
+    object oItem = GetFirstItemInInventory(oPC);
+    while(GetIsObjectValid(oItem))
+    {
+        if(GetTag(oItem) == HOM_REAGENT_TAG)
+            nCount += GetItemStackSize(oItem);
+        oItem = GetNextItemInInventory(oPC);
+    }
+    return nCount;
+}
+
+void HomConsumeReagents(object oPC, int nNeeded)
+{
+    int nLeft = nNeeded;
+    object oItem = GetFirstItemInInventory(oPC);
+    while(GetIsObjectValid(oItem) && nLeft > 0)
+    {
+        if(GetTag(oItem) == HOM_REAGENT_TAG)
+        {
+            int nStack = GetItemStackSize(oItem);
+            if(nStack <= nLeft)
+            {
+                nLeft -= nStack;
+                DestroyObject(oItem);
+            }
+            else
+            {
+                SetItemStackSize(oItem, nStack - nLeft);
+                nLeft = 0;
+            }
+        }
+        oItem = GetNextItemInInventory(oPC);
+    }
+}
+
+void HomCraft(object oPC)
+{
+    if(HomExists(oPC))
+    {
+        SendMessageToPC(oPC, "[Homunkulus] Posiadasz już żywego homunkulus. Nie możesz stworzyć drugiego.");
+        return;
+    }
+    if(HomCountReagents(oPC) < HOM_REAGENT_NEEDED)
+    {
+        SendMessageToPC(oPC,
+            "[Homunkulus] Potrzebujesz " + IntToString(HOM_REAGENT_NEEDED)
+            + " reagentów alchemicznych (tag: " + HOM_REAGENT_TAG + ").");
+        return;
+    }
+
+    HomConsumeReagents(oPC, HOM_REAGENT_NEEDED);
+    HomCreate(oPC, "Bezimienny");
+    HomAddLog(oPC, "Homunkulus stworzony.");
+    HomApplyPresenceVFX(oPC);
+
+    SendMessageToPC(oPC,
+        "[Homunkulus] Mieszanina bulgocze, krzepnie i otwiera oczy. Homunkulus żyje!"
+        " Użyj panelu, by nadać mu imię.");
+    FloatingTextStringOnCreature(
+        "Homunkulus przebudził się!", oPC, FALSE);
+}
+
+// ----------------------------------------------------------------
+// NUI — swap group content builders
+// ----------------------------------------------------------------
+
+json HomBuildStatusView(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 30.0);
+    float fDescH = GetNuiScaleDimension(oPC, 80.0);
+    float fLogH  = GetNuiScaleDimension(oPC, 22.0);
+
+    // Bond progress bar (NuiProgress expects a float bind 0.0–1.0)
+    json jBondLbl = NuiLabel(NuiBind(HOM_BIND_BOND_LBL),
+                             JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jBondLbl = NuiHeight(jBondLbl, fBtnH);
+
+    json jBar = NuiProgress(NuiBind(HOM_BIND_BOND_PROG));
+    jBar = NuiHeight(jBar, GetNuiScaleDimension(oPC, 14.0));
+
+    // Status line (hunger/health)
+    json jStatus = NuiLabel(NuiBind(HOM_BIND_STATUS),
+                            JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jStatus = NuiStyleForegroundColor(jStatus, NuiBind(HOM_BIND_STATUS_CLR));
+    jStatus = NuiHeight(jStatus, fBtnH);
+
+    // Ability section
+    json jANameLbl = NuiLabel(NuiBind(HOM_BIND_ANAME),
+                              JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jANameLbl = NuiHeight(jANameLbl, fBtnH);
+
+    json jADesc = NuiGroup(NuiText(NuiBind(HOM_BIND_ADESC), FALSE), TRUE, NUI_SCROLLBARS_NONE);
+    jADesc = NuiHeight(jADesc, fDescH);
+
+    json jUseBtn = NuiButton(NuiBind(HOM_BIND_ABTN_LBL));
+    jUseBtn = NuiId(jUseBtn, HOM_BTN_USE);
+    jUseBtn = NuiEnabled(jUseBtn, NuiBind(HOM_BIND_AENA));
+    jUseBtn = NuiHeight(jUseBtn, fBtnH);
+
+    // Feed / Rename / Sacrifice row
+    json jFeedBtn = NuiButton(JsonString("Nakarm"));
+    jFeedBtn = NuiId(jFeedBtn, HOM_BTN_FEED);
+    jFeedBtn = NuiEnabled(jFeedBtn, NuiBind(HOM_BIND_FEED_ENA));
+    jFeedBtn = NuiWidth(jFeedBtn, GetNuiScaleDimension(oPC, 120.0));
+    jFeedBtn = NuiHeight(jFeedBtn, fBtnH);
+    jFeedBtn = NuiTooltip(jFeedBtn, JsonString("Zużywa 1 item (tag: hom_feed)."));
+
+    json jRenBtn = NuiButton(JsonString("Zmień imię"));
+    jRenBtn = NuiId(jRenBtn, HOM_BTN_RENAME);
+    jRenBtn = NuiWidth(jRenBtn, GetNuiScaleDimension(oPC, 110.0));
+    jRenBtn = NuiHeight(jRenBtn, fBtnH);
+
+    json jSacBtn = NuiButton(JsonString("Poświęć"));
+    jSacBtn = NuiId(jSacBtn, HOM_BTN_SACRIFICE);
+    jSacBtn = NuiEnabled(jSacBtn, NuiBind(HOM_BIND_SAC_ENA));
+    jSacBtn = NuiWidth(jSacBtn, GetNuiScaleDimension(oPC, 100.0));
+    jSacBtn = NuiHeight(jSacBtn, fBtnH);
+    jSacBtn = NuiTooltip(jSacBtn,
+        JsonString("Poświęca homunkulus w zamian za potężny jednorazowy efekt.\n"
+                   "Wymaga więzi poziomu 10. Nie do odwrócenia!"));
+
+    json jActRow = JsonArray();
+    jActRow = JsonArrayInsert(jActRow, jFeedBtn);
+    jActRow = JsonArrayInsert(jActRow, NuiSpacer());
+    jActRow = JsonArrayInsert(jActRow, jRenBtn);
+    jActRow = JsonArrayInsert(jActRow, jSacBtn);
+
+    // Log section (last 3 entries)
+    json jLog0 = NuiLabel(NuiBind(HOM_BIND_LOG0), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jLog0 = NuiStyleForegroundColor(jLog0, NuiColor(160, 160, 160));
+    jLog0 = NuiHeight(jLog0, fLogH);
+
+    json jLog1 = NuiLabel(NuiBind(HOM_BIND_LOG1), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jLog1 = NuiStyleForegroundColor(jLog1, NuiColor(130, 130, 130));
+    jLog1 = NuiHeight(jLog1, fLogH);
+
+    json jLog2 = NuiLabel(NuiBind(HOM_BIND_LOG2), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jLog2 = NuiStyleForegroundColor(jLog2, NuiColor(100, 100, 100));
+    jLog2 = NuiHeight(jLog2, fLogH);
+
+    // Assemble column
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jBondLbl);
+    jCol = JsonArrayInsert(jCol, jBar);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jStatus);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, jANameLbl);
+    jCol = JsonArrayInsert(jCol, jADesc);
+    jCol = JsonArrayInsert(jCol, jUseBtn);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jActRow));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 10.0));
+    jCol = JsonArrayInsert(jCol, jLog0);
+    jCol = JsonArrayInsert(jCol, jLog1);
+    jCol = JsonArrayInsert(jCol, jLog2);
+
+    // Center with side spacers
+    json jSide = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    float fContentW = GetNuiScaleDimension(oPC, 560.0);
+    json jMain = JsonArray();
+    jMain = JsonArrayInsert(jMain, jSide);
+    jMain = JsonArrayInsert(jMain, NuiWidth(NuiCol(jCol), fContentW));
+    jMain = JsonArrayInsert(jMain, jSide);
+    return NuiRow(jMain);
+}
+
+json HomBuildCraftView(object oPC)
+{
+    float fBtnH = GetNuiScaleDimension(oPC, 30.0);
+
+    json jMsg = NuiText(NuiBind(HOM_BIND_CRAFT_MSG), FALSE);
+    jMsg = NuiHeight(jMsg, GetNuiScaleDimension(oPC, 160.0));
+
+    json jBtn = NuiButton(JsonString("Stwórz Homunkulus"));
+    jBtn = NuiId(jBtn, HOM_BTN_CRAFT);
+    jBtn = NuiHeight(jBtn, fBtnH);
+    jBtn = NuiWidth(jBtn, GetNuiScaleDimension(oPC, 220.0));
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jBtn);
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jMsg);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 10.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+
+    json jSide = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    float fW   = GetNuiScaleDimension(oPC, 560.0);
+    json jMain = JsonArray();
+    jMain = JsonArrayInsert(jMain, jSide);
+    jMain = JsonArrayInsert(jMain, NuiWidth(NuiCol(jCol), fW));
+    jMain = JsonArrayInsert(jMain, jSide);
+    return NuiRow(jMain);
+}
+
+json HomBuildRenameView(object oPC)
+{
+    float fBtnH = GetNuiScaleDimension(oPC, 30.0);
+
+    json jLbl = NuiLabel(JsonString("Nowe imię homunkulus:"),
+                         JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jLbl = NuiHeight(jLbl, fBtnH);
+
+    json jField = NuiTextEdit(JsonString(""), NuiBind(HOM_BIND_NAME_TXT), HOM_MAX_NAME, FALSE);
+    jField = NuiHeight(jField, fBtnH);
+
+    json jOk = NuiButton(JsonString("Potwierdź"));
+    jOk = NuiId(jOk, HOM_BTN_RENAME_OK);
+    jOk = NuiWidth(jOk, GetNuiScaleDimension(oPC, 110.0));
+    jOk = NuiHeight(jOk, fBtnH);
+
+    json jCc = NuiButton(JsonString("Anuluj"));
+    jCc = NuiId(jCc, HOM_BTN_RENAME_CC);
+    jCc = NuiWidth(jCc, GetNuiScaleDimension(oPC, 90.0));
+    jCc = NuiHeight(jCc, fBtnH);
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jOk);
+    jBtnRow = JsonArrayInsert(jBtnRow, jCc);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 40.0));
+    jCol = JsonArrayInsert(jCol, jLbl);
+    jCol = JsonArrayInsert(jCol, jField);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 10.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+
+    json jSide = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    float fW   = GetNuiScaleDimension(oPC, 400.0);
+    json jMain = JsonArray();
+    jMain = JsonArrayInsert(jMain, jSide);
+    jMain = JsonArrayInsert(jMain, NuiWidth(NuiCol(jCol), fW));
+    jMain = JsonArrayInsert(jMain, jSide);
+    return NuiRow(jMain);
+}
+
+// ----------------------------------------------------------------
+// Feed functions — push data into existing binds
+// ----------------------------------------------------------------
+
+void HomShowMain(object oPC, int nToken)
+{
+    NuiSetGroupLayout(oPC, nToken, HOM_GRP_SWAP,
+        HomExists(oPC) ? HomBuildStatusView(oPC) : HomBuildCraftView(oPC));
+    SetLocalInt(oPC, HOM_LVAR_VIEW, 0);
+
+    if(!HomExists(oPC))
+    {
+        string sCraftMsg =
+            "Nie posiadasz homunkulus.\n\n"
+            "Aby stworzyć towarzysza, zbierz " + IntToString(HOM_REAGENT_NEEDED)
+            + " reagenty alchemiczne (tag: " + HOM_REAGENT_TAG + ")\n"
+            "i naciśnij przycisk poniżej.\n\n"
+            "Więź z homunkulus rośnie z każdym karmieniem. Wraz z jej wzrostem\n"
+            "dostępne stają się nowe zdolności:\n"
+            "  • Więź 1-2  :  Percepcja Zagrożeń\n"
+            "  • Więź 3-5  :  Zbieraczka Składników\n"
+            "  • Więź 6-8  :  Tarcza Alchemiczna\n"
+            "  • Więź 9-10 :  Wzmocnienie Duszy\n"
+            "  • Więź 10   :  Opcja Poświęcenia";
+        NuiSetBind(oPC, nToken, HOM_BIND_CRAFT_MSG, JsonString(sCraftMsg));
+        return;
+    }
+
+    json jData  = HomGetData(oPC);
+    int  nBond  = JsonGetInt(JsonObjectGet(jData, "bond_level"));
+    string sName = JsonGetString(JsonObjectGet(jData, "name"));
+    int  nFedSecs = HomSecondsSinceFed(oPC);
+    int  bOnCD   = HomAbilityOnCooldown(oPC);
+
+    // Title line
+    NuiSetBind(oPC, nToken, HOM_BIND_TITLE, JsonString(sName));
+
+    // Bond label and progress bar
+    string sBondLbl = "Więź: " + IntToString(nBond) + " / 10  •  " + HomTierName(nBond);
+    NuiSetBind(oPC, nToken, HOM_BIND_BOND_LBL,  JsonString(sBondLbl));
+    NuiSetBind(oPC, nToken, HOM_BIND_BOND_PROG,  JsonFloat(IntToFloat(nBond) / 10.0));
+
+    // Maintenance status
+    string sStatus;
+    json   jStatusClr;
+    if(nFedSecs < HOM_FEED_INTERVAL)
+    {
+        sStatus    = "Najedzony — kolejne karmienie za "
+                   + IntToString((HOM_FEED_INTERVAL - nFedSecs) / 3600)
+                   + " godz.";
+        jStatusClr = NuiColor(120, 200, 100);
+    }
+    else if(nFedSecs < HOM_STARVE_TIMEOUT)
+    {
+        sStatus    = "Głodny! Nakarm homunkulus, by więź nie osłabła.";
+        jStatusClr = NuiColor(240, 180, 40);
+    }
+    else
+    {
+        sStatus    = "Zagłodzony! Więź opada. Nakarm natychmiast!";
+        jStatusClr = NuiColor(220, 60, 60);
+    }
+    NuiSetBind(oPC, nToken, HOM_BIND_STATUS,     JsonString(sStatus));
+    NuiSetBind(oPC, nToken, HOM_BIND_STATUS_CLR, jStatusClr);
+
+    // Ability info
+    NuiSetBind(oPC, nToken, HOM_BIND_ANAME, JsonString(HomAbilityName(nBond)));
+    NuiSetBind(oPC, nToken, HOM_BIND_ADESC, JsonString(HomAbilityDesc(nBond)));
+
+    string sAbtnLbl = bOnCD ? "Wyczerpany (odnawia się jutro)" : "Użyj zdolności";
+    NuiSetBind(oPC, nToken, HOM_BIND_ABTN_LBL, JsonString(sAbtnLbl));
+    NuiSetBind(oPC, nToken, HOM_BIND_AENA,     JsonBool(!bOnCD));
+    NuiSetBind(oPC, nToken, HOM_BIND_FEED_ENA, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, HOM_BIND_SAC_ENA,  JsonBool(nBond >= 10));
+
+    // Log
+    json jLog = HomGetLog(oPC, 3);
+    int nLogCount = JsonGetLength(jLog);
+    NuiSetBind(oPC, nToken, HOM_BIND_LOG0,
+        JsonString(nLogCount > 0 ? JsonGetString(JsonArrayGet(jLog, 0)) : ""));
+    NuiSetBind(oPC, nToken, HOM_BIND_LOG1,
+        JsonString(nLogCount > 1 ? JsonGetString(JsonArrayGet(jLog, 1)) : ""));
+    NuiSetBind(oPC, nToken, HOM_BIND_LOG2,
+        JsonString(nLogCount > 2 ? JsonGetString(JsonArrayGet(jLog, 2)) : ""));
+}
+
+void HomShowRename(object oPC, int nToken)
+{
+    NuiSetGroupLayout(oPC, nToken, HOM_GRP_SWAP, HomBuildRenameView(oPC));
+    SetLocalInt(oPC, HOM_LVAR_VIEW, 1);
+
+    json jData = HomGetData(oPC);
+    string sName = JsonGetString(JsonObjectGet(jData, "name"));
+    NuiSetBind(oPC, nToken, HOM_BIND_NAME_TXT, JsonString(sName));
+}
+
+// ----------------------------------------------------------------
+// Window creation
+// ----------------------------------------------------------------
+
+void HomCreateWindow(object oPC)
+{
+    if(NuiFindWindow(oPC, HOM_WINDOW) != 0)
+    {
+        int nToken = NuiFindWindow(oPC, HOM_WINDOW);
+        HomShowMain(oPC, nToken);
+        return;
+    }
+
+    float fGuiW = IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH));
+    float fGuiH = IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT));
+    float fW    = GetNuiScaleDimension(oPC, HOM_W);
+    float fH    = GetNuiScaleDimension(oPC, HOM_H);
+    float fCX   = (fGuiW - fW) / 2.0;
+    float fCY   = (fGuiH - fH) / 2.0;
+    json  jGeom = NuiRect(fCX, fCY, fW, fH);
+
+    float fBtnH = GetNuiScaleDimension(oPC, 30.0);
+
+    // Title bar: companion name + close button
+    json jTitleLbl = NuiLabel(NuiBind(HOM_BIND_TITLE),
+                              JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitleLbl = NuiHeight(jTitleLbl, fBtnH);
+
+    json jCloseBtn = NuiButton(JsonString("X"));
+    jCloseBtn = NuiId(jCloseBtn, HOM_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, GetNuiScaleDimension(oPC, 30.0));
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jTitleRow = JsonArray();
+    jTitleRow = JsonArrayInsert(jTitleRow, jTitleLbl);
+    jTitleRow = JsonArrayInsert(jTitleRow, jCloseBtn);
+
+    // Swap group — holds either the status view or the craft/rename view
+    json jSwapGrp = NuiGroup(
+        HomExists(oPC) ? HomBuildStatusView(oPC) : HomBuildCraftView(oPC),
+        FALSE, NUI_SCROLLBARS_NONE);
+    jSwapGrp = NuiId(jSwapGrp, HOM_GRP_SWAP);
+
+    json jRoot = NuiCol(JsonArray());
+    json jChildren = JsonArray();
+    jChildren = JsonArrayInsert(jChildren, NuiRow(jTitleRow));
+    jChildren = JsonArrayInsert(jChildren, jSwapGrp);
+    jRoot = NuiCol(jChildren);
+
+    json jWin = NuiWindow(jRoot,
+        JsonBool(FALSE),
+        NuiBind(HOM_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    int nToken = NuiCreate(oPC, jWin, HOM_WINDOW, HOM_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, HOM_WIN_GEOM, jGeom);
+
+    // Initial title for the title bar bind (used in both views)
+    json jData = HomGetData(oPC);
+    string sTitle = HomExists(oPC)
+        ? JsonGetString(JsonObjectGet(jData, "name"))
+        : "Laboratorium Alchemiczne";
+    NuiSetBind(oPC, nToken, HOM_BIND_TITLE, JsonString(sTitle));
+
+    HomShowMain(oPC, nToken);
+}

--- a/Homunculus/Scripts/lib_hom_def.nss
+++ b/Homunculus/Scripts/lib_hom_def.nss
@@ -1,0 +1,146 @@
+// lib_hom_def.nss — constants, bind IDs, and tier helpers for Homunculus module
+#include "lib_nui"
+#include "sql_hom"
+
+void HomCreateWindow(object oPC);
+void HomShowMain(object oPC, int nToken);
+void HomShowRename(object oPC, int nToken);
+void HomCheckMaintenance(object oPC);
+void HomApplyPresenceVFX(object oPC);
+void HomRemovePresenceVFX(object oPC);
+
+// ----------------------------------------------------------------
+// Window identifiers
+// ----------------------------------------------------------------
+
+const string HOM_WINDOW    = "HOM_WINDOW";
+const string HOM_EV_SCRIPT = "lib_hom_ev";
+const string HOM_GRP_SWAP  = "HOM_GRP_SWAP";
+const string HOM_WIN_GEOM  = "hom_win_geom";
+
+const float  HOM_W         = 620.0;
+const float  HOM_H         = 490.0;
+
+// ----------------------------------------------------------------
+// Bind IDs — main (status) view
+// ----------------------------------------------------------------
+
+const string HOM_BIND_TITLE     = "hom_title";
+const string HOM_BIND_BOND_LBL  = "hom_bond_lbl";  // e.g. "Więź: 4 / 10  •  Lojalny"
+const string HOM_BIND_BOND_PROG = "hom_bond_prog";  // float 0.0–1.0 for progress bar
+const string HOM_BIND_STATUS    = "hom_status";     // maintenance status sentence
+const string HOM_BIND_STATUS_CLR= "hom_status_clr"; // color of status text
+const string HOM_BIND_ANAME     = "hom_aname";      // ability name
+const string HOM_BIND_ADESC     = "hom_adesc";      // ability description (multiline)
+const string HOM_BIND_AENA      = "hom_aena";       // ability button enabled
+const string HOM_BIND_ABTN_LBL  = "hom_abtn_lbl";  // button label (includes cooldown hint)
+const string HOM_BIND_FEED_ENA  = "hom_feed_ena";   // feed button enabled
+const string HOM_BIND_SAC_ENA   = "hom_sac_ena";    // sacrifice button enabled (bond=10 only)
+const string HOM_BIND_LOG0      = "hom_log0";
+const string HOM_BIND_LOG1      = "hom_log1";
+const string HOM_BIND_LOG2      = "hom_log2";
+
+// "No companion" craft panel bind
+const string HOM_BIND_CRAFT_MSG = "hom_craft_msg";
+
+// ----------------------------------------------------------------
+// Bind IDs — rename view
+// ----------------------------------------------------------------
+
+const string HOM_BIND_NAME_TXT  = "hom_name_txt";
+
+// ----------------------------------------------------------------
+// Button IDs
+// ----------------------------------------------------------------
+
+const string HOM_BTN_CLOSE     = "hom_btn_close";
+const string HOM_BTN_USE       = "hom_btn_use";
+const string HOM_BTN_FEED      = "hom_btn_feed";
+const string HOM_BTN_RENAME    = "hom_btn_rename";
+const string HOM_BTN_SACRIFICE = "hom_btn_sac";
+const string HOM_BTN_CRAFT     = "hom_btn_craft";
+const string HOM_BTN_RENAME_OK = "hom_btn_rnok";
+const string HOM_BTN_RENAME_CC = "hom_btn_rncc";
+
+// ----------------------------------------------------------------
+// Local variables on PC
+// ----------------------------------------------------------------
+
+const string HOM_LVAR_VIEW     = "HOM_VIEW";   // 0 = status, 1 = rename
+const string HOM_LVAR_VFX_SLOT = "HOM_VFX";   // slot ID of the presence effect
+
+// ----------------------------------------------------------------
+// Gameplay constants
+// ----------------------------------------------------------------
+
+// Iounstone orbiting VFX symbolises the homunculus presence
+const int    HOM_VFX            = VFX_DUR_IOUNSTONE_BLUE;
+
+// Feed interval: companion expects sustenance every 24 hours (real time via campaign DB clock)
+const int    HOM_FEED_INTERVAL  = 86400;
+
+// If not fed within 48 hours, bond begins to collapse
+const int    HOM_STARVE_TIMEOUT = 172800;
+
+// Daily ability cooldown (one use per 24h)
+const int    HOM_ABILITY_CD     = 86400;
+
+// Crafting recipe: player must carry this many HOM_REAGENT_TAG items to create a companion
+const string HOM_REAGENT_TAG    = "hom_reagent";
+const int    HOM_REAGENT_NEEDED = 3;
+
+// Feeding item (1 consumed per feeding)
+const string HOM_FEED_ITEM_TAG  = "hom_feed";
+
+// Max name length for the rename field
+const int    HOM_MAX_NAME       = 32;
+
+// ----------------------------------------------------------------
+// Tier helpers — pure functions, no SQL
+// ----------------------------------------------------------------
+
+string HomTierName(int nBond)
+{
+    if(nBond <= 0) return "Martwy";
+    if(nBond <= 2) return "Zaciekawiony";
+    if(nBond <= 5) return "Lojalny";
+    if(nBond <= 8) return "Oddany";
+    return "Jednomyślny";
+}
+
+string HomAbilityName(int nBond)
+{
+    if(nBond <= 2) return "Percepcja Zagrożeń";
+    if(nBond <= 5) return "Zbieraczka Składników";
+    if(nBond <= 8) return "Tarcza Alchemiczna";
+    return "Wzmocnienie Duszy";
+}
+
+string HomAbilityDesc(int nBond)
+{
+    if(nBond <= 2)
+        return "Homunkulus wyostrzył zmysły i szepcze ostrzeżenia\n"
+             + "o pobliskich wrogach i aktywnych pułapkach.\n"
+             + "(Zasięg: 15 m — efekt natychmiastowy)";
+    if(nBond <= 5)
+        return "Wierna istotka przeszukuje zakamarki i wraca\n"
+             + "z garścią alchemicznych składników.\n"
+             + "(Otrzymujesz losowy reagent — 1×)";
+    if(nBond <= 8)
+        return "Homunkulus oplata cię błoną alchemicznej substancji,\n"
+             + "wzmacniając pancerz i żywotność.\n"
+             + "(+10 tymcz. HP,  +2 AC  przez 1 godzinę)";
+    return "Istota wlewa w ciebie strumień skondensowanej esencji.\n"
+         + "Twoje zmysły i refleks osiągają nadludzki poziom.\n"
+         + "(+4 do wszystkich rzutów obronnych przez 30 minut)";
+}
+
+// Returns the resref of a random alchemical ingredient to give via the Scavenge ability.
+string HomRandomIngredientResref()
+{
+    int nRoll = d4();
+    if(nRoll == 1) return "nw_it_mpotion001"; // potion placeholder
+    if(nRoll == 2) return "nw_it_mpotion002";
+    if(nRoll == 3) return "nw_it_msmlmisc18"; // misc component
+    return "nw_it_msmlmisc20";
+}

--- a/Homunculus/Scripts/lib_hom_ev.nss
+++ b/Homunculus/Scripts/lib_hom_ev.nss
@@ -1,0 +1,103 @@
+// lib_hom_ev.nss — NUI event handler for the Homunculus module
+#include "lib_hom"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+
+    if(nToken != NuiFindWindow(oPC, HOM_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalInt(oPC, HOM_LVAR_VIEW);
+        return;
+    }
+
+    if(sEvent != EVENT_TYPE_CLICK) return;
+
+    int nView = GetLocalInt(oPC, HOM_LVAR_VIEW);
+
+    // ---- Status / craft view buttons ----
+    if(nView == 0)
+    {
+        if(sElem == HOM_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        if(sElem == HOM_BTN_CRAFT)
+        {
+            HomCraft(oPC);
+            HomShowMain(oPC, nToken);
+            NuiSetBind(oPC, nToken, HOM_BIND_TITLE, JsonString("Homunkulus"));
+            return;
+        }
+
+        if(sElem == HOM_BTN_USE)
+        {
+            HomUseAbility(oPC);
+            HomShowMain(oPC, nToken);
+            return;
+        }
+
+        if(sElem == HOM_BTN_FEED)
+        {
+            HomFeedCompanion(oPC);
+            HomShowMain(oPC, nToken);
+            return;
+        }
+
+        if(sElem == HOM_BTN_RENAME)
+        {
+            if(!HomExists(oPC)) return;
+            HomShowRename(oPC, nToken);
+            return;
+        }
+
+        if(sElem == HOM_BTN_SACRIFICE)
+        {
+            HomSacrifice(oPC);
+            HomShowMain(oPC, nToken);
+            NuiSetBind(oPC, nToken, HOM_BIND_TITLE, JsonString("Laboratorium Alchemiczne"));
+            return;
+        }
+
+        return;
+    }
+
+    // ---- Rename view buttons ----
+    if(nView == 1)
+    {
+        if(sElem == HOM_BTN_RENAME_CC)
+        {
+            HomShowMain(oPC, nToken);
+            return;
+        }
+
+        if(sElem == HOM_BTN_RENAME_OK)
+        {
+            string sNewName = JsonGetString(NuiGetBind(oPC, nToken, HOM_BIND_NAME_TXT));
+            sNewName = GetStringLeft(TrimString(sNewName), HOM_MAX_NAME);
+
+            if(sNewName == "")
+            {
+                SendMessageToPC(oPC, "[Homunkulus] Imię nie może być puste.");
+                return;
+            }
+
+            HomSetName(oPC, sNewName);
+            HomAddLog(oPC, "Zmieniono imię na: " + sNewName);
+            SendMessageToPC(oPC, "[Homunkulus] Twój towarzysz zostanie odtąd zwany: " + sNewName + ".");
+
+            NuiSetBind(oPC, nToken, HOM_BIND_TITLE, JsonString(sNewName));
+            HomShowMain(oPC, nToken);
+            return;
+        }
+
+        return;
+    }
+}

--- a/Homunculus/Scripts/lib_nui.nss
+++ b/Homunculus/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Homunculus/Scripts/lib_nui_utility.nss
+++ b/Homunculus/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Homunculus/Scripts/sql_hom.nss
+++ b/Homunculus/Scripts/sql_hom.nss
@@ -1,0 +1,192 @@
+// sql_hom.nss — persistence layer for the Homunculus module
+// Campaign DB name: "homunculus"
+
+void HomCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("homunculus",
+        "CREATE TABLE IF NOT EXISTS hom_companions ("
+        " owner_uuid TEXT PRIMARY KEY,"
+        " name       TEXT    DEFAULT 'Bezimienny',"
+        " bond_level INTEGER DEFAULT 1,"
+        " last_fed   INTEGER DEFAULT 0,"
+        " last_used  INTEGER DEFAULT 0,"
+        " tasks_done INTEGER DEFAULT 0,"
+        " created_at INTEGER DEFAULT 0,"
+        " is_alive   INTEGER DEFAULT 1"
+        ")");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("homunculus",
+        "CREATE TABLE IF NOT EXISTS hom_log ("
+        " id         INTEGER PRIMARY KEY AUTOINCREMENT,"
+        " owner_uuid TEXT    NOT NULL,"
+        " entry      TEXT    DEFAULT '',"
+        " logged_at  INTEGER DEFAULT 0"
+        ")");
+    SqlStep(q);
+}
+
+// Returns a JsonObject with all fields, or JsonNull() if the player has no companion.
+json HomGetData(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("homunculus",
+        "SELECT name, bond_level, last_fed, last_used, tasks_done, created_at, is_alive"
+        " FROM hom_companions WHERE owner_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(!SqlStep(q)) return JsonNull();
+
+    json j = JsonObject();
+    j = JsonObjectSet(j, "name",       JsonString(SqlGetString(q, 0)));
+    j = JsonObjectSet(j, "bond_level", JsonInt(SqlGetInt(q, 1)));
+    j = JsonObjectSet(j, "last_fed",   JsonInt(SqlGetInt(q, 2)));
+    j = JsonObjectSet(j, "last_used",  JsonInt(SqlGetInt(q, 3)));
+    j = JsonObjectSet(j, "tasks_done", JsonInt(SqlGetInt(q, 4)));
+    j = JsonObjectSet(j, "created_at", JsonInt(SqlGetInt(q, 5)));
+    j = JsonObjectSet(j, "is_alive",   JsonInt(SqlGetInt(q, 6)));
+    return j;
+}
+
+// Returns TRUE if the player has a living companion.
+int HomExists(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("homunculus",
+        "SELECT 1 FROM hom_companions WHERE owner_uuid = @uuid AND is_alive = 1");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    return SqlStep(q);
+}
+
+// Creates a new companion record. Replaces any dead one.
+void HomCreate(object oPC, string sName)
+{
+    sqlquery q = SqlPrepareQueryCampaign("homunculus",
+        "INSERT OR REPLACE INTO hom_companions"
+        " (owner_uuid, name, bond_level, last_fed, last_used, tasks_done, created_at, is_alive)"
+        " VALUES (@uuid, @name, 1, strftime('%s','now'), 0, 0, strftime('%s','now'), 1)");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindString(q, "@name", sName);
+    SqlStep(q);
+}
+
+void HomSetName(object oPC, string sName)
+{
+    sqlquery q = SqlPrepareQueryCampaign("homunculus",
+        "UPDATE hom_companions SET name = @name WHERE owner_uuid = @uuid");
+    SqlBindString(q, "@name", sName);
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+// Refreshes the last_fed timestamp to now.
+void HomFeed(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("homunculus",
+        "UPDATE hom_companions SET last_fed = strftime('%s','now') WHERE owner_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+void HomMarkAbilityUsed(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("homunculus",
+        "UPDATE hom_companions"
+        " SET last_used = strftime('%s','now'), tasks_done = tasks_done + 1"
+        " WHERE owner_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+// Raises bond by 1, capped at 10.
+void HomRaiseBond(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("homunculus",
+        "UPDATE hom_companions SET bond_level = MIN(bond_level + 1, 10)"
+        " WHERE owner_uuid = @uuid AND is_alive = 1");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+// Lowers bond by 1. If bond reaches 0, companion dies.
+void HomLowerBond(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("homunculus",
+        "UPDATE hom_companions SET bond_level = MAX(bond_level - 1, 0)"
+        " WHERE owner_uuid = @uuid AND is_alive = 1");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+
+    // Kill companion if bond collapsed.
+    q = SqlPrepareQueryCampaign("homunculus",
+        "UPDATE hom_companions SET is_alive = 0"
+        " WHERE owner_uuid = @uuid AND is_alive = 1 AND bond_level = 0");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+void HomKill(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("homunculus",
+        "UPDATE hom_companions SET is_alive = 0, bond_level = 0 WHERE owner_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+// Appends an event log entry; trims the log to the last 20 entries.
+void HomAddLog(object oPC, string sEntry)
+{
+    sqlquery q = SqlPrepareQueryCampaign("homunculus",
+        "INSERT INTO hom_log (owner_uuid, entry, logged_at)"
+        " VALUES (@uuid, @entry, strftime('%s','now'))");
+    SqlBindString(q, "@uuid",  GetObjectUUID(oPC));
+    SqlBindString(q, "@entry", sEntry);
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("homunculus",
+        "DELETE FROM hom_log WHERE owner_uuid = @uuid AND id NOT IN"
+        " (SELECT id FROM hom_log WHERE owner_uuid = @uuid ORDER BY logged_at DESC LIMIT 20)");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+// Returns a JsonArray of the last nLimit log entries (newest first).
+json HomGetLog(object oPC, int nLimit)
+{
+    json jLog = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("homunculus",
+        "SELECT entry FROM hom_log WHERE owner_uuid = @uuid"
+        " ORDER BY logged_at DESC LIMIT @lim");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt(q,   "@lim",  nLimit);
+    while(SqlStep(q))
+        jLog = JsonArrayInsert(jLog, JsonString(SqlGetString(q, 0)));
+    return jLog;
+}
+
+int HomGetBondLevel(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("homunculus",
+        "SELECT bond_level FROM hom_companions WHERE owner_uuid = @uuid AND is_alive = 1");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// Seconds elapsed since the companion was last fed. Returns a large number if no record exists.
+int HomSecondsSinceFed(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("homunculus",
+        "SELECT CAST(strftime('%s','now') AS INTEGER) - last_fed"
+        " FROM hom_companions WHERE owner_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 999999;
+}
+
+// Returns TRUE if the daily ability has already been used today.
+int HomAbilityOnCooldown(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("homunculus",
+        "SELECT 1 FROM hom_companions WHERE owner_uuid = @uuid"
+        "  AND last_used > CAST(strftime('%s','now') AS INTEGER) - 86400");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    return SqlStep(q);
+}

--- a/Homunculus/Scripts/sys_on_enter.nss
+++ b/Homunculus/Scripts/sys_on_enter.nss
@@ -1,0 +1,31 @@
+// sys_on_enter.nss — runs on ClientEnter; restores VFX presence and checks maintenance
+#include "lib_hom"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC)) return;
+
+    HomCheckMaintenance(oPC);
+
+    if(HomExists(oPC))
+    {
+        // Small delay to let the client finish loading before we apply effects.
+        DelayCommand(3.0, HomApplyPresenceVFX(oPC));
+
+        int nBond = HomGetBondLevel(oPC);
+        string sName = JsonGetString(JsonObjectGet(HomGetData(oPC), "name"));
+        string sMsg  = "[Homunkulus] " + sName + " czeka na ciebie. Więź: "
+                     + IntToString(nBond) + " / 10  •  " + HomTierName(nBond) + ".";
+        DelayCommand(4.0, SendMessageToPC(oPC, sMsg));
+
+        int nSecsFed = HomSecondsSinceFed(oPC);
+        if(nSecsFed >= HOM_FEED_INTERVAL)
+        {
+            DelayCommand(5.0, SendMessageToPC(oPC,
+                "[Homunkulus] Homunkulus jest głodny! Nakarm go, zanim więź osłabnie."));
+            DelayCommand(5.0, FloatingTextStringOnCreature(
+                "Homunkulus jest głodny!", oPC, FALSE));
+        }
+    }
+}

--- a/Homunculus/Scripts/sys_on_load.nss
+++ b/Homunculus/Scripts/sys_on_load.nss
@@ -1,0 +1,7 @@
+// sys_on_load.nss — initialise the Homunculus module on module load
+#include "sql_hom"
+
+void main()
+{
+    HomCreateTables();
+}

--- a/Homunculus/Scripts/test_hom.nss
+++ b/Homunculus/Scripts/test_hom.nss
@@ -1,0 +1,11 @@
+// test_hom.nss — placeable OnUsed script; opens the Homunculus panel
+// Attach to a placeable (e.g. an alchemical workbench) as its OnUsed event.
+#include "lib_hom"
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    HomCreateWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

System alchemicznego towarzysza (homunkulus). Gracz wytwarza małe stworzenie z reagentów alchemicznych — jest ono trwale zapisane w SQLite i manifestuje się jako orbita VFX (`VFX_DUR_IOUNSTONE_BLUE`) wokół postaci. Panel NUI pozwala zarządzać towarzyszem: karmić go, nadać mu imię, używać zdolności dobowych i — przy więzi 10 — złożyć go w ofierze w zamian za potężny jednorazowy efekt.

## Mechanika

**Więź (1–10)** rośnie przy każdym karmieniu po upływie 24h okna. Jej poziom wyznacza dostępną zdolność dzienną:

| Więź | Nazwa tygodnia | Zdolność dobowa |
|------|----------------|-----------------|
| 1–2  | Zaciekawiony   | Percepcja Zagrożeń — wykrywa pobliskich wrogów i pułapki w zasięgu 15 m |
| 3–5  | Lojalny        | Zbieraczka Składników — daje graczowi losowy reagent alchemiczny |
| 6–8  | Oddany         | Tarcza Alchemiczna — +10 tymcz. HP i +2 AC przez 1 godzinę |
| 9–10 | Jednomyślny    | Wzmocnienie Duszy — +4 do wszystkich rzutów obronnych przez 30 minut |
| 10   | —              | Poświęcenie — pełna regeneracja HP + 5 HP/6s przez 10 minut; niszczy towarzysza |

**Karmienie**: wymaga przedmiotu z tagiem `hom_feed` (1 sztuka / sesja karmienia). Jeśli homunkulus nie jest karmiony przez ponad 48h, więź spada o 1 przy każdym logowaniu. Spadek do 0 = permanentna śmierć.

**Tworzenie**: potrzeba 3 itemów z tagiem `hom_reagent`. Tylko jeden homunkulus na gracza jednocześnie.

## Pliki

```
Homunculus/
  Scripts/
    sql_hom.nss         — schemat SQLite + wszystkie zapytania (CREATE TABLE IF NOT EXISTS)
    lib_hom_def.nss     — stałe, ID bindów, ID przycisków, helpery poziomów więzi
    lib_hom.nss         — VFX, zdolności, karmienie, stworzenie, sacrifice, NUI builder + feed
    lib_hom_ev.nss      — główny handler NUI (switch po NuiGetEventType/Element)
    sys_on_load.nss     — tworzy tabele przy starcie modułu
    sys_on_enter.nss    — przywraca VFX, sprawdza utrzymanie, powiadamia gracza
    test_hom.nss        — placeable OnUsed otwierający panel (demo)
    lib_nui.nss         — kopia współdzielona (skala, helpery)
    lib_nui_utility.nss — kopia współdzielona
  INTEGRATION.md        — instrukcja integracji, tagi itemów, co pominięto
```

## Zależności (NWNX? SQL?)

- **NWNX**: brak. Moduł działa wyłącznie w oparciu o NWScript + NUI + `SqlPrepareQueryCampaign`.
- **SQL**: kampania `"homunculus"`, tabele `hom_companions` i `hom_log`. Idempotentna migracja (`CREATE TABLE IF NOT EXISTS`).
- **VFX**: standardowe assety NWN:EE (`VFX_DUR_IOUNSTONE_BLUE`).

## Jak włączyć w istniejącym module

1. Dodaj `sys_on_load.nss` do zdarzenia **OnModuleLoad** (lub wywołaj `HomCreateTables()` z istniejącego skryptu).
2. Dodaj `sys_on_enter.nss` do **OnClientEnter**.
3. Umieść placeable z `test_hom.nss` jako OnUsed na mapie.
4. Utwórz (lub oznacz istniejące) itemy tagami `hom_reagent` (×3 do craftu) i `hom_feed` (×1 do karmienia).

## Co celowo pominięto

- **Fizyczny NPC w świecie** (poruszający się companion) — wymaga NWNX Creature lub dedykowanego AI; pominięto, by moduł był standalone.
- **Wiele typów homunkulus** (żywiołowe warianty) — architektura to umożliwia przez dodanie kolumny `type` do tabeli; pominięto by nie komplikować pierwszej wersji.
- **Śmierć w walce** — aktualnie homunkulus umiera tylko przez głód lub poświęcenie; hook na OnCreatureDeath możliwy przy wersji z fizycznym NPC.
- **Globalny cooldown na ability via `strftime`** — obecny mechanizm to 24h od użycia (real-time kampania), nie midnight reset; celowe uproszczenie.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bmo69TpteBstYALJMmNXiJ)_