### PR TITLE
feat: Scrying Mirror (Zwierciadlo Dalekowzrocznosci)

### DIFF
--- a/Scrying Mirror/INTEGRATION.md
+++ b/Scrying Mirror/INTEGRATION.md
@@ -1,0 +1,74 @@
+# Scrying Mirror — Zwierciadlo Dalekowzrocznosci
+
+System magicznych zwierciadeł nastrojonych na konkretne lokacje.
+Gracze wpatruja sie w zwierciadlo, widzac kto aktualnie przebywa
+w danym obszarze, kosztem reagentu; obserwowani moga wyczuc spojrzenie.
+
+## Wymagania
+
+- NWN:EE 8193.35+
+- Brak zaleznosci od NWNX
+- SQLite (wbudowany w NWN:EE) — baza `scrying`
+
+## Hooki modulu
+
+| Zdarzenie modulu | Skrypt                        | Co dodac                    |
+|-----------------|-------------------------------|-----------------------------|
+| OnModuleLoad    | `sys_on_load.nss`             | `ScryCreateTables()`        |
+
+Wywolaj `ScryCreateTables()` raz przy starcie modulu.
+Brak hooka OnClientEnter — sledzenie lokacji odbywa sie w czasie
+rzeczywistym przez `GetArea(oPC)`.
+
+## Placeable testowy
+
+1. Utwórz placeable "Krysztalne Zrodlo" w obszarze testowym.
+2. Skrypt OnUsed: `test_scry`.
+3. Gracze i DM uzywaja go, by otworzyc okno systemu.
+
+## Itemy (HAK / Toolset)
+
+Nalezy stworzyc dwa blueprinty przedmiotow:
+
+| Tag             | Nazwa                | Opis                                          |
+|----------------|----------------------|-----------------------------------------------|
+| `scry_tear`    | Lza Jasnowidza       | Stackowalny, 1 zu zycia / wpatrzenie           |
+| `scry_crystal` | Kamien Krysztalowy   | 1 szt. / nastrojenie (nie DM)                 |
+
+Przedmioty moga byc craftowane, znajdowane w skarbach lub sprzedawane
+przez NPC — decyzja nalezaca do DM.
+
+## Mechanika wpatrzenia
+
+1. Gracz otwiera okno (placeable lub komenda DM).
+2. Wybiera zwierciadlo z listy — widzi liczbe obecnosci w obszarze
+   (darmowe, bez reagentu).
+3. Klika **Wpatrz sie** — zuzywana jest 1 Lza Jasnowidza.
+4. Wynik pokazuje imiona i stan zdrowia obserwowanych graczy.
+5. Kazdy obserwowany gracz wykonuje automatycznie rzut na Czujnosc:
+   - DC = 15 + modyfikator INT jasnowidza
+   - Sukces: gracz widzi floating text "Czujesz na sobie obce spojrzenie..."
+   - Wynik >= 25: gracz widzi imie obserwatora
+
+## Nastrojenie nowego zwierciadla
+
+- DM: zawsze mozliwe (bez kosztow).
+- Gracz: musi posiadac Kamien Krysztalowy (zuzywany przy nastrojeniu).
+- Nastrojenie rejestruje obszar, w ktorym stoi postac w chwili klikniecia.
+- Limit: 20 aktywnych zwierciatel (stala `SCRY_MAX_MIRRORS`).
+
+## Wygaszanie
+
+Wlasciciel zwierciadla lub DM moze je wygasic przyciskiem **Wygasz**.
+Wpis jest oznaczany jako nieaktywny (`is_active = 0`) — nie jest usuwany,
+co pozwala na audyt historii.
+
+## Co celowo pominieto
+
+- Brak wizualnej minigry (widok krysztalu to tekst, nie render obszaru).
+- Brak trybu "blokowania" lustra przez obserwowanego — mechanika
+  kontrskrywingu ograniczona do ostrzezenia i ujawnienia twarzy.
+- Brak timera wygasniecia nastrojenia — zwierciadla trwaja do wygaszenia
+  przez wlasciciela lub DM.
+- Brak persystencji "ostatnio obserwowany przez X" — mozliwe
+  rozszerzenie w przyszlosci.

--- a/Scrying Mirror/scripts/lib_scry.nss
+++ b/Scrying Mirror/scripts/lib_scry.nss
@@ -1,0 +1,522 @@
+#include "lib_scry_def"
+
+// ----------------------------------------------------------------
+// Authorization helpers
+// ----------------------------------------------------------------
+
+int ScryCanAttune(object oPC)
+{
+    if(GetIsDM(oPC) || GetIsDMPossessed(oPC)) return TRUE;
+    return GetIsObjectValid(GetItemPossessedBy(oPC, SCRY_ITEM_CRYSTAL));
+}
+
+int ScryCanDeactivate(object oPC, json jMirror)
+{
+    if(GetIsDM(oPC) || GetIsDMPossessed(oPC)) return TRUE;
+    return (JsonGetString(JsonObjectGet(jMirror, "attuner_uuid")) == GetObjectUUID(oPC));
+}
+
+// ----------------------------------------------------------------
+// Area query — returns {names: [], hps: []} for all PCs in area
+// ----------------------------------------------------------------
+
+json ScryGetPCsInArea(string sAreaTag)
+{
+    json jNames = JsonArray();
+    json jHPs   = JsonArray();
+
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        if(GetTag(GetArea(oPC)) == sAreaTag)
+        {
+            jNames = JsonArrayInsert(jNames, JsonString(GetName(oPC)));
+            int nHP  = GetCurrentHitPoints(oPC);
+            int nMax = GetMaxHitPoints(oPC);
+            int nPct = (nMax > 0) ? (nHP * 100 / nMax) : 0;
+            jHPs = JsonArrayInsert(jHPs, JsonInt(nPct));
+        }
+        oPC = GetNextPC();
+    }
+
+    json jResult = JsonObject();
+    jResult = JsonObjectSet(jResult, "names", jNames);
+    jResult = JsonObjectSet(jResult, "hps",   jHPs);
+    return jResult;
+}
+
+// ----------------------------------------------------------------
+// NUI layout builders
+// ----------------------------------------------------------------
+
+json ScryBuildListPanel(object oPC)
+{
+    float fRowH  = GetNuiScaleDimension(oPC, 42.0);
+    float fBtnH  = GetNuiScaleDimension(oPC, 28.0);
+    float fListH = GetNuiScaleDimension(oPC, SCRY_H - 110.0);
+    float fListW = GetNuiScaleDimension(oPC, SCRY_LIST_W);
+
+    // Section header
+    json jHdr = NuiLabel(JsonString("Zwierciarta"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jHdr = NuiHeight(jHdr, GetNuiScaleDimension(oPC, 26.0));
+
+    // List row template: mirror name + area name stacked
+    json jNameLbl = NuiLabel(NuiBind(SCRY_BIND_ROW_NAME), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+
+    json jAreaLbl = NuiLabel(NuiBind(SCRY_BIND_ROW_AREA), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jAreaLbl = NuiStyleForegroundColor(jAreaLbl, NuiColor(160, 140, 120));
+
+    json jCellCol = JsonArray();
+    jCellCol = JsonArrayInsert(jCellCol, jNameLbl);
+    jCellCol = JsonArrayInsert(jCellCol, jAreaLbl);
+
+    json jCell = NuiGroup(NuiCol(jCellCol), TRUE, NUI_SCROLLBARS_NONE);
+    jCell = NuiId(jCell, SCRY_BTN_ROW);
+    jCell = NuiEncouraged(jCell, NuiBind(SCRY_BIND_ROW_ENC));
+
+    json jTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jCell, 0.0, TRUE));
+    json jList  = NuiList(jTmpl, NuiBind(SCRY_BIND_ROW_COUNT), fRowH);
+    jList = NuiHeight(jList, fListH);
+
+    // Refresh button
+    json jRefresh = NuiButton(JsonString("Odswiez"));
+    jRefresh = NuiId(jRefresh, SCRY_BTN_REFRESH);
+    jRefresh = NuiHeight(jRefresh, fBtnH);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jHdr)));
+    jCol = JsonArrayInsert(jCol, jList);
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jRefresh)));
+
+    return NuiWidth(NuiCol(jCol), fListW);
+}
+
+json ScryBuildDetailPanel(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 28.0);
+    float fNoteH = GetNuiScaleDimension(oPC, 72.0);
+    float fPresH = GetNuiScaleDimension(oPC, 190.0);
+
+    // Mirror name (large, white)
+    json jName = NuiLabel(NuiBind(SCRY_BIND_DET_NAME), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jName = NuiHeight(jName, GetNuiScaleDimension(oPC, 28.0));
+
+    // Area label (small, amber)
+    json jArea = NuiLabel(NuiBind(SCRY_BIND_DET_AREA), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jArea = NuiStyleForegroundColor(jArea, NuiColor(160, 140, 120));
+    jArea = NuiHeight(jArea, GetNuiScaleDimension(oPC, 22.0));
+
+    // Note text block
+    json jNote = NuiGroup(NuiText(NuiBind(SCRY_BIND_DET_NOTE), FALSE), TRUE, NUI_SCROLLBARS_NONE);
+    jNote = NuiHeight(jNote, fNoteH);
+
+    // Presence / gaze result text block
+    json jPres = NuiGroup(NuiText(NuiBind(SCRY_BIND_DET_PRES), FALSE), TRUE, NUI_SCROLLBARS_NONE);
+    jPres = NuiHeight(jPres, fPresH);
+
+    // Action buttons
+    json jGaze = NuiButton(JsonString("Wpatrz sie (Lza)"));
+    jGaze = NuiId(jGaze, SCRY_BTN_GAZE);
+    jGaze = NuiEnabled(jGaze, NuiBind(SCRY_BIND_DET_GAZE));
+    jGaze = NuiHeight(jGaze, fBtnH);
+
+    json jAttune = NuiButton(JsonString("Nastraj..."));
+    jAttune = NuiId(jAttune, SCRY_BTN_ATTUNE);
+    jAttune = NuiEnabled(jAttune, NuiBind(SCRY_BIND_DET_ATT));
+    jAttune = NuiWidth(jAttune, GetNuiScaleDimension(oPC, 90.0));
+    jAttune = NuiHeight(jAttune, fBtnH);
+
+    json jDeact = NuiButton(JsonString("Wygasz"));
+    jDeact = NuiId(jDeact, SCRY_BTN_DEACT);
+    jDeact = NuiEnabled(jDeact, NuiBind(SCRY_BIND_DET_DEACT));
+    jDeact = NuiWidth(jDeact, GetNuiScaleDimension(oPC, 80.0));
+    jDeact = NuiHeight(jDeact, fBtnH);
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, jGaze);
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jAttune);
+    jBtnRow = JsonArrayInsert(jBtnRow, jDeact);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jName)));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jArea)));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, jNote);
+    jCol = JsonArrayInsert(jCol, jPres);
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+
+    return NuiCol(jCol);
+}
+
+// ----------------------------------------------------------------
+// Window create / reopen
+// ----------------------------------------------------------------
+
+void ScryCreateWindow(object oPC)
+{
+    if(NuiFindWindow(oPC, SCRY_WINDOW) != 0)
+    {
+        int nToken = NuiFindWindow(oPC, SCRY_WINDOW);
+        SetLocalInt(oPC, SCRY_LVAR_SEL_ID, 0);
+        ScryFeedMirrorList(oPC, nToken);
+        ScryFeedDetail(oPC, nToken, 0);
+        return;
+    }
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - GetNuiScaleDimension(oPC, SCRY_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - GetNuiScaleDimension(oPC, SCRY_H)) / 2.0;
+    json jGeom = NuiRect(fCX, fCY, GetNuiScaleDimension(oPC, SCRY_W), GetNuiScaleDimension(oPC, SCRY_H));
+
+    float fBtnH = GetNuiScaleDimension(oPC, 28.0);
+
+    // Top bar: title + close button
+    json jTitle = NuiLabel(JsonString("Zwierciadlo Dalekowzrocznosci"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitle = NuiHeight(jTitle, fBtnH);
+
+    json jClose = NuiButton(JsonString("X"));
+    jClose = NuiId(jClose, SCRY_BTN_CLOSE);
+    jClose = NuiWidth(jClose, GetNuiScaleDimension(oPC, 28.0));
+    jClose = NuiHeight(jClose, fBtnH);
+
+    json jTopRow = JsonArray();
+    jTopRow = JsonArrayInsert(jTopRow, jTitle);
+    jTopRow = JsonArrayInsert(jTopRow, NuiSpacer());
+    jTopRow = JsonArrayInsert(jTopRow, jClose);
+
+    // Body: list panel (left) + detail panel (right)
+    json jBody = JsonArray();
+    jBody = JsonArrayInsert(jBody, ScryBuildListPanel(oPC));
+    jBody = JsonArrayInsert(jBody, ScryBuildDetailPanel(oPC));
+
+    json jRoot = JsonArray();
+    jRoot = JsonArrayInsert(jRoot, NuiRow(jTopRow));
+    jRoot = JsonArrayInsert(jRoot, NuiRow(jBody));
+
+    json jWin = NuiWindow(NuiCol(jRoot),
+        JsonBool(FALSE),
+        NuiBind(SCRY_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE));
+
+    int nToken = NuiCreate(oPC, jWin, SCRY_WINDOW, SCRY_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, SCRY_WIN_GEOM, jGeom);
+
+    SetLocalInt(oPC, SCRY_LVAR_SEL_ID, 0);
+    ScryFeedMirrorList(oPC, nToken);
+    ScryFeedDetail(oPC, nToken, 0);
+}
+
+// ----------------------------------------------------------------
+// Feed: mirror list
+// ----------------------------------------------------------------
+
+void ScryFeedMirrorList(object oPC, int nToken)
+{
+    json jMirrors = ScryGetMirrors();
+    int  nCount   = JsonGetLength(jMirrors);
+    int  nSel     = GetLocalInt(oPC, SCRY_LVAR_SEL_ID);
+
+    SetLocalJson(oPC, SCRY_LVAR_MIRRORS, jMirrors);
+
+    json jNames = JsonArray();
+    json jAreas = JsonArray();
+    json jEncs  = JsonArray();
+
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jRow  = JsonArrayGet(jMirrors, i);
+        int  nId   = JsonGetInt   (JsonObjectGet(jRow, "id"));
+        string sN  = JsonGetString(JsonObjectGet(jRow, "mirror_name"));
+        string sA  = JsonGetString(JsonObjectGet(jRow, "area_name"));
+
+        jNames = JsonArrayInsert(jNames, JsonString(sN));
+        jAreas = JsonArrayInsert(jAreas, JsonString(sA));
+        jEncs  = JsonArrayInsert(jEncs,  JsonBool(nSel > 0 && nId == nSel));
+    }
+
+    NuiSetBind(oPC, nToken, SCRY_BIND_ROW_NAME,  jNames);
+    NuiSetBind(oPC, nToken, SCRY_BIND_ROW_AREA,  jAreas);
+    NuiSetBind(oPC, nToken, SCRY_BIND_ROW_ENC,   jEncs);
+    NuiSetBind(oPC, nToken, SCRY_BIND_ROW_COUNT, JsonInt(nCount));
+}
+
+// ----------------------------------------------------------------
+// Feed: detail panel
+// ----------------------------------------------------------------
+
+void ScryFeedDetail(object oPC, int nToken, int nMirrorId)
+{
+    int bCanAttune = ScryCanAttune(oPC);
+
+    if(nMirrorId <= 0)
+    {
+        NuiSetBind(oPC, nToken, SCRY_BIND_DET_NAME,  JsonString("Wybierz zwierciadlo..."));
+        NuiSetBind(oPC, nToken, SCRY_BIND_DET_AREA,  JsonString(""));
+        NuiSetBind(oPC, nToken, SCRY_BIND_DET_NOTE,  JsonString("Krysztalna powierzchnia jest milczaca i ciemna."));
+        NuiSetBind(oPC, nToken, SCRY_BIND_DET_PRES,  JsonString(""));
+        NuiSetBind(oPC, nToken, SCRY_BIND_DET_GAZE,  JsonBool(FALSE));
+        NuiSetBind(oPC, nToken, SCRY_BIND_DET_DEACT, JsonBool(FALSE));
+        NuiSetBind(oPC, nToken, SCRY_BIND_DET_ATT,   JsonBool(bCanAttune));
+        return;
+    }
+
+    json jMirror = ScryGetMirrorById(nMirrorId);
+    if(JsonGetType(jMirror) == JSON_TYPE_NULL)
+    {
+        SetLocalInt(oPC, SCRY_LVAR_SEL_ID, 0);
+        ScryFeedDetail(oPC, nToken, 0);
+        return;
+    }
+
+    string sMirrorName = JsonGetString(JsonObjectGet(jMirror, "mirror_name"));
+    string sAreaName   = JsonGetString(JsonObjectGet(jMirror, "area_name"));
+    string sAreaTag    = JsonGetString(JsonObjectGet(jMirror, "area_tag"));
+    string sNote       = JsonGetString(JsonObjectGet(jMirror, "note"));
+    string sAttuner    = JsonGetString(JsonObjectGet(jMirror, "attuner_name"));
+
+    // Quick presence count without consuming a reagent
+    json jPCs    = ScryGetPCsInArea(sAreaTag);
+    int  nPresent = JsonGetLength(JsonObjectGet(jPCs, "names"));
+
+    string sPresLabel;
+    if(nPresent == 0)
+        sPresLabel = "W tym miejscu nie wyczuwasz zadnych obecnosci.\n[Wpatrz sie, aby sprawdzic szczegoly]";
+    else if(nPresent == 1)
+        sPresLabel = "Wyczuwasz jedna obecnosc w tym miejscu.\n[Wpatrz sie, aby zobaczyc kogo]";
+    else
+        sPresLabel = "Wyczuwasz " + IntToString(nPresent) + " obecnosci w tym miejscu.\n[Wpatrz sie, aby zobaczyc kogo]";
+
+    string sNoteDisp = (sNote != "") ? ("\"" + sNote + "\"") : "(Brak notatki)";
+    sNoteDisp = sNoteDisp + "\n-- nastrojone przez " + sAttuner;
+
+    NuiSetBind(oPC, nToken, SCRY_BIND_DET_NAME,  JsonString(sMirrorName));
+    NuiSetBind(oPC, nToken, SCRY_BIND_DET_AREA,  JsonString("Obszar: " + sAreaName));
+    NuiSetBind(oPC, nToken, SCRY_BIND_DET_NOTE,  JsonString(sNoteDisp));
+    NuiSetBind(oPC, nToken, SCRY_BIND_DET_PRES,  JsonString(sPresLabel));
+    NuiSetBind(oPC, nToken, SCRY_BIND_DET_GAZE,  JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, SCRY_BIND_DET_DEACT, JsonBool(ScryCanDeactivate(oPC, jMirror)));
+    NuiSetBind(oPC, nToken, SCRY_BIND_DET_ATT,   JsonBool(bCanAttune));
+}
+
+// ----------------------------------------------------------------
+// Gaze mechanic: consumes Lza Jasnowidza, reveals presences,
+// triggers detection rolls for observed PCs
+// ----------------------------------------------------------------
+
+void ScryPerformGaze(object oPC, int nToken, int nMirrorId)
+{
+    json jMirror = ScryGetMirrorById(nMirrorId);
+    if(JsonGetType(jMirror) == JSON_TYPE_NULL)
+    {
+        SendMessageToPC(oPC, "[Zwierciadlo] To zwierciadlo zostalo zgaszone.");
+        return;
+    }
+
+    object oTear = GetItemPossessedBy(oPC, SCRY_ITEM_TEAR);
+    if(!GetIsObjectValid(oTear))
+    {
+        SendMessageToPC(oPC, "[Zwierciadlo] Potrzebujesz Lzy Jasnowidza, aby wpatrzec sie w zwierciadlo.");
+        return;
+    }
+
+    string sAreaTag  = JsonGetString(JsonObjectGet(jMirror, "area_tag"));
+    string sAreaName = JsonGetString(JsonObjectGet(jMirror, "area_name"));
+
+    // Consume one tear (stack-aware)
+    int nStack = GetItemStackSize(oTear);
+    if(nStack > 1)
+        SetItemStackSize(oTear, nStack - 1);
+    else
+        DestroyObject(oTear);
+
+    int nINTMod = GetAbilityModifier(ABILITY_INTELLIGENCE, oPC);
+    int nDC     = 15 + nINTMod;
+
+    string sResult = "Twoj wzrok przenika przez powierzchnie zwierciadla...\n\n";
+    int nFound = 0;
+
+    object oTarget = GetFirstPC();
+    while(GetIsObjectValid(oTarget))
+    {
+        if(GetTag(GetArea(oTarget)) == sAreaTag && oTarget != oPC)
+        {
+            nFound++;
+            int nHP  = GetCurrentHitPoints(oTarget);
+            int nMax = GetMaxHitPoints(oTarget);
+            int nPct = (nMax > 0) ? (nHP * 100 / nMax) : 0;
+
+            string sCond;
+            if(nPct >= 90)      sCond = "bez szwanku";
+            else if(nPct >= 60) sCond = "lekko ranny";
+            else if(nPct >= 30) sCond = "powazanie ranny";
+            else                sCond = "o krok od smierci";
+
+            sResult = sResult + "- " + GetName(oTarget) + " [" + sCond + "]\n";
+
+            // Spot check: DC 15 + scryer's INT modifier
+            int nRoll = d20() + GetSkillRank(SKILL_SPOT, oTarget);
+            if(nRoll >= nDC)
+            {
+                string sDetMsg;
+                if(nRoll >= 25)
+                    sDetMsg = "Twarz " + GetName(oPC) + " miga w twoim umysle niczym zlowroga zjawa — ktos cie szpieguje przez zwierciadlo!";
+                else
+                    sDetMsg = "Czujesz na sobie obce spojrzenie... ktos obserwuje cie przez zwierciadlo.";
+                FloatingTextStringOnCreature(sDetMsg, oTarget, FALSE);
+                SendMessageToPC(oTarget, "[Zwierciadlo] " + sDetMsg);
+            }
+        }
+        oTarget = GetNextPC();
+    }
+
+    if(nFound == 0)
+        sResult = sResult + "Miejsce jest puste. Jedynie ciszе i cien widzisz w krysztale.";
+
+    NuiSetBind(oPC, nToken, SCRY_BIND_DET_PRES, JsonString(sResult));
+    FloatingTextStringOnCreature("Pieczen krysztalu pulsuje slabo...", oPC, FALSE);
+}
+
+// ----------------------------------------------------------------
+// Attune popup
+// ----------------------------------------------------------------
+
+void ScryFeedAttunePopup(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, SCRY_WIN_ATTUNE);
+    if(nToken == 0) return;
+
+    string sAreaName = GetName(GetArea(oPC));
+    NuiSetBind(oPC, nToken, SCRY_BIND_ATT_AREA, JsonString("Obszar: " + sAreaName));
+    NuiSetBind(oPC, nToken, SCRY_BIND_ATT_NAME, JsonString(""));
+    NuiSetBind(oPC, nToken, SCRY_BIND_ATT_NOTE, JsonString(""));
+    NuiSetBind(oPC, nToken, SCRY_BIND_ATT_SAVE, JsonBool(FALSE));
+    NuiSetBindWatch(oPC, nToken, SCRY_BIND_ATT_NAME, TRUE);
+}
+
+void ScryCreateAttunePopup(object oPC)
+{
+    if(!ScryCanAttune(oPC))
+    {
+        SendMessageToPC(oPC, "[Zwierciadlo] Potrzebujesz Kamienia Krysztalowego, aby nastroic nowe zwierciadlo.");
+        return;
+    }
+    if(ScryGetActiveMirrorCount() >= SCRY_MAX_MIRRORS)
+    {
+        SendMessageToPC(oPC, "[Zwierciadlo] Osiagnieto limit aktywnych zwierciatel (" + IntToString(SCRY_MAX_MIRRORS) + ").");
+        return;
+    }
+    if(NuiFindWindow(oPC, SCRY_WIN_ATTUNE) != 0)
+        NuiDestroy(oPC, NuiFindWindow(oPC, SCRY_WIN_ATTUNE));
+
+    float fW    = GetNuiScaleDimension(oPC, 400.0);
+    float fH    = GetNuiScaleDimension(oPC, 300.0);
+    float fBtnH = GetNuiScaleDimension(oPC, 28.0);
+    float fX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - fW) / 2.0;
+    float fY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - fH) / 2.0;
+
+    // Current area label
+    json jAreaLbl = NuiLabel(NuiBind(SCRY_BIND_ATT_AREA), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jAreaLbl = NuiStyleForegroundColor(jAreaLbl, NuiColor(160, 140, 120));
+    jAreaLbl = NuiHeight(jAreaLbl, GetNuiScaleDimension(oPC, 22.0));
+
+    // Name row
+    json jNameLbl = NuiLabel(JsonString("Nazwa:"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jNameLbl = NuiWidth(jNameLbl, GetNuiScaleDimension(oPC, 60.0));
+    jNameLbl = NuiHeight(jNameLbl, fBtnH);
+    json jNameEdit = NuiTextEdit(JsonString("np. Oko Burzy..."), NuiBind(SCRY_BIND_ATT_NAME), SCRY_NAME_MAX, FALSE);
+    jNameEdit = NuiHeight(jNameEdit, fBtnH);
+    json jNameRow = JsonArray();
+    jNameRow = JsonArrayInsert(jNameRow, jNameLbl);
+    jNameRow = JsonArrayInsert(jNameRow, jNameEdit);
+
+    // Note field
+    json jNoteLbl = NuiLabel(JsonString("Notatka (opcjonalna):"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jNoteLbl = NuiHeight(jNoteLbl, GetNuiScaleDimension(oPC, 20.0));
+    json jNoteEdit = NuiTextEdit(JsonString(""), NuiBind(SCRY_BIND_ATT_NOTE), SCRY_NOTE_MAX, TRUE);
+    jNoteEdit = NuiHeight(jNoteEdit, GetNuiScaleDimension(oPC, 110.0));
+
+    // Buttons
+    json jSave = NuiButton(JsonString("Nastraj"));
+    jSave = NuiId(jSave, SCRY_BTN_ATT_SAVE);
+    jSave = NuiEnabled(jSave, NuiBind(SCRY_BIND_ATT_SAVE));
+    jSave = NuiWidth(jSave, GetNuiScaleDimension(oPC, 100.0));
+    jSave = NuiHeight(jSave, fBtnH);
+
+    json jCancel = NuiButton(JsonString("Anuluj"));
+    jCancel = NuiId(jCancel, SCRY_BTN_ATT_CANCEL);
+    jCancel = NuiWidth(jCancel, GetNuiScaleDimension(oPC, 80.0));
+    jCancel = NuiHeight(jCancel, fBtnH);
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jSave);
+    jBtnRow = JsonArrayInsert(jBtnRow, jCancel);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jAreaLbl)));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jNameRow));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jNoteLbl)));
+    jCol = JsonArrayInsert(jCol, jNoteEdit);
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+
+    json jWin = NuiWindow(NuiCol(jCol),
+        JsonString("Nastrojenie Zwierciadla"),
+        NuiRect(fX, fY, fW, fH),
+        JsonBool(FALSE), JsonBool(FALSE), JsonBool(TRUE),
+        JsonBool(FALSE), JsonBool(TRUE));
+
+    NuiCreate(oPC, jWin, SCRY_WIN_ATTUNE, SCRY_EV_SCRIPT);
+    ScryFeedAttunePopup(oPC);
+}
+
+void ScryHandleSaveAttunement(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, SCRY_WIN_ATTUNE);
+    if(nToken == 0) return;
+
+    string sName = JsonGetString(NuiGetBind(oPC, nToken, SCRY_BIND_ATT_NAME));
+    string sNote = JsonGetString(NuiGetBind(oPC, nToken, SCRY_BIND_ATT_NOTE));
+
+    if(sName == "")
+    {
+        SendMessageToPC(oPC, "[Zwierciadlo] Nazwa zwierciadla nie moze byc pusta.");
+        return;
+    }
+
+    // Non-DMs must have and consume the crystal
+    if(!GetIsDM(oPC) && !GetIsDMPossessed(oPC))
+    {
+        object oCrystal = GetItemPossessedBy(oPC, SCRY_ITEM_CRYSTAL);
+        if(!GetIsObjectValid(oCrystal))
+        {
+            SendMessageToPC(oPC, "[Zwierciadlo] Brak Kamienia Krysztalowego — nastrojenie niemozliwe.");
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+        int nStack = GetItemStackSize(oCrystal);
+        if(nStack > 1)
+            SetItemStackSize(oCrystal, nStack - 1);
+        else
+            DestroyObject(oCrystal);
+    }
+
+    int nNewId = ScryAddMirror(oPC, sName, sNote);
+    NuiDestroy(oPC, nToken);
+
+    int nMainToken = NuiFindWindow(oPC, SCRY_WINDOW);
+    if(nMainToken != 0)
+    {
+        SetLocalInt(oPC, SCRY_LVAR_SEL_ID, nNewId);
+        ScryFeedMirrorList(oPC, nMainToken);
+        ScryFeedDetail(oPC, nMainToken, nNewId);
+    }
+
+    SendMessageToPC(oPC, "[Zwierciadlo] Zwierciadlo \"" + sName + "\" nastrojone pomyslnie.");
+    FloatingTextStringOnCreature("Pieczen krysztalu pulsuje slabo, po czym gasnie.", oPC, FALSE);
+}

--- a/Scrying Mirror/scripts/lib_scry_def.nss
+++ b/Scrying Mirror/scripts/lib_scry_def.nss
@@ -1,0 +1,68 @@
+#include "lib_nui"
+#include "sql_scry"
+
+void ScryCreateWindow(object oPC);
+void ScryFeedMirrorList(object oPC, int nToken);
+void ScryFeedDetail(object oPC, int nToken, int nMirrorId);
+void ScryFeedAttunePopup(object oPC);
+void ScryCreateAttunePopup(object oPC);
+void ScryHandleSaveAttunement(object oPC);
+json ScryGetPCsInArea(string sAreaTag);
+void ScryPerformGaze(object oPC, int nToken, int nMirrorId);
+int  ScryCanAttune(object oPC);
+int  ScryCanDeactivate(object oPC, json jMirror);
+
+// Window IDs
+const string SCRY_WINDOW         = "SCRY_WINDOW";
+const string SCRY_EV_SCRIPT      = "lib_scry_ev";
+const string SCRY_WIN_ATTUNE     = "SCRY_WIN_ATTUNE";
+const string SCRY_WIN_GEOM       = "scry_win_geom";
+
+// Mirror list binds (array binds, one value per row)
+const string SCRY_BIND_ROW_NAME  = "scry_row_name";
+const string SCRY_BIND_ROW_AREA  = "scry_row_area";
+const string SCRY_BIND_ROW_ENC   = "scry_row_enc";
+const string SCRY_BIND_ROW_COUNT = "scry_rowcount";
+
+// Detail panel binds
+const string SCRY_BIND_DET_NAME  = "scry_det_name";
+const string SCRY_BIND_DET_AREA  = "scry_det_area";
+const string SCRY_BIND_DET_NOTE  = "scry_det_note";
+const string SCRY_BIND_DET_PRES  = "scry_det_pres";
+const string SCRY_BIND_DET_GAZE  = "scry_det_gaze_ena";
+const string SCRY_BIND_DET_DEACT = "scry_det_deact_ena";
+const string SCRY_BIND_DET_ATT   = "scry_det_att_ena";
+
+// Attune popup binds
+const string SCRY_BIND_ATT_NAME  = "scry_att_name";
+const string SCRY_BIND_ATT_NOTE  = "scry_att_note";
+const string SCRY_BIND_ATT_AREA  = "scry_att_area";
+const string SCRY_BIND_ATT_SAVE  = "scry_att_save_ena";
+
+// Button IDs
+const string SCRY_BTN_CLOSE      = "scry_btn_close";
+const string SCRY_BTN_ROW        = "scry_btn_row";
+const string SCRY_BTN_GAZE       = "scry_btn_gaze";
+const string SCRY_BTN_ATTUNE     = "scry_btn_attune";
+const string SCRY_BTN_DEACT      = "scry_btn_deact";
+const string SCRY_BTN_REFRESH    = "scry_btn_refresh";
+const string SCRY_BTN_ATT_SAVE   = "scry_btn_att_save";
+const string SCRY_BTN_ATT_CANCEL = "scry_btn_att_cancel";
+
+// LVARs stored on the PC object during session
+const string SCRY_LVAR_SEL_ID    = "SCRY_SEL_ID";
+const string SCRY_LVAR_MIRRORS   = "SCRY_MIRRORS_CACHE";
+
+// Item tags — create these blueprints in the HAK/toolset
+const string SCRY_ITEM_TEAR      = "scry_tear";      // Lza Jasnowidza — consumed per gaze
+const string SCRY_ITEM_CRYSTAL   = "scry_crystal";   // Kamien Krysztalowy — consumed per attunement (non-DMs)
+
+// Text limits
+const int    SCRY_NAME_MAX       = 60;
+const int    SCRY_NOTE_MAX       = 200;
+const int    SCRY_MAX_MIRRORS    = 20;
+
+// Window base dimensions (scaled per player GUI setting)
+const float  SCRY_W              = 720.0;
+const float  SCRY_H              = 480.0;
+const float  SCRY_LIST_W         = 245.0;

--- a/Scrying Mirror/scripts/lib_scry_ev.nss
+++ b/Scrying Mirror/scripts/lib_scry_ev.nss
@@ -1,0 +1,124 @@
+#include "lib_scry"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    // ---- Attune popup ----
+    if(nToken == NuiFindWindow(oPC, SCRY_WIN_ATTUNE))
+    {
+        if(sEvent == EVENT_TYPE_WATCH && sElem == SCRY_BIND_ATT_NAME)
+        {
+            string sName = JsonGetString(NuiGetBind(oPC, nToken, SCRY_BIND_ATT_NAME));
+            NuiSetBind(oPC, nToken, SCRY_BIND_ATT_SAVE, JsonBool(sName != ""));
+            return;
+        }
+        if(sEvent == EVENT_TYPE_CLICK)
+        {
+            if(sElem == SCRY_BTN_ATT_SAVE)
+            {
+                ScryHandleSaveAttunement(oPC);
+                return;
+            }
+            if(sElem == SCRY_BTN_ATT_CANCEL)
+            {
+                NuiDestroy(oPC, nToken);
+                return;
+            }
+        }
+        return;
+    }
+
+    if(nToken != NuiFindWindow(oPC, SCRY_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalInt (oPC, SCRY_LVAR_SEL_ID);
+        DeleteLocalJson(oPC, SCRY_LVAR_MIRRORS);
+        if(NuiFindWindow(oPC, SCRY_WIN_ATTUNE) != 0)
+            NuiDestroy(oPC, NuiFindWindow(oPC, SCRY_WIN_ATTUNE));
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == SCRY_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        if(sElem == SCRY_BTN_REFRESH)
+        {
+            SetLocalInt(oPC, SCRY_LVAR_SEL_ID, 0);
+            ScryFeedMirrorList(oPC, nToken);
+            ScryFeedDetail(oPC, nToken, 0);
+            return;
+        }
+
+        if(sElem == SCRY_BTN_ATTUNE)
+        {
+            ScryCreateAttunePopup(oPC);
+            return;
+        }
+
+        if(sElem == SCRY_BTN_GAZE)
+        {
+            int nSelId = GetLocalInt(oPC, SCRY_LVAR_SEL_ID);
+            if(nSelId > 0)
+                ScryPerformGaze(oPC, nToken, nSelId);
+            return;
+        }
+
+        if(sElem == SCRY_BTN_DEACT)
+        {
+            int nSelId = GetLocalInt(oPC, SCRY_LVAR_SEL_ID);
+            if(nSelId <= 0) return;
+
+            json jMirror = ScryGetMirrorById(nSelId);
+            if(JsonGetType(jMirror) == JSON_TYPE_NULL) return;
+
+            if(!ScryCanDeactivate(oPC, jMirror))
+            {
+                SendMessageToPC(oPC, "[Zwierciadlo] Mozesz wygaszac tylko zwierciadla, ktore sam nastroiles.");
+                return;
+            }
+
+            string sMirrorName = JsonGetString(JsonObjectGet(jMirror, "mirror_name"));
+            ScryDeactivateMirror(nSelId);
+            SetLocalInt(oPC, SCRY_LVAR_SEL_ID, 0);
+            ScryFeedMirrorList(oPC, nToken);
+            ScryFeedDetail(oPC, nToken, 0);
+            SendMessageToPC(oPC, "[Zwierciadlo] Zwierciadlo \"" + sMirrorName + "\" zostalo zgaszone.");
+            FloatingTextStringOnCreature("Pieczen krysztalu gasnie na zawsze.", oPC, FALSE);
+            return;
+        }
+    }
+
+    // List row click — select a mirror
+    if(sEvent == EVENT_TYPE_MOUSEDOWN && sElem == SCRY_BTN_ROW)
+    {
+        json jMirrors = GetLocalJson(oPC, SCRY_LVAR_MIRRORS);
+        if(nIdx < 0 || nIdx >= JsonGetLength(jMirrors)) return;
+
+        json jRow = JsonArrayGet(jMirrors, nIdx);
+        int  nId  = JsonGetInt(JsonObjectGet(jRow, "id"));
+
+        SetLocalInt(oPC, SCRY_LVAR_SEL_ID, nId);
+
+        // Rebuild encouraged array
+        int  nCount = JsonGetLength(jMirrors);
+        json jEncs  = JsonArray();
+        int i;
+        for(i = 0; i < nCount; i++)
+            jEncs = JsonArrayInsert(jEncs, JsonBool(i == nIdx));
+        NuiSetBind(oPC, nToken, SCRY_BIND_ROW_ENC, jEncs);
+
+        ScryFeedDetail(oPC, nToken, nId);
+        return;
+    }
+}

--- a/Scrying Mirror/scripts/sql_scry.nss
+++ b/Scrying Mirror/scripts/sql_scry.nss
@@ -1,0 +1,80 @@
+void ScryCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("scrying",
+        "CREATE TABLE IF NOT EXISTS scry_mirrors (id INTEGER PRIMARY KEY AUTOINCREMENT, mirror_name TEXT NOT NULL DEFAULT '', area_tag TEXT NOT NULL DEFAULT '', area_name TEXT NOT NULL DEFAULT '', note TEXT DEFAULT '', attuner_name TEXT NOT NULL DEFAULT '', attuner_uuid TEXT NOT NULL DEFAULT '', created_at INTEGER DEFAULT 0, is_active INTEGER DEFAULT 1)");
+    SqlStep(q);
+}
+
+int ScryAddMirror(object oPC, string sMirrorName, string sNote)
+{
+    string sAreaTag  = GetTag(GetArea(oPC));
+    string sAreaName = GetName(GetArea(oPC));
+
+    sqlquery q = SqlPrepareQueryCampaign("scrying",
+        "INSERT INTO scry_mirrors (mirror_name, area_tag, area_name, note, attuner_name, attuner_uuid, created_at) VALUES (@name, @area_tag, @area_name, @note, @attuner_name, @attuner_uuid, strftime('%s','now'))");
+    SqlBindString(q, "@name",         sMirrorName);
+    SqlBindString(q, "@area_tag",     sAreaTag);
+    SqlBindString(q, "@area_name",    sAreaName);
+    SqlBindString(q, "@note",         sNote);
+    SqlBindString(q, "@attuner_name", GetName(oPC));
+    SqlBindString(q, "@attuner_uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+
+    sqlquery qId = SqlPrepareQueryCampaign("scrying", "SELECT last_insert_rowid()");
+    if(SqlStep(qId)) return SqlGetInt(qId, 0);
+    return 0;
+}
+
+void ScryDeactivateMirror(int nId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("scrying",
+        "UPDATE scry_mirrors SET is_active = 0 WHERE id = @id");
+    SqlBindInt(q, "@id", nId);
+    SqlStep(q);
+}
+
+int ScryGetActiveMirrorCount()
+{
+    sqlquery q = SqlPrepareQueryCampaign("scrying",
+        "SELECT COUNT(*) FROM scry_mirrors WHERE is_active = 1");
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+json ScryGetMirrors()
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("scrying",
+        "SELECT id, mirror_name, area_tag, area_name, note, attuner_name, created_at FROM scry_mirrors WHERE is_active = 1 ORDER BY created_at ASC");
+    while(SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "id",           JsonInt   (SqlGetInt   (q, 0)));
+        jRow = JsonObjectSet(jRow, "mirror_name",  JsonString(SqlGetString(q, 1)));
+        jRow = JsonObjectSet(jRow, "area_tag",     JsonString(SqlGetString(q, 2)));
+        jRow = JsonObjectSet(jRow, "area_name",    JsonString(SqlGetString(q, 3)));
+        jRow = JsonObjectSet(jRow, "note",         JsonString(SqlGetString(q, 4)));
+        jRow = JsonObjectSet(jRow, "attuner_name", JsonString(SqlGetString(q, 5)));
+        jRow = JsonObjectSet(jRow, "created_at",   JsonInt   (SqlGetInt   (q, 6)));
+        jRows = JsonArrayInsert(jRows, jRow);
+    }
+    return jRows;
+}
+
+json ScryGetMirrorById(int nId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("scrying",
+        "SELECT id, mirror_name, area_tag, area_name, note, attuner_name, attuner_uuid FROM scry_mirrors WHERE id = @id AND is_active = 1");
+    SqlBindInt(q, "@id", nId);
+    if(!SqlStep(q)) return JsonNull();
+
+    json jRow = JsonObject();
+    jRow = JsonObjectSet(jRow, "id",           JsonInt   (SqlGetInt   (q, 0)));
+    jRow = JsonObjectSet(jRow, "mirror_name",  JsonString(SqlGetString(q, 1)));
+    jRow = JsonObjectSet(jRow, "area_tag",     JsonString(SqlGetString(q, 2)));
+    jRow = JsonObjectSet(jRow, "area_name",    JsonString(SqlGetString(q, 3)));
+    jRow = JsonObjectSet(jRow, "note",         JsonString(SqlGetString(q, 4)));
+    jRow = JsonObjectSet(jRow, "attuner_name", JsonString(SqlGetString(q, 5)));
+    jRow = JsonObjectSet(jRow, "attuner_uuid", JsonString(SqlGetString(q, 6)));
+    return jRow;
+}

--- a/Scrying Mirror/scripts/sys_on_load.nss
+++ b/Scrying Mirror/scripts/sys_on_load.nss
@@ -1,0 +1,6 @@
+#include "lib_scry_def"
+
+void main()
+{
+    ScryCreateTables();
+}

--- a/Scrying Mirror/scripts/test_scry.nss
+++ b/Scrying Mirror/scripts/test_scry.nss
@@ -1,0 +1,21 @@
+#include "lib_scry"
+
+// OnUsed on a "Krysztalne Zrodlo" placeable.
+// DMs who activate it also receive both test items if they are missing,
+// so the full flow can be exercised immediately.
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    if(GetIsDM(oPC))
+    {
+        // Hand out reagents if not present, so a DM can test without toolset items
+        if(!GetIsObjectValid(GetItemPossessedBy(oPC, SCRY_ITEM_TEAR)))
+            SendMessageToPC(oPC, "[Test] Dodaj item z tagiem '" + SCRY_ITEM_TEAR + "' (Lza Jasnowidza) przez DM-narzedzia.");
+        if(!GetIsObjectValid(GetItemPossessedBy(oPC, SCRY_ITEM_CRYSTAL)))
+            SendMessageToPC(oPC, "[Test] Dodaj item z tagiem '" + SCRY_ITEM_CRYSTAL + "' (Kamien Krysztalowy) przez DM-narzedzia.");
+    }
+
+    ScryCreateWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

System magicznych zwierciadeł nastrojonych na konkretne lokacje. Gracze
mogą wpatrywać się w zwierciadło, by zobaczyć kto aktualnie przebywa
w powiązanym obszarze — kosztem reagentu. Obserwowani mogą wyczuć
cudze spojrzenie i — przy dobrym rzucie — zidentyfikować szpiega.

## Mechanika

1. **Nastrojenie** — DM lub gracz z Kamieniem Kryształowym (`scry_crystal`)
   rejestruje nowe zwierciadło: tworzy wpis w SQLite z nazwą, tagiem obszaru
   i opcjonalną notatką kolorystyczną. Kamień jest zużywany przy nastrojeniu
   (DM nie płaci).

2. **Przeglądanie** — Dwupanelowe okno NUI:
   lewy panel lista aktywnych zwierciadeł, prawy panel pokazuje nazwę,
   obszar, notatkę nastrajającego oraz bieżącą liczbę obecności
   (bezpłatne; odpytanie `GetArea(oPC)` w czasie rzeczywistym).

3. **Wpatrzenie** — przycisk „Wpatrz się" zużywa 1 Łzę Jasnowidza
   (`scry_tear`), ujawnia imiona i stan zdrowia obserwowanych graczy
   słownie (bez szwanku / lekko ranny / poważnie ranny / o krok od śmierci),
   a następnie dla każdego z nich wykonuje rzut na Czujność:
   - DC = 15 + modyfikator INT jasnowidza
   - Sukces: obserwowany widzi floating text „Czujesz na sobie obce spojrzenie…"
   - Wynik ≥ 25: widzi imię obserwatora

4. **Wygaszanie** — właściciel zwierciadła lub DM może je wygasić;
   wpis pozostaje w bazie jako `is_active = 0` (audyt historii).

## Pliki

```
Scrying Mirror/
  scripts/
    sql_scry.nss        — schemat SQLite + zapytania CRUD
    lib_scry_def.nss    — stałe, ID bindów, ID przycisków, forward declarations
    lib_scry.nss        — budowanie UI, feed functions, logika gazowania, popup nastrojenia
    lib_scry_ev.nss     — handler NUI eventów (main window + attune popup)
    sys_on_load.nss     — ScryCreateTables() przy starcie modułu
    test_scry.nss       — OnUsed na placeable "Krysztalne Źródło"
  INTEGRATION.md        — instrukcja integracji, itemy, hooki
```

## Zależności (NWNX? SQL?)

- **Brak NWNX** — tylko NWN:EE 8193.35+
- **SQLite** wbudowany w NWN:EE — baza campaign `"scrying"`,
  tabela `scry_mirrors`, `CREATE TABLE IF NOT EXISTS` (idempotentna migracja)

## Jak włączyć w istniejącym module

1. Dodaj wywołanie `ScryCreateTables()` do skryptu OnModuleLoad.
2. Umieść placeable z OnUsed = `test_scry` w dowolnym obszarze.
3. Utwórz w Toolsecie dwa blueprinty przedmiotów:
   - tag `scry_tear` — Łza Jasnowidza (stackowalny reagent)
   - tag `scry_crystal` — Kamień Kryształowy (zużywany przy nastrojeniu)
4. Brak hooka OnClientEnter — śledzenie lokacji odbywa się w czasie
   rzeczywistym przez `GetArea(oPC)`.

## Co celowo pominięto

- **Wizualny render obszaru** — obecność to lista tekstowa, nie miniatura lokacji
  (NWN:EE nie udostępnia renderowania widoku obszaru w UI).
- **Blokowanie zwierciadła** przez obserwowanego — kontrszpiegostwo ograniczone
  do ostrzeżenia i ujawnienia twarzy przy rzucie ≥ 25.
- **Timer wygaśnięcia** nastrojenia — zwierciadła trwają do ręcznego wygaszenia.
- **Persystencja historii obserwacji** — brak logowania „kto kogo obserwował kiedy";
  możliwe rozszerzenie w przyszłości.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GBGEvbhhqJK3EJfmYHrxM9)_