### PR TITLE
feat: Inquisition

### DIFF
--- a/Inquisition/INTEGRATION.md
+++ b/Inquisition/INTEGRATION.md
@@ -1,0 +1,82 @@
+# Inquisition System — Integration Guide
+
+## What It Does
+
+Tracks heretical acts committed by PCs and maintains a persistent **Inquisition Rating**
+(0–100) per character. As the rating grows the PC crosses four tiers — Under Suspicion,
+Accused, Convicted, Condemned — each with escalating mechanical penalties (-Charisma,
+-AC, -Saving Throws) and floating-text notifications.
+
+Players can reduce their rating through:
+- **Confession** — pay gold to a priest; reduces by 15 points.
+- **Public Recantation** — broadcast announcement to the area; reduces by 25 points,
+  cooldown of one in-game hour.
+
+DMs have a separate control panel to view all suspects, add charges manually,
+and issue pardons.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `Scripts/sql_inq.nss` | SQLite schema + all queries |
+| `Scripts/lib_inq_def.nss` | Constants, IDs, flavor helpers |
+| `Scripts/lib_inq.nss` | Core logic, effect application, NUI layout |
+| `Scripts/lib_inq_ev.nss` | NUI event handler (registered via `NuiCreate`) |
+| `Scripts/sys_on_load.nss` | Module OnLoad: creates tables |
+| `Scripts/sys_on_enter.nss` | ClientEnter: restores effects, upserts PC name |
+| `Scripts/test_inq.nss` | OnUsed placeable: opens dossier (PC) / DM panel (DM) |
+
+## Dependencies
+
+- **NWScript + NUI only** — no NWNX required.
+- **Campaign DB**: uses `SqlPrepareQueryCampaign("inquisition", ...)`.
+  The `inquisition` campaign DB is auto-created by SQLite on first use.
+
+## Hooks to Wire in Toolset
+
+| Event | Script |
+|---|---|
+| Module → OnModuleLoad | `sys_on_load` |
+| Module → OnClientEnter | `sys_on_enter` |
+
+The `lib_inq_ev.nss` script is passed as the 4th argument to `NuiCreate` for
+each window — no module-level OnNuiEvent hook needed for routing.
+
+## Adding a Heretical Act Programmatically
+
+```nwscript
+#include "lib_inq"
+
+// Called from any spell, item, or area script to flag a PC:
+InqAddCharge(oPC, INQ_ACT_FORBIDDEN_MAGIC);   // +12 rating
+InqAddCharge(oPC, INQ_ACT_DARK_RITUAL);        // +25 rating
+```
+
+Available act IDs and their weights:
+
+| Constant | Weight |
+|---|---|
+| `INQ_ACT_FORBIDDEN_MAGIC` | +12 |
+| `INQ_ACT_BLASPHEMY` | +8 |
+| `INQ_ACT_FORBIDDEN_TOME` | +15 |
+| `INQ_ACT_DEMON_CONTACT` | +18 |
+| `INQ_ACT_UNDEAD_CONSORTING` | +20 |
+| `INQ_ACT_DARK_RITUAL` | +25 |
+
+## Test Placeable
+
+Place a placeable with `test_inq` as the **OnUsed** script:
+- **PC** clicks it → opens their personal Dossier window.
+- **DM** clicks it → opens the DM control panel.
+- Set local int `inq_test_act` (0–5) on the PC before clicking to inject a test charge.
+
+## What Was Deliberately Omitted
+
+- **Inquisitor NPC spawning** — the DM panel has a pardon/charge tool but does not
+  auto-spawn NPC patrols; that requires campaign-specific creature blueprints.
+- **Offline effect persistence** — stat penalties are re-applied on `ClientEnter`;
+  they are not stored as item properties and will not persist across reboots for offline PCs.
+- **Informant mechanic** — shifting charges to another PC was scoped out to avoid
+  potential abuse; could be added in a future revision.
+- **Rating decay over time** — no passive decay; intentional so charges feel meaningful.

--- a/Inquisition/Scripts/lib_inq.nss
+++ b/Inquisition/Scripts/lib_inq.nss
@@ -1,0 +1,706 @@
+// lib_inq.nss - Inquisition: core logic, effect application, NUI layout
+
+#include "lib_inq_def"
+
+// ============================================================
+// Effect management
+// ============================================================
+
+void InqRemoveRatingEffects(object oPC)
+{
+    effect eEff = GetFirstEffect(oPC);
+    while(GetIsEffectValid(eEff))
+    {
+        string sTag = GetEffectTag(eEff);
+        if(sTag == INQ_EFFECT_TAG_ACCUSED ||
+           sTag == INQ_EFFECT_TAG_CONVICT ||
+           sTag == INQ_EFFECT_TAG_CONDEMN)
+        {
+            RemoveEffect(oPC, eEff);
+        }
+        eEff = GetNextEffect(oPC);
+    }
+}
+
+// Strips old effects then re-applies effects matching current rating tier.
+void InqApplyRatingEffects(object oPC, int nRating)
+{
+    InqRemoveRatingEffects(oPC);
+
+    if(nRating < INQ_THRESHOLD_ACCUSED)
+        return;
+
+    effect eSet;
+    string sTag;
+
+    if(nRating < INQ_THRESHOLD_CONVICTED)
+    {
+        sTag = INQ_EFFECT_TAG_ACCUSED;
+        eSet = TagEffect(
+            ExtraordinaryEffect(EffectAbilityDecrease(ABILITY_CHARISMA, 2)),
+            sTag);
+    }
+    else if(nRating < INQ_THRESHOLD_CONDEMNED)
+    {
+        sTag = INQ_EFFECT_TAG_CONVICT;
+        effect eCha = TagEffect(EffectAbilityDecrease(ABILITY_CHARISMA, 2), sTag);
+        effect eAC  = TagEffect(EffectACDecrease(1),                        sTag);
+        eSet = ExtraordinaryEffect(EffectLinkEffects(eCha, eAC));
+    }
+    else
+    {
+        sTag = INQ_EFFECT_TAG_CONDEMN;
+        effect eCha  = TagEffect(EffectAbilityDecrease(ABILITY_CHARISMA, 4),        sTag);
+        effect eAC   = TagEffect(EffectACDecrease(2),                               sTag);
+        effect eSave = TagEffect(EffectSavingThrowDecrease(SAVING_THROW_ALL, 2),    sTag);
+        eSet = ExtraordinaryEffect(EffectLinkEffects(eCha, EffectLinkEffects(eAC, eSave)));
+    }
+
+    ApplyEffectToObject(DURATION_TYPE_PERMANENT, eSet, oPC);
+}
+
+// ============================================================
+// Public API: add a charge against a PC
+// ============================================================
+
+void InqAddCharge(object oPC, int nActId)
+{
+    if(!GetIsPC(oPC) || GetIsDMPossessed(oPC)) return;
+
+    string sPcUuid = GetObjectUUID(oPC);
+    string sPcName = GetName(oPC);
+    int    nWeight = InqGetActWeight(nActId);
+
+    int nOldRating = InqGetRating(sPcUuid);
+    int nNewRating = InqInsertCharge(sPcUuid, sPcName, nActId, nWeight);
+
+    InqApplyRatingEffects(oPC, nNewRating);
+
+    if(nOldRating < INQ_THRESHOLD_ACCUSED && nNewRating >= INQ_THRESHOLD_ACCUSED)
+        FloatingTextStringOnCreature(
+            "Inkwizycja wydała nakaz twojego aresztowania. Uważaj.", oPC, FALSE);
+    else if(nOldRating < INQ_THRESHOLD_CONVICTED && nNewRating >= INQ_THRESHOLD_CONVICTED)
+        FloatingTextStringOnCreature(
+            "Pieczęć heretyka wypala twoją skórę. Zostałeś skazany.", oPC, FALSE);
+    else if(nOldRating < INQ_THRESHOLD_CONDEMNED && nNewRating >= INQ_THRESHOLD_CONDEMNED)
+        FloatingTextStringOnCreature(
+            "Jesteś wyklęty przez Inkwizycję. Polują na ciebie.", oPC, FALSE);
+    else if(nOldRating < INQ_THRESHOLD_SUSPECT && nNewRating >= INQ_THRESHOLD_SUSPECT)
+        FloatingTextStringOnCreature(
+            "Inkwizycja odnotowała twój czyn. Jesteś obserwowany.", oPC, FALSE);
+
+    int nToken = NuiFindWindow(oPC, INQ_WINDOW_DOSSIER);
+    if(nToken) InqFeedDossier(oPC, nToken);
+}
+
+// ============================================================
+// NUI layout — dossier charge row (fixed-count, visibility-toggled)
+// ============================================================
+
+json InqChargeRow(object oPC, int nIdx)
+{
+    float fH    = GetNuiScaleDimension(oPC, 26.0);
+    float fValW = GetNuiScaleDimension(oPC, 60.0);
+
+    json jName = NuiLabel(
+        NuiBind(INQ_BIND_CHARGE_NAME + IntToString(nIdx)),
+        JsonInt(NUI_HALIGN_LEFT),
+        JsonInt(NUI_VALIGN_MIDDLE));
+    jName = NuiHeight(jName, fH);
+
+    json jVal = NuiLabel(
+        NuiBind(INQ_BIND_CHARGE_TOTAL + IntToString(nIdx)),
+        JsonInt(NUI_HALIGN_RIGHT),
+        JsonInt(NUI_VALIGN_MIDDLE));
+    jVal = NuiWidth(jVal, fValW);
+    jVal = NuiHeight(jVal, fH);
+
+    json jChildren = JsonArray();
+    jChildren = JsonArrayInsert(jChildren, jName);
+    jChildren = JsonArrayInsert(jChildren, jVal);
+
+    json jRow = NuiRow(jChildren);
+    jRow = NuiVisible(jRow, NuiBind(INQ_BIND_CHARGE_VIS + IntToString(nIdx)));
+    jRow = NuiHeight(jRow, fH);
+    return jRow;
+}
+
+// ============================================================
+// NUI layout — dossier window
+// ============================================================
+
+json InqBuildDossierLayout(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 32.0);
+    float fLblH  = GetNuiScaleDimension(oPC, 28.0);
+    float fMtrH  = GetNuiScaleDimension(oPC, 22.0);
+    float fFlvH  = GetNuiScaleDimension(oPC, 60.0);
+    float fBtnW  = GetNuiScaleDimension(oPC, 150.0);
+    float fRatW  = GetNuiScaleDimension(oPC, 65.0);
+
+    // Header: title + close button
+    json jTitle = NuiLabel(JsonString("Dossier Inkwizycji"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitle = NuiHeight(jTitle, fBtnH);
+
+    json jClose = NuiButton(JsonString("X"));
+    jClose = NuiId(jClose, INQ_BTN_CLOSE);
+    jClose = NuiWidth(jClose, GetNuiScaleDimension(oPC, 30.0));
+    jClose = NuiHeight(jClose, fBtnH);
+
+    json jHdr = JsonArray();
+    jHdr = JsonArrayInsert(jHdr, jTitle);
+    jHdr = JsonArrayInsert(jHdr, jClose);
+    json jHeader = NuiRow(jHdr);
+    jHeader = NuiHeight(jHeader, fBtnH);
+
+    // Status label
+    json jStatusLbl = NuiLabel(NuiBind(INQ_BIND_STATUS_LBL),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jStatusLbl = NuiStyleForegroundColor(jStatusLbl, NuiBind(INQ_BIND_STATUS_COLOR));
+    jStatusLbl = NuiHeight(jStatusLbl, fLblH);
+
+    // Rating meter + text
+    json jMeter = NuiProgress(NuiBind(INQ_BIND_METER_VAL));
+    jMeter = NuiHeight(jMeter, fMtrH);
+
+    json jRatLbl = NuiLabel(NuiBind(INQ_BIND_RATING_TXT),
+        JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jRatLbl = NuiWidth(jRatLbl, fRatW);
+    jRatLbl = NuiHeight(jRatLbl, fMtrH);
+
+    json jMeterRow = JsonArray();
+    jMeterRow = JsonArrayInsert(jMeterRow, jMeter);
+    jMeterRow = JsonArrayInsert(jMeterRow, jRatLbl);
+    json jMRow = NuiRow(jMeterRow);
+    jMRow = NuiHeight(jMRow, fMtrH);
+
+    // Charges section heading
+    json jChrgHdr = NuiLabel(JsonString("Zarzuty:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jChrgHdr = NuiHeight(jChrgHdr, fLblH);
+
+    // Charge rows
+    json jChrgRows = JsonArray();
+    int i;
+    for(i = 0; i < INQ_ACT_COUNT; i++)
+        jChrgRows = JsonArrayInsert(jChrgRows, InqChargeRow(oPC, i));
+    json jChrgGroup = NuiCol(jChrgRows);
+
+    // Flavor text (multi-line)
+    json jFlavor = NuiLabel(NuiBind(INQ_BIND_FLAVOR_TXT),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_TOP));
+    jFlavor = NuiHeight(jFlavor, fFlvH);
+
+    // Action buttons
+    json jConfess = NuiButton(JsonString("Wyznaj grzechy"));
+    jConfess = NuiId(jConfess, INQ_BTN_CONFESS);
+    jConfess = NuiEnabled(jConfess, NuiBind(INQ_BIND_CONFESS_ENA));
+    jConfess = NuiWidth(jConfess, fBtnW);
+    jConfess = NuiHeight(jConfess, fBtnH);
+    jConfess = NuiTooltip(jConfess, JsonString(
+        "Wyznaj winy kapłanowi za złoto. Redukuje ocenę o "
+        + IntToString(INQ_CONFESS_REDUCTION) + " punktów."));
+
+    json jRecant = NuiButton(JsonString("Odwołaj publicznie"));
+    jRecant = NuiId(jRecant, INQ_BTN_RECANT);
+    jRecant = NuiEnabled(jRecant, NuiBind(INQ_BIND_RECANT_ENA));
+    jRecant = NuiWidth(jRecant, fBtnW);
+    jRecant = NuiHeight(jRecant, fBtnH);
+    jRecant = NuiTooltip(jRecant, JsonString(
+        "Publiczne odwołanie. Większa redukcja (" + IntToString(INQ_RECANT_REDUCTION)
+        + " pkt), lecz dozwolone raz na godzinę."));
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, jConfess);
+    jBtnRow = JsonArrayInsert(jBtnRow, jRecant);
+    json jButtons = NuiRow(jBtnRow);
+    jButtons = NuiHeight(jButtons, fBtnH);
+
+    // Assemble root column
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jHeader);
+    jCol = JsonArrayInsert(jCol, jStatusLbl);
+    jCol = JsonArrayInsert(jCol, jMRow);
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+    jCol = JsonArrayInsert(jCol, jChrgHdr);
+    jCol = JsonArrayInsert(jCol, jChrgGroup);
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+    jCol = JsonArrayInsert(jCol, jFlavor);
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+    jCol = JsonArrayInsert(jCol, jButtons);
+
+    return NuiCol(jCol);
+}
+
+// ============================================================
+// Dossier window: open + feed
+// ============================================================
+
+void InqOpenDossierWindow(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, INQ_WINDOW_DOSSIER);
+    if(!nToken)
+    {
+        json jWin = NuiWindow(
+            InqBuildDossierLayout(oPC),
+            JsonString("Dossier Inkwizycji"),
+            NuiBind(INQ_WIN_GEOM),
+            JsonBool(FALSE),
+            JsonBool(FALSE),
+            JsonBool(TRUE),
+            JsonBool(FALSE),
+            JsonBool(TRUE));
+        nToken = NuiCreate(oPC, jWin, INQ_WINDOW_DOSSIER, INQ_EV_SCRIPT);
+    }
+
+    SetLocalInt(oPC, INQ_LVAR_TOKEN, nToken);
+    InqFeedDossier(oPC, nToken);
+}
+
+void InqFeedDossier(object oPC, int nToken)
+{
+    string sPcUuid = GetObjectUUID(oPC);
+    int    nRating = InqGetRating(sPcUuid);
+
+    NuiSetBind(oPC, nToken, INQ_BIND_STATUS_LBL,   JsonString(InqGetStatusLabel(nRating)));
+    NuiSetBind(oPC, nToken, INQ_BIND_STATUS_COLOR,  InqGetStatusColor(nRating));
+    NuiSetBind(oPC, nToken, INQ_BIND_RATING_TXT,
+        JsonString(IntToString(nRating) + " / " + IntToString(INQ_RATING_MAX)));
+    NuiSetBind(oPC, nToken, INQ_BIND_METER_VAL,
+        JsonFloat(IntToFloat(nRating) / IntToFloat(INQ_RATING_MAX)));
+    NuiSetBind(oPC, nToken, INQ_BIND_FLAVOR_TXT, JsonString(InqGetStatusFlavor(nRating)));
+
+    int bHasCharges = (nRating > 0);
+    NuiSetBind(oPC, nToken, INQ_BIND_CONFESS_ENA, JsonBool(bHasCharges));
+    NuiSetBind(oPC, nToken, INQ_BIND_RECANT_ENA,  JsonBool(bHasCharges));
+
+    json jCharges = InqGetChargesSummary(sPcUuid);
+    int  nCount   = JsonGetLength(jCharges);
+    int i;
+    for(i = 0; i < INQ_ACT_COUNT; i++)
+    {
+        int bVis = (i < nCount);
+        NuiSetBind(oPC, nToken, INQ_BIND_CHARGE_VIS + IntToString(i), JsonBool(bVis));
+        if(bVis)
+        {
+            json jEntry = JsonArrayGet(jCharges, i);
+            int  nActId = JsonGetInt(JsonObjectGet(jEntry, "act_id"));
+            int  nTotal = JsonGetInt(JsonObjectGet(jEntry, "total_weight"));
+            int  nCnt   = JsonGetInt(JsonObjectGet(jEntry, "count"));
+
+            string sName = InqGetActName(nActId);
+            if(nCnt > 1) sName += " (x" + IntToString(nCnt) + ")";
+
+            NuiSetBind(oPC, nToken, INQ_BIND_CHARGE_NAME  + IntToString(i), JsonString(sName));
+            NuiSetBind(oPC, nToken, INQ_BIND_CHARGE_TOTAL + IntToString(i),
+                JsonString("+" + IntToString(nTotal)));
+        }
+    }
+}
+
+// ============================================================
+// Confession handler
+// ============================================================
+
+void InqHandleConfess(object oPC, int nToken)
+{
+    string sPcUuid = GetObjectUUID(oPC);
+    string sPcName = GetName(oPC);
+    int    nRating = InqGetRating(sPcUuid);
+
+    if(nRating <= 0)
+    {
+        SendMessageToPC(oPC, "[Inkwizycja] Nie masz nic do wyznania.");
+        return;
+    }
+
+    int nGoldCost = (nRating / 10 + 1) * INQ_CONFESS_GOLD_PER_10;
+    if(GetGold(oPC) < nGoldCost)
+    {
+        SendMessageToPC(oPC, "[Inkwizycja] Spowiedź kosztuje "
+            + IntToString(nGoldCost) + " szt. złota. Brakuje ci funduszy.");
+        return;
+    }
+
+    AssignCommand(oPC, TakeGoldFromCreature(nGoldCost, oPC, TRUE));
+
+    int nNewRating = InqReduceRating(sPcUuid, sPcName, INQ_CONFESS_REDUCTION);
+    InqApplyRatingEffects(oPC, nNewRating);
+
+    SendMessageToPC(oPC, "[Inkwizycja] Spowiedź wysłuchana. Zapłacono "
+        + IntToString(nGoldCost) + " zł. Nowa ocena: " + IntToString(nNewRating) + ".");
+    FloatingTextStringOnCreature(
+        "Kapłan Inkwizycji przyjął twoją spowiedź.", oPC, FALSE);
+
+    InqFeedDossier(oPC, nToken);
+}
+
+// ============================================================
+// Recantation handler (once per in-game hour)
+// ============================================================
+
+void InqHandleRecant(object oPC, int nToken)
+{
+    string sPcUuid = GetObjectUUID(oPC);
+    string sPcName = GetName(oPC);
+
+    string sLastKey = "INQ_RECANT_" + sPcUuid;
+    int    nLastT   = GetLocalInt(GetModule(), sLastKey);
+    int    nNow     = FloatToInt(GetGameTime());
+
+    if(nLastT > 0 && (nNow - nLastT) < 3600)
+    {
+        SendMessageToPC(oPC, "[Inkwizycja] Odwołanie publiczne możliwe raz na godzinę.");
+        return;
+    }
+
+    int nRating = InqGetRating(sPcUuid);
+    if(nRating <= 0)
+    {
+        SendMessageToPC(oPC, "[Inkwizycja] Nie masz przed czym się odwoływać.");
+        return;
+    }
+
+    SetLocalInt(GetModule(), sLastKey, nNow);
+
+    int nNewRating = InqReduceRating(sPcUuid, sPcName, INQ_RECANT_REDUCTION);
+    InqApplyRatingEffects(oPC, nNewRating);
+
+    // Broadcast recantation to all PCs in the same area
+    string sMsg = GetName(oPC) + " publicznie odwołuje wszelkie czyny heretyckie!";
+    object oOther = GetFirstPC();
+    while(GetIsObjectValid(oOther))
+    {
+        if(GetArea(oOther) == GetArea(oPC))
+            SendMessageToPC(oOther, "[Inkwizycja] " + sMsg);
+        oOther = GetNextPC();
+    }
+
+    SendMessageToPC(oPC, "[Inkwizycja] Odwołanie ogłoszone. Nowa ocena: "
+        + IntToString(nNewRating) + ".");
+    InqFeedDossier(oPC, nToken);
+}
+
+// ============================================================
+// DM window layout — suspect list template
+// ============================================================
+
+json InqBuildDmListTemplate(object oDM)
+{
+    float fNameW   = GetNuiScaleDimension(oDM, 175.0);
+    float fRatW    = GetNuiScaleDimension(oDM, 52.0);
+    float fStatW   = GetNuiScaleDimension(oDM, 155.0);
+    float fBtnW    = GetNuiScaleDimension(oDM, 70.0);
+    float fRowH    = GetNuiScaleDimension(oDM, 28.0);
+
+    json jName = NuiLabel(NuiBind(INQ_BIND_DM_LIST_NAME),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jName = NuiWidth(jName, fNameW);
+    jName = NuiHeight(jName, fRowH);
+
+    json jRat = NuiLabel(NuiBind(INQ_BIND_DM_LIST_RATING),
+        JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jRat = NuiWidth(jRat, fRatW);
+    jRat = NuiHeight(jRat, fRowH);
+
+    json jStat = NuiLabel(NuiBind(INQ_BIND_DM_LIST_STATUS),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jStat = NuiWidth(jStat, fStatW);
+    jStat = NuiHeight(jStat, fRowH);
+
+    json jBtn = NuiButton(JsonString("Wybierz"));
+    jBtn = NuiId(jBtn, INQ_BTN_DM_ROW);
+    jBtn = NuiWidth(jBtn, fBtnW);
+    jBtn = NuiHeight(jBtn, fRowH);
+
+    json jCells = JsonArray();
+    jCells = JsonArrayInsert(jCells, jName);
+    jCells = JsonArrayInsert(jCells, jRat);
+    jCells = JsonArrayInsert(jCells, jStat);
+    jCells = JsonArrayInsert(jCells, jBtn);
+    json jRow = NuiRow(jCells);
+    jRow = NuiEncouraged(jRow, NuiBind(INQ_BIND_DM_LIST_ENC));
+    jRow = NuiHeight(jRow, fRowH);
+
+    return JsonArrayInsert(JsonArray(), NuiListTemplateCell(jRow, 0.0, TRUE));
+}
+
+json InqBuildDmLayout(object oDM)
+{
+    float fBtnH  = GetNuiScaleDimension(oDM, 32.0);
+    float fLblH  = GetNuiScaleDimension(oDM, 26.0);
+    float fListH = GetNuiScaleDimension(oDM, 220.0);
+    float fRowH  = GetNuiScaleDimension(oDM, 28.0);
+    float fBtnW  = GetNuiScaleDimension(oDM, 120.0);
+
+    // Header
+    json jTitle = NuiLabel(JsonString("Rejestr Inkwizycji"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitle = NuiHeight(jTitle, fBtnH);
+
+    json jClose = NuiButton(JsonString("X"));
+    jClose = NuiId(jClose, INQ_BTN_DM_CLOSE);
+    jClose = NuiWidth(jClose, GetNuiScaleDimension(oDM, 30.0));
+    jClose = NuiHeight(jClose, fBtnH);
+
+    json jHdrRow = JsonArray();
+    jHdrRow = JsonArrayInsert(jHdrRow, jTitle);
+    jHdrRow = JsonArrayInsert(jHdrRow, jClose);
+    json jHeader = NuiRow(jHdrRow);
+    jHeader = NuiHeight(jHeader, fBtnH);
+
+    // Column header labels
+    json jColHdr = NuiLabel(JsonString("Imię                        Ocena  Status"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jColHdr = NuiHeight(jColHdr, fLblH);
+
+    // Suspect list
+    json jList = NuiList(InqBuildDmListTemplate(oDM), NuiBind(INQ_BIND_DM_LIST_COUNT), fRowH);
+    jList = NuiHeight(jList, fListH);
+
+    // Selected suspect detail
+    json jDetail = NuiLabel(NuiBind(INQ_BIND_DM_DETAIL_LBL),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jDetail = NuiHeight(jDetail, fLblH);
+
+    // Action buttons
+    json jAdd = NuiButton(JsonString("Dodaj zarzut"));
+    jAdd = NuiId(jAdd, INQ_BTN_DM_ADD_ACT);
+    jAdd = NuiWidth(jAdd, fBtnW);
+    jAdd = NuiHeight(jAdd, fBtnH);
+
+    json jPardon = NuiButton(JsonString("Ułaskaw"));
+    jPardon = NuiId(jPardon, INQ_BTN_DM_PARDON);
+    jPardon = NuiWidth(jPardon, fBtnW);
+    jPardon = NuiHeight(jPardon, fBtnH);
+
+    json jClear = NuiButton(JsonString("Wyczyść zarzuty"));
+    jClear = NuiId(jClear, INQ_BTN_DM_CLEAR);
+    jClear = NuiWidth(jClear, fBtnW);
+    jClear = NuiHeight(jClear, fBtnH);
+
+    json jActBtns = JsonArray();
+    jActBtns = JsonArrayInsert(jActBtns, jAdd);
+    jActBtns = JsonArrayInsert(jActBtns, jPardon);
+    jActBtns = JsonArrayInsert(jActBtns, jClear);
+    json jBtnsRow = NuiRow(jActBtns);
+    jBtnsRow = NuiHeight(jBtnsRow, fBtnH);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jHeader);
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+    jCol = JsonArrayInsert(jCol, jColHdr);
+    jCol = JsonArrayInsert(jCol, jList);
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+    jCol = JsonArrayInsert(jCol, jDetail);
+    jCol = JsonArrayInsert(jCol, jBtnsRow);
+
+    return NuiCol(jCol);
+}
+
+// ============================================================
+// DM window: open + feed
+// ============================================================
+
+void InqOpenDmWindow(object oDM)
+{
+    int nToken = NuiFindWindow(oDM, INQ_WINDOW_DM);
+    if(!nToken)
+    {
+        json jWin = NuiWindow(
+            InqBuildDmLayout(oDM),
+            JsonString("Rejestr Inkwizycji [DM]"),
+            NuiBind(INQ_WIN_GEOM),
+            JsonBool(FALSE),
+            JsonBool(FALSE),
+            JsonBool(TRUE),
+            JsonBool(FALSE),
+            JsonBool(TRUE));
+        nToken = NuiCreate(oDM, jWin, INQ_WINDOW_DM, INQ_EV_SCRIPT);
+    }
+
+    SetLocalInt(oDM, INQ_LVAR_DM_TOKEN, nToken);
+    InqFeedDmPanel(oDM, nToken);
+}
+
+void InqFeedDmPanel(object oDM, int nToken)
+{
+    json jSuspects = InqGetAllSuspects();
+    int  nCount    = JsonGetLength(jSuspects);
+
+    json jNames   = JsonArray();
+    json jRatings = JsonArray();
+    json jStats   = JsonArray();
+    json jEncs    = JsonArray();
+
+    string sSelUuid = GetLocalString(oDM, INQ_LVAR_DM_SEL_UUID);
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json   jRow  = JsonArrayGet(jSuspects, i);
+        string sUuid = JsonGetString(JsonObjectGet(jRow, "uuid"));
+        string sName = JsonGetString(JsonObjectGet(jRow, "name"));
+        int    nRat  = JsonGetInt   (JsonObjectGet(jRow, "rating"));
+
+        jNames   = JsonArrayInsert(jNames,   JsonString(sName));
+        jRatings = JsonArrayInsert(jRatings, JsonString(IntToString(nRat)));
+        jStats   = JsonArrayInsert(jStats,   JsonString(InqGetStatusLabel(nRat)));
+        jEncs    = JsonArrayInsert(jEncs,    JsonBool(sUuid == sSelUuid));
+    }
+
+    NuiSetBind(oDM, nToken, INQ_BIND_DM_LIST_COUNT,  JsonInt(nCount));
+    NuiSetBind(oDM, nToken, INQ_BIND_DM_LIST_NAME,   jNames);
+    NuiSetBind(oDM, nToken, INQ_BIND_DM_LIST_RATING, jRatings);
+    NuiSetBind(oDM, nToken, INQ_BIND_DM_LIST_STATUS, jStats);
+    NuiSetBind(oDM, nToken, INQ_BIND_DM_LIST_ENC,    jEncs);
+
+    string sSelName = GetLocalString(oDM, INQ_LVAR_DM_SEL_NAME);
+    if(sSelName == "" || sSelUuid == "")
+        NuiSetBind(oDM, nToken, INQ_BIND_DM_DETAIL_LBL, JsonString("Wybierz postać z listy."));
+    else
+    {
+        int nRat = InqGetRating(sSelUuid);
+        NuiSetBind(oDM, nToken, INQ_BIND_DM_DETAIL_LBL,
+            JsonString("Wybrany: " + sSelName + "  |  Ocena: " + IntToString(nRat)
+                + "  |  " + InqGetStatusLabel(nRat)));
+    }
+}
+
+// ============================================================
+// Act picker popup (DM selects which heretical act to apply)
+// ============================================================
+
+json InqBuildActPickerLayout(object oDM)
+{
+    float fBtnH = GetNuiScaleDimension(oDM, 32.0);
+    float fBtnW = GetNuiScaleDimension(oDM, 290.0);
+    float fLblH = GetNuiScaleDimension(oDM, 28.0);
+
+    json jTitleRow = JsonArray();
+    json jTitleLbl = NuiLabel(JsonString("Wybierz zarzut do dodania:"),
+        JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitleLbl = NuiHeight(jTitleLbl, fLblH);
+    jTitleRow = JsonArrayInsert(jTitleRow, jTitleLbl);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(jTitleRow));
+
+    int i;
+    for(i = 0; i < INQ_ACT_COUNT; i++)
+    {
+        string sLabel = InqGetActName(i) + "  (+" + IntToString(InqGetActWeight(i)) + " pkt)";
+        json jBtn = NuiButton(JsonString(sLabel));
+        jBtn = NuiId(jBtn, INQ_BTN_DM_ACT_ROW + IntToString(i));
+        jBtn = NuiWidth(jBtn, fBtnW);
+        jBtn = NuiHeight(jBtn, fBtnH);
+        jCol = JsonArrayInsert(jCol, jBtn);
+    }
+
+    json jCancel = NuiButton(JsonString("Anuluj"));
+    jCancel = NuiId(jCancel, INQ_BTN_DM_ACT_CLOSE);
+    jCancel = NuiWidth(jCancel, fBtnW);
+    jCancel = NuiHeight(jCancel, fBtnH);
+    jCol = JsonArrayInsert(jCol, jCancel);
+
+    return NuiCol(jCol);
+}
+
+void InqOpenActPicker(object oDM)
+{
+    int nToken = NuiFindWindow(oDM, INQ_WINDOW_DM_ACT);
+    if(nToken) NuiDestroy(oDM, nToken);
+
+    json jWin = NuiWindow(
+        InqBuildActPickerLayout(oDM),
+        JsonString("Dodaj zarzut"),
+        NuiBind(INQ_WIN_ACT_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE),
+        JsonBool(FALSE));
+    NuiCreate(oDM, jWin, INQ_WINDOW_DM_ACT, INQ_EV_SCRIPT);
+}
+
+// ============================================================
+// DM: apply a charge to the selected PC
+// ============================================================
+
+void InqDmApplyCharge(object oDM, int nActId)
+{
+    string sSelUuid = GetLocalString(oDM, INQ_LVAR_DM_SEL_UUID);
+    string sSelName = GetLocalString(oDM, INQ_LVAR_DM_SEL_NAME);
+
+    if(sSelUuid == "")
+    {
+        SendMessageToPC(oDM, "[Inkwizycja] Wybierz najpierw postać.");
+        return;
+    }
+
+    // Find the PC online to apply effects live
+    object oTarget = OBJECT_INVALID;
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        if(GetObjectUUID(oPC) == sSelUuid) { oTarget = oPC; break; }
+        oPC = GetNextPC();
+    }
+
+    int nNewRating;
+    if(GetIsObjectValid(oTarget))
+    {
+        InqAddCharge(oTarget, nActId);
+        nNewRating = InqGetRating(sSelUuid);
+        SendMessageToPC(oTarget, "[Inkwizycja] Odnotowano: " + InqGetActName(nActId) + ".");
+    }
+    else
+    {
+        int nWeight = InqGetActWeight(nActId);
+        nNewRating  = InqInsertCharge(sSelUuid, sSelName, nActId, nWeight);
+    }
+
+    SendMessageToPC(oDM, "[Inkwizycja] Zarzut dodany: " + InqGetActName(nActId)
+        + " (" + sSelName + "). Nowa ocena: " + IntToString(nNewRating) + ".");
+
+    int nDmToken = NuiFindWindow(oDM, INQ_WINDOW_DM);
+    if(nDmToken) InqFeedDmPanel(oDM, nDmToken);
+}
+
+// ============================================================
+// DM: full pardon for selected PC
+// ============================================================
+
+void InqDmPardon(object oDM)
+{
+    string sSelUuid = GetLocalString(oDM, INQ_LVAR_DM_SEL_UUID);
+    string sSelName = GetLocalString(oDM, INQ_LVAR_DM_SEL_NAME);
+
+    if(sSelUuid == "")
+    {
+        SendMessageToPC(oDM, "[Inkwizycja] Wybierz najpierw postać.");
+        return;
+    }
+
+    InqClearAll(sSelUuid, sSelName);
+
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        if(GetObjectUUID(oPC) == sSelUuid)
+        {
+            InqRemoveRatingEffects(oPC);
+            SendMessageToPC(oPC,
+                "[Inkwizycja] Zostałeś ułaskawiony przez biskupa. Twoja karta jest czysta.");
+            int nPcToken = NuiFindWindow(oPC, INQ_WINDOW_DOSSIER);
+            if(nPcToken) InqFeedDossier(oPC, nPcToken);
+            break;
+        }
+        oPC = GetNextPC();
+    }
+
+    SendMessageToPC(oDM, "[Inkwizycja] " + sSelName + " ułaskawiony.");
+
+    int nDmToken = NuiFindWindow(oDM, INQ_WINDOW_DM);
+    if(nDmToken) InqFeedDmPanel(oDM, nDmToken);
+}

--- a/Inquisition/Scripts/lib_inq_def.nss
+++ b/Inquisition/Scripts/lib_inq_def.nss
@@ -1,0 +1,191 @@
+// lib_inq_def.nss - Inquisition: constants, IDs, flavor helpers
+
+#include "lib_nui"
+#include "sql_inq"
+
+void InqOpenDossierWindow(object oPC);
+void InqOpenDmWindow(object oDM);
+void InqAddCharge(object oPC, int nActId);
+void InqApplyRatingEffects(object oPC, int nRating);
+void InqRemoveRatingEffects(object oPC);
+void InqFeedDossier(object oPC, int nToken);
+void InqFeedDmPanel(object oDM, int nToken);
+
+// ============================================================
+// Heretical act IDs
+// ============================================================
+const int INQ_ACT_FORBIDDEN_MAGIC    = 0;
+const int INQ_ACT_DEMON_CONTACT      = 1;
+const int INQ_ACT_BLASPHEMY          = 2;
+const int INQ_ACT_FORBIDDEN_TOME     = 3;
+const int INQ_ACT_UNDEAD_CONSORTING  = 4;
+const int INQ_ACT_DARK_RITUAL        = 5;
+const int INQ_ACT_COUNT              = 6;
+
+// ============================================================
+// Rating thresholds
+// ============================================================
+const int INQ_THRESHOLD_CLEAN        = 0;
+const int INQ_THRESHOLD_SUSPECT      = 1;
+const int INQ_THRESHOLD_ACCUSED      = 26;
+const int INQ_THRESHOLD_CONVICTED    = 51;
+const int INQ_THRESHOLD_CONDEMNED    = 76;
+const int INQ_RATING_MAX             = 100;
+
+// ============================================================
+// Reduction amounts
+// ============================================================
+const int INQ_CONFESS_REDUCTION      = 15;
+const int INQ_RECANT_REDUCTION       = 25;
+const int INQ_CONFESS_GOLD_PER_10    = 100;
+
+// ============================================================
+// Window identifiers
+// ============================================================
+const string INQ_WINDOW_DOSSIER      = "INQ_DOSSIER";
+const string INQ_WINDOW_DM           = "INQ_DM";
+const string INQ_WINDOW_DM_ACT       = "INQ_DM_ACT";
+const string INQ_EV_SCRIPT           = "lib_inq_ev";
+
+// ============================================================
+// Bind names — dossier window
+// ============================================================
+const string INQ_BIND_STATUS_LBL     = "inq_status_lbl";
+const string INQ_BIND_STATUS_COLOR   = "inq_status_color";
+const string INQ_BIND_RATING_TXT     = "inq_rating_txt";
+const string INQ_BIND_METER_VAL      = "inq_meter_val";
+const string INQ_BIND_CHARGE_NAME    = "inq_charge_name";
+const string INQ_BIND_CHARGE_TOTAL   = "inq_charge_total";
+const string INQ_BIND_CHARGE_VIS     = "inq_charge_vis";
+const string INQ_BIND_FLAVOR_TXT     = "inq_flavor_txt";
+const string INQ_BIND_CONFESS_ENA    = "inq_confess_ena";
+const string INQ_BIND_RECANT_ENA     = "inq_recant_ena";
+
+// ============================================================
+// Bind names — DM window
+// ============================================================
+const string INQ_BIND_DM_LIST_NAME   = "inq_dm_name";
+const string INQ_BIND_DM_LIST_RATING = "inq_dm_rating";
+const string INQ_BIND_DM_LIST_STATUS = "inq_dm_status";
+const string INQ_BIND_DM_LIST_ENC    = "inq_dm_enc";
+const string INQ_BIND_DM_DETAIL_LBL  = "inq_dm_detail";
+const string INQ_BIND_DM_ACT_LABEL   = "inq_dm_act_lbl";
+const string INQ_BIND_DM_ACT_ENC     = "inq_dm_act_enc";
+
+// ============================================================
+// Button IDs
+// ============================================================
+const string INQ_BTN_CLOSE           = "inq_btn_close";
+const string INQ_BTN_CONFESS         = "inq_btn_confess";
+const string INQ_BTN_RECANT          = "inq_btn_recant";
+const string INQ_BTN_DM_CLOSE        = "inq_btn_dm_close";
+const string INQ_BTN_DM_ROW          = "inq_btn_dm_row";
+const string INQ_BTN_DM_ADD_ACT      = "inq_btn_dm_add";
+const string INQ_BTN_DM_PARDON       = "inq_btn_dm_pardon";
+const string INQ_BTN_DM_CLEAR        = "inq_btn_dm_clear";
+const string INQ_BTN_DM_ACT_ROW      = "inq_btn_dm_act";
+const string INQ_BTN_DM_ACT_CLOSE    = "inq_btn_dm_act_cls";
+
+// ============================================================
+// Local variables on PC / DM
+// ============================================================
+const string INQ_LVAR_TOKEN          = "INQ_NUI_TOKEN";
+const string INQ_LVAR_DM_TOKEN       = "INQ_DM_NUI_TOKEN";
+const string INQ_LVAR_DM_SEL_UUID    = "INQ_DM_SEL_UUID";
+const string INQ_LVAR_DM_SEL_NAME    = "INQ_DM_SEL_NAME";
+
+// Tags for persistent effect identification
+const string INQ_EFFECT_TAG_SUSPECT  = "INQ_EFF_SUSPECT";
+const string INQ_EFFECT_TAG_ACCUSED  = "INQ_EFF_ACCUSED";
+const string INQ_EFFECT_TAG_CONVICT  = "INQ_EFF_CONVICT";
+const string INQ_EFFECT_TAG_CONDEMN  = "INQ_EFF_CONDEMN";
+
+// Layout
+const float INQ_W                    = 520.0;
+const float INQ_H                    = 500.0;
+const float INQ_DM_W                 = 580.0;
+const float INQ_DM_H                 = 520.0;
+
+// Window geometry bind names
+const string INQ_WIN_GEOM            = "inq_win_geom";
+const string INQ_WIN_ACT_GEOM        = "inq_win_act_geom";
+
+// DM list count bind
+const string INQ_BIND_DM_LIST_COUNT  = "inq_dm_count";
+
+// ============================================================
+// Pure data helpers
+// ============================================================
+
+int InqGetActWeight(int nActId)
+{
+    switch(nActId)
+    {
+        case INQ_ACT_FORBIDDEN_MAGIC:   return 12;
+        case INQ_ACT_DEMON_CONTACT:     return 18;
+        case INQ_ACT_BLASPHEMY:         return 8;
+        case INQ_ACT_FORBIDDEN_TOME:    return 15;
+        case INQ_ACT_UNDEAD_CONSORTING: return 20;
+        case INQ_ACT_DARK_RITUAL:       return 25;
+    }
+    return 10;
+}
+
+string InqGetActName(int nActId)
+{
+    switch(nActId)
+    {
+        case INQ_ACT_FORBIDDEN_MAGIC:   return "Użycie zakazanej magii";
+        case INQ_ACT_DEMON_CONTACT:     return "Kontakt z demonem";
+        case INQ_ACT_BLASPHEMY:         return "Bluźnierstwo";
+        case INQ_ACT_FORBIDDEN_TOME:    return "Posiadanie zakazanego tomu";
+        case INQ_ACT_UNDEAD_CONSORTING: return "Obcowanie z nieumarłymi";
+        case INQ_ACT_DARK_RITUAL:       return "Udział w mrocznym rytuale";
+    }
+    return "Nieznana herezja";
+}
+
+string InqGetStatusLabel(int nRating)
+{
+    if(nRating < INQ_THRESHOLD_SUSPECT)   return "Czysty";
+    if(nRating < INQ_THRESHOLD_ACCUSED)   return "Pod obserwacją";
+    if(nRating < INQ_THRESHOLD_CONVICTED) return "Oskarżony heretyk";
+    if(nRating < INQ_THRESHOLD_CONDEMNED) return "Skazany heretyk";
+    return "Wyklęty";
+}
+
+string InqGetStatusFlavor(int nRating)
+{
+    if(nRating < INQ_THRESHOLD_SUSPECT)
+        return "Twoja dusza jest czysta w oczach Inkwizycji — przynajmniej na razie.";
+    if(nRating < INQ_THRESHOLD_ACCUSED)
+        return "Inkwizytorzy zaczęli zadawać pytania. Strzeż się, dokąd chodzisz i z kim rozmawiasz.";
+    if(nRating < INQ_THRESHOLD_CONVICTED)
+        return "Formalny nakaz aresztowania został wydany. Każdy inkwizytor ma twoje imię na liście.";
+    if(nRating < INQ_THRESHOLD_CONDEMNED)
+        return "Pieczęć heretyka wypala twoją skórę. Każdy widzi. Nie ma odwrotu bez łaski biskupa.";
+    return "Jesteś wyklęty. Inkwizycja poluje na ciebie bez ostrzeżenia. Śmierć albo wygnanie.";
+}
+
+json InqGetStatusColor(int nRating)
+{
+    if(nRating < INQ_THRESHOLD_SUSPECT)   return NuiColor(160, 220, 160, 255);
+    if(nRating < INQ_THRESHOLD_ACCUSED)   return NuiColor(220, 220, 80,  255);
+    if(nRating < INQ_THRESHOLD_CONVICTED) return NuiColor(220, 130, 50,  255);
+    if(nRating < INQ_THRESHOLD_CONDEMNED) return NuiColor(200, 70,  70,  255);
+    return NuiColor(160, 40, 160, 255);
+}
+
+// Effect description shown at each threshold
+string InqGetEffectDesc(int nRating)
+{
+    if(nRating < INQ_THRESHOLD_SUSPECT)
+        return "Brak efektów.";
+    if(nRating < INQ_THRESHOLD_ACCUSED)
+        return "Inkwizytorzy mogą cię przesłuchać. Brak mechanicznych kar.";
+    if(nRating < INQ_THRESHOLD_CONVICTED)
+        return "-2 do Charyzmatu: napiętnowany społecznie.";
+    if(nRating < INQ_THRESHOLD_CONDEMNED)
+        return "-2 Charyzma, -1 AC: pieczęć heretyka i permanentny strach.";
+    return "-4 Charyzma, -2 AC, -2 do rzutów obronnych: wyklęty.";
+}

--- a/Inquisition/Scripts/lib_inq_ev.nss
+++ b/Inquisition/Scripts/lib_inq_ev.nss
@@ -1,0 +1,152 @@
+// lib_inq_ev.nss - Inquisition: NUI event handler
+// Registered via NuiCreate(..., INQ_EV_SCRIPT) for all three Inquisition windows.
+
+#include "lib_inq"
+
+void main()
+{
+    object oPlayer = NuiGetEventPlayer();
+    int    nToken  = NuiGetEventWindow();
+    string sEvent  = NuiGetEventType();
+    string sElem   = NuiGetEventElement();
+    int    nIdx    = NuiGetEventArrayIndex();
+    string sWinId  = NuiGetWindowId(oPlayer, nToken);
+
+    // ---- Act picker popup ----
+    if(sWinId == INQ_WINDOW_DM_ACT)
+    {
+        if(sEvent == EVENT_TYPE_CLICK)
+        {
+            if(sElem == INQ_BTN_DM_ACT_CLOSE)
+            {
+                NuiDestroy(oPlayer, nToken);
+                return;
+            }
+
+            string sPrefix = INQ_BTN_DM_ACT_ROW;
+            int    nPLen   = GetStringLength(sPrefix);
+            if(GetStringLeft(sElem, nPLen) == sPrefix)
+            {
+                int nActId = StringToInt(GetStringRight(sElem, GetStringLength(sElem) - nPLen));
+                NuiDestroy(oPlayer, nToken);
+                InqDmApplyCharge(oPlayer, nActId);
+                return;
+            }
+        }
+        return;
+    }
+
+    // ---- DM panel ----
+    if(sWinId == INQ_WINDOW_DM)
+    {
+        if(sEvent == EVENT_TYPE_CLOSE)
+        {
+            DeleteLocalString(oPlayer, INQ_LVAR_DM_SEL_UUID);
+            DeleteLocalString(oPlayer, INQ_LVAR_DM_SEL_NAME);
+            return;
+        }
+
+        if(sEvent == EVENT_TYPE_CLICK)
+        {
+            if(sElem == INQ_BTN_DM_CLOSE)
+            {
+                NuiDestroy(oPlayer, nToken);
+                return;
+            }
+
+            if(sElem == INQ_BTN_DM_ROW)
+            {
+                json jSuspects = InqGetAllSuspects();
+                if(nIdx < 0 || nIdx >= JsonGetLength(jSuspects)) return;
+
+                json   jRow  = JsonArrayGet(jSuspects, nIdx);
+                string sUuid = JsonGetString(JsonObjectGet(jRow, "uuid"));
+                string sName = JsonGetString(JsonObjectGet(jRow, "name"));
+
+                SetLocalString(oPlayer, INQ_LVAR_DM_SEL_UUID, sUuid);
+                SetLocalString(oPlayer, INQ_LVAR_DM_SEL_NAME, sName);
+                InqFeedDmPanel(oPlayer, nToken);
+                return;
+            }
+
+            if(sElem == INQ_BTN_DM_ADD_ACT)
+            {
+                if(GetLocalString(oPlayer, INQ_LVAR_DM_SEL_UUID) == "")
+                {
+                    SendMessageToPC(oPlayer, "[Inkwizycja] Wybierz najpierw postać z listy.");
+                    return;
+                }
+                InqOpenActPicker(oPlayer);
+                return;
+            }
+
+            if(sElem == INQ_BTN_DM_PARDON)
+            {
+                InqDmPardon(oPlayer);
+                return;
+            }
+
+            if(sElem == INQ_BTN_DM_CLEAR)
+            {
+                string sUuid = GetLocalString(oPlayer, INQ_LVAR_DM_SEL_UUID);
+                string sName = GetLocalString(oPlayer, INQ_LVAR_DM_SEL_NAME);
+                if(sUuid == "")
+                {
+                    SendMessageToPC(oPlayer, "[Inkwizycja] Wybierz najpierw postać.");
+                    return;
+                }
+
+                InqClearAll(sUuid, sName);
+
+                object oPC = GetFirstPC();
+                while(GetIsObjectValid(oPC))
+                {
+                    if(GetObjectUUID(oPC) == sUuid)
+                    {
+                        InqRemoveRatingEffects(oPC);
+                        int nPcToken = NuiFindWindow(oPC, INQ_WINDOW_DOSSIER);
+                        if(nPcToken) InqFeedDossier(oPC, nPcToken);
+                        break;
+                    }
+                    oPC = GetNextPC();
+                }
+
+                SendMessageToPC(oPlayer,
+                    "[Inkwizycja] Wymazano zarzuty dla " + sName + ".");
+                InqFeedDmPanel(oPlayer, nToken);
+                return;
+            }
+        }
+        return;
+    }
+
+    // ---- Player dossier ----
+    if(sWinId != INQ_WINDOW_DOSSIER) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalInt(oPlayer, INQ_LVAR_TOKEN);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == INQ_BTN_CLOSE)
+        {
+            NuiDestroy(oPlayer, nToken);
+            return;
+        }
+
+        if(sElem == INQ_BTN_CONFESS)
+        {
+            InqHandleConfess(oPlayer, nToken);
+            return;
+        }
+
+        if(sElem == INQ_BTN_RECANT)
+        {
+            InqHandleRecant(oPlayer, nToken);
+            return;
+        }
+    }
+}

--- a/Inquisition/Scripts/sql_inq.nss
+++ b/Inquisition/Scripts/sql_inq.nss
@@ -1,0 +1,179 @@
+// sql_inq.nss - Inquisition: schema + queries
+
+void InqCreateTables()
+{
+    sqlquery q;
+
+    // One row per PC per heretical act committed. Multiple rows for same act = repeat offence.
+    q = SqlPrepareQueryCampaign("inquisition",
+        "CREATE TABLE IF NOT EXISTS inq_charges ("
+        "  id          INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "  pc_uuid     TEXT    NOT NULL,"
+        "  pc_name     TEXT    NOT NULL DEFAULT '',"
+        "  act_id      INTEGER NOT NULL,"
+        "  weight      INTEGER NOT NULL DEFAULT 0,"
+        "  recorded_at INTEGER NOT NULL DEFAULT 0"
+        ")");
+    SqlStep(q);
+
+    // Aggregated rating cache + state per PC. Rebuilt from inq_charges on demand.
+    q = SqlPrepareQueryCampaign("inquisition",
+        "CREATE TABLE IF NOT EXISTS inq_ratings ("
+        "  pc_uuid     TEXT PRIMARY KEY,"
+        "  pc_name     TEXT    NOT NULL DEFAULT '',"
+        "  rating      INTEGER NOT NULL DEFAULT 0,"
+        "  last_update INTEGER NOT NULL DEFAULT 0"
+        ")");
+    SqlStep(q);
+}
+
+// Returns current rating for PC, or 0 if no record.
+int InqGetRating(string sPcUuid)
+{
+    sqlquery q = SqlPrepareQueryCampaign("inquisition",
+        "SELECT rating FROM inq_ratings WHERE pc_uuid = @uuid");
+    SqlBindString(q, "@uuid", sPcUuid);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// Recomputes rating from charges table and writes to cache.
+int InqRebuildRating(string sPcUuid, string sPcName)
+{
+    sqlquery q = SqlPrepareQueryCampaign("inquisition",
+        "SELECT COALESCE(SUM(weight), 0) FROM inq_charges WHERE pc_uuid = @uuid");
+    SqlBindString(q, "@uuid", sPcUuid);
+    int nRating = 0;
+    if(SqlStep(q)) nRating = SqlGetInt(q, 0);
+    if(nRating > 100) nRating = 100;
+
+    q = SqlPrepareQueryCampaign("inquisition",
+        "INSERT OR REPLACE INTO inq_ratings (pc_uuid, pc_name, rating, last_update)"
+        "  VALUES (@uuid, @name, @rating, strftime('%s','now'))");
+    SqlBindString(q, "@uuid",   sPcUuid);
+    SqlBindString(q, "@name",   sPcName);
+    SqlBindInt   (q, "@rating", nRating);
+    SqlStep(q);
+
+    return nRating;
+}
+
+// Inserts a new charge, returns updated rating.
+int InqInsertCharge(string sPcUuid, string sPcName, int nActId, int nWeight)
+{
+    sqlquery q = SqlPrepareQueryCampaign("inquisition",
+        "INSERT INTO inq_charges (pc_uuid, pc_name, act_id, weight, recorded_at)"
+        "  VALUES (@uuid, @name, @act, @weight, strftime('%s','now'))");
+    SqlBindString(q, "@uuid",   sPcUuid);
+    SqlBindString(q, "@name",   sPcName);
+    SqlBindInt   (q, "@act",    nActId);
+    SqlBindInt   (q, "@weight", nWeight);
+    SqlStep(q);
+
+    return InqRebuildRating(sPcUuid, sPcName);
+}
+
+// Reduces rating by nAmount (removes oldest charges until nAmount weight removed or none left).
+int InqReduceRating(string sPcUuid, string sPcName, int nAmount)
+{
+    int nCurrent = InqGetRating(sPcUuid);
+    int nTarget  = nCurrent - nAmount;
+    if(nTarget < 0) nTarget = 0;
+
+    // Remove oldest charges until we hit target
+    sqlquery qList = SqlPrepareQueryCampaign("inquisition",
+        "SELECT id, weight FROM inq_charges WHERE pc_uuid = @uuid ORDER BY recorded_at ASC");
+    SqlBindString(qList, "@uuid", sPcUuid);
+
+    int nRemoved = 0;
+    while(SqlStep(qList) && (nCurrent - nRemoved) > nTarget)
+    {
+        int nId     = SqlGetInt(qList, 0);
+        int nWeight = SqlGetInt(qList, 1);
+
+        sqlquery qDel = SqlPrepareQueryCampaign("inquisition",
+            "DELETE FROM inq_charges WHERE id = @id");
+        SqlBindInt(qDel, "@id", nId);
+        SqlStep(qDel);
+
+        nRemoved += nWeight;
+    }
+
+    return InqRebuildRating(sPcUuid, sPcName);
+}
+
+// Clears ALL charges for a PC (full pardon).
+int InqClearAll(string sPcUuid, string sPcName)
+{
+    sqlquery q = SqlPrepareQueryCampaign("inquisition",
+        "DELETE FROM inq_charges WHERE pc_uuid = @uuid");
+    SqlBindString(q, "@uuid", sPcUuid);
+    SqlStep(q);
+
+    return InqRebuildRating(sPcUuid, sPcName);
+}
+
+// Returns JsonArray of charge summaries for a PC:
+// [{act_id, act_name, weight, count, total_weight}, ...]  grouped by act_id.
+json InqGetChargesSummary(string sPcUuid)
+{
+    json jResult = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("inquisition",
+        "SELECT act_id, weight, COUNT(*) as cnt, SUM(weight) as total"
+        "  FROM inq_charges WHERE pc_uuid = @uuid"
+        "  GROUP BY act_id ORDER BY total DESC");
+    SqlBindString(q, "@uuid", sPcUuid);
+    while(SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "act_id",       JsonInt(SqlGetInt(q, 0)));
+        jRow = JsonObjectSet(jRow, "weight",        JsonInt(SqlGetInt(q, 1)));
+        jRow = JsonObjectSet(jRow, "count",         JsonInt(SqlGetInt(q, 2)));
+        jRow = JsonObjectSet(jRow, "total_weight",  JsonInt(SqlGetInt(q, 3)));
+        jResult = JsonArrayInsert(jResult, jRow);
+    }
+    return jResult;
+}
+
+// Returns JsonArray of all PCs with nonzero rating for DM panel:
+// [{uuid, name, rating}, ...]
+json InqGetAllSuspects()
+{
+    json jResult = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("inquisition",
+        "SELECT pc_uuid, pc_name, rating FROM inq_ratings"
+        "  WHERE rating > 0 ORDER BY rating DESC LIMIT 50");
+    while(SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "uuid",   JsonString(SqlGetString(q, 0)));
+        jRow = JsonObjectSet(jRow, "name",   JsonString(SqlGetString(q, 1)));
+        jRow = JsonObjectSet(jRow, "rating", JsonInt   (SqlGetInt   (q, 2)));
+        jResult = JsonArrayInsert(jResult, jRow);
+    }
+    return jResult;
+}
+
+// Upserts PC name (call on enter to keep names current).
+void InqUpsertPcName(string sPcUuid, string sPcName)
+{
+    sqlquery q = SqlPrepareQueryCampaign("inquisition",
+        "INSERT OR IGNORE INTO inq_ratings (pc_uuid, pc_name, rating, last_update)"
+        "  VALUES (@uuid, @name, 0, strftime('%s','now'))");
+    SqlBindString(q, "@uuid", sPcUuid);
+    SqlBindString(q, "@name", sPcName);
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("inquisition",
+        "UPDATE inq_ratings SET pc_name = @name WHERE pc_uuid = @uuid");
+    SqlBindString(q, "@uuid", sPcUuid);
+    SqlBindString(q, "@name", sPcName);
+    SqlStep(q);
+
+    // Keep charge rows in sync too
+    q = SqlPrepareQueryCampaign("inquisition",
+        "UPDATE inq_charges SET pc_name = @name WHERE pc_uuid = @uuid");
+    SqlBindString(q, "@uuid", sPcUuid);
+    SqlBindString(q, "@name", sPcName);
+    SqlStep(q);
+}

--- a/Inquisition/Scripts/sys_on_enter.nss
+++ b/Inquisition/Scripts/sys_on_enter.nss
@@ -1,0 +1,36 @@
+// sys_on_enter.nss - Inquisition: ClientEnter hook
+// Restores rating effects and registers PC name on login.
+
+#include "lib_inq"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC) || GetIsDMPossessed(oPC)) return;
+
+    string sPcUuid = GetObjectUUID(oPC);
+    string sPcName = GetName(oPC);
+
+    // Keep name current in DB (handles renames)
+    InqUpsertPcName(sPcUuid, sPcName);
+
+    int nRating = InqGetRating(sPcUuid);
+    if(nRating > 0)
+    {
+        // Re-apply effects after server restart
+        DelayCommand(3.0, InqApplyRatingEffects(oPC, nRating));
+
+        if(nRating >= INQ_THRESHOLD_CONDEMNED)
+            DelayCommand(4.0, SendMessageToPC(oPC,
+                "[Inkwizycja] Jesteś wyklęty. Inkwizycja aktywnie poluje na ciebie."));
+        else if(nRating >= INQ_THRESHOLD_CONVICTED)
+            DelayCommand(4.0, SendMessageToPC(oPC,
+                "[Inkwizycja] Pieczęć heretyka nadal cię napiętnowuje."));
+        else if(nRating >= INQ_THRESHOLD_ACCUSED)
+            DelayCommand(4.0, SendMessageToPC(oPC,
+                "[Inkwizycja] Nakaz aresztowania wciąż jest aktywny."));
+        else
+            DelayCommand(4.0, SendMessageToPC(oPC,
+                "[Inkwizycja] Inkwizycja ma cię na oku."));
+    }
+}

--- a/Inquisition/Scripts/sys_on_load.nss
+++ b/Inquisition/Scripts/sys_on_load.nss
@@ -1,0 +1,8 @@
+// sys_on_load.nss - Inquisition: module OnLoad hook
+
+#include "sql_inq"
+
+void main()
+{
+    InqCreateTables();
+}

--- a/Inquisition/Scripts/test_inq.nss
+++ b/Inquisition/Scripts/test_inq.nss
@@ -1,0 +1,33 @@
+// test_inq.nss - OnUsed placeable: demonstrates Inquisition system.
+// Place a "Tablica Inkwizycji" placeable in the module with this script as OnUsed.
+// - Regular PCs: opens their personal dossier.
+// - DMs: opens the DM management panel.
+// - Console command variant: add "inq_charge <act_id>" as a local var on PC to test charge injection.
+
+#include "lib_inq"
+
+void main()
+{
+    object oUser = GetLastUsedBy();
+    if(!GetIsObjectValid(oUser)) return;
+
+    if(GetIsDM(oUser) || GetIsDMPossessed(oUser))
+    {
+        InqOpenDmWindow(oUser);
+        return;
+    }
+
+    if(GetIsPC(oUser))
+    {
+        // Check for debug charge injection via local variable "inq_test_act"
+        int nTestAct = GetLocalInt(oUser, "inq_test_act");
+        if(nTestAct >= 0 && nTestAct < INQ_ACT_COUNT)
+        {
+            DeleteLocalInt(oUser, "inq_test_act");
+            InqAddCharge(oUser, nTestAct);
+            SendMessageToPC(oUser, "[INQ TEST] Dodano zarzut: " + InqGetActName(nTestAct));
+        }
+
+        InqOpenDossierWindow(oUser);
+    }
+}


### PR DESCRIPTION
## Co to robi

Moduł **Inkwizycja** śledzi heretyckie czyny postaci graczy i utrzymuje trwałą **Ocenę Inkwizycji** (0–100) per PC. W miarę jak ocena rośnie, postać przechodzi przez cztery progi:

| Próg | Etykieta | Kara mechaniczna |
|---|---|---|
| 0 | Czysty | brak |
| 1–25 | Pod obserwacją | brak (nadzór) |
| 26–50 | Oskarżony heretyk | -2 Charyzma |
| 51–75 | Skazany heretyk | -2 Cha, -1 AC |
| 76–100 | Wyklęty | -4 Cha, -2 AC, -2 do rzutów obronnych |

## Mechanika

**Dla graczy** (okno *Dossier Inkwizycji*):
- Widok oceny na pasku postępu z etykietą statusu i tekstem fabularnym (PL)
- Lista aktywnych zarzutów z wagami punktowymi
- **Wyznaj grzechy** — koszt złota (skala z oceną), redukuje ocenę o 15 pkt
- **Odwołaj publicznie** — ogłoszenie do całego obszaru, redukuje o 25 pkt, cooldown 1h (in-game)

**Dla DM** (okno *Rejestr Inkwizycji*):
- Lista wszystkich podejrzanych z oceną i statusem
- Wybór postaci → **Dodaj zarzut** (popup z 6 typami czynów) / **Ułaskaw** / **Wyczyść zarzuty**
- Działa na postaciach online (efekty natychmiastowe) i offline (zapis do DB)

**Integracja zewnętrzna** — wywoływanie z innych skryptów:
```nwscript
#include "lib_inq"
InqAddCharge(oPC, INQ_ACT_DARK_RITUAL);       // +25 pkt
InqAddCharge(oPC, INQ_ACT_FORBIDDEN_MAGIC);   // +12 pkt
```

## Pliki

```
Inquisition/
├── Scripts/
│   ├── sql_inq.nss         — schemat SQLite + wszystkie zapytania
│   ├── lib_inq_def.nss     — stałe, ID zarzutów, helpery tekstów
│   ├── lib_inq.nss         — rdzeń: efekty, UI (NUI), logika akcji
│   ├── lib_inq_ev.nss      — handler eventów NUI
│   ├── sys_on_load.nss     — OnModuleLoad: CREATE TABLE IF NOT EXISTS
│   ├── sys_on_enter.nss    — ClientEnter: przywraca efekty, aktualizuje imię w DB
│   └── test_inq.nss        — placeable OnUsed: demo (PC → dossier, DM → panel)
└── INTEGRATION.md          — instrukcja podpięcia hooków i API
```

## Zależności (NWNX? SQL?)

- **Brak NWNX** — tylko NWScript + NUI.
- **SQLite campaign DB**: `SqlPrepareQueryCampaign("inquisition", ...)` — baza tworzona automatycznie.

## Jak włączyć w istniejącym module

1. Skopiuj folder `Inquisition/Scripts/` do haka modułu.
2. Podepnij hooki w Toolset:
   - Module → OnModuleLoad → `sys_on_load`
   - Module → OnClientEnter → `sys_on_enter`
3. Umieść placeable z `test_inq` jako OnUsed (opcjonalnie, dla testów).
4. Aby automatycznie dodawać zarzuty: dodaj `#include "lib_inq"` i wywołaj `InqAddCharge(oPC, nActId)` z odpowiednich hooków (czary, przedmioty, obszary).

## Co celowo pominięto

- **Spawning inkwizytorów NPC** — panel DM ma narzędzia do zarządzania, ale nie spawnuje patroli; wymagałoby to blueprint-ów specyficznych dla kampanii.
- **Mechanika donosiciela** — przesunięcie zarzutów na innego gracza było wycięte ze względu na ryzyko nadużyć.
- **Pasywny decay oceny** — brak automatycznego zmniejszania z upływem czasu; zamierzone, by zarzuty miały wagę.
- **Efekty dla offline PC** — kary są przywracane przy logowaniu (ClientEnter); nie są przechowywane jako właściwości przedmiotów.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SBsFEWpfpJ4m35k3jkpdsM)_