### PR TITLE
feat: Festering Wounds

### DIFF
--- a/Festering Wounds/INTEGRATION.md
+++ b/Festering Wounds/INTEGRATION.md
@@ -1,0 +1,88 @@
+# Festering Wounds — Integracja
+
+## Wymagania
+
+- NWN:EE 8193.36.13+ (`GetEffectTag`, `TagEffect`, `ExtraordinaryEffect`)
+- Brak NWNX (moduł w pełni vanilla NWN:EE)
+
+## Hooki modułu
+
+| Zdarzenie | Skrypt do podpięcia lub wywołania |
+|---|---|
+| `OnModuleLoad` | `sys_on_load` — tworzy tabelę SQL |
+| `OnClientEnter` | `sys_on_enter` — przywraca efekty, startuje pętlę serca |
+| `OnClientLeave` | `sys_on_leave` — zatrzymuje pętlę serca |
+
+Jeśli serwer ma już własne skrypty na te zdarzenia, wywołaj odpowiednie funkcje bezpośrednio:
+
+```nwscript
+// W istniejącym OnModuleLoad:
+#include "lib_fwnd_def"
+FwndCreateTables();
+
+// W istniejącym OnClientEnter:
+#include "lib_fwnd"
+// (po sprawdzeniu GetIsPC)
+int nCount = FwndCountWounds(oPC);
+if(nCount > 0) { ... }
+SetLocalInt(oPC, FWND_LVAR_LOOP_RUN, 1);
+DelayCommand(5.0, FwndPCLoop(oPC));
+
+// W istniejącym OnClientLeave:
+SetLocalInt(oPC, FWND_LVAR_LOOP_RUN, 0);
+```
+
+## Zadawanie ran (przez DM lub mechanikę serwera)
+
+W skrypcie OnHitCastSpell itemu, OnPhysicalAttackHit (NWNX_Events), lub dowolnym OnUsed:
+
+```nwscript
+#include "lib_fwnd"
+
+// nType: FWND_TYPE_VAMPIRE / NECROTIC / DEMONIC / VENOM / CURSED
+FwndInflictWound(oTarget, FWND_TYPE_VAMPIRE, GetName(OBJECT_SELF));
+FwndApplyWoundEffects(oTarget);
+```
+
+Wywołanie `FwndInflictWound` dwukrotnie z tym samym typem wzmacnia istniejącą ranę o 1 (do max 5), nie tworzy duplikatu.
+
+## Otwieranie UI z poziomu innego skryptu
+
+```nwscript
+#include "lib_fwnd"
+FwndOpen(oPC);
+```
+
+## Itemy lecznicze
+
+Stwórz stackowalne itemy (Miscellaneous Small) z poniższymi tagami. Gracze kupują/zbierają je i leczą rany przez UI.
+
+| Tag | Leczy ranę |
+|---|---|
+| `fwnd_holy_water` | Ukąszenie Wampira (CON) |
+| `fwnd_life_salve` | Gnilna Rana (STR) |
+| `fwnd_ward_herb` | Szrama Demoniczna (WIS) |
+| `fwnd_antitoxin` | Głębokie Zatrucie (DEX) |
+| `fwnd_exorcism` | Przeklęte Cięcie (ATK) |
+| `fwnd_life_leaf` | Dowolna rana (-1 siła) |
+
+Użycie lekarstwa niszczy 1 sztukę ze stosu.
+
+## Baza danych
+
+Campaign DB: `festering_wounds`, tabela `fwnd_wounds`.  
+Schemat: `(id, pc_uuid, wound_type, severity, inflicted_at, last_progressed, source_name)`.
+
+## Testowanie
+
+1. Umieść na mapie placeable z OnUsed = `test_fwnd`.
+2. Kliknij kolejno — każde kliknięcie dodaje kolejny typ rany (1→2→3→4→5→1...).
+3. UI otworzy się automatycznie.
+4. Sprawdź efekty w ekranie postaci (kary STR/CON/WIS/DEX/ATK).
+
+## Co celowo pominięto
+
+- **Wizualne tintowanie postaci** — wymaga NWNX_Appearance lub Engine plugin
+- **Automatyczny wyzwalacz przy trafieniu** — wymaga NWNX_Events (OnPhysicalAttackHit); bez NWNX rany zadawane są przez osobne skrypty DM/itemy
+- **Timer odliczania do progresji w UI** — wymagałby synchronizacji heartbeat z frontendem; dodaje złożoność bez proporcjonalnej wartości
+- **Limit ran** — celowo brak (maks. 5 typów × siła 5 = max kary; mechanika jest samodyscyplinująca)

--- a/Festering Wounds/Scripts/lib_fwnd.nss
+++ b/Festering Wounds/Scripts/lib_fwnd.nss
@@ -1,0 +1,576 @@
+#include "lib_fwnd_def"
+
+void FwndOpen(object oPC);
+void FwndPCLoop(object oPC);
+void FwndFeedList(object oPC, int nToken);
+void FwndFeedDetail(object oPC, int nToken, int nWoundId);
+void FwndSwapToList(object oPC, int nToken);
+void FwndSwapToDetail(object oPC, int nToken, int nWoundId);
+void FwndRemoveDebuffs(object oPC);
+void FwndApplyWoundEffects(object oPC);
+
+// ----------------------------------------------------------------
+// Label helpers
+// ----------------------------------------------------------------
+
+string FwndTypeName(int nType)
+{
+    switch(nType)
+    {
+        case FWND_TYPE_VAMPIRE:  return "Ukąszenie Wampira";
+        case FWND_TYPE_NECROTIC: return "Gnilna Rana";
+        case FWND_TYPE_DEMONIC:  return "Szrama Demoniczna";
+        case FWND_TYPE_VENOM:    return "Głębokie Zatrucie";
+        case FWND_TYPE_CURSED:   return "Przeklęte Cięcie";
+    }
+    return "Nieznana Rana";
+}
+
+string FwndTypeIcon(int nType)
+{
+    switch(nType)
+    {
+        case FWND_TYPE_VAMPIRE:  return "[K]";
+        case FWND_TYPE_NECROTIC: return "[G]";
+        case FWND_TYPE_DEMONIC:  return "[D]";
+        case FWND_TYPE_VENOM:    return "[T]";
+        case FWND_TYPE_CURSED:   return "[P]";
+    }
+    return "[?]";
+}
+
+string FwndSeverityLabel(int nSev)
+{
+    switch(nSev)
+    {
+        case 1: return "I — Swierza";
+        case 2: return "II — Narastajaca";
+        case 3: return "III — Gleboka";
+        case 4: return "IV — Agonizujaca";
+        case 5: return "V — Smiertelna";
+    }
+    return "—";
+}
+
+string FwndSeverityStars(int nSev)
+{
+    if(nSev == 1) return "*....";
+    if(nSev == 2) return "**...";
+    if(nSev == 3) return "***..";
+    if(nSev == 4) return "****.";
+    return "*****";
+}
+
+json FwndSeverityColor(int nSev)
+{
+    switch(nSev)
+    {
+        case 1: return NuiColor(200, 200, 200);
+        case 2: return NuiColor(220, 180,  80);
+        case 3: return NuiColor(220, 120,  40);
+        case 4: return NuiColor(200,  60,  30);
+        case 5: return NuiColor(200,  20,  20);
+    }
+    return NuiColor(255, 255, 255);
+}
+
+string FwndTypeDescription(int nType, int nSev)
+{
+    string sDesc;
+    switch(nType)
+    {
+        case FWND_TYPE_VAMPIRE:
+            sDesc = "Wampirze ukąszenie sączy żywotność z ciała. Krew stygnie, siły opuszczają kończyny. Rana szuka drogi do serca.\n\nKara: Konstytucja -" + IntToString(nSev);
+            break;
+        case FWND_TYPE_NECROTIC:
+            sDesc = "Gnilna magia wżera się w mięśnie, pozostawiając tkanki martwe i kruche. Cada z ciężarem ziemi.\n\nKara: Siła -" + IntToString(nSev);
+            break;
+        case FWND_TYPE_DEMONIC:
+            sDesc = "Szrama nosi piętno demonicznej esencji. Umysł oplata fałszywymi wizjami i szeptami z Otchłani.\n\nKara: Mądrość -" + IntToString(nSev);
+            break;
+        case FWND_TYPE_VENOM:
+            sDesc = "Jad wsiąka głęboko, blokując nerwy. Każdy ruch wymaga skupienia, którego już nie ma — trzęsące się dłonie nie słuchają woli.\n\nKara: Zręczność -" + IntToString(nSev);
+            break;
+        case FWND_TYPE_CURSED:
+            sDesc = "Przeklęte ostrze pozostawiło ślad mroku w ranie. Ręka drży, wzrok traci cel — zaklęcie ciągnie broń w bok przy każdym ciosie.\n\nKara: Atak -" + IntToString(nSev);
+            break;
+        default:
+            sDesc = "Nieznana magia. Rana pulsuje słabo, ciągnąc życie powoli.";
+            break;
+    }
+    return sDesc;
+}
+
+string FwndTreatmentText(int nType)
+{
+    switch(nType)
+    {
+        case FWND_TYPE_VAMPIRE:  return "Wymagane: Woda Święcona  (fwnd_holy_water)";
+        case FWND_TYPE_NECROTIC: return "Wymagane: Żywica Życia   (fwnd_life_salve)";
+        case FWND_TYPE_DEMONIC:  return "Wymagane: Ziele Odczynienia (fwnd_ward_herb)";
+        case FWND_TYPE_VENOM:    return "Wymagane: Antytoksyna     (fwnd_antitoxin)";
+        case FWND_TYPE_CURSED:   return "Wymagane: Olej Egzorcyzmu (fwnd_exorcism)";
+    }
+    return "";
+}
+
+string FwndTreatmentTag(int nType)
+{
+    switch(nType)
+    {
+        case FWND_TYPE_VAMPIRE:  return FWND_ITEM_HOLY_WATER;
+        case FWND_TYPE_NECROTIC: return FWND_ITEM_LIFE_SALVE;
+        case FWND_TYPE_DEMONIC:  return FWND_ITEM_WARD_HERB;
+        case FWND_TYPE_VENOM:    return FWND_ITEM_ANTITOXIN;
+        case FWND_TYPE_CURSED:   return FWND_ITEM_EXORCISM;
+    }
+    return "";
+}
+
+// ----------------------------------------------------------------
+// Effect management
+// ----------------------------------------------------------------
+
+void FwndRemoveDebuffs(object oPC)
+{
+    effect eEff = GetFirstEffect(oPC);
+    while(GetIsEffectValid(eEff))
+    {
+        if(GetEffectTag(eEff) == FWND_EFFECT_TAG)
+            RemoveEffect(oPC, eEff);
+        eEff = GetNextEffect(oPC);
+    }
+}
+
+void FwndApplyWoundEffects(object oPC)
+{
+    FwndRemoveDebuffs(oPC);
+
+    json jWounds = FwndGetWounds(oPC);
+    int nCount   = JsonGetLength(jWounds);
+    if(nCount == 0) return;
+
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jW   = JsonArrayGet(jWounds, i);
+        int nType = JsonGetInt(JsonObjectGet(jW, "wound_type"));
+        int nSev  = JsonGetInt(JsonObjectGet(jW, "severity"));
+
+        effect eDebuff;
+        int bValid = TRUE;
+
+        switch(nType)
+        {
+            case FWND_TYPE_VAMPIRE:
+                eDebuff = EffectAbilityDecrease(ABILITY_CONSTITUTION, nSev);
+                break;
+            case FWND_TYPE_NECROTIC:
+                eDebuff = EffectAbilityDecrease(ABILITY_STRENGTH, nSev);
+                break;
+            case FWND_TYPE_DEMONIC:
+                eDebuff = EffectAbilityDecrease(ABILITY_WISDOM, nSev);
+                break;
+            case FWND_TYPE_VENOM:
+                eDebuff = EffectAbilityDecrease(ABILITY_DEXTERITY, nSev);
+                break;
+            case FWND_TYPE_CURSED:
+                eDebuff = EffectAttackDecrease(nSev);
+                break;
+            default:
+                bValid = FALSE;
+                break;
+        }
+
+        if(bValid)
+        {
+            eDebuff = TagEffect(eDebuff, FWND_EFFECT_TAG);
+            eDebuff = ExtraordinaryEffect(eDebuff);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, eDebuff, oPC);
+        }
+    }
+}
+
+// ----------------------------------------------------------------
+// Wound progression and per-PC loop
+// ----------------------------------------------------------------
+
+void FwndProgressWounds(object oPC)
+{
+    json jDue  = FwndGetWoundsToProgress(oPC);
+    int nCount = JsonGetLength(jDue);
+    if(nCount == 0) return;
+
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jW   = JsonArrayGet(jDue, i);
+        int nId   = JsonGetInt(JsonObjectGet(jW, "id"));
+        int nSev  = JsonGetInt(JsonObjectGet(jW, "severity"));
+        int nType = JsonGetInt(JsonObjectGet(jW, "wound_type"));
+
+        int nNewSev = nSev + 1;
+        FwndSetSeverity(nId, nNewSev);
+
+        string sWName = FwndTypeName(nType);
+        SendMessageToPC(oPC, "[Rany] " + sWName + " się pogłębia... (" + FwndSeverityLabel(nNewSev) + ")");
+
+        if(nNewSev >= 5)
+            FloatingTextStringOnCreature("Rana osiągnęła poziom ŚMIERTELNY!", oPC, FALSE);
+    }
+
+    int nToken = NuiFindWindow(oPC, FWND_WINDOW);
+    if(nToken != 0)
+        FwndFeedList(oPC, nToken);
+}
+
+void FwndPCLoop(object oPC)
+{
+    if(!GetIsObjectValid(oPC)) return;
+    if(!GetIsPC(oPC))          return;
+    if(!GetLocalInt(oPC, FWND_LVAR_LOOP_RUN)) return;
+
+    FwndProgressWounds(oPC);
+    FwndApplyWoundEffects(oPC);
+
+    DelayCommand(FWND_LOOP_DELAY, FwndPCLoop(oPC));
+}
+
+// ----------------------------------------------------------------
+// Treatment
+// ----------------------------------------------------------------
+
+int FwndHasTreatmentItem(object oPC, int nType)
+{
+    string sTag = FwndTreatmentTag(nType);
+    if(sTag != "" && GetIsObjectValid(GetItemPossessedBy(oPC, sTag))) return TRUE;
+    if(GetIsObjectValid(GetItemPossessedBy(oPC, FWND_ITEM_LIFE_LEAF))) return TRUE;
+    return FALSE;
+}
+
+void FwndApplyTreatment(object oPC, int nWoundId)
+{
+    json jW = FwndGetWound(nWoundId);
+    if(JsonGetType(jW) == JSON_TYPE_NULL) return;
+
+    int nType = JsonGetInt(JsonObjectGet(jW, "wound_type"));
+    int nSev  = JsonGetInt(JsonObjectGet(jW, "severity"));
+
+    string sSpecTag  = FwndTreatmentTag(nType);
+    object oItem     = OBJECT_INVALID;
+    int    bUniversal = FALSE;
+
+    if(sSpecTag != "")
+        oItem = GetItemPossessedBy(oPC, sSpecTag);
+
+    if(!GetIsObjectValid(oItem))
+    {
+        oItem = GetItemPossessedBy(oPC, FWND_ITEM_LIFE_LEAF);
+        if(!GetIsObjectValid(oItem))
+        {
+            SendMessageToPC(oPC, "[Rany] Nie posiadasz odpowiedniego leku.");
+            return;
+        }
+        bUniversal = TRUE;
+    }
+
+    int nStack = GetItemStackSize(oItem);
+    if(nStack > 1)
+        SetItemStackSize(oItem, nStack - 1);
+    else
+        DestroyObject(oItem);
+
+    int nNewSev = nSev - 1;
+    FwndSetSeverity(nWoundId, nNewSev);
+
+    string sWName = FwndTypeName(nType);
+    if(nNewSev <= 0)
+    {
+        SendMessageToPC(oPC, "[Rany] " + sWName + " — uleczona. Rana zamknęła się.");
+        FloatingTextStringOnCreature("Rana zagojona!", oPC, FALSE);
+    }
+    else
+    {
+        SendMessageToPC(oPC, "[Rany] " + sWName + " — złagodzona do: " + FwndSeverityLabel(nNewSev));
+    }
+
+    FwndApplyWoundEffects(oPC);
+}
+
+// ----------------------------------------------------------------
+// NUI layout builders
+// ----------------------------------------------------------------
+
+json FwndBuildListView(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 30.0);
+    float fRowH  = GetNuiScaleDimension(oPC, 30.0);
+    float fIconW = GetNuiScaleDimension(oPC, 44.0);
+    float fSevW  = GetNuiScaleDimension(oPC, 84.0);
+
+    json jHeaderLbl = NuiLabel(NuiBind(FWND_BIND_HEADER),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jHeaderLbl = NuiHeight(jHeaderLbl, fBtnH);
+
+    json jIconLbl = NuiLabel(NuiBind(FWND_BIND_LIST_ICON),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jIconLbl = NuiWidth(jIconLbl, fIconW);
+    jIconLbl = NuiStyleForegroundColor(jIconLbl, NuiBind(FWND_BIND_LIST_COL));
+
+    json jNameLbl = NuiLabel(NuiBind(FWND_BIND_LIST_NAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jNameLbl = NuiStyleForegroundColor(jNameLbl, NuiBind(FWND_BIND_LIST_COL));
+
+    json jSevLbl = NuiLabel(NuiBind(FWND_BIND_LIST_SEV),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jSevLbl = NuiWidth(jSevLbl, fSevW);
+    jSevLbl = NuiStyleForegroundColor(jSevLbl, NuiBind(FWND_BIND_LIST_COL));
+
+    json jCellInner = JsonArray();
+    jCellInner = JsonArrayInsert(jCellInner, jIconLbl);
+    jCellInner = JsonArrayInsert(jCellInner, jNameLbl);
+    jCellInner = JsonArrayInsert(jCellInner, jSevLbl);
+
+    json jCell = NuiGroup(NuiRow(jCellInner), TRUE, NUI_SCROLLBARS_NONE);
+    jCell = NuiId(jCell, FWND_BTN_ROW);
+    jCell = NuiEncouraged(jCell, NuiBind(FWND_BIND_LIST_ENC));
+
+    json jTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jCell, 0.0, TRUE));
+
+    float fListH = GetNuiScaleDimension(oPC, 295.0);
+    json  jList  = NuiList(jTmpl, NuiBind(FWND_BIND_ROWCOUNT), fRowH);
+    jList = NuiHeight(jList, fListH);
+
+    json jCloseBtn = NuiButton(JsonString("Zamknij"));
+    jCloseBtn = NuiId(jCloseBtn, FWND_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, GetNuiScaleDimension(oPC, 100.0));
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jBotRow = JsonArray();
+    jBotRow = JsonArrayInsert(jBotRow, NuiSpacer());
+    jBotRow = JsonArrayInsert(jBotRow, jCloseBtn);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jHeaderLbl)));
+    jCol = JsonArrayInsert(jCol, jList);
+    jCol = JsonArrayInsert(jCol, NuiRow(jBotRow));
+
+    json jSide    = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    float fContW  = GetNuiScaleDimension(oPC, 520.0);
+    json jMainRow = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiCol(jCol), fContW));
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    return NuiRow(jMainRow);
+}
+
+json FwndBuildDetailView(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 30.0);
+    float fDescH = GetNuiScaleDimension(oPC, 175.0);
+
+    json jNameLbl = NuiLabel(NuiBind(FWND_BIND_DET_WNAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jNameLbl = NuiHeight(jNameLbl, GetNuiScaleDimension(oPC, 26.0));
+
+    json jTypeLbl = NuiLabel(NuiBind(FWND_BIND_DET_TYPE),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTypeLbl = NuiHeight(jTypeLbl, GetNuiScaleDimension(oPC, 22.0));
+
+    json jSevLbl = NuiLabel(NuiBind(FWND_BIND_DET_SEV),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jSevLbl = NuiHeight(jSevLbl, GetNuiScaleDimension(oPC, 22.0));
+
+    json jDescBox = NuiGroup(NuiText(NuiBind(FWND_BIND_DET_DESC), FALSE), TRUE, NUI_SCROLLBARS_NONE);
+    jDescBox = NuiHeight(jDescBox, fDescH);
+
+    json jTreatLbl = NuiLabel(NuiBind(FWND_BIND_DET_TREAT),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTreatLbl = NuiHeight(jTreatLbl, GetNuiScaleDimension(oPC, 24.0));
+
+    json jTreatBtn = NuiButton(JsonString("Zastosuj Lekarstwo"));
+    jTreatBtn = NuiId(jTreatBtn, FWND_BTN_TREAT);
+    jTreatBtn = NuiEnabled(jTreatBtn, NuiBind(FWND_BIND_TREAT_ENA));
+    jTreatBtn = NuiWidth(jTreatBtn, GetNuiScaleDimension(oPC, 200.0));
+    jTreatBtn = NuiHeight(jTreatBtn, fBtnH);
+
+    json jBackBtn = NuiButton(JsonString("Powrot"));
+    jBackBtn = NuiId(jBackBtn, FWND_BTN_BACK);
+    jBackBtn = NuiWidth(jBackBtn, GetNuiScaleDimension(oPC, 80.0));
+    jBackBtn = NuiHeight(jBackBtn, fBtnH);
+
+    json jBotRow = JsonArray();
+    jBotRow = JsonArrayInsert(jBotRow, jBackBtn);
+    jBotRow = JsonArrayInsert(jBotRow, NuiSpacer());
+    jBotRow = JsonArrayInsert(jBotRow, jTreatBtn);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jNameLbl)));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jTypeLbl)));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jSevLbl)));
+    jCol = JsonArrayInsert(jCol, jDescBox);
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jTreatLbl)));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBotRow));
+
+    json jSide    = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    float fContW  = GetNuiScaleDimension(oPC, 520.0);
+    json jMainRow = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiCol(jCol), fContW));
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    return NuiRow(jMainRow);
+}
+
+// ----------------------------------------------------------------
+// Feed functions
+// ----------------------------------------------------------------
+
+void FwndFeedList(object oPC, int nToken)
+{
+    json jWounds = FwndGetWounds(oPC);
+    int  nCount  = JsonGetLength(jWounds);
+
+    string sHeader;
+    if(nCount == 0)
+        sHeader = "Rany Gnijące — brak aktywnych ran";
+    else if(nCount == 1)
+        sHeader = "Rany Gnijące — 1 aktywna rana";
+    else
+        sHeader = "Rany Gnijące — " + IntToString(nCount) + " aktywnych ran";
+
+    NuiSetBind(oPC, nToken, FWND_BIND_HEADER,   JsonString(sHeader));
+    NuiSetBind(oPC, nToken, FWND_BIND_ROWCOUNT, JsonInt(nCount));
+
+    json jIcons  = JsonArray();
+    json jNames  = JsonArray();
+    json jSevs   = JsonArray();
+    json jColors = JsonArray();
+    json jEncs   = JsonArray();
+
+    int nSelId = GetLocalInt(oPC, FWND_LVAR_SEL_ID);
+
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jW   = JsonArrayGet(jWounds, i);
+        int nType = JsonGetInt(JsonObjectGet(jW, "wound_type"));
+        int nSev  = JsonGetInt(JsonObjectGet(jW, "severity"));
+        int nId   = JsonGetInt(JsonObjectGet(jW, "id"));
+
+        jIcons  = JsonArrayInsert(jIcons,  JsonString(FwndTypeIcon(nType)));
+        jNames  = JsonArrayInsert(jNames,  JsonString(FwndTypeName(nType)));
+        jSevs   = JsonArrayInsert(jSevs,   JsonString(FwndSeverityStars(nSev)));
+        jColors = JsonArrayInsert(jColors, FwndSeverityColor(nSev));
+        jEncs   = JsonArrayInsert(jEncs,   JsonBool(nSelId > 0 && nId == nSelId));
+    }
+
+    NuiSetBind(oPC, nToken, FWND_BIND_LIST_ICON, jIcons);
+    NuiSetBind(oPC, nToken, FWND_BIND_LIST_NAME, jNames);
+    NuiSetBind(oPC, nToken, FWND_BIND_LIST_SEV,  jSevs);
+    NuiSetBind(oPC, nToken, FWND_BIND_LIST_COL,  jColors);
+    NuiSetBind(oPC, nToken, FWND_BIND_LIST_ENC,  jEncs);
+}
+
+void FwndFeedDetail(object oPC, int nToken, int nWoundId)
+{
+    json jW = FwndGetWound(nWoundId);
+    if(JsonGetType(jW) == JSON_TYPE_NULL)
+    {
+        // Wound no longer exists — return to list
+        FwndSwapToList(oPC, nToken);
+        return;
+    }
+
+    int    nType = JsonGetInt   (JsonObjectGet(jW, "wound_type"));
+    int    nSev  = JsonGetInt   (JsonObjectGet(jW, "severity"));
+    string sSrc  = JsonGetString(JsonObjectGet(jW, "source_name"));
+
+    string sDesc = FwndTypeDescription(nType, nSev);
+    if(sSrc != "")
+        sDesc += "\n\nZadana przez: " + sSrc;
+
+    string sTreat = FwndTreatmentText(nType)
+                  + "\n" + "Lisc Zywotnika: dziala na kazda rane (-1 sila).";
+
+    int bHasItem = FwndHasTreatmentItem(oPC, nType);
+
+    SetLocalInt(oPC, FWND_LVAR_SEL_ID, nWoundId);
+
+    NuiSetBind(oPC, nToken, FWND_BIND_DET_WNAME, JsonString(FwndTypeName(nType)));
+    NuiSetBind(oPC, nToken, FWND_BIND_DET_TYPE,  JsonString("Typ: " + FwndTypeIcon(nType) + "  " + FwndTypeName(nType)));
+    NuiSetBind(oPC, nToken, FWND_BIND_DET_SEV,
+        JsonString("Sila rany: " + FwndSeverityLabel(nSev) + "  " + FwndSeverityStars(nSev)));
+    NuiSetBind(oPC, nToken, FWND_BIND_DET_DESC,  JsonString(sDesc));
+    NuiSetBind(oPC, nToken, FWND_BIND_DET_TREAT, JsonString(sTreat));
+    NuiSetBind(oPC, nToken, FWND_BIND_TREAT_ENA, JsonBool(bHasItem));
+}
+
+// ----------------------------------------------------------------
+// View switching
+// ----------------------------------------------------------------
+
+void FwndSwapToList(object oPC, int nToken)
+{
+    NuiSetGroupLayout(oPC, nToken, FWND_GRP_SWAP, FwndBuildListView(oPC));
+    SetLocalInt(oPC, FWND_LVAR_SEL_ID, 0);
+    FwndFeedList(oPC, nToken);
+}
+
+void FwndSwapToDetail(object oPC, int nToken, int nWoundId)
+{
+    NuiSetGroupLayout(oPC, nToken, FWND_GRP_SWAP, FwndBuildDetailView(oPC));
+    FwndFeedDetail(oPC, nToken, nWoundId);
+}
+
+// ----------------------------------------------------------------
+// Window creation
+// ----------------------------------------------------------------
+
+void FwndOpen(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, FWND_WINDOW);
+    if(nToken != 0)
+    {
+        FwndSwapToList(oPC, nToken);
+        return;
+    }
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))
+                 - GetNuiScaleDimension(oPC, FWND_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT))
+                 - GetNuiScaleDimension(oPC, FWND_H)) / 2.0;
+    json jGeom = NuiRect(fCX, fCY,
+                         GetNuiScaleDimension(oPC, FWND_W),
+                         GetNuiScaleDimension(oPC, FWND_H));
+
+    json jSwapGrp = NuiGroup(FwndBuildListView(oPC), FALSE, NUI_SCROLLBARS_NONE);
+    jSwapGrp = NuiId(jSwapGrp, FWND_GRP_SWAP);
+
+    float fBtnH    = GetNuiScaleDimension(oPC, 30.0);
+    json  jCloseX  = NuiButton(JsonString("X"));
+    jCloseX = NuiId(jCloseX, FWND_BTN_CLOSE);
+    jCloseX = NuiWidth(jCloseX, GetNuiScaleDimension(oPC, 30.0));
+    jCloseX = NuiHeight(jCloseX, fBtnH);
+
+    json jTopBar = JsonArray();
+    jTopBar = JsonArrayInsert(jTopBar, NuiSpacer());
+    jTopBar = JsonArrayInsert(jTopBar, jCloseX);
+
+    json jRootCol = JsonArray();
+    jRootCol = JsonArrayInsert(jRootCol, NuiRow(jTopBar));
+    jRootCol = JsonArrayInsert(jRootCol, jSwapGrp);
+
+    json jWin = NuiWindow(NuiCol(jRootCol),
+        JsonBool(FALSE),
+        NuiBind(FWND_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    nToken = NuiCreate(oPC, jWin, FWND_WINDOW, FWND_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, FWND_WIN_GEOM, jGeom);
+
+    FwndSwapToList(oPC, nToken);
+}

--- a/Festering Wounds/Scripts/lib_fwnd_def.nss
+++ b/Festering Wounds/Scripts/lib_fwnd_def.nss
@@ -1,0 +1,71 @@
+#include "lib_nui"
+#include "sql_fwnd"
+
+void FwndOpen(object oPC);
+void FwndPCLoop(object oPC);
+
+// ----------------------------------------------------------------
+// Wound types
+// ----------------------------------------------------------------
+
+const int FWND_TYPE_VAMPIRE  = 1; // "Ukąszenie Wampira"   — CON drain
+const int FWND_TYPE_NECROTIC = 2; // "Gnilna Rana"         — STR drain
+const int FWND_TYPE_DEMONIC  = 3; // "Szrama Demoniczna"   — WIS drain
+const int FWND_TYPE_VENOM    = 4; // "Głębokie Zatrucie"   — DEX penalty
+const int FWND_TYPE_CURSED   = 5; // "Przeklęte Cięcie"    — ATK penalty
+
+// Treatment item resrefs (must exist in module/HAK)
+const string FWND_ITEM_HOLY_WATER = "fwnd_holy_water";
+const string FWND_ITEM_LIFE_SALVE = "fwnd_life_salve";
+const string FWND_ITEM_WARD_HERB  = "fwnd_ward_herb";
+const string FWND_ITEM_ANTITOXIN  = "fwnd_antitoxin";
+const string FWND_ITEM_EXORCISM   = "fwnd_exorcism";
+const string FWND_ITEM_LIFE_LEAF  = "fwnd_life_leaf"; // universal -1 severity
+
+// Marks all active wound debuff effects for clean removal
+const string FWND_EFFECT_TAG    = "FWND_DEBUFF";
+
+// Heartbeat loop delay in seconds
+const float FWND_LOOP_DELAY     = 30.0;
+
+// LVAR — 1 while loop should fire, 0 after logout
+const string FWND_LVAR_LOOP_RUN = "FWND_LOOP";
+
+// LVAR — DB id of the wound selected in UI
+const string FWND_LVAR_SEL_ID   = "FWND_SEL_ID";
+
+// ----------------------------------------------------------------
+// NUI identifiers
+// ----------------------------------------------------------------
+
+const string FWND_WINDOW    = "FWND_WINDOW";
+const string FWND_EV_SCRIPT = "lib_fwnd_ev";
+const string FWND_GRP_SWAP  = "FWND_GRP_SWAP";
+const string FWND_WIN_GEOM  = "fwnd_win_geom";
+
+// List view binds
+const string FWND_BIND_LIST_ICON = "fwnd_list_icon";
+const string FWND_BIND_LIST_NAME = "fwnd_list_name";
+const string FWND_BIND_LIST_SEV  = "fwnd_list_sev";
+const string FWND_BIND_LIST_COL  = "fwnd_list_col";
+const string FWND_BIND_LIST_ENC  = "fwnd_list_enc";
+const string FWND_BIND_ROWCOUNT  = "fwnd_rowcount";
+const string FWND_BIND_HEADER    = "fwnd_header";
+
+// Detail view binds
+const string FWND_BIND_DET_WNAME = "fwnd_det_wname";
+const string FWND_BIND_DET_TYPE  = "fwnd_det_type";
+const string FWND_BIND_DET_SEV   = "fwnd_det_sev";
+const string FWND_BIND_DET_DESC  = "fwnd_det_desc";
+const string FWND_BIND_DET_TREAT = "fwnd_det_treat";
+const string FWND_BIND_TREAT_ENA = "fwnd_treat_ena";
+
+// Button IDs
+const string FWND_BTN_CLOSE = "fwnd_btn_close";
+const string FWND_BTN_ROW   = "fwnd_btn_row";
+const string FWND_BTN_TREAT = "fwnd_btn_treat";
+const string FWND_BTN_BACK  = "fwnd_btn_back";
+
+// Window dimensions (unscaled)
+const float FWND_W = 560.0;
+const float FWND_H = 400.0;

--- a/Festering Wounds/Scripts/lib_fwnd_ev.nss
+++ b/Festering Wounds/Scripts/lib_fwnd_ev.nss
@@ -1,0 +1,73 @@
+#include "lib_fwnd"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    if(nToken != NuiFindWindow(oPC, FWND_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalInt(oPC, FWND_LVAR_SEL_ID);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == FWND_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        if(sElem == FWND_BTN_BACK)
+        {
+            FwndSwapToList(oPC, nToken);
+            return;
+        }
+
+        if(sElem == FWND_BTN_TREAT)
+        {
+            int nSelId = GetLocalInt(oPC, FWND_LVAR_SEL_ID);
+            if(nSelId <= 0) return;
+
+            FwndApplyTreatment(oPC, nSelId);
+
+            // If the wound was fully healed, go back to list; otherwise refresh detail.
+            json jW = FwndGetWound(nSelId);
+            if(JsonGetType(jW) == JSON_TYPE_NULL)
+                FwndSwapToList(oPC, nToken);
+            else
+                FwndFeedDetail(oPC, nToken, nSelId);
+
+            return;
+        }
+    }
+
+    if(sEvent == EVENT_TYPE_MOUSEDOWN)
+    {
+        if(sElem == FWND_BTN_ROW)
+        {
+            json jWounds = FwndGetWounds(oPC);
+            if(nIdx < 0 || nIdx >= JsonGetLength(jWounds)) return;
+
+            json jW  = JsonArrayGet(jWounds, nIdx);
+            int  nId = JsonGetInt(JsonObjectGet(jW, "id"));
+
+            // Highlight selected row before switching view
+            int nCount = JsonGetLength(jWounds);
+            json jEncs = JsonArray();
+            int i;
+            for(i = 0; i < nCount; i++)
+                jEncs = JsonArrayInsert(jEncs, JsonBool(i == nIdx));
+            NuiSetBind(oPC, nToken, FWND_BIND_LIST_ENC, jEncs);
+
+            FwndSwapToDetail(oPC, nToken, nId);
+            return;
+        }
+    }
+}

--- a/Festering Wounds/Scripts/sql_fwnd.nss
+++ b/Festering Wounds/Scripts/sql_fwnd.nss
@@ -1,0 +1,138 @@
+// How many real seconds before an untreated wound progresses +1 severity
+const int FWND_PROGRESS_INTERVAL = 600;
+
+void FwndCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("festering_wounds",
+        "CREATE TABLE IF NOT EXISTS fwnd_wounds ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "pc_uuid TEXT NOT NULL, "
+        "wound_type INTEGER NOT NULL DEFAULT 1, "
+        "severity INTEGER NOT NULL DEFAULT 1, "
+        "inflicted_at INTEGER NOT NULL DEFAULT 0, "
+        "last_progressed INTEGER NOT NULL DEFAULT 0, "
+        "source_name TEXT DEFAULT '')");
+    SqlStep(q);
+}
+
+// If a wound of the same type already exists, worsen it instead of inserting.
+void FwndInflictWound(object oPC, int nType, string sSource)
+{
+    sqlquery qCheck = SqlPrepareQueryCampaign("festering_wounds",
+        "SELECT id, severity FROM fwnd_wounds "
+        "WHERE pc_uuid = @uuid AND wound_type = @type LIMIT 1");
+    SqlBindString(qCheck, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (qCheck, "@type", nType);
+    if(SqlStep(qCheck))
+    {
+        int nId  = SqlGetInt(qCheck, 0);
+        int nSev = SqlGetInt(qCheck, 1);
+        if(nSev < 5)
+        {
+            sqlquery qUp = SqlPrepareQueryCampaign("festering_wounds",
+                "UPDATE fwnd_wounds SET severity = @sev, source_name = @src "
+                "WHERE id = @id");
+            SqlBindInt   (qUp, "@sev", nSev + 1);
+            SqlBindString(qUp, "@src", sSource);
+            SqlBindInt   (qUp, "@id",  nId);
+            SqlStep(qUp);
+        }
+        return;
+    }
+
+    sqlquery q = SqlPrepareQueryCampaign("festering_wounds",
+        "INSERT INTO fwnd_wounds "
+        "(pc_uuid, wound_type, severity, inflicted_at, last_progressed, source_name) "
+        "VALUES (@uuid, @type, 1, strftime('%s','now'), strftime('%s','now'), @src)");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@type", nType);
+    SqlBindString(q, "@src",  sSource);
+    SqlStep(q);
+}
+
+json FwndGetWounds(object oPC)
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("festering_wounds",
+        "SELECT id, wound_type, severity, inflicted_at, last_progressed, source_name "
+        "FROM fwnd_wounds WHERE pc_uuid = @uuid ORDER BY inflicted_at ASC");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    while(SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "id",              JsonInt   (SqlGetInt   (q, 0)));
+        jRow = JsonObjectSet(jRow, "wound_type",      JsonInt   (SqlGetInt   (q, 1)));
+        jRow = JsonObjectSet(jRow, "severity",        JsonInt   (SqlGetInt   (q, 2)));
+        jRow = JsonObjectSet(jRow, "inflicted_at",    JsonInt   (SqlGetInt   (q, 3)));
+        jRow = JsonObjectSet(jRow, "last_progressed", JsonInt   (SqlGetInt   (q, 4)));
+        jRow = JsonObjectSet(jRow, "source_name",     JsonString(SqlGetString(q, 5)));
+        jRows = JsonArrayInsert(jRows, jRow);
+    }
+    return jRows;
+}
+
+json FwndGetWound(int nId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("festering_wounds",
+        "SELECT id, wound_type, severity, inflicted_at, last_progressed, source_name "
+        "FROM fwnd_wounds WHERE id = @id");
+    SqlBindInt(q, "@id", nId);
+    if(!SqlStep(q)) return JsonNull();
+    json jRow = JsonObject();
+    jRow = JsonObjectSet(jRow, "id",              JsonInt   (SqlGetInt   (q, 0)));
+    jRow = JsonObjectSet(jRow, "wound_type",      JsonInt   (SqlGetInt   (q, 1)));
+    jRow = JsonObjectSet(jRow, "severity",        JsonInt   (SqlGetInt   (q, 2)));
+    jRow = JsonObjectSet(jRow, "inflicted_at",    JsonInt   (SqlGetInt   (q, 3)));
+    jRow = JsonObjectSet(jRow, "last_progressed", JsonInt   (SqlGetInt   (q, 4)));
+    jRow = JsonObjectSet(jRow, "source_name",     JsonString(SqlGetString(q, 5)));
+    return jRow;
+}
+
+// nNewSev <= 0 removes the wound entirely.
+void FwndSetSeverity(int nId, int nNewSev)
+{
+    if(nNewSev <= 0)
+    {
+        sqlquery q = SqlPrepareQueryCampaign("festering_wounds",
+            "DELETE FROM fwnd_wounds WHERE id = @id");
+        SqlBindInt(q, "@id", nId);
+        SqlStep(q);
+        return;
+    }
+    sqlquery q = SqlPrepareQueryCampaign("festering_wounds",
+        "UPDATE fwnd_wounds SET severity = @sev, last_progressed = strftime('%s','now') "
+        "WHERE id = @id");
+    SqlBindInt(q, "@sev", nNewSev);
+    SqlBindInt(q, "@id",  nId);
+    SqlStep(q);
+}
+
+int FwndCountWounds(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("festering_wounds",
+        "SELECT COUNT(*) FROM fwnd_wounds WHERE pc_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+json FwndGetWoundsToProgress(object oPC)
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("festering_wounds",
+        "SELECT id, wound_type, severity FROM fwnd_wounds "
+        "WHERE pc_uuid = @uuid "
+        "AND last_progressed < strftime('%s','now') - @interval "
+        "AND severity < 5");
+    SqlBindString(q, "@uuid",     GetObjectUUID(oPC));
+    SqlBindInt   (q, "@interval", FWND_PROGRESS_INTERVAL);
+    while(SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "id",         JsonInt(SqlGetInt(q, 0)));
+        jRow = JsonObjectSet(jRow, "wound_type", JsonInt(SqlGetInt(q, 1)));
+        jRow = JsonObjectSet(jRow, "severity",   JsonInt(SqlGetInt(q, 2)));
+        jRows = JsonArrayInsert(jRows, jRow);
+    }
+    return jRows;
+}

--- a/Festering Wounds/Scripts/sys_on_enter.nss
+++ b/Festering Wounds/Scripts/sys_on_enter.nss
@@ -1,0 +1,21 @@
+#include "lib_fwnd"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC)) return;
+
+    int nCount = FwndCountWounds(oPC);
+    if(nCount > 0)
+    {
+        string sMsg = "[Rany] Masz " + IntToString(nCount)
+                    + (nCount == 1 ? " aktywną ranę gnijącą." : " aktywnych ran gnijących.")
+                    + " Szukaj leczenia.";
+        FloatingTextStringOnCreature(sMsg, oPC, FALSE);
+        SendMessageToPC(oPC, sMsg);
+        DelayCommand(2.0, FwndApplyWoundEffects(oPC));
+    }
+
+    SetLocalInt(oPC, FWND_LVAR_LOOP_RUN, 1);
+    DelayCommand(5.0, FwndPCLoop(oPC));
+}

--- a/Festering Wounds/Scripts/sys_on_leave.nss
+++ b/Festering Wounds/Scripts/sys_on_leave.nss
@@ -1,0 +1,10 @@
+#include "lib_fwnd_def"
+
+void main()
+{
+    object oPC = GetExitingObject();
+    if(!GetIsPC(oPC)) return;
+
+    // Stop the per-PC heartbeat loop — effects are re-applied on next login.
+    SetLocalInt(oPC, FWND_LVAR_LOOP_RUN, 0);
+}

--- a/Festering Wounds/Scripts/sys_on_load.nss
+++ b/Festering Wounds/Scripts/sys_on_load.nss
@@ -1,0 +1,6 @@
+#include "lib_fwnd_def"
+
+void main()
+{
+    FwndCreateTables();
+}

--- a/Festering Wounds/Scripts/test_fwnd.nss
+++ b/Festering Wounds/Scripts/test_fwnd.nss
@@ -1,0 +1,22 @@
+#include "lib_fwnd"
+
+// OnUsed demo: each use inflicts the next wound type in sequence (1–5),
+// then opens the Festering Wounds journal for the activating PC.
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    int nNext = GetLocalInt(OBJECT_SELF, "FWND_TEST_NEXT") + 1;
+    if(nNext > 5) nNext = 1;
+    SetLocalInt(OBJECT_SELF, "FWND_TEST_NEXT", nNext);
+
+    FwndInflictWound(oPC, nNext, "Kamienny Posąg [Test]");
+    FwndApplyWoundEffects(oPC);
+
+    SendMessageToPC(oPC,
+        "[Test Ran] Zadano: " + FwndTypeName(nNext)
+        + "  |  Uzyj ponownie, by dodac kolejny typ rany (1-5 cykl).");
+
+    FwndOpen(oPC);
+}


### PR DESCRIPTION
## Co to robi

System **Gnijących Ran** — 5 typów nadprzyrodzonych ran, które utrzymują się między sesjami (SQL), samoczynnie się pogarszają z upływem czasu, nakładają kary statystyk i wymagają konkretnych itemów do leczenia. Gracz przegląda aktywne rany i leczy je przez dedykowane UI (NUI).

## Mechanika

- **5 typów ran** odpowiadających różnym źródłom ciemnej magii: ukąszenie wampira (CON), gnilna rana (STR), szrama demoniczna (WIS), głębokie zatrucie (DEX), przeklęte cięcie (ATK penalty).
- **Progresja**: bez leczenia każda rana co 10 min (realnych) wzmacnia się o 1 stopień (skala I–V). Na stopniu V pojawia się floating text ostrzeżenia.
- **Stackowanie po typie**: dwie rany tego samego typu wzmacniają istniejącą zamiast tworzyć duplikat (max siła 5 na typ, max 5 typów).
- **Efekty**: tagowane `ExtraordinaryEffect` (przeżywają odpoczynek), aplikowane/usuwane przez pętlę heartbeat per-PC co 30 s. Czyste usunięcie przez `GetEffectTag` + `RemoveEffect`.
- **Leczenie przez UI**: każdy typ rany wymaga odpowiedniego itemu (tag z INTEGRATION.md); "Liść Żywotnika" to uniwersalny item -1 stopień. Kliknięcie „Zastosuj Lekarstwo" niszczy 1 sztukę ze stosu i odświeża widok.
- **Persistent**: kampanijna baza danych `festering_wounds`, tabela `fwnd_wounds` (pc_uuid, typ, siła, znaczniki czasu). Stan przywracany przy każdym logowaniu.

## Pliki

```
Festering Wounds/
  Scripts/
    sql_fwnd.nss        — schemat DB, CRUD queries (138 LOC)
    lib_fwnd_def.nss    — stałe typów, ID bindów NUI, wymiary okna (71 LOC)
    lib_fwnd.nss        — core: labele, efekty, progresja, NUI build+feed (577 LOC)
    lib_fwnd_ev.nss     — handler NUI eventów (73 LOC)
    sys_on_load.nss     — init tabel przy starcie modułu
    sys_on_enter.nss    — przywróć efekty + startuj pętlę heartbeat na login
    sys_on_leave.nss    — zatrzymaj pętlę na logout
    test_fwnd.nss       — OnUsed placeable: demo cyklujące przez typy 1-5
  INTEGRATION.md        — hooki, API dla DM/serwera, tagi itemów
```

Łącznie: **919 LOC NWScript**.

## Zależności (NWNX? SQL?)

- **SQL**: `SqlPrepareQueryCampaign("festering_wounds", ...)` — vanilla NWN:EE, brak NWNX.
- **NWN:EE 8193.36.13+** wymagane dla `GetEffectTag`, `TagEffect`, `NuiSetGroupLayout`.
- **Brak NWNX** — moduł w pełni vanilla.

## Jak włączyć w istniejącym module

1. Dodaj skrypty do haka / override folderu modułu.
2. Podepnij `sys_on_load` pod **OnModuleLoad**, `sys_on_enter` pod **OnClientEnter**, `sys_on_leave` pod **OnClientLeave** (lub wywołaj odpowiednie funkcje z istniejących skryptów — patrz INTEGRATION.md).
3. Stwórz itemy lecznicze z tagami z INTEGRATION.md (stackowalne Miscellaneous Small).
4. Zadawanie ran: wywołaj `FwndInflictWound(oPC, FWND_TYPE_*, sSource)` + `FwndApplyWoundEffects(oPC)` z OnHit itemu lub skryptu DM.
5. Test: umieść placeable z OnUsed = `test_fwnd`.

## Co celowo pominięto

- Wizualne tintowanie postaci przy wysokiej sile rany — wymaga NWNX_Appearance
- Automatyczny trigger przy OnPhysicalAttackHit — wymaga NWNX_Events; bez NWNX rany zadawane przez DM/itemy
- Timer odliczania do progresji widoczny w UI — komplikuje synchronizację heartbeat bez proporcjonalnej wartości gameplay
- Limit liczby ran — celowo brak; 5 typów × max siła 5 tworzy naturalny pułap kar


---
_Generated by [Claude Code](https://claude.ai/code/session_0161a48pDCFskP3K87o5jKHe)_