### PR TITLE
feat: Duchy Przodków (Ancestor Spirits)

### DIFF
--- a/Ancestor Spirits/INTEGRATION.md
+++ b/Ancestor Spirits/INTEGRATION.md
@@ -1,0 +1,63 @@
+# Ancestor Spirits — Duchy Przodków
+
+## Co to robi
+System kultu przodków dla dark fantasy CRPG. Gracz raz wybiera jeden z 5 rodowodów krwi (Wojowniczy, Magiczny, Lotrzykowski, Szlachecki, Wiesniaezy), skladajac ofiare ze zlota w zamian za Laske (0–100). Zgromadzona Laske wydaje na przywolanie jednego z 3 duchow przodkow przynaleznych do rodu — kazdy daje inny tymczasowy efekt mechaniczny i ma 24h cooldown. NUI zawiera dwa widoki: wybor rodu (jednorazowy) i panel oltarza z paskiem Laski, trzema wierszami przodkow ze statusem i historia ostatnich 5 przywolan.
+
+## Wymagania
+- NWN:EE 8193.35.14+
+- Brak zaleznosci od NWNX
+- Baza SQL: kampania `anc` (SQLite, tworzona automatycznie przy starcie modulu)
+
+## Pliki
+| Plik | Rola |
+|---|---|
+| `sql_anc.nss` | Warstwa SQL: tabele, CRUD |
+| `lib_anc_def.nss` | Stale, dane przodkow, aplikacja efektow, AncInvokeAncestor |
+| `lib_anc.nss` | Budowanie NUI, feed danych, handlery akcji |
+| `lib_anc_ev.nss` | Handler zdarzen NUI (skrypt zdarzenia okna) |
+| `sys_on_load.nss` | OnModuleLoad — tworzy tabele SQL |
+| `sys_on_enter.nss` | OnClientEnter — rejestruje PC i pokazuje stan Laski |
+| `test_anc.nss` | OnUsed dla placeabla-oltarza |
+| `lib_nui.nss` | Wspoldzielona biblioteka NUI (kopia z Mailbox) |
+| `lib_nui_utility.nss` | Wspoldzielona biblioteka NUI utils |
+
+## Jak wlaczyc w istniejacym module
+1. Dodaj wszystkie skrypty z folderu `Scripts/` do HAK lub bezposrednio do modulu.
+2. Podepnij `sys_on_load` do zdarzenia **OnModuleLoad** modulu.
+3. Podepnij `sys_on_enter` do zdarzenia **OnClientEnter** modulu.
+4. Dodaj placeable (np. `plc_altar2` lub dowolny oltarz) do modulu.
+5. Ustaw **OnUsed** tego placeabla na `test_anc`.
+
+## Zależnosci SQL
+Trzy tabele w kampanii SQLite `anc`:
+- `anc_chars` — rodowod i stan Laski per postac (klucz: UUID)
+- `anc_cooldowns` — znaczniki czasu ostatnich przywolan (klucz: UUID + ancestor_id)
+- `anc_history` — historia do 5 ostatnich przywolan per postac
+
+Wszystkie tabele sa idempotentnie tworzone przez `AncCreateTables()` (CREATE TABLE IF NOT EXISTS).
+
+## Efekty przodkow
+
+| Ród | Przodek (slot 0 / 1 / 2) | Efekt |
+|---|---|---|
+| Wojowniczy | Ragnar Zelazny | STR +4 / 10 min |
+| Wojowniczy | Zbroja Krwi | AC +4 / 5 min |
+| Wojowniczy | Duchy Berserow | Haste + STR +4 / 2 min |
+| Magiczny | Stara Wiedzma | INT +4 / 10 min |
+| Magiczny | Mistrz Ritualow | WIS +4 / 10 min |
+| Magiczny | Straznik Runow | Spell Resistance +10 / 10 min |
+| Lotrzykowski | Czarny Noz | DEX +4 / 10 min |
+| Lotrzykowski | Mistrzyni Cieni | Niewidzialnosc / 1 min |
+| Lotrzykowski | Gildyjny Szpieg | Hide+MoveS +10 / 30 min |
+| Szlachecki | Lord Ashenvale | CHA +4 / 10 min |
+| Szlachecki | Pani Fortuny | WIS+INT+CHA +2 / 10 min |
+| Szlachecki | Krwawa Rada | Saves ALL +5 / 5 min |
+| Wiesniaezy | Stara Zielarka | Temp HP +50 / 1h |
+| Wiesniaezy | Matka Ziemia | Immunity Disease / 2h |
+| Wiesniaezy | Duch Pol | CON +4 + Regen 2/6s / 10 min |
+
+## Co celowo pominieto
+- Animacje przywolania i efekty dzwiekowe (wymagalyby zasobow w HAK).
+- Mozliwosc zmiany rodu — jest to celowa, permanentna decyzja fabularna.
+- Plik `.mod` — srodowisko nie obsluguje pakowania modulu; uzyj Toolset NWN:EE.
+- Ochrona przed DM-restem (resetem buflow) — out of scope dla tej wersji.

--- a/Ancestor Spirits/Scripts/lib_anc.nss
+++ b/Ancestor Spirits/Scripts/lib_anc.nss
@@ -1,0 +1,447 @@
+// lib_anc.nss — Ancestor Spirits: NUI building, data feeding, open/close
+
+#include "lib_anc_def"
+
+// ---------------------------------------------------------------
+// NUI layout builders
+// ---------------------------------------------------------------
+
+json AncBuildAncestorRow(object oPC, int nSlot)
+{
+    string sSuffix  = IntToString(nSlot);
+    float fRowH     = GetNuiScaleDimension(oPC, 70.0);
+    float fBtnW     = GetNuiScaleDimension(oPC, 82.0);
+    float fBtnH     = GetNuiScaleDimension(oPC, 26.0);
+    float fCostW    = GetNuiScaleDimension(oPC, 90.0);
+    float fLblH     = GetNuiScaleDimension(oPC, 20.0);
+
+    // Text column: name / desc / status
+    json jName = NuiLabel(NuiBind(ANC_BIND_ANAME + sSuffix),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jName = NuiHeight(jName, fLblH);
+
+    json jDesc = NuiLabel(NuiBind(ANC_BIND_ADESC + sSuffix),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jDesc = NuiHeight(jDesc, fLblH);
+
+    json jStat = NuiLabel(NuiBind(ANC_BIND_ASTAT + sSuffix),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jStat = NuiStyleForegroundColor(jStat, NuiBind(ANC_BIND_ASTATCOL + sSuffix));
+    jStat = NuiHeight(jStat, fLblH);
+
+    json jInfoElems = JsonArray();
+    jInfoElems = JsonArrayInsert(jInfoElems, jName);
+    jInfoElems = JsonArrayInsert(jInfoElems, jDesc);
+    jInfoElems = JsonArrayInsert(jInfoElems, jStat);
+
+    // Cost label
+    json jCost = NuiLabel(NuiBind(ANC_BIND_ACOST + sSuffix),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jCost = NuiWidth(jCost, fCostW);
+
+    // Invoke button
+    json jBtn = NuiButton(JsonString("Wezwij"));
+    jBtn = NuiId(jBtn, ANC_BTN_INVOKE + sSuffix);
+    jBtn = NuiEnabled(jBtn, NuiBind(ANC_BIND_ABTN_ENA + sSuffix));
+    jBtn = NuiWidth(jBtn, fBtnW);
+    jBtn = NuiHeight(jBtn, fBtnH);
+
+    json jCells = JsonArray();
+    jCells = JsonArrayInsert(jCells, NuiCol(jInfoElems));
+    jCells = JsonArrayInsert(jCells, jCost);
+    jCells = JsonArrayInsert(jCells, jBtn);
+
+    json jGrp = NuiGroup(NuiRow(jCells), FALSE, NUI_SCROLLBARS_NONE);
+    jGrp = NuiHeight(jGrp, fRowH);
+    return jGrp;
+}
+
+json AncBuildAltarView(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 28.0);
+    float fBarH  = GetNuiScaleDimension(oPC, 16.0);
+    float fSpcH  = GetNuiScaleDimension(oPC, 8.0);
+    float fHdrH  = GetNuiScaleDimension(oPC, 22.0);
+    float fFldW  = GetNuiScaleDimension(oPC, 90.0);
+    float fBtnOfW= GetNuiScaleDimension(oPC, 90.0);
+
+    // -- Header: lineage name | favor label --
+    json jLinLbl = NuiLabel(NuiBind(ANC_BIND_LINEAGE_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jLinLbl = NuiHeight(jLinLbl, fHdrH);
+
+    json jFavLbl = NuiLabel(NuiBind(ANC_BIND_FAVOR_LBL),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jFavLbl = NuiHeight(jFavLbl, fHdrH);
+
+    json jHdrRow = JsonArray();
+    jHdrRow = JsonArrayInsert(jHdrRow, jLinLbl);
+    jHdrRow = JsonArrayInsert(jHdrRow, jFavLbl);
+
+    // -- Favor progress bar --
+    json jBar = NuiProgress(NuiBind(ANC_BIND_FAVOR_VAL));
+    jBar = NuiHeight(jBar, fBarH);
+
+    // -- Offer row: label | text input | button --
+    json jOfferLbl = NuiLabel(JsonString("Ofiara:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jOfferLbl = NuiWidth(jOfferLbl, GetNuiScaleDimension(oPC, 60.0));
+
+    json jOfferFld = NuiTextEdit(JsonString("ilosc zlota"),
+        NuiBind(ANC_BIND_OFFER_TXT), 8, FALSE);
+    jOfferFld = NuiWidth(jOfferFld, fFldW);
+    jOfferFld = NuiHeight(jOfferFld, fBtnH);
+
+    json jOfferBtn = NuiButton(JsonString("Ofiaruj"));
+    jOfferBtn = NuiId(jOfferBtn, ANC_BTN_OFFER);
+    jOfferBtn = NuiEnabled(jOfferBtn, NuiBind(ANC_BIND_OFFER_ENA));
+    jOfferBtn = NuiWidth(jOfferBtn, fBtnOfW);
+    jOfferBtn = NuiHeight(jOfferBtn, fBtnH);
+
+    json jOfferRow = JsonArray();
+    jOfferRow = JsonArrayInsert(jOfferRow, jOfferLbl);
+    jOfferRow = JsonArrayInsert(jOfferRow, jOfferFld);
+    jOfferRow = JsonArrayInsert(jOfferRow, NuiSpacer());
+    jOfferRow = JsonArrayInsert(jOfferRow, jOfferBtn);
+
+    // -- Ancestor section header --
+    json jAncHdr = NuiLabel(JsonString("-- Duchy Przodkow --"),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jAncHdr = NuiHeight(jAncHdr, fHdrH);
+
+    // -- 3 ancestor rows --
+    json jAnc0 = AncBuildAncestorRow(oPC, 0);
+    json jAnc1 = AncBuildAncestorRow(oPC, 1);
+    json jAnc2 = AncBuildAncestorRow(oPC, 2);
+
+    // -- History section --
+    json jHistHdr = NuiLabel(JsonString("-- Historia Przyzwan --"),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jHistHdr = NuiHeight(jHistHdr, fHdrH);
+
+    json jHistLbl = NuiLabel(NuiBind(ANC_BIND_HIST_ROWS),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+
+    float fHistRowH = GetNuiScaleDimension(oPC, 20.0);
+    json jHistTmpl  = JsonArrayInsert(JsonArray(),
+        NuiListTemplateCell(jHistLbl, 0.0, TRUE));
+    json jHistList  = NuiList(jHistTmpl, NuiBind(ANC_BIND_HIST_CNT), fHistRowH);
+    jHistList = NuiHeight(jHistList, GetNuiScaleDimension(oPC, 110.0));
+
+    // -- Assemble --
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(jHdrRow));
+    jCol = JsonArrayInsert(jCol, jBar);
+    jCol = JsonArrayInsert(jCol, NuiHeight(NuiSpacer(), fSpcH));
+    jCol = JsonArrayInsert(jCol, NuiRow(jOfferRow));
+    jCol = JsonArrayInsert(jCol, NuiHeight(NuiSpacer(), fSpcH));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jAncHdr)));
+    jCol = JsonArrayInsert(jCol, jAnc0);
+    jCol = JsonArrayInsert(jCol, jAnc1);
+    jCol = JsonArrayInsert(jCol, jAnc2);
+    jCol = JsonArrayInsert(jCol, NuiHeight(NuiSpacer(), fSpcH));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jHistHdr)));
+    jCol = JsonArrayInsert(jCol, jHistList);
+
+    float fContentW = GetNuiScaleDimension(oPC, ANC_W - 20.0);
+    json jSide      = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    json jMainRow   = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiCol(jCol), fContentW));
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    return NuiRow(jMainRow);
+}
+
+json AncBuildLineageView(object oPC)
+{
+    float fHdrH   = GetNuiScaleDimension(oPC, 24.0);
+    float fSubH   = GetNuiScaleDimension(oPC, 18.0);
+    float fRowH   = GetNuiScaleDimension(oPC, 74.0);
+    float fListH  = GetNuiScaleDimension(oPC, 380.0);
+
+    json jTitle = NuiLabel(
+        JsonString("Wybierz Rod Krwi"),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitle = NuiHeight(jTitle, fHdrH);
+
+    json jSub = NuiLabel(
+        JsonString("To dziedzictwo zostanie zapisane w kosci — nie mozna go zmienic."),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jSub = NuiHeight(jSub, fSubH);
+
+    // List row template: clickable group with name + desc stacked
+    json jName = NuiLabel(NuiBind(ANC_BIND_LIN_NAMES),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jName = NuiHeight(jName, GetNuiScaleDimension(oPC, 26.0));
+
+    json jDesc = NuiLabel(NuiBind(ANC_BIND_LIN_DESCS),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_TOP));
+    jDesc = NuiHeight(jDesc, GetNuiScaleDimension(oPC, 38.0));
+
+    json jInnerCol = JsonArray();
+    jInnerCol = JsonArrayInsert(jInnerCol, jName);
+    jInnerCol = JsonArrayInsert(jInnerCol, jDesc);
+
+    json jRowGrp = NuiGroup(NuiCol(jInnerCol), TRUE, NUI_SCROLLBARS_NONE);
+    jRowGrp = NuiId(jRowGrp, ANC_BTN_LIN_ROW);
+    jRowGrp = NuiEncouraged(jRowGrp, NuiBind(ANC_BIND_LIN_ENC));
+
+    json jLinTmpl = JsonArrayInsert(JsonArray(),
+        NuiListTemplateCell(jRowGrp, 0.0, TRUE));
+    json jLinList = NuiList(jLinTmpl, NuiBind(ANC_BIND_LIN_ROWCOUNT), fRowH);
+    jLinList = NuiHeight(jLinList, fListH);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jTitle)));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jSub)));
+    jCol = JsonArrayInsert(jCol, jLinList);
+
+    float fContentW = GetNuiScaleDimension(oPC, ANC_W - 20.0);
+    json jSide      = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    json jMainRow   = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiCol(jCol), fContentW));
+    jMainRow = JsonArrayInsert(jMainRow, jSide);
+    return NuiRow(jMainRow);
+}
+
+// ---------------------------------------------------------------
+// Window creation
+// ---------------------------------------------------------------
+
+void AncCreateWindow(object oPC)
+{
+    if(NuiFindWindow(oPC, ANC_WINDOW) != 0)
+    {
+        int nToken = NuiFindWindow(oPC, ANC_WINDOW);
+        int nLin   = AncGetLineage(oPC);
+        if(nLin == ANC_LINEAGE_NONE)
+        {
+            NuiSetGroupLayout(oPC, nToken, ANC_GRP_SWAP, AncBuildLineageView(oPC));
+            AncFeedLineage(oPC, nToken);
+        }
+        else
+        {
+            NuiSetGroupLayout(oPC, nToken, ANC_GRP_SWAP, AncBuildAltarView(oPC));
+            AncFeedAltar(oPC, nToken);
+        }
+        return;
+    }
+
+    int nLineage    = AncGetLineage(oPC);
+    json jInitView  = (nLineage == ANC_LINEAGE_NONE)
+                    ? AncBuildLineageView(oPC)
+                    : AncBuildAltarView(oPC);
+
+    json jSwapGrp = NuiGroup(jInitView, FALSE, NUI_SCROLLBARS_NONE);
+    jSwapGrp = NuiId(jSwapGrp, ANC_GRP_SWAP);
+
+    float fBtnH = GetNuiScaleDimension(oPC, 28.0);
+    json jCloseBtn = NuiButton(JsonString("X"));
+    jCloseBtn = NuiId(jCloseBtn, ANC_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, GetNuiScaleDimension(oPC, 28.0));
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jTopBar = JsonArray();
+    jTopBar = JsonArrayInsert(jTopBar, NuiSpacer());
+    jTopBar = JsonArrayInsert(jTopBar, jCloseBtn);
+
+    json jRootElems = JsonArray();
+    jRootElems = JsonArrayInsert(jRootElems, NuiRow(jTopBar));
+    jRootElems = JsonArrayInsert(jRootElems, jSwapGrp);
+    json jRoot = NuiCol(jRootElems);
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))
+                 - GetNuiScaleDimension(oPC, ANC_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT))
+                 - GetNuiScaleDimension(oPC, ANC_H)) / 2.0;
+    json jGeom = NuiRect(fCX, fCY,
+        GetNuiScaleDimension(oPC, ANC_W),
+        GetNuiScaleDimension(oPC, ANC_H));
+
+    json jWin = NuiWindow(jRoot,
+        JsonBool(FALSE),        // no text title bar
+        NuiBind(ANC_WIN_GEOM),
+        JsonBool(FALSE),        // not resizable
+        JsonBool(FALSE),        // not collapsed
+        JsonBool(FALSE),        // closable = FALSE (own close btn)
+        JsonBool(FALSE),        // not transparent
+        JsonBool(TRUE));        // border visible
+
+    int nToken = NuiCreate(oPC, jWin, ANC_WINDOW, ANC_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, ANC_WIN_GEOM, jGeom);
+
+    if(nLineage == ANC_LINEAGE_NONE)
+        AncFeedLineage(oPC, nToken);
+    else
+        AncFeedAltar(oPC, nToken);
+}
+
+void AncOpen(object oPC)
+{
+    if(!GetIsPC(oPC)) return;
+    AncRegisterPC(oPC);
+    AncCreateWindow(oPC);
+}
+
+// ---------------------------------------------------------------
+// Data feed — lineage selection view
+// ---------------------------------------------------------------
+
+void AncFeedLineage(object oPC, int nToken)
+{
+    json jNames = JsonArray();
+    json jDescs = JsonArray();
+    json jEncs  = JsonArray();
+    int i;
+    for(i = 0; i < ANC_LINEAGE_COUNT; i++)
+    {
+        jNames = JsonArrayInsert(jNames, JsonString(AncGetLineageName(i)));
+        jDescs = JsonArrayInsert(jDescs, JsonString(AncGetLineageDesc(i)));
+        jEncs  = JsonArrayInsert(jEncs,  JsonBool(FALSE));
+    }
+    NuiSetBind(oPC, nToken, ANC_BIND_LIN_NAMES,    jNames);
+    NuiSetBind(oPC, nToken, ANC_BIND_LIN_DESCS,    jDescs);
+    NuiSetBind(oPC, nToken, ANC_BIND_LIN_ENC,      jEncs);
+    NuiSetBind(oPC, nToken, ANC_BIND_LIN_ROWCOUNT, JsonInt(ANC_LINEAGE_COUNT));
+}
+
+// ---------------------------------------------------------------
+// Data feed — altar view
+// ---------------------------------------------------------------
+
+void AncFeedAncestors(object oPC, int nToken)
+{
+    int nLineage = AncGetLineage(oPC);
+    int nFavor   = AncGetFavor(oPC);
+    int nSlot;
+
+    for(nSlot = 0; nSlot < 3; nSlot++)
+    {
+        int nAncId    = nLineage * 3 + nSlot;
+        int nCost     = AncGetCostBySlot(nSlot);
+        int nCooldown = AncGetCooldownRemaining(oPC, nAncId);
+        int bAvail    = (nCooldown == 0) && (nFavor >= nCost);
+
+        string sSuffix = IntToString(nSlot);
+        string sStatus = AncFormatCooldown(nCooldown);
+        json jColor;
+        if(bAvail)
+            jColor = NuiColor(80, 220, 80);    // green — available
+        else if(nCooldown > 0)
+            jColor = NuiColor(210, 160, 60);   // orange — on cooldown
+        else
+            jColor = NuiColor(190, 70, 70);    // red — insufficient Favor
+
+        NuiSetBind(oPC, nToken, ANC_BIND_ANAME    + sSuffix, JsonString(AncGetAncestorName(nAncId)));
+        NuiSetBind(oPC, nToken, ANC_BIND_ADESC    + sSuffix, JsonString(AncGetAncestorDesc(nAncId)));
+        NuiSetBind(oPC, nToken, ANC_BIND_ACOST    + sSuffix, JsonString(IntToString(nCost) + " Laski"));
+        NuiSetBind(oPC, nToken, ANC_BIND_ASTAT    + sSuffix, JsonString(sStatus));
+        NuiSetBind(oPC, nToken, ANC_BIND_ASTATCOL + sSuffix, jColor);
+        NuiSetBind(oPC, nToken, ANC_BIND_ABTN_ENA + sSuffix, JsonBool(bAvail));
+    }
+}
+
+void AncFeedHistory(object oPC, int nToken)
+{
+    json jHist  = AncGetHistory(oPC);
+    int  nCount = JsonGetLength(jHist);
+    json jRows  = JsonArray();
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jEntry  = JsonArrayGet(jHist, i);
+        string sName = JsonGetString(JsonObjectGet(jEntry, "name"));
+        string sDate = JsonGetString(JsonObjectGet(jEntry, "date"));
+        jRows = JsonArrayInsert(jRows, JsonString(sDate + "  " + sName));
+    }
+    NuiSetBind(oPC, nToken, ANC_BIND_HIST_ROWS, jRows);
+    NuiSetBind(oPC, nToken, ANC_BIND_HIST_CNT,  JsonInt(nCount));
+}
+
+void AncFeedAltar(object oPC, int nToken)
+{
+    int   nLineage = AncGetLineage(oPC);
+    int   nFavor   = AncGetFavor(oPC);
+    float fRatio   = IntToFloat(nFavor) / IntToFloat(ANC_FAVOR_MAX);
+
+    NuiSetBind(oPC, nToken, ANC_BIND_LINEAGE_LBL,
+        JsonString(AncGetLineageName(nLineage)));
+    NuiSetBind(oPC, nToken, ANC_BIND_FAVOR_LBL,
+        JsonString("Laska: " + IntToString(nFavor) + " / " + IntToString(ANC_FAVOR_MAX)));
+    NuiSetBind(oPC, nToken, ANC_BIND_FAVOR_VAL,
+        JsonFloat(fRatio));
+    NuiSetBind(oPC, nToken, ANC_BIND_OFFER_ENA, JsonBool(TRUE));
+
+    AncFeedAncestors(oPC, nToken);
+    AncFeedHistory(oPC, nToken);
+}
+
+// ---------------------------------------------------------------
+// Action handlers (called from event script)
+// ---------------------------------------------------------------
+
+void AncHandleSelectLineage(object oPC, int nToken, int nLineageIdx)
+{
+    if(nLineageIdx < 0 || nLineageIdx >= ANC_LINEAGE_COUNT) return;
+    if(AncGetLineage(oPC) != ANC_LINEAGE_NONE)
+    {
+        SendMessageToPC(oPC, "[Przodkowie] Rod krwi zostal juz wybrany i nie moze byc zmieniony.");
+        return;
+    }
+
+    AncSetLineage(oPC, nLineageIdx);
+
+    SendMessageToPC(oPC,
+        "[Przodkowie] Wybrano " + AncGetLineageName(nLineageIdx) + ". "
+        + "Krew przodkow przyjela twoje slowo.");
+    FloatingTextStringOnCreature(
+        "Pieczen rodu " + AncGetLineageName(nLineageIdx) + " wypalona w pamiec...",
+        oPC, FALSE);
+
+    NuiSetGroupLayout(oPC, nToken, ANC_GRP_SWAP, AncBuildAltarView(oPC));
+    AncFeedAltar(oPC, nToken);
+}
+
+void AncHandleOffer(object oPC, int nToken)
+{
+    string sVal = JsonGetString(NuiGetBind(oPC, nToken, ANC_BIND_OFFER_TXT));
+    int nGold   = StringToInt(sVal);
+
+    if(nGold <= 0)
+    {
+        SendMessageToPC(oPC, "[Przodkowie] Wpisz prawidlowa ilosc zlota.");
+        return;
+    }
+    if(GetGold(oPC) < nGold)
+    {
+        SendMessageToPC(oPC,
+            "[Przodkowie] Nie posiadasz " + IntToString(nGold) + " sztuk zlota.");
+        return;
+    }
+    if(AncGetFavor(oPC) >= ANC_FAVOR_MAX)
+    {
+        SendMessageToPC(oPC,
+            "[Przodkowie] Laska przodkow osiagnela pelen poziom. "
+            "Wezwij duchy, by zwolnic miejsce.");
+        return;
+    }
+
+    AssignCommand(oPC, TakeGoldFromCreature(nGold, oPC, TRUE));
+    int nAdded = AncAddFavor(oPC, nGold);
+
+    FloatingTextStringOnCreature(
+        "Ofiara z " + IntToString(nGold) + " zlota przyjeta przez przodkow.",
+        oPC, FALSE);
+    SendMessageToPC(oPC,
+        "[Przodkowie] +" + IntToString(nAdded) + " Laski.");
+
+    NuiSetBind(oPC, nToken, ANC_BIND_OFFER_TXT, JsonString(""));
+    AncFeedAltar(oPC, nToken);
+}
+
+void AncHandleInvoke(object oPC, int nToken, int nSlot)
+{
+    AncInvokeAncestor(oPC, nSlot);
+    AncFeedAltar(oPC, nToken);
+}

--- a/Ancestor Spirits/Scripts/lib_anc_def.nss
+++ b/Ancestor Spirits/Scripts/lib_anc_def.nss
@@ -1,0 +1,353 @@
+// lib_anc_def.nss — Ancestor Spirits: constants, data accessors, effects
+
+#include "lib_nui"
+#include "sql_anc"
+
+// Forward declarations for functions defined in lib_anc.nss
+void AncCreateWindow(object oPC);
+void AncFeedAltar(object oPC, int nToken);
+void AncFeedLineage(object oPC, int nToken);
+void AncOpen(object oPC);
+
+// ---------------------------------------------------------------
+// Window / group / event
+// ---------------------------------------------------------------
+
+const string ANC_WINDOW     = "ANC_WINDOW";
+const string ANC_EV_SCRIPT  = "lib_anc_ev";
+const string ANC_GRP_SWAP   = "ANC_GRP_SWAP";
+const string ANC_WIN_GEOM   = "anc_win_geom";
+
+// ---------------------------------------------------------------
+// Bind names — lineage selection view
+// ---------------------------------------------------------------
+
+const string ANC_BIND_LIN_NAMES    = "anc_lin_names";
+const string ANC_BIND_LIN_DESCS    = "anc_lin_descs";
+const string ANC_BIND_LIN_ENC      = "anc_lin_enc";
+const string ANC_BIND_LIN_ROWCOUNT = "anc_lin_cnt";
+
+// ---------------------------------------------------------------
+// Bind names — altar view
+// ---------------------------------------------------------------
+
+const string ANC_BIND_LINEAGE_LBL  = "anc_lin_lbl";
+const string ANC_BIND_FAVOR_LBL    = "anc_favor_lbl";
+const string ANC_BIND_FAVOR_VAL    = "anc_favor_val";
+const string ANC_BIND_OFFER_TXT    = "anc_offer_txt";
+const string ANC_BIND_OFFER_ENA    = "anc_offer_ena";
+
+// Ancestor row binds — append slot index (0/1/2) to each prefix
+const string ANC_BIND_ANAME        = "anc_aname_";
+const string ANC_BIND_ADESC        = "anc_adesc_";
+const string ANC_BIND_ACOST        = "anc_acost_";
+const string ANC_BIND_ASTAT        = "anc_astat_";
+const string ANC_BIND_ASTATCOL     = "anc_astatcol_";
+const string ANC_BIND_ABTN_ENA     = "anc_abtn_ena_";
+
+// History list
+const string ANC_BIND_HIST_ROWS    = "anc_hist_rows";
+const string ANC_BIND_HIST_CNT     = "anc_hist_cnt";
+
+// ---------------------------------------------------------------
+// Button IDs
+// ---------------------------------------------------------------
+
+const string ANC_BTN_CLOSE         = "anc_btn_close";
+const string ANC_BTN_LIN_ROW       = "anc_btn_linrow";
+const string ANC_BTN_OFFER         = "anc_btn_offer";
+const string ANC_BTN_INVOKE        = "anc_btn_invoke_";  // + slot index
+
+// ---------------------------------------------------------------
+// Lineage IDs
+// ---------------------------------------------------------------
+
+const int ANC_LINEAGE_NONE    = -1;
+const int ANC_LINEAGE_WARRIOR =  0;
+const int ANC_LINEAGE_MAGE    =  1;
+const int ANC_LINEAGE_ROGUE   =  2;
+const int ANC_LINEAGE_NOBLE   =  3;
+const int ANC_LINEAGE_PEASANT =  4;
+const int ANC_LINEAGE_COUNT   =  5;
+
+// ---------------------------------------------------------------
+// Costs per slot (slot 0 = cheapest, slot 2 = most powerful)
+// ---------------------------------------------------------------
+
+const int ANC_COST_SLOT_0     = 15;
+const int ANC_COST_SLOT_1     = 30;
+const int ANC_COST_SLOT_2     = 60;
+
+// ---------------------------------------------------------------
+// Window dimensions
+// ---------------------------------------------------------------
+
+const float ANC_W             = 480.0;
+const float ANC_H             = 590.0;
+
+// ---------------------------------------------------------------
+// Lineage data
+// ---------------------------------------------------------------
+
+string AncGetLineageName(int nLineage)
+{
+    switch(nLineage)
+    {
+        case ANC_LINEAGE_WARRIOR: return "Ród Wojowniczy";
+        case ANC_LINEAGE_MAGE:    return "Ród Magiczny";
+        case ANC_LINEAGE_ROGUE:   return "Ród Łotrzykowski";
+        case ANC_LINEAGE_NOBLE:   return "Ród Szlachecki";
+        case ANC_LINEAGE_PEASANT: return "Ród Wieśniaczy";
+    }
+    return "Nieznany Ród";
+}
+
+string AncGetLineageDesc(int nLineage)
+{
+    switch(nLineage)
+    {
+        case ANC_LINEAGE_WARRIOR:
+            return "Krew wojowników. Przodkowie dadzą siłę, pancerz i szaleństwo bitewne.";
+        case ANC_LINEAGE_MAGE:
+            return "Linia czarowników. Duchy użyczą wiedzy, wglądu i ochrony przed magią.";
+        case ANC_LINEAGE_ROGUE:
+            return "Ród łotrzyków. Przodkowie nauczą cienia, zwinności i niewidzialności.";
+        case ANC_LINEAGE_NOBLE:
+            return "Szlachecka krew. Duchy obdarzą dostojeństwem, wdziękiem i ochroną losu.";
+        case ANC_LINEAGE_PEASANT:
+            return "Korzenie sięgają ziemi. Przodkowie dadzą hart ciała, odporność i odrodzenie.";
+    }
+    return "";
+}
+
+// ---------------------------------------------------------------
+// Ancestor data  (ancestor ID = lineage * 3 + slot)
+// ---------------------------------------------------------------
+
+string AncGetAncestorName(int nAncId)
+{
+    switch(nAncId)
+    {
+        // Warrior lineage
+        case  0: return "Ragnar Żelazny";
+        case  1: return "Zbroja Krwi";
+        case  2: return "Duchy Berserków";
+        // Mage lineage
+        case  3: return "Stara Wiedźma";
+        case  4: return "Mistrz Rytuałów";
+        case  5: return "Strażnik Runów";
+        // Rogue lineage
+        case  6: return "Czarny Nóż";
+        case  7: return "Mistrzyni Cieni";
+        case  8: return "Gildyjny Szpieg";
+        // Noble lineage
+        case  9: return "Lord Ashenvale";
+        case 10: return "Pani Fortuny";
+        case 11: return "Krwawa Rada";
+        // Peasant lineage
+        case 12: return "Stara Zielarka";
+        case 13: return "Matka Ziemia";
+        case 14: return "Duch Pól";
+    }
+    return "Nieznany Przodek";
+}
+
+string AncGetAncestorDesc(int nAncId)
+{
+    switch(nAncId)
+    {
+        case  0: return "Siła +4 przez 10 min.";
+        case  1: return "Pancerz +4 przez 5 min.";
+        case  2: return "Pośpiech i Siła +4 przez 2 min.";
+        case  3: return "Inteligencja +4 przez 10 min.";
+        case  4: return "Mądrość +4 przez 10 min.";
+        case  5: return "Odporność na zaklęcia +10 przez 10 min.";
+        case  6: return "Zręczność +4 przez 10 min.";
+        case  7: return "Niewidzialność przez 1 min.";
+        case  8: return "Ukrycie i Cichy Krok +10 przez 30 min.";
+        case  9: return "Charyzma +4 przez 10 min.";
+        case 10: return "MĄD+INT+CHA +2 przez 10 min.";
+        case 11: return "Rzuty obronne +5 przez 5 min.";
+        case 12: return "Tymczasowe HP +50 przez 1 godz.";
+        case 13: return "Odporność na choroby przez 2 godz.";
+        case 14: return "Kondycja +4 i regeneracja 2 HP/6s przez 10 min.";
+    }
+    return "";
+}
+
+int AncGetCostBySlot(int nSlot)
+{
+    switch(nSlot)
+    {
+        case 0: return ANC_COST_SLOT_0;
+        case 1: return ANC_COST_SLOT_1;
+        case 2: return ANC_COST_SLOT_2;
+    }
+    return 9999;
+}
+
+// ---------------------------------------------------------------
+// Status / cooldown helpers
+// ---------------------------------------------------------------
+
+// Returns seconds remaining on cooldown, or 0 if ready.
+int AncGetCooldownRemaining(object oPC, int nAncestorId)
+{
+    int nNow      = AncGetCurrentUnix();
+    int nLast     = AncGetLastInvoked(oPC, nAncestorId);
+    if(nLast == 0) return 0;
+    int nElapsed  = nNow - nLast;
+    if(nElapsed >= ANC_COOLDOWN_SECS) return 0;
+    return ANC_COOLDOWN_SECS - nElapsed;
+}
+
+string AncFormatCooldown(int nSecsRemaining)
+{
+    if(nSecsRemaining <= 0) return "Dostepny";
+    int nHours = nSecsRemaining / 3600;
+    int nMins  = (nSecsRemaining % 3600) / 60;
+    if(nHours > 0)
+        return "Odnawia sie: " + IntToString(nHours) + "h " + IntToString(nMins) + "m";
+    return "Odnawia sie: " + IntToString(nMins) + "m";
+}
+
+// ---------------------------------------------------------------
+// Effect application helpers (complex multi-effect cases)
+// ---------------------------------------------------------------
+
+void AncApplyBerserk(object oPC)
+{
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+        EffectLinkEffects(
+            EffectHaste(),
+            EffectAbilityIncrease(ABILITY_STRENGTH, 4)),
+        oPC, 120.0);
+}
+
+void AncApplySpy(object oPC)
+{
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+        EffectLinkEffects(
+            EffectSkillIncrease(SKILL_HIDE, 10),
+            EffectSkillIncrease(SKILL_MOVE_SILENTLY, 10)),
+        oPC, 1800.0);
+}
+
+void AncApplyFortune(object oPC)
+{
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+        EffectLinkEffects(
+            EffectLinkEffects(
+                EffectAbilityIncrease(ABILITY_WISDOM, 2),
+                EffectAbilityIncrease(ABILITY_INTELLIGENCE, 2)),
+            EffectAbilityIncrease(ABILITY_CHARISMA, 2)),
+        oPC, 600.0);
+}
+
+void AncApplySpirit(object oPC)
+{
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+        EffectLinkEffects(
+            EffectAbilityIncrease(ABILITY_CONSTITUTION, 4),
+            EffectRegenerate(2, 6.0)),
+        oPC, 600.0);
+}
+
+void AncApplyAncestorEffect(object oPC, int nAncId)
+{
+    switch(nAncId)
+    {
+        case  0:
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                EffectAbilityIncrease(ABILITY_STRENGTH, 4), oPC, 600.0);
+            break;
+        case  1:
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                EffectACIncrease(4, AC_DODGE_BONUS, DAMAGE_TYPE_ALL), oPC, 300.0);
+            break;
+        case  2: AncApplyBerserk(oPC);  break;
+        case  3:
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                EffectAbilityIncrease(ABILITY_INTELLIGENCE, 4), oPC, 600.0);
+            break;
+        case  4:
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                EffectAbilityIncrease(ABILITY_WISDOM, 4), oPC, 600.0);
+            break;
+        case  5:
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                EffectSpellResistanceIncrease(10), oPC, 600.0);
+            break;
+        case  6:
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                EffectAbilityIncrease(ABILITY_DEXTERITY, 4), oPC, 600.0);
+            break;
+        case  7:
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                EffectInvisibility(INVISIBILITY_TYPE_NORMAL), oPC, 60.0);
+            break;
+        case  8: AncApplySpy(oPC);      break;
+        case  9:
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                EffectAbilityIncrease(ABILITY_CHARISMA, 4), oPC, 600.0);
+            break;
+        case 10: AncApplyFortune(oPC);  break;
+        case 11:
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                EffectSavingThrowIncrease(SAVING_THROW_ALL, 5, SAVING_THROW_TYPE_ALL),
+                oPC, 300.0);
+            break;
+        case 12:
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                EffectTemporaryHitpoints(50), oPC, 3600.0);
+            break;
+        case 13:
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                EffectImmunity(IMMUNITY_TYPE_DISEASE), oPC, 7200.0);
+            break;
+        case 14: AncApplySpirit(oPC);   break;
+    }
+}
+
+// ---------------------------------------------------------------
+// Core invocation logic (does not touch NUI — callers do that)
+// ---------------------------------------------------------------
+
+void AncInvokeAncestor(object oPC, int nSlot)
+{
+    int nLineage  = AncGetLineage(oPC);
+    if(nLineage == ANC_LINEAGE_NONE) return;
+
+    int nAncId    = nLineage * 3 + nSlot;
+    int nCost     = AncGetCostBySlot(nSlot);
+    int nFavor    = AncGetFavor(oPC);
+    int nCooldown = AncGetCooldownRemaining(oPC, nAncId);
+    string sName  = AncGetAncestorName(nAncId);
+
+    if(nCooldown > 0)
+    {
+        SendMessageToPC(oPC,
+            "[Przodkowie] " + sName + " nie moze jeszcze odpowiedziec. "
+            + AncFormatCooldown(nCooldown) + ".");
+        return;
+    }
+    if(nFavor < nCost)
+    {
+        SendMessageToPC(oPC,
+            "[Przodkowie] Za malo Laski, by wezwac " + sName
+            + ". Potrzebujesz " + IntToString(nCost)
+            + " (masz " + IntToString(nFavor) + ").");
+        return;
+    }
+
+    AncSpendFavor(oPC, nCost);
+    AncSetInvoked(oPC, nAncId);
+    AncAddHistory(oPC, nAncId, sName);
+    AncApplyAncestorEffect(oPC, nAncId);
+
+    FloatingTextStringOnCreature(
+        "Pieczen krwi pulsuje slabo... duch " + sName + " przemawia.", oPC, FALSE);
+    SendMessageToPC(oPC,
+        "[Przodkowie] " + sName + " odpowiedzial na twoje wezwanie. Laska -"
+        + IntToString(nCost) + ".");
+}

--- a/Ancestor Spirits/Scripts/lib_anc_ev.nss
+++ b/Ancestor Spirits/Scripts/lib_anc_ev.nss
@@ -1,0 +1,52 @@
+// lib_anc_ev.nss — Ancestor Spirits: NUI event handler
+
+#include "lib_anc"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    if(nToken != NuiFindWindow(oPC, ANC_WINDOW)) return;
+
+    // ---- Window closed via OS chrome (alt+F4, etc.) ----
+    if(sEvent == EVENT_TYPE_CLOSE)
+        return;
+
+    if(sEvent != EVENT_TYPE_CLICK && sEvent != EVENT_TYPE_MOUSEDOWN) return;
+
+    // ---- Close button ----
+    if(sElem == ANC_BTN_CLOSE)
+    {
+        NuiDestroy(oPC, nToken);
+        return;
+    }
+
+    // ---- Lineage selection row click ----
+    if(sEvent == EVENT_TYPE_MOUSEDOWN && sElem == ANC_BTN_LIN_ROW)
+    {
+        AncHandleSelectLineage(oPC, nToken, nIdx);
+        return;
+    }
+
+    // ---- Offer button ----
+    if(sElem == ANC_BTN_OFFER)
+    {
+        AncHandleOffer(oPC, nToken);
+        return;
+    }
+
+    // ---- Invoke buttons (slot 0 / 1 / 2) ----
+    int nSlot;
+    for(nSlot = 0; nSlot < 3; nSlot++)
+    {
+        if(sElem == ANC_BTN_INVOKE + IntToString(nSlot))
+        {
+            AncHandleInvoke(oPC, nToken, nSlot);
+            return;
+        }
+    }
+}

--- a/Ancestor Spirits/Scripts/lib_nui.nss
+++ b/Ancestor Spirits/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Ancestor Spirits/Scripts/lib_nui_utility.nss
+++ b/Ancestor Spirits/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Ancestor Spirits/Scripts/sql_anc.nss
+++ b/Ancestor Spirits/Scripts/sql_anc.nss
@@ -1,0 +1,173 @@
+// sql_anc.nss — Ancestor Spirits: SQL layer (campaign "anc")
+
+const int ANC_FAVOR_MAX      = 100;
+const int ANC_COOLDOWN_SECS  = 86400;   // 24 hours
+
+void AncCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("anc",
+        "CREATE TABLE IF NOT EXISTS anc_chars ("
+        "  uuid          TEXT PRIMARY KEY, "
+        "  char_name     TEXT DEFAULT '', "
+        "  lineage       INTEGER DEFAULT -1, "
+        "  favor         INTEGER DEFAULT 0, "
+        "  total_offered INTEGER DEFAULT 0"
+        ")");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("anc",
+        "CREATE TABLE IF NOT EXISTS anc_cooldowns ("
+        "  uuid         TEXT NOT NULL, "
+        "  ancestor_id  INTEGER NOT NULL, "
+        "  last_invoked INTEGER DEFAULT 0, "
+        "  PRIMARY KEY (uuid, ancestor_id)"
+        ")");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("anc",
+        "CREATE TABLE IF NOT EXISTS anc_history ("
+        "  id            INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "  uuid          TEXT NOT NULL, "
+        "  ancestor_id   INTEGER NOT NULL, "
+        "  ancestor_name TEXT DEFAULT '', "
+        "  invoked_at    INTEGER DEFAULT 0"
+        ")");
+    SqlStep(q);
+}
+
+void AncRegisterPC(object oPC)
+{
+    string sUuid = GetObjectUUID(oPC);
+    string sName = GetName(oPC);
+
+    sqlquery q = SqlPrepareQueryCampaign("anc",
+        "INSERT OR IGNORE INTO anc_chars (uuid, char_name) VALUES (@uuid, @name)");
+    SqlBindString(q, "@uuid", sUuid);
+    SqlBindString(q, "@name", sName);
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("anc",
+        "UPDATE anc_chars SET char_name = @name WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", sUuid);
+    SqlBindString(q, "@name", sName);
+    SqlStep(q);
+}
+
+int AncGetLineage(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("anc",
+        "SELECT lineage FROM anc_chars WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return -1;
+}
+
+void AncSetLineage(object oPC, int nLineage)
+{
+    sqlquery q = SqlPrepareQueryCampaign("anc",
+        "UPDATE anc_chars SET lineage = @lin WHERE uuid = @uuid");
+    SqlBindInt   (q, "@lin",  nLineage);
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+}
+
+int AncGetFavor(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("anc",
+        "SELECT favor FROM anc_chars WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// Returns how many Favor points were actually added (capped at MAX).
+int AncAddFavor(object oPC, int nAmount)
+{
+    int nCurrent = AncGetFavor(oPC);
+    int nNew     = nCurrent + nAmount;
+    if(nNew > ANC_FAVOR_MAX) nNew = ANC_FAVOR_MAX;
+    int nAdded   = nNew - nCurrent;
+    if(nAdded <= 0) return 0;
+
+    sqlquery q = SqlPrepareQueryCampaign("anc",
+        "UPDATE anc_chars SET favor = @fav, total_offered = total_offered + @add "
+        "WHERE uuid = @uuid");
+    SqlBindInt   (q, "@fav",  nNew);
+    SqlBindInt   (q, "@add",  nAdded);
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+    return nAdded;
+}
+
+// Returns TRUE on success, FALSE if insufficient Favor.
+int AncSpendFavor(object oPC, int nCost)
+{
+    if(AncGetFavor(oPC) < nCost) return FALSE;
+
+    sqlquery q = SqlPrepareQueryCampaign("anc",
+        "UPDATE anc_chars SET favor = favor - @cost WHERE uuid = @uuid");
+    SqlBindInt   (q, "@cost", nCost);
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+    return TRUE;
+}
+
+int AncGetCurrentUnix()
+{
+    sqlquery q = SqlPrepareQueryCampaign("anc", "SELECT strftime('%s','now')");
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// Returns unix timestamp of the last invocation, or 0 if never invoked.
+int AncGetLastInvoked(object oPC, int nAncestorId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("anc",
+        "SELECT last_invoked FROM anc_cooldowns "
+        "WHERE uuid = @uuid AND ancestor_id = @aid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@aid",  nAncestorId);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+void AncSetInvoked(object oPC, int nAncestorId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("anc",
+        "INSERT OR REPLACE INTO anc_cooldowns (uuid, ancestor_id, last_invoked) "
+        "VALUES (@uuid, @aid, strftime('%s','now'))");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@aid",  nAncestorId);
+    SqlStep(q);
+}
+
+void AncAddHistory(object oPC, int nAncestorId, string sName)
+{
+    sqlquery q = SqlPrepareQueryCampaign("anc",
+        "INSERT INTO anc_history (uuid, ancestor_id, ancestor_name, invoked_at) "
+        "VALUES (@uuid, @aid, @name, strftime('%s','now'))");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@aid",  nAncestorId);
+    SqlBindString(q, "@name", sName);
+    SqlStep(q);
+}
+
+// Returns JsonArray of last 5 entries: [{name, date}, ...]
+json AncGetHistory(object oPC)
+{
+    json jHist = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("anc",
+        "SELECT ancestor_name, "
+        "strftime('%d.%m %H:%M', invoked_at, 'unixepoch') AS dt "
+        "FROM anc_history WHERE uuid = @uuid "
+        "ORDER BY invoked_at DESC LIMIT 5");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    while(SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "name", JsonString(SqlGetString(q, 0)));
+        jRow = JsonObjectSet(jRow, "date", JsonString(SqlGetString(q, 1)));
+        jHist = JsonArrayInsert(jHist, jRow);
+    }
+    return jHist;
+}

--- a/Ancestor Spirits/Scripts/sys_on_enter.nss
+++ b/Ancestor Spirits/Scripts/sys_on_enter.nss
@@ -1,0 +1,19 @@
+// sys_on_enter.nss — Ancestor Spirits: OnClientEnter hook
+#include "lib_anc_def"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC)) return;
+
+    AncRegisterPC(oPC);
+
+    int nLineage = AncGetLineage(oPC);
+    if(nLineage == ANC_LINEAGE_NONE)
+        return;
+
+    int nFavor = AncGetFavor(oPC);
+    SendMessageToPC(oPC,
+        "[Przodkowie] Rod: " + AncGetLineageName(nLineage)
+        + "  |  Laska: " + IntToString(nFavor) + "/" + IntToString(ANC_FAVOR_MAX));
+}

--- a/Ancestor Spirits/Scripts/sys_on_load.nss
+++ b/Ancestor Spirits/Scripts/sys_on_load.nss
@@ -1,0 +1,7 @@
+// sys_on_load.nss — Ancestor Spirits: OnModuleLoad hook
+#include "lib_anc_def"
+
+void main()
+{
+    AncCreateTables();
+}

--- a/Ancestor Spirits/Scripts/test_anc.nss
+++ b/Ancestor Spirits/Scripts/test_anc.nss
@@ -1,0 +1,10 @@
+// test_anc.nss — Ancestor Spirits: OnUsed script for altar placeable
+// Assign this as the OnUsed event of any placeable that serves as an Ancestral Altar.
+#include "lib_anc"
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+    AncOpen(oPC);
+}


### PR DESCRIPTION
## Co to robi

System kultu przodków dla dark fantasy CRPG. Gracz raz na stałe wybiera jeden z 5 **rodowodów krwi** (Wojowniczy, Magiczny, Łotrzykowski, Szlachecki, Wieśniaczy) i buduje relację z duchami przodków przez **ofiary ze złota** → **Łaska (0–100)** → **przyzwanie ducha** → **tymczasowy buff** z 24h cooldownem.

## Mechanika

- **Wybór rodu** — jednorazowy, permanentny (zapisany w SQL), otwiera widok ołtarza
- **Ofiara** — gracz wpisuje ilość złota; złoto zostaje odjęte, Łaska rośnie (max 100)
- **Przizwanie** — każdy ród ma 3 duchy (slot 0/1/2), koszty 15/30/60 Łaski, cooldown 24h; system sprawdza oba warunki i raportuje stan graczu
- **Efekty** — 15 unikalnych ancestralnych efektów NWN: ability increases, AC, haste, spell resistance, invisibility, skill buffs, saving throw boost, temp HP, disease immunity, regeneration
- **Historia** — ostatnie 5 przywołań widoczne w panelu NUI (data + imię przodka)

## Pliki

| Plik | Opis |
|---|---|
| `Scripts/sql_anc.nss` | SQL layer: tabele `anc_chars`, `anc_cooldowns`, `anc_history` w kampanii `anc` |
| `Scripts/lib_anc_def.nss` | Stałe NUI/bind, dane 15 przodków × 5 rodów, aplikacja efektów, `AncInvokeAncestor` |
| `Scripts/lib_anc.nss` | Budowanie NUI (2 widoki), feed danych, handlery akcji |
| `Scripts/lib_anc_ev.nss` | Handler zdarzeń NUI (script na okno) |
| `Scripts/sys_on_load.nss` | OnModuleLoad — `AncCreateTables()` |
| `Scripts/sys_on_enter.nss` | OnClientEnter — rejestruje PC, pokazuje stan Łaski przy zalogowaniu |
| `Scripts/test_anc.nss` | OnUsed na placeable-ołtarzu — otwiera UI |
| `Scripts/lib_nui.nss` / `lib_nui_utility.nss` | Współdzielone utility NUI (kopia z Mailbox) |
| `INTEGRATION.md` | Pełna instrukcja integracji, tabela efektów, opis SQL |

## Zależności (NWNX? SQL?)

- **Brak NWNX** — wyłącznie NWScript + NUI + SQLite wbudowany w NWN:EE
- **SQL:** kampania SQLite `anc`; 3 tabele z `CREATE TABLE IF NOT EXISTS` — migracja idempotentna, bezpieczna przy wielokrotnym starcie

## Jak włączyć w istniejącym module

1. Skopiuj wszystkie `.nss` z `Scripts/` do projektu (HAK lub bezpośrednio do modułu)
2. Dodaj `sys_on_load` do **OnModuleLoad**
3. Dodaj `sys_on_enter` do **OnClientEnter**
4. Umieść dowolny placeable (np. `plc_altar2`) i ustaw jego **OnUsed** na `test_anc`

## Co celowo pominięto

- Plik `.mod` — środowisko nie wspiera pakowania; zastąpiony przez `INTEGRATION.md`
- Animacje / dźwięki przy ołtarzu — wymagałyby zasobów w HAK
- Możliwość zmiany rodu — celowa permanentna decyzja fabularna (zgodnie z logiką dark fantasy)
- Ochrona przed DM-restem bufffów — out of scope tej wersji


---
_Generated by [Claude Code](https://claude.ai/code/session_01BRbvqXuGremG8exHGedDEM)_