### PR TITLE
feat: Vengeance Ledger (Księga Krzywd)

### DIFF
--- a/Vengeance Ledger/INTEGRATION.md
+++ b/Vengeance Ledger/INTEGRATION.md
@@ -1,0 +1,96 @@
+# Vengeance Ledger — Integracja
+
+## Co to jest
+
+**Księga Krzywd** – system zemsty i urazy dla persistent world. Każda krzywda (śmierć z ręki
+innego gracza, kradzież, klątwa) tworzy wpis w Księdze ofiary. Aktywne wpisy dają premię do
+ataku i obrażeń (**Furia**). Przetrzymywane zbyt długo karzą karą do PP (**Żal**). Rozliczenie
+krzywdy przez zabicie krzywdziciela nagradza tymczasowym bufem bitewnym (**Zemsta**). Gracz może
+też Wyrzec się krzywdy za cenę 50 PD.
+
+---
+
+## Wymagane hooki modułu
+
+| Zdarzenie | Skrypt | Rola |
+|---|---|---|
+| `OnModuleLoad` | `sys_on_load.nss` | Tworzy tabele SQLite |
+| `OnClientEnter` | `sys_on_enter.nss` | Rejestruje gracza, aplikuje efekty |
+| `OnPlayerDeath` | `sys_on_death.nss` | Tworzy wpis po śmierci z ręki PC |
+
+Jeśli moduł ma już własne skrypty w tych hookach, wywołaj bezpośrednio:
+
+```nss
+// OnModuleLoad — po innych inicjalizacjach:
+#include "lib_vend_def"
+VendCreateTables();
+
+// OnClientEnter:
+#include "lib_vend"
+object oPC = GetEnteringObject();
+if (GetIsPC(oPC)) { VendRegisterPlayer(oPC); ApplyVendEffects(oPC); }
+
+// OnPlayerDeath — na końcu skryptu śmierci:
+#include "lib_vend"
+// (patrz sys_on_death.nss — wywołaj VendAddGrudge + VendCheckFulfillment)
+```
+
+---
+
+## Otwieranie UI
+
+Podepnij `test_vend.nss` jako **OnUsed** do placeable (np. mroczna tablica, krwawy ołtarz, czarna
+księga). Normalny gracz otwiera okno; DM może wstrzykiwać testowe wpisy.
+
+Lub wywołaj bezpośrednio:
+```nss
+#include "lib_vend"
+CreateVendWindow(oPC);
+```
+
+---
+
+## Dodawanie krzywd ręcznie (DM / integracja z innymi systemami)
+
+```nss
+#include "lib_vend"
+
+// nWrongType: VEND_WRONG_KILLED=1, VEND_WRONG_STOLEN=2, VEND_WRONG_CURSED=3
+// sItemTag: tag przedmiotu (dla STOLEN), "" w pozostałych przypadkach
+VendAddGrudge(oVictim, oWrongdoer, VEND_WRONG_STOLEN, "item_tag");
+```
+
+Funkcja ignoruje duplikaty (nie doda dwóch aktywnych wpisów tego samego typu dla tej samej pary).
+
+---
+
+## Mechanika — szczegóły
+
+| Efekt | Warunek | Wartość | Tag efektu |
+|---|---|---|---|
+| **Furia** (+AB, +OBR magiczne) | ≥1 aktywny wpis | +1/+1 za wpis, max +3 | `VEND_FURY` |
+| **Żal** (–PP) | wpis starszy niż 21 dni | –1 PP za wpis, max –3 | `VEND_RESENT` |
+| **Zemsta** (+AB, +OBR, +rzuty) | zabicie krzywdziciela | +2/+2/+2 na 1h | `VEND_FULFILL` |
+
+Efekty Furia i Żal są permanentne (reaplikowane przy logowaniu i zmianie stanu). Zemsta jest
+tymczasowa (3600 sekund).
+
+---
+
+## Zależności
+
+- **NWN:EE 87.8193.37+** — wymagane `GetEffectTag()` / `TagEffect()` (dodane w EE)
+- **lib_nui.nss + lib_nui_utility.nss** — dostępne w tym repo (Mailbox, Appearance); wrzuć
+  do skryptów modułu, jeśli jeszcze ich nie masz
+- **NWNX**: brak — w pełni vanilla NWN:EE
+
+---
+
+## Co celowo pominięto
+
+- **Auto-wykrywanie kradzieży i kląt**: NWN bez NWNX nie dostarcza niezawodnego zdarzenia
+  OnItemStolen PC→PC. Wpisuj ręcznie przez VendAddGrudge() lub DM.
+- **Alianse / krzywdy na bliskich**: mechanika "wróg wroga" to osobny moduł.
+- **Wielokrotne wpisy tego samego typu w tej samej parze**: system blokuje duplikaty —
+  jedno aktywne Morderstwo na parę. Drugi kill tworzy wpis dopiero po rozliczeniu pierwszego.
+- **Edycja historii**: historia jest tylko do odczytu; wpisy archiwalne nie mogą być usunięte.

--- a/Vengeance Ledger/Scripts/lib_vend.nss
+++ b/Vengeance Ledger/Scripts/lib_vend.nss
@@ -1,0 +1,456 @@
+#include "lib_vend_def"
+
+// NUI layout forward declarations
+json BuildVendMainView(object oPC);
+void CreateVendConfirmPopup(object oPC, int nGrudgeId, string sWrongdoerName);
+
+// ================================================================
+// Effect management
+// ================================================================
+
+// Removes all Fury and Resentment passive effects from oPC.
+// Uses restart-on-remove to safely iterate a live effect list.
+void VendRemovePassiveEffects(object oPC)
+{
+    int bFound = TRUE;
+    while (bFound)
+    {
+        bFound = FALSE;
+        effect e = GetFirstEffect(oPC);
+        while (GetIsEffectValid(e))
+        {
+            string sTag = GetEffectTag(e);
+            if (sTag == VEND_TAG_FURY || sTag == VEND_TAG_RESENT)
+            {
+                RemoveEffect(oPC, e);
+                bFound = TRUE;
+                break;
+            }
+            e = GetNextEffect(oPC);
+        }
+    }
+}
+
+void ApplyVendEffects(object oPC)
+{
+    VendRemovePassiveEffects(oPC);
+
+    int nActive  = VendGetActiveCount(oPC);
+    int nOverdue = VendGetOverdueCount(oPC);
+    int nFury    = nActive  < VEND_MAX_FURY   ? nActive  : VEND_MAX_FURY;
+    int nResent  = nOverdue < VEND_MAX_RESENT  ? nOverdue : VEND_MAX_RESENT;
+
+    if (nFury > 0)
+    {
+        effect eAtk = TagEffect(EffectAttackIncrease(nFury), VEND_TAG_FURY);
+        effect eDmg = TagEffect(EffectDamageIncrease(nFury, DAMAGE_TYPE_MAGICAL), VEND_TAG_FURY);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eAtk, oPC);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eDmg, oPC);
+    }
+
+    if (nResent > 0)
+    {
+        effect eAC = TagEffect(EffectACDecrease(nResent), VEND_TAG_RESENT);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eAC, oPC);
+    }
+}
+
+// ================================================================
+// Public API
+// ================================================================
+
+// Adds a grudge entry for oVictim against oWrongdoer.
+// No-ops if an active grudge of the same type already exists between this pair.
+void VendAddGrudge(object oVictim, object oWrongdoer, int nWrongType, string sItemTag)
+{
+    if (!GetIsObjectValid(oVictim) || !GetIsObjectValid(oWrongdoer)) return;
+    if (oVictim == oWrongdoer) return;
+
+    string sVictimUuid    = GetObjectUUID(oVictim);
+    string sWrongdoerUuid = GetObjectUUID(oWrongdoer);
+    string sWrongdoerName = GetName(oWrongdoer);
+
+    if (VendHasActiveGrudge(sVictimUuid, sWrongdoerUuid, nWrongType)) return;
+
+    VendAddGrudgeDB(sVictimUuid, sWrongdoerUuid, sWrongdoerName, nWrongType, sItemTag);
+
+    SendMessageToPC(oVictim,
+        "[Księga Krzywd] " + sWrongdoerName +
+        " wpisany do Księgi: " + VendWrongTypeName(nWrongType) + ".");
+    FloatingTextStringOnCreature("Krew woła o zemstę...", oVictim, FALSE);
+
+    ApplyVendEffects(oVictim);
+
+    int nToken = NuiFindWindow(oVictim, VEND_WINDOW);
+    if (nToken != 0) FeedVendWindow(oVictim, nToken);
+}
+
+// Call after oAvenger kills oWrongdoer.
+// Fulfills any active grudges oAvenger held against oWrongdoer and rewards them.
+void VendCheckFulfillment(object oAvenger, object oWrongdoer)
+{
+    if (!GetIsObjectValid(oAvenger) || !GetIsObjectValid(oWrongdoer)) return;
+
+    string sAvengerUuid   = GetObjectUUID(oAvenger);
+    string sWrongdoerUuid = GetObjectUUID(oWrongdoer);
+    int    nFulfilled     = VendFulfillGrudgesAgainst(sAvengerUuid, sWrongdoerUuid);
+    if (nFulfilled <= 0) return;
+
+    // Vengeance Fulfilled: +2 AB, +2 magical damage, +2 all saves for 1h
+    effect eAtk  = EffectAttackIncrease(2);
+    effect eDmg  = EffectDamageIncrease(2, DAMAGE_TYPE_MAGICAL);
+    effect eSave = EffectSavingThrowIncrease(SAVING_THROW_ALL, 2, SAVING_THROW_TYPE_ALL);
+    effect eFull = EffectLinkEffects(eAtk, EffectLinkEffects(eDmg, eSave));
+    eFull = TagEffect(eFull, VEND_TAG_FULFILL);
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eFull, oAvenger, IntToFloat(VEND_FULFILL_DURATION));
+
+    SendMessageToPC(oAvenger,
+        "[Księga Krzywd] Zemsta spełniona! Krew została zmyta krwią. (" +
+        IntToString(nFulfilled) + " wpisów rozliczono)");
+    FloatingTextStringOnCreature("Zemsta!", oAvenger, FALSE);
+
+    ApplyVendEffects(oAvenger);
+
+    int nToken = NuiFindWindow(oAvenger, VEND_WINDOW);
+    if (nToken != 0) FeedVendWindow(oAvenger, nToken);
+}
+
+// ================================================================
+// Feed functions
+// ================================================================
+
+void FeedVendActiveList(object oPC, int nToken)
+{
+    json jActive  = VendGetActiveGrudges(oPC);
+    int  nCount   = JsonGetLength(jActive);
+
+    // Derive active/overdue counts from the already-fetched rows
+    int nActive  = nCount;
+    int nOverdue = 0;
+    int k;
+    for (k = 0; k < nCount; k++)
+    {
+        if (JsonGetInt(JsonObjectGet(JsonArrayGet(jActive, k), "is_overdue")))
+            nOverdue++;
+    }
+
+    int  nFury    = nActive  < VEND_MAX_FURY  ? nActive  : VEND_MAX_FURY;
+    int  nResent  = nOverdue < VEND_MAX_RESENT ? nOverdue : VEND_MAX_RESENT;
+
+    string sFuryLbl   = "Furia:  +" + IntToString(nFury)   + " AB / +" + IntToString(nFury)   + " OBR";
+    string sResentLbl = "Żal:  -"   + IntToString(nResent) + " PP";
+
+    json jFuryColor   = nFury   > 0 ? NuiColor(210, 150,  60) : NuiColor(100, 100, 100);
+    json jResentColor = nResent > 0 ? NuiColor(190,  50,  50) : NuiColor(100, 100, 100);
+
+    NuiSetBind(oPC, nToken, VEND_BIND_FURY_LBL,    JsonString(sFuryLbl));
+    NuiSetBind(oPC, nToken, VEND_BIND_FURY_COLOR,  jFuryColor);
+    NuiSetBind(oPC, nToken, VEND_BIND_RESENT_LBL,  JsonString(sResentLbl));
+    NuiSetBind(oPC, nToken, VEND_BIND_RESENT_COLOR, jResentColor);
+
+    json jNames    = JsonArray();
+    json jTypes    = JsonArray();
+    json jDates    = JsonArray();
+    json jODs      = JsonArray();
+    json jODColors = JsonArray();
+    json jEncs     = JsonArray();
+
+    int  nSelId  = GetLocalInt(oPC, VEND_LVAR_SEL_ID);
+    json jRed    = NuiColor(200, 50, 50);
+    json jGray   = NuiColor(80, 80, 80);
+
+    int i;
+    for (i = 0; i < nCount; i++)
+    {
+        json   jRow   = JsonArrayGet(jActive, i);
+        int    nId    = JsonGetInt(JsonObjectGet(jRow, "id"));
+        int    nType  = JsonGetInt(JsonObjectGet(jRow, "wrong_type"));
+        int    nTs    = JsonGetInt(JsonObjectGet(jRow, "created_at"));
+        int    nOD    = JsonGetInt(JsonObjectGet(jRow, "is_overdue"));
+
+        jNames    = JsonArrayInsert(jNames,    JsonString(JsonGetString(JsonObjectGet(jRow, "wrongdoer_name"))));
+        jTypes    = JsonArrayInsert(jTypes,    JsonString(VendWrongTypeName(nType)));
+        jDates    = JsonArrayInsert(jDates,    JsonString(VendFormatDate(nTs)));
+        jODs      = JsonArrayInsert(jODs,      JsonString(nOD ? "!" : ""));
+        jODColors = JsonArrayInsert(jODColors, nOD ? jRed : jGray);
+        jEncs     = JsonArrayInsert(jEncs,     JsonBool(nSelId != 0 && nId == nSelId));
+    }
+
+    NuiSetBind(oPC, nToken, VEND_BIND_ACT_NAME,    jNames);
+    NuiSetBind(oPC, nToken, VEND_BIND_ACT_TYPE,    jTypes);
+    NuiSetBind(oPC, nToken, VEND_BIND_ACT_DATE,    jDates);
+    NuiSetBind(oPC, nToken, VEND_BIND_ACT_OD,      jODs);
+    NuiSetBind(oPC, nToken, VEND_BIND_ACT_ODCOLOR, jODColors);
+    NuiSetBind(oPC, nToken, VEND_BIND_ACT_ENC,     jEncs);
+    NuiSetBind(oPC, nToken, VEND_BIND_ACT_COUNT,   JsonInt(nCount));
+    NuiSetBind(oPC, nToken, VEND_BIND_FORSW_ENA,   JsonBool(nSelId != 0));
+}
+
+void FeedVendHistoryList(object oPC, int nToken)
+{
+    json jHistory = VendGetHistoryGrudges(oPC);
+    int  nCount   = JsonGetLength(jHistory);
+
+    json jNames    = JsonArray();
+    json jTypes    = JsonArray();
+    json jDates    = JsonArray();
+    json jStatuses = JsonArray();
+    json jColors   = JsonArray();
+
+    json jGreen = NuiColor(70, 180, 70);
+    json jGray  = NuiColor(100, 100, 100);
+
+    int i;
+    for (i = 0; i < nCount; i++)
+    {
+        json   jRow    = JsonArrayGet(jHistory, i);
+        int    nType   = JsonGetInt(JsonObjectGet(jRow, "wrong_type"));
+        int    nStatus = JsonGetInt(JsonObjectGet(jRow, "status"));
+        int    nTs     = nStatus == 1
+            ? JsonGetInt(JsonObjectGet(jRow, "fulfilled_at"))
+            : JsonGetInt(JsonObjectGet(jRow, "forsworn_at"));
+        string sStatus = nStatus == 1 ? "Zemsta" : "Wybaczone";
+
+        jNames    = JsonArrayInsert(jNames,    JsonString(JsonGetString(JsonObjectGet(jRow, "wrongdoer_name"))));
+        jTypes    = JsonArrayInsert(jTypes,    JsonString(VendWrongTypeName(nType)));
+        jDates    = JsonArrayInsert(jDates,    JsonString(VendFormatDate(nTs)));
+        jStatuses = JsonArrayInsert(jStatuses, JsonString(sStatus));
+        jColors   = JsonArrayInsert(jColors,   nStatus == 1 ? jGreen : jGray);
+    }
+
+    NuiSetBind(oPC, nToken, VEND_BIND_HIS_NAME,   jNames);
+    NuiSetBind(oPC, nToken, VEND_BIND_HIS_TYPE,   jTypes);
+    NuiSetBind(oPC, nToken, VEND_BIND_HIS_DATE,   jDates);
+    NuiSetBind(oPC, nToken, VEND_BIND_HIS_STATUS, jStatuses);
+    NuiSetBind(oPC, nToken, VEND_BIND_HIS_COLOR,  jColors);
+    NuiSetBind(oPC, nToken, VEND_BIND_HIS_COUNT,  JsonInt(nCount));
+}
+
+void FeedVendWindow(object oPC, int nToken)
+{
+    FeedVendActiveList(oPC, nToken);
+    FeedVendHistoryList(oPC, nToken);
+}
+
+// ================================================================
+// NUI layout
+// ================================================================
+
+json BuildVendMainView(object oPC)
+{
+    float fBtnH   = GetNuiScaleDimension(oPC, 28.0);
+    float fRowH   = GetNuiScaleDimension(oPC, 26.0);
+    float fSmH    = GetNuiScaleDimension(oPC, 22.0);
+    float fListH  = GetNuiScaleDimension(oPC, 158.0);
+    float fHisH   = GetNuiScaleDimension(oPC, 106.0);
+
+    float fColName = GetNuiScaleDimension(oPC, 172.0);
+    float fColType = GetNuiScaleDimension(oPC, 90.0);
+    float fColDate = GetNuiScaleDimension(oPC, 58.0);
+    float fColOD   = GetNuiScaleDimension(oPC, 18.0);
+    float fColStat = GetNuiScaleDimension(oPC, 78.0);
+
+    // --- Status bar ---
+    json jFuryLbl = NuiLabel(NuiBind(VEND_BIND_FURY_LBL), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jFuryLbl = NuiStyleForegroundColor(jFuryLbl, NuiBind(VEND_BIND_FURY_COLOR));
+
+    json jResentLbl = NuiLabel(NuiBind(VEND_BIND_RESENT_LBL), JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jResentLbl = NuiStyleForegroundColor(jResentLbl, NuiBind(VEND_BIND_RESENT_COLOR));
+
+    json jStatusRow = JsonArray();
+    jStatusRow = JsonArrayInsert(jStatusRow, jFuryLbl);
+    jStatusRow = JsonArrayInsert(jStatusRow, NuiSpacer());
+    jStatusRow = JsonArrayInsert(jStatusRow, jResentLbl);
+
+    // --- Active grudge list row template ---
+    json jActName = NuiLabel(NuiBind(VEND_BIND_ACT_NAME), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jActName = NuiWidth(jActName, fColName);
+
+    json jActType = NuiLabel(NuiBind(VEND_BIND_ACT_TYPE), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jActType = NuiWidth(jActType, fColType);
+
+    json jActDate = NuiLabel(NuiBind(VEND_BIND_ACT_DATE), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jActDate = NuiWidth(jActDate, fColDate);
+
+    json jActOD = NuiLabel(NuiBind(VEND_BIND_ACT_OD), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jActOD = NuiStyleForegroundColor(jActOD, NuiBind(VEND_BIND_ACT_ODCOLOR));
+    jActOD = NuiWidth(jActOD, fColOD);
+
+    json jActCells = JsonArray();
+    jActCells = JsonArrayInsert(jActCells, jActName);
+    jActCells = JsonArrayInsert(jActCells, jActType);
+    jActCells = JsonArrayInsert(jActCells, jActDate);
+    jActCells = JsonArrayInsert(jActCells, jActOD);
+
+    json jActCell = NuiGroup(NuiRow(jActCells), TRUE, NUI_SCROLLBARS_NONE);
+    jActCell = NuiId(jActCell, VEND_BTN_ROW_ACT);
+    jActCell = NuiEncouraged(jActCell, NuiBind(VEND_BIND_ACT_ENC));
+
+    json jActTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jActCell, 0.0, TRUE));
+    json jActList = NuiList(jActTmpl, NuiBind(VEND_BIND_ACT_COUNT), fRowH);
+    jActList = NuiHeight(jActList, fListH);
+
+    // Forswear action row
+    json jForswBtn = NuiButton(JsonString("Wyrzeknij się krzywdy"));
+    jForswBtn = NuiId(jForswBtn, VEND_BTN_FORSWEAR);
+    jForswBtn = NuiEnabled(jForswBtn, NuiBind(VEND_BIND_FORSW_ENA));
+    jForswBtn = NuiWidth(jForswBtn, GetNuiScaleDimension(oPC, 200.0));
+    jForswBtn = NuiHeight(jForswBtn, fBtnH);
+
+    json jForswRow = JsonArray();
+    jForswRow = JsonArrayInsert(jForswRow, NuiSpacer());
+    jForswRow = JsonArrayInsert(jForswRow, jForswBtn);
+
+    // --- History list row template ---
+    json jHisName = NuiLabel(NuiBind(VEND_BIND_HIS_NAME), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jHisName = NuiWidth(jHisName, fColName);
+    jHisName = NuiStyleForegroundColor(jHisName, NuiBind(VEND_BIND_HIS_COLOR));
+
+    json jHisType = NuiLabel(NuiBind(VEND_BIND_HIS_TYPE), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jHisType = NuiWidth(jHisType, fColType);
+    jHisType = NuiStyleForegroundColor(jHisType, NuiBind(VEND_BIND_HIS_COLOR));
+
+    json jHisDate = NuiLabel(NuiBind(VEND_BIND_HIS_DATE), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jHisDate = NuiWidth(jHisDate, fColDate);
+    jHisDate = NuiStyleForegroundColor(jHisDate, NuiBind(VEND_BIND_HIS_COLOR));
+
+    json jHisStat = NuiLabel(NuiBind(VEND_BIND_HIS_STATUS), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jHisStat = NuiWidth(jHisStat, fColStat);
+    jHisStat = NuiStyleForegroundColor(jHisStat, NuiBind(VEND_BIND_HIS_COLOR));
+
+    json jHisCells = JsonArray();
+    jHisCells = JsonArrayInsert(jHisCells, jHisName);
+    jHisCells = JsonArrayInsert(jHisCells, jHisType);
+    jHisCells = JsonArrayInsert(jHisCells, jHisDate);
+    jHisCells = JsonArrayInsert(jHisCells, jHisStat);
+
+    json jHisCell = NuiGroup(NuiRow(jHisCells), TRUE, NUI_SCROLLBARS_NONE);
+
+    json jHisTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jHisCell, 0.0, TRUE));
+    json jHisList = NuiList(jHisTmpl, NuiBind(VEND_BIND_HIS_COUNT), fSmH);
+    jHisList = NuiHeight(jHisList, fHisH);
+
+    // Section headers
+    json jActHdr = NuiLabel(JsonString("— Aktywne Krzywdy —"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jActHdr = NuiStyleForegroundColor(jActHdr, NuiColor(180, 60, 60));
+
+    json jHisHdr = NuiLabel(JsonString("— Historia —"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jHisHdr = NuiStyleForegroundColor(jHisHdr, NuiColor(110, 110, 110));
+
+    // Main column assembly
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(jStatusRow));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jActHdr);
+    jCol = JsonArrayInsert(jCol, jActList);
+    jCol = JsonArrayInsert(jCol, NuiRow(jForswRow));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, jHisHdr);
+    jCol = JsonArrayInsert(jCol, jHisList);
+
+    json jSide    = NuiCol(JsonArrayInsert(JsonArray(), NuiSpacer()));
+    float fConW   = GetNuiScaleDimension(oPC, 540.0);
+
+    json jMain = JsonArray();
+    jMain = JsonArrayInsert(jMain, jSide);
+    jMain = JsonArrayInsert(jMain, NuiWidth(NuiCol(jCol), fConW));
+    jMain = JsonArrayInsert(jMain, jSide);
+    return NuiRow(jMain);
+}
+
+// ================================================================
+// Window creation
+// ================================================================
+
+void CreateVendWindow(object oPC)
+{
+    int nExist = NuiFindWindow(oPC, VEND_WINDOW);
+    if (nExist != 0)
+    {
+        FeedVendWindow(oPC, nExist);
+        return;
+    }
+
+    float fSW  = IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH));
+    float fSH  = IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT));
+    float fW   = GetNuiScaleDimension(oPC, VEND_W);
+    float fH   = GetNuiScaleDimension(oPC, VEND_H);
+    json  jGeom = NuiRect((fSW - fW) / 2.0, (fSH - fH) / 2.0, fW, fH);
+
+    float fBtnH   = GetNuiScaleDimension(oPC, 28.0);
+    json  jCloseBtn = NuiButton(JsonString("X"));
+    jCloseBtn = NuiId(jCloseBtn, VEND_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, GetNuiScaleDimension(oPC, 28.0));
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jTopRow = JsonArray();
+    jTopRow = JsonArrayInsert(jTopRow, NuiSpacer());
+    jTopRow = JsonArrayInsert(jTopRow, jCloseBtn);
+
+    json jRoot = JsonArray();
+    jRoot = JsonArrayInsert(jRoot, NuiRow(jTopRow));
+    jRoot = JsonArrayInsert(jRoot, BuildVendMainView(oPC));
+
+    json jWin = NuiWindow(NuiCol(jRoot),
+        JsonString("Księga Krzywd"),
+        NuiBind(VEND_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    int nToken = NuiCreate(oPC, jWin, VEND_WINDOW, VEND_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, VEND_WIN_GEOM, jGeom);
+    FeedVendWindow(oPC, nToken);
+}
+
+// ================================================================
+// Forswear confirmation popup
+// ================================================================
+
+void CreateVendConfirmPopup(object oPC, int nGrudgeId, string sWrongdoerName)
+{
+    SetLocalInt(oPC, VEND_LVAR_PENDING_ID, nGrudgeId);
+
+    if (NuiFindWindow(oPC, VEND_WIN_CONFIRM) != 0)
+        NuiDestroy(oPC, NuiFindWindow(oPC, VEND_WIN_CONFIRM));
+
+    float fSW = IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH));
+    float fSH = IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT));
+    float fW  = GetNuiScaleDimension(oPC, 400.0);
+    float fH  = GetNuiScaleDimension(oPC, 170.0);
+
+    json jMsg = NuiLabel(
+        JsonString("Wyrzekasz się zemsty na " + sWrongdoerName + ".\n"
+                 + "Koszt: " + IntToString(VEND_FORSW_XP_PENALTY) + " PD."),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+
+    json jYes = NuiButton(JsonString("Wyrzeknij się"));
+    jYes = NuiId(jYes, VEND_BTN_FORSW_OK);
+    jYes = NuiWidth(jYes, GetNuiScaleDimension(oPC, 130.0));
+
+    json jNo = NuiButton(JsonString("Anuluj"));
+    jNo = NuiId(jNo, VEND_BTN_FORSW_CANCEL);
+    jNo = NuiWidth(jNo, GetNuiScaleDimension(oPC, 80.0));
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jYes);
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jNo);
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jMsg);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 10.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jBtnRow));
+
+    json jWin = NuiWindow(NuiCol(jCol),
+        JsonString("Wyrzeczenie"),
+        NuiRect((fSW - fW) / 2.0, (fSH - fH) / 2.0, fW, fH),
+        JsonBool(FALSE), JsonBool(FALSE), JsonBool(TRUE),
+        JsonBool(FALSE), JsonBool(TRUE));
+
+    NuiCreate(oPC, jWin, VEND_WIN_CONFIRM, VEND_EV_SCRIPT);
+}

--- a/Vengeance Ledger/Scripts/lib_vend_def.nss
+++ b/Vengeance Ledger/Scripts/lib_vend_def.nss
@@ -1,0 +1,105 @@
+#include "lib_nui"
+#include "sql_vend"
+
+// Forward declarations for cross-file use
+void VendAddGrudge(object oVictim, object oWrongdoer, int nWrongType, string sItemTag);
+void VendCheckFulfillment(object oAvenger, object oWrongdoer);
+void ApplyVendEffects(object oPC);
+void FeedVendWindow(object oPC, int nToken);
+
+// ----------------------------------------------------------------
+// Window / group identifiers
+// ----------------------------------------------------------------
+
+const string VEND_WINDOW            = "VEND_WINDOW";
+const string VEND_EV_SCRIPT         = "lib_vend_ev";
+const string VEND_WIN_GEOM          = "vend_win_geom";
+const string VEND_WIN_CONFIRM       = "VEND_WIN_CONFIRM";
+
+// ----------------------------------------------------------------
+// Layout dimensions (pre-scale values)
+// ----------------------------------------------------------------
+
+const float  VEND_W                 = 580.0;
+const float  VEND_H                 = 460.0;
+
+// ----------------------------------------------------------------
+// Wrong types
+// ----------------------------------------------------------------
+
+const int    VEND_WRONG_KILLED      = 1;
+const int    VEND_WRONG_STOLEN      = 2;
+const int    VEND_WRONG_CURSED      = 3;
+
+// ----------------------------------------------------------------
+// Mechanical limits and effect tags
+// ----------------------------------------------------------------
+
+const int    VEND_MAX_FURY          = 3;
+const int    VEND_MAX_RESENT        = 3;
+
+const string VEND_TAG_FURY          = "VEND_FURY";
+const string VEND_TAG_RESENT        = "VEND_RESENT";
+const string VEND_TAG_FULFILL       = "VEND_FULFILL";
+
+// ----------------------------------------------------------------
+// PC local variables
+// ----------------------------------------------------------------
+
+const string VEND_LVAR_SEL_ID       = "VEND_SEL_ID";
+const string VEND_LVAR_PENDING_ID   = "VEND_PENDING_ID";
+
+// ----------------------------------------------------------------
+// NUI bind names — active grudge list
+// ----------------------------------------------------------------
+
+const string VEND_BIND_ACT_NAME     = "vend_act_name";
+const string VEND_BIND_ACT_TYPE     = "vend_act_type";
+const string VEND_BIND_ACT_DATE     = "vend_act_date";
+const string VEND_BIND_ACT_OD       = "vend_act_od";
+const string VEND_BIND_ACT_ODCOLOR  = "vend_act_odcolor";
+const string VEND_BIND_ACT_ENC      = "vend_act_enc";
+const string VEND_BIND_ACT_COUNT    = "vend_act_count";
+
+// ----------------------------------------------------------------
+// NUI bind names — history list
+// ----------------------------------------------------------------
+
+const string VEND_BIND_HIS_NAME     = "vend_his_name";
+const string VEND_BIND_HIS_TYPE     = "vend_his_type";
+const string VEND_BIND_HIS_DATE     = "vend_his_date";
+const string VEND_BIND_HIS_STATUS   = "vend_his_status";
+const string VEND_BIND_HIS_COLOR    = "vend_his_color";
+const string VEND_BIND_HIS_COUNT    = "vend_his_count";
+
+// ----------------------------------------------------------------
+// NUI bind names — status bar
+// ----------------------------------------------------------------
+
+const string VEND_BIND_FURY_LBL     = "vend_fury_lbl";
+const string VEND_BIND_FURY_COLOR   = "vend_fury_color";
+const string VEND_BIND_RESENT_LBL   = "vend_resent_lbl";
+const string VEND_BIND_RESENT_COLOR = "vend_resent_color";
+const string VEND_BIND_FORSW_ENA    = "vend_forsw_ena";
+
+// ----------------------------------------------------------------
+// NUI button identifiers
+// ----------------------------------------------------------------
+
+const string VEND_BTN_CLOSE         = "vend_btn_close";
+const string VEND_BTN_ROW_ACT       = "vend_btn_row_act";
+const string VEND_BTN_FORSWEAR      = "vend_btn_forswear";
+const string VEND_BTN_FORSW_OK      = "vend_btn_forsw_ok";
+const string VEND_BTN_FORSW_CANCEL  = "vend_btn_forsw_cancel";
+
+// ----------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------
+
+string VendWrongTypeName(int nType)
+{
+    if (nType == VEND_WRONG_KILLED) return "Morderstwo";
+    if (nType == VEND_WRONG_STOLEN) return "Kradzież";
+    if (nType == VEND_WRONG_CURSED) return "Klątwa";
+    return "Zniewaga";
+}

--- a/Vengeance Ledger/Scripts/lib_vend_ev.nss
+++ b/Vengeance Ledger/Scripts/lib_vend_ev.nss
@@ -1,0 +1,135 @@
+#include "lib_vend"
+
+// ================================================================
+// Forswear confirmation handler
+// ================================================================
+
+void HandleForswearConfirm(object oPC)
+{
+    int nId = GetLocalInt(oPC, VEND_LVAR_PENDING_ID);
+    if (nId <= 0) return;
+
+    VendForswearGrudge(nId);
+
+    int nNewXP = GetXP(oPC) - VEND_FORSW_XP_PENALTY;
+    if (nNewXP < 0) nNewXP = 0;
+    SetXP(oPC, nNewXP);
+
+    SendMessageToPC(oPC,
+        "[Księga Krzywd] Wyrzekasz się zemsty. "
+        "Niech ciężar tej zniewagi spoczywa na twej duszy.");
+
+    DeleteLocalInt(oPC, VEND_LVAR_PENDING_ID);
+    SetLocalInt(oPC, VEND_LVAR_SEL_ID, 0);
+
+    ApplyVendEffects(oPC);
+
+    NuiDestroy(oPC, NuiFindWindow(oPC, VEND_WIN_CONFIRM));
+
+    int nMain = NuiFindWindow(oPC, VEND_WINDOW);
+    if (nMain) FeedVendWindow(oPC, nMain);
+}
+
+// ================================================================
+// Active list row selection
+// ================================================================
+
+void HandleRowSelect(object oPC, int nToken, int nIdx)
+{
+    json jActive = VendGetActiveGrudges(oPC);
+    if (nIdx < 0 || nIdx >= JsonGetLength(jActive)) return;
+
+    json jRow = JsonArrayGet(jActive, nIdx);
+    int  nId  = JsonGetInt(JsonObjectGet(jRow, "id"));
+
+    SetLocalInt(oPC, VEND_LVAR_SEL_ID, nId);
+
+    int  nCount = JsonGetLength(jActive);
+    json jEncs  = JsonArray();
+    int  i;
+    for (i = 0; i < nCount; i++)
+        jEncs = JsonArrayInsert(jEncs, JsonBool(i == nIdx));
+
+    NuiSetBind(oPC, nToken, VEND_BIND_ACT_ENC,   jEncs);
+    NuiSetBind(oPC, nToken, VEND_BIND_FORSW_ENA, JsonBool(TRUE));
+}
+
+// ================================================================
+// Forswear button — opens confirmation popup
+// ================================================================
+
+void HandleForswearRequest(object oPC)
+{
+    int nSelId = GetLocalInt(oPC, VEND_LVAR_SEL_ID);
+    if (nSelId <= 0) return;
+
+    json   jActive = VendGetActiveGrudges(oPC);
+    string sName   = "";
+    int    i;
+    for (i = 0; i < JsonGetLength(jActive); i++)
+    {
+        json jRow = JsonArrayGet(jActive, i);
+        if (JsonGetInt(JsonObjectGet(jRow, "id")) == nSelId)
+        {
+            sName = JsonGetString(JsonObjectGet(jRow, "wrongdoer_name"));
+            break;
+        }
+    }
+
+    CreateVendConfirmPopup(oPC, nSelId, sName);
+}
+
+// ================================================================
+// Main event handler
+// ================================================================
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    // --- Forswear confirmation popup ---
+    if (nToken == NuiFindWindow(oPC, VEND_WIN_CONFIRM))
+    {
+        if (sEvent == EVENT_TYPE_CLICK)
+        {
+            if (sElem == VEND_BTN_FORSW_OK)
+                HandleForswearConfirm(oPC);
+            else if (sElem == VEND_BTN_FORSW_CANCEL)
+                NuiDestroy(oPC, nToken);
+        }
+        return;
+    }
+
+    if (nToken != NuiFindWindow(oPC, VEND_WINDOW)) return;
+
+    if (sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalInt(oPC, VEND_LVAR_SEL_ID);
+        return;
+    }
+
+    if (sEvent == EVENT_TYPE_CLICK)
+    {
+        if (sElem == VEND_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        if (sElem == VEND_BTN_FORSWEAR)
+        {
+            HandleForswearRequest(oPC);
+            return;
+        }
+    }
+
+    if (sEvent == EVENT_TYPE_MOUSEDOWN && sElem == VEND_BTN_ROW_ACT)
+    {
+        HandleRowSelect(oPC, nToken, nIdx);
+        return;
+    }
+}

--- a/Vengeance Ledger/Scripts/sql_vend.nss
+++ b/Vengeance Ledger/Scripts/sql_vend.nss
@@ -1,0 +1,175 @@
+// Persistent grudge storage.
+// Status: 0=active, 1=fulfilled (wrongdoer killed), 2=forsworn (released by victim).
+
+const int VEND_OVERDUE_DAYS     = 21;
+const int VEND_FULFILL_DURATION = 3600;
+const int VEND_MAX_HISTORY      = 10;
+const int VEND_FORSW_XP_PENALTY = 50;
+
+void VendCreateTables()
+{
+    sqlquery q;
+    q = SqlPrepareQueryCampaign("vend",
+        "CREATE TABLE IF NOT EXISTS vend_grudges ("
+        "  id             INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "  victim_uuid    TEXT    NOT NULL,"
+        "  wrongdoer_uuid TEXT    NOT NULL,"
+        "  wrongdoer_name TEXT    DEFAULT '',"
+        "  wrong_type     INTEGER DEFAULT 1,"
+        "  item_tag       TEXT    DEFAULT '',"
+        "  created_at     INTEGER DEFAULT 0,"
+        "  fulfilled_at   INTEGER DEFAULT 0,"
+        "  forsworn_at    INTEGER DEFAULT 0,"
+        "  status         INTEGER DEFAULT 0)");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("vend",
+        "CREATE TABLE IF NOT EXISTS vend_players ("
+        "  uuid      TEXT PRIMARY KEY,"
+        "  char_name TEXT DEFAULT '')");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("vend",
+        "CREATE INDEX IF NOT EXISTS vend_idx_victim ON vend_grudges (victim_uuid, status)");
+    SqlStep(q);
+}
+
+void VendRegisterPlayer(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("vend",
+        "INSERT OR REPLACE INTO vend_players (uuid, char_name) VALUES (@uuid, @name)");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindString(q, "@name", GetName(oPC));
+    SqlStep(q);
+}
+
+int VendHasActiveGrudge(string sVictimUuid, string sWrongdoerUuid, int nWrongType)
+{
+    sqlquery q = SqlPrepareQueryCampaign("vend",
+        "SELECT COUNT(*) FROM vend_grudges "
+        "WHERE victim_uuid=@v AND wrongdoer_uuid=@w AND wrong_type=@t AND status=0");
+    SqlBindString(q, "@v", sVictimUuid);
+    SqlBindString(q, "@w", sWrongdoerUuid);
+    SqlBindInt   (q, "@t", nWrongType);
+    if (SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+int VendAddGrudgeDB(string sVictimUuid, string sWrongdoerUuid, string sWrongdoerName,
+                    int nWrongType, string sItemTag)
+{
+    sqlquery q = SqlPrepareQueryCampaign("vend",
+        "INSERT INTO vend_grudges "
+        "(victim_uuid, wrongdoer_uuid, wrongdoer_name, wrong_type, item_tag, created_at) "
+        "VALUES (@v, @w, @wn, @t, @it, strftime('%s','now'))");
+    SqlBindString(q, "@v",  sVictimUuid);
+    SqlBindString(q, "@w",  sWrongdoerUuid);
+    SqlBindString(q, "@wn", sWrongdoerName);
+    SqlBindInt   (q, "@t",  nWrongType);
+    SqlBindString(q, "@it", sItemTag);
+    SqlStep(q);
+    sqlquery qId = SqlPrepareQueryCampaign("vend", "SELECT last_insert_rowid()");
+    if (SqlStep(qId)) return SqlGetInt(qId, 0);
+    return 0;
+}
+
+// Returns JsonArray: [{id, wrongdoer_name, wrong_type, created_at, is_overdue}, ...]
+json VendGetActiveGrudges(object oPC)
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("vend",
+        "SELECT id, wrongdoer_name, wrong_type, created_at, "
+        "  (strftime('%s','now') - created_at > @overdue) AS is_overdue "
+        "FROM vend_grudges WHERE victim_uuid=@uuid AND status=0 ORDER BY created_at ASC");
+    SqlBindString(q, "@uuid",    GetObjectUUID(oPC));
+    SqlBindInt   (q, "@overdue", VEND_OVERDUE_DAYS * 86400);
+    while (SqlStep(q))
+    {
+        json j = JsonObject();
+        j = JsonObjectSet(j, "id",             JsonInt   (SqlGetInt   (q, 0)));
+        j = JsonObjectSet(j, "wrongdoer_name", JsonString(SqlGetString(q, 1)));
+        j = JsonObjectSet(j, "wrong_type",     JsonInt   (SqlGetInt   (q, 2)));
+        j = JsonObjectSet(j, "created_at",     JsonInt   (SqlGetInt   (q, 3)));
+        j = JsonObjectSet(j, "is_overdue",     JsonInt   (SqlGetInt   (q, 4)));
+        jRows = JsonArrayInsert(jRows, j);
+    }
+    return jRows;
+}
+
+// Returns last VEND_MAX_HISTORY resolved entries, newest first.
+json VendGetHistoryGrudges(object oPC)
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("vend",
+        "SELECT wrongdoer_name, wrong_type, fulfilled_at, forsworn_at, status "
+        "FROM vend_grudges WHERE victim_uuid=@uuid AND status>0 "
+        "ORDER BY CASE WHEN status=1 THEN fulfilled_at ELSE forsworn_at END DESC "
+        "LIMIT @lim");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@lim",  VEND_MAX_HISTORY);
+    while (SqlStep(q))
+    {
+        json j = JsonObject();
+        j = JsonObjectSet(j, "wrongdoer_name", JsonString(SqlGetString(q, 0)));
+        j = JsonObjectSet(j, "wrong_type",     JsonInt   (SqlGetInt   (q, 1)));
+        j = JsonObjectSet(j, "fulfilled_at",   JsonInt   (SqlGetInt   (q, 2)));
+        j = JsonObjectSet(j, "forsworn_at",    JsonInt   (SqlGetInt   (q, 3)));
+        j = JsonObjectSet(j, "status",         JsonInt   (SqlGetInt   (q, 4)));
+        jRows = JsonArrayInsert(jRows, j);
+    }
+    return jRows;
+}
+
+int VendGetActiveCount(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("vend",
+        "SELECT COUNT(*) FROM vend_grudges WHERE victim_uuid=@uuid AND status=0");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if (SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+int VendGetOverdueCount(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("vend",
+        "SELECT COUNT(*) FROM vend_grudges "
+        "WHERE victim_uuid=@uuid AND status=0 "
+        "AND (strftime('%s','now') - created_at) > @overdue");
+    SqlBindString(q, "@uuid",    GetObjectUUID(oPC));
+    SqlBindInt   (q, "@overdue", VEND_OVERDUE_DAYS * 86400);
+    if (SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// Marks all active grudges of sAvengerUuid against sWrongdoerUuid as fulfilled.
+// Returns count of rows updated.
+int VendFulfillGrudgesAgainst(string sAvengerUuid, string sWrongdoerUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign("vend",
+        "UPDATE vend_grudges SET status=1, fulfilled_at=strftime('%s','now') "
+        "WHERE victim_uuid=@v AND wrongdoer_uuid=@w AND status=0");
+    SqlBindString(q, "@v", sAvengerUuid);
+    SqlBindString(q, "@w", sWrongdoerUuid);
+    SqlStep(q);
+    sqlquery qCnt = SqlPrepareQueryCampaign("vend", "SELECT changes()");
+    if (SqlStep(qCnt)) return SqlGetInt(qCnt, 0);
+    return 0;
+}
+
+void VendForswearGrudge(int nId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("vend",
+        "UPDATE vend_grudges SET status=2, forsworn_at=strftime('%s','now') "
+        "WHERE id=@id AND status=0");
+    SqlBindInt(q, "@id", nId);
+    SqlStep(q);
+}
+
+string VendFormatDate(int nUnix)
+{
+    sqlquery q = SqlPrepareQueryCampaign("vend",
+        "SELECT strftime('%d.%m', @ts, 'unixepoch')");
+    SqlBindInt(q, "@ts", nUnix);
+    if (SqlStep(q)) return SqlGetString(q, 0);
+    return "??";
+}

--- a/Vengeance Ledger/Scripts/sys_on_death.nss
+++ b/Vengeance Ledger/Scripts/sys_on_death.nss
@@ -1,0 +1,19 @@
+#include "lib_vend"
+
+void main()
+{
+    object oPC = OBJECT_SELF;
+    if (!GetIsPC(oPC)) return;
+
+    object oKiller = GetLastKiller();
+    if (!GetIsObjectValid(oKiller)) return;
+    if (!GetIsPC(oKiller))         return;
+    if (oKiller == oPC)            return;   // suicide: no grudge
+
+    // The dead PC earns a grudge against their killer
+    VendAddGrudge(oPC, oKiller, VEND_WRONG_KILLED, "");
+
+    // If the killer had an active grudge against the victim,
+    // this kill fulfills it — vengeance answered with vengeance
+    VendCheckFulfillment(oKiller, oPC);
+}

--- a/Vengeance Ledger/Scripts/sys_on_enter.nss
+++ b/Vengeance Ledger/Scripts/sys_on_enter.nss
@@ -1,0 +1,30 @@
+#include "lib_vend"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if (!GetIsPC(oPC)) return;
+
+    VendRegisterPlayer(oPC);
+    ApplyVendEffects(oPC);
+
+    int nActive  = VendGetActiveCount(oPC);
+    if (nActive <= 0) return;
+
+    int nOverdue = VendGetOverdueCount(oPC);
+    int nFury    = nActive  < VEND_MAX_FURY  ? nActive  : VEND_MAX_FURY;
+    int nResent  = nOverdue < VEND_MAX_RESENT ? nOverdue : VEND_MAX_RESENT;
+
+    string sMsg = "[Księga Krzywd] Masz " + IntToString(nActive) + " aktywnych wpisów w Księdze. "
+        + "Furia: +" + IntToString(nFury) + " AB/OBR";
+    if (nResent > 0)
+        sMsg = sMsg + ", Żal: -" + IntToString(nResent) + " PP";
+    sMsg = sMsg + ".";
+
+    SendMessageToPC(oPC, sMsg);
+    if (nOverdue > 0)
+        SendMessageToPC(oPC,
+            "[Księga Krzywd] " + IntToString(nOverdue) +
+            " wpisów przekroczyło termin — Pieczęć krwi pulsuje słabo, żal cię pochłania.");
+    FloatingTextStringOnCreature("Krew woła o zemstę...", oPC, FALSE);
+}

--- a/Vengeance Ledger/Scripts/sys_on_load.nss
+++ b/Vengeance Ledger/Scripts/sys_on_load.nss
@@ -1,0 +1,6 @@
+#include "lib_vend_def"
+
+void main()
+{
+    VendCreateTables();
+}

--- a/Vengeance Ledger/Scripts/test_vend.nss
+++ b/Vengeance Ledger/Scripts/test_vend.nss
@@ -1,0 +1,35 @@
+#include "lib_vend"
+
+// OnUsed placeable — opens Vengeance Ledger window.
+// DM use: injects a test grudge from the first other online PC.
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if (!GetIsPC(oPC)) return;
+
+    if (GetIsDM(oPC))
+    {
+        // DM helper: add one grudge of each type from the first other online PC
+        object oOther = GetFirstPC();
+        while (GetIsObjectValid(oOther) && oOther == oPC)
+            oOther = GetNextPC();
+
+        if (!GetIsObjectValid(oOther))
+        {
+            SendMessageToPC(oPC, "[Test] Potrzebny jest drugi gracz online jako krzywdziciel.");
+            return;
+        }
+
+        VendAddGrudge(oPC, oOther, VEND_WRONG_KILLED, "");
+        VendAddGrudge(oPC, oOther, VEND_WRONG_STOLEN, "sword_01");
+        VendAddGrudge(oPC, oOther, VEND_WRONG_CURSED, "");
+
+        SendMessageToPC(oPC,
+            "[Test] Dodano 3 testowe wpisy krzywdy od: " + GetName(oOther));
+        SendMessageToPC(oPC,
+            "[Test] Aby przetestować Zemstę, zabij " + GetName(oOther) + ".");
+        return;
+    }
+
+    CreateVendWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

System zemsty i urazy dla PC w persistent world. Krzywdy (śmierć z ręki innego gracza, kradzież, klątwa) zapisywane są w osobistej **Księdze Krzywd** ofiary. Moduł napędza mechanikę zemsty: aktywne wpisy nagradzają gracza premią bojową, przetrzymywane zbyt długo go karzą, a rozliczenie krzywdy daje jednorazowy buff. Gracz może też Wyrzec się krzywdy za cenę PD. Pełne NUI (lista aktywnych krzywd + historia), trwały zapis w SQLite.

## Mechanika

| Efekt | Warunek | Wartość |
|---|---|---|
| **Furia** (+AB, +OBR magiczne) | ≥1 aktywny wpis | +1/+1 za wpis, max +3 |
| **Żal** (–PP) | wpis starszy niż 21 dni | –1 PP za wpis, max –3 |
| **Zemsta** (+AB, +OBR, +rzuty) | zabicie krzywdziciela | +2/+2/+2 na 1h |
| **Wyrzeczenie** | klik w UI + potwierdzenie | –50 PD, wpis archiwizowany |

System blokuje duplikaty: 1 aktywny wpis danego typu na parę victim–wrongdoer. Zabicie krzywdziciela auto-wykrywa fulfillment przez `sys_on_death.nss`. Kradzieże i klątwy wpisywane ręcznie (DM lub integracja z innymi modułami).

## Pliki

```
Vengeance Ledger/
  Scripts/
    sql_vend.nss        — tabele SQLite, wszystkie zapytania
    lib_vend_def.nss    — stałe, ID bindów, ID przycisków, VendWrongTypeName()
    lib_vend.nss        — publiczne API (VendAddGrudge, VendCheckFulfillment,
                          ApplyVendEffects), budowa NUI, FeedVendWindow,
                          CreateVendWindow, popup Wyrzeczenia
    lib_vend_ev.nss     — handler eventów NUI (klik wiersza, Forswear, Close)
    sys_on_load.nss     — VendCreateTables()
    sys_on_enter.nss    — rejestracja gracza + reaplikacja efektów + notyfikacja
    sys_on_death.nss    — tworzenie wpisu + sprawdzanie fulfillment po śmierci PC
    test_vend.nss       — OnUsed placeable: okno dla gracza, test-injekcja dla DM
  INTEGRATION.md        — instrukcja integracji z istniejącym modułem
```

**3 commity atomowe:** data layer → UI + logika → hooki + integracja.

## Zależności (NWNX? SQL?)

- **SQLite**: kampania `"vend"` — dwie tabele, jeden indeks. Vanilla NWN:EE.
- **NWNX**: brak.
- **NWN:EE 87.8193.37+**: wymagane `GetEffectTag()` / `TagEffect()`.
- **lib_nui.nss + lib_nui_utility.nss**: już w repo (Mailbox, Appearance).

## Jak włączyć w istniejącym module

1. Skopiuj `Vengeance Ledger/Scripts/` do skryptów modułu.
2. Podepnij hooki:
   - **OnModuleLoad** → `sys_on_load.nss`
   - **OnClientEnter** → `sys_on_enter.nss`
   - **OnPlayerDeath** → `sys_on_death.nss`
3. Placeable z **OnUsed** = `test_vend.nss` jako punkt wejścia dla gracza.
4. Opcjonalnie: wywołaj `VendAddGrudge(victim, wrongdoer, VEND_WRONG_STOLEN, "")` z własnych systemów kradzieży/kląt.

Szczegóły w `INTEGRATION.md`.

## Co celowo pominięto

- Auto-wykrywanie kradzieży i kląt PC→PC (brak niezawodnego zdarzenia bez NWNX).
- Krzywdy „przez proxy" (atak na sprzymierzeńca) — osobny moduł.
- Edycja / usuwanie archiwalnych wpisów — historia jest read-only.
- Wielokrotne wpisy tego samego typu w tej samej parze — deduplikacja by design.


---
_Generated by [Claude Code](https://claude.ai/code/session_01C51DiCjTHQ2oSRXFufCgzG)_