### PR TITLE
feat: Szynkarz (Tavern Brewing System)

### DIFF
--- a/Szynkarz/INTEGRATION.md
+++ b/Szynkarz/INTEGRATION.md
@@ -1,0 +1,69 @@
+# Szynkarz — Integration Guide
+
+## What it does
+
+Tavern brewing system with 8 dark-fantasy drink recipes. Players collect ingredients,
+brew drinks at a Brewing Kit placeable, and store them in a per-character "cellar" (SQL).
+Drinking applies recipe-specific effects and adds intoxication points; intox decays
+over time via heartbeat and crosses threshold bands that toggle stacking stat effects.
+
+## Hooks to connect
+
+| Event | Script to call / chain |
+|---|---|
+| Module OnModuleLoad | `sys_on_load.nss` (or call `SynCreateTables()` from your existing load script) |
+| Module OnClientEnter | `sys_on_enter.nss` (or call `SynOnClientEnter(GetEnteringObject())`) |
+| Module OnHeartbeat | `sys_module_hb.nss` (or call the inner loop from your existing HB script) |
+
+If you already have scripts for these events, add `#include "lib_syn"` and call the
+corresponding function instead of replacing your script.
+
+## Brewing Kit placeable
+
+1. Create a placeable in the toolset (any model — a barrel, cask, or alembic works well).
+2. Set its **OnUsed** script to `test_syn.nss`.
+3. The window opens automatically for any non-DM PC who activates it.
+
+## Ingredient items
+
+Each ingredient is identified by item **tag** (not resref). Create items in your HAK
+or palette with the following tags, then distribute them as loot or merchant stock:
+
+| Tag | Polish name |
+|---|---|
+| `syn_hop` | Chmiel |
+| `syn_barley` | Słód Jęczmienny |
+| `syn_midnight` | Korzeń Północy |
+| `syn_honey` | Miód Dzikich Pszczół |
+| `syn_wormwood` | Piołun |
+| `syn_bone_dust` | Proch Kostny |
+| `syn_grapes` | Czarne Winogrona |
+| `syn_blood` | Świeża Krew |
+| `syn_ghost_ess` | Esencja Zjaw |
+| `syn_moonwater` | Woda Księżycowa |
+| `syn_iron_fil` | Opiłki Żelaza |
+| `syn_cinder` | Korzeń Żużlowy |
+| `syn_spider_ven` | Jad Pająka |
+| `syn_arcane_cry` | Kryształ Arkanistyczny |
+
+Items can stack freely; the brewing logic drains the required quantity from whatever
+stacks are present.
+
+## NWNX dependencies
+
+None. All persistence uses `SqlPrepareQueryCampaign("szynkarz", ...)` (vanilla EE
+campaign DB). No NWNX plugins required.
+
+## Testing
+
+Set `SetLocalInt(GetModule(), "SYN_DEBUG", 1)` in OnModuleLoad to enable a debug flag.
+When the flag is active, activating the Brewing Kit placeable prints the required
+ingredient tags to the player's chat log so you can create matching items manually.
+
+## What was intentionally omitted
+
+- **Addiction mechanic** — easily added as a fourth SQL column tracking drink frequency
+- **Brewing mini-game** — kept as a single button; timing/skill-check minigame could extend the brew tab
+- **Drink stacking / limits** — currently a player can drink indefinitely; a cap at e.g. 3 drinks before forced rest would add balance
+- **DM panel** — no DM-facing UI for inspecting or resetting player intox
+- **Item resrefs for brewed drinks** — drinks exist only in SQL, not as physical item objects; add `CreateItemOnObject` if physical hand-off between players is needed

--- a/Szynkarz/Scripts/lib_syn.nss
+++ b/Szynkarz/Scripts/lib_syn.nss
@@ -1,0 +1,673 @@
+// lib_syn.nss — Szynkarz: NUI layout, game logic, effect application
+
+#include "lib_syn_def"
+
+// ----------------------------------------------------------------
+// Layout constants (scaled from base dimensions)
+// ----------------------------------------------------------------
+
+const float SYN_WIN_W   = 620.0;
+const float SYN_WIN_H   = 430.0;
+const float SYN_ROW_H   = 26.0;
+const float SYN_LIST_H  = 280.0;
+
+// ----------------------------------------------------------------
+// Ingredient list text helper
+// ----------------------------------------------------------------
+
+string SynIngListText(int nRecipeId)
+{
+    json jIngs  = SynGetRecipeIngredients(nRecipeId);
+    int  nCount = JsonGetLength(jIngs);
+    string sOut = "";
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jIng   = JsonArrayGet(jIngs, i);
+        string sN   = JsonGetString(JsonObjectGet(jIng, "name"));
+        int    nQ   = JsonGetInt   (JsonObjectGet(jIng, "qty"));
+        if(sOut != "") sOut += "\n";
+        sOut += "  " + sN + " x" + IntToString(nQ);
+    }
+    return sOut;
+}
+
+// ----------------------------------------------------------------
+// Layout builders — each returns the content for the swappable group
+// ----------------------------------------------------------------
+
+json SynBuildRecipesLayout(object oPC)
+{
+    float fRowH = GetNuiScaleDimension(oPC, SYN_ROW_H);
+    float fListW = GetNuiScaleDimension(oPC, 175.0);
+
+    // Left column: scrollable recipe list
+    // Group wraps the label; enc is on the group so the full row background highlights.
+    json jRecRow = JsonArray();
+    jRecRow = JsonArrayInsert(jRecRow,
+        NuiLabel(NuiBind(SYN_BIND_REC_NAMES), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)));
+
+    json jRowGrp = NuiGroup(NuiRow(jRecRow), FALSE, NUI_SCROLLBARS_NONE);
+    jRowGrp = NuiId(jRowGrp, SYN_BTN_REC_ROW);
+    jRowGrp = NuiEncouraged(jRowGrp, NuiBind(SYN_BIND_REC_ENC));
+
+    json jTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jRowGrp, 0.0, TRUE));
+
+    json jList = NuiList(jTmpl, NuiBind("syn_rec_count"), fRowH);
+    jList = NuiHeight(jList, GetNuiScaleDimension(oPC, SYN_LIST_H));
+
+    json jLeftItems = JsonArray();
+    jLeftItems = JsonArrayInsert(jLeftItems,
+        NuiLabel(JsonString("Receptury"), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE)));
+    jLeftItems = JsonArrayInsert(jLeftItems, jList);
+    json jLeft = NuiWidth(NuiCol(jLeftItems), fListW);
+
+    // Right column: recipe detail
+    json jRightItems = JsonArray();
+    jRightItems = JsonArrayInsert(jRightItems,
+        NuiLabel(NuiBind(SYN_BIND_DET_NAME),
+                 JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)));
+    jRightItems = JsonArrayInsert(jRightItems, NuiSpacer());
+    jRightItems = JsonArrayInsert(jRightItems,
+        NuiText(NuiBind(SYN_BIND_DET_FLAV), FALSE));
+    jRightItems = JsonArrayInsert(jRightItems, NuiSpacer());
+    jRightItems = JsonArrayInsert(jRightItems,
+        NuiLabel(JsonString("Składniki:"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)));
+    jRightItems = JsonArrayInsert(jRightItems,
+        NuiLabel(NuiBind(SYN_BIND_DET_INGS), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_TOP)));
+    jRightItems = JsonArrayInsert(jRightItems, NuiSpacer());
+    jRightItems = JsonArrayInsert(jRightItems,
+        NuiLabel(JsonString("Efekty:"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)));
+    jRightItems = JsonArrayInsert(jRightItems,
+        NuiLabel(NuiBind(SYN_BIND_DET_EFFS), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_TOP)));
+    jRightItems = JsonArrayInsert(jRightItems, NuiSpacer());
+    jRightItems = JsonArrayInsert(jRightItems,
+        NuiLabel(NuiBind(SYN_BIND_DET_INTOX), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)));
+
+    json jRight = NuiCol(jRightItems);
+
+    json jMainRow = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, jLeft);
+    jMainRow = JsonArrayInsert(jMainRow, jRight);
+
+    return NuiCol(JsonArrayInsert(JsonArray(), NuiRow(jMainRow)));
+}
+
+json SynBuildBrewLayout(object oPC)
+{
+    json jRows = JsonArray();
+
+    jRows = JsonArrayInsert(jRows, NuiHeight(
+        NuiLabel(NuiBind(SYN_BIND_BREW_NAME), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE)),
+        GetNuiScaleDimension(oPC, 28.0)));
+
+    jRows = JsonArrayInsert(jRows,
+        NuiLabel(JsonString("Składniki:"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)));
+
+    jRows = JsonArrayInsert(jRows,
+        NuiText(NuiBind(SYN_BIND_BREW_LINES), FALSE));
+
+    jRows = JsonArrayInsert(jRows, NuiSpacer());
+
+    json jBrewBtn = NuiButton(JsonString("Warzyj Trunek"));
+    jBrewBtn = NuiId(jBrewBtn, SYN_BTN_BREW);
+    jBrewBtn = NuiEnabled(jBrewBtn, NuiBind(SYN_BIND_BREW_ENA));
+    jBrewBtn = NuiWidth(jBrewBtn, GetNuiScaleDimension(oPC, 160.0));
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jBrewBtn);
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jRows = JsonArrayInsert(jRows, NuiRow(jBtnRow));
+
+    return NuiCol(jRows);
+}
+
+json SynBuildCellarLayout(object oPC)
+{
+    float fRowH = GetNuiScaleDimension(oPC, SYN_ROW_H);
+    float fQtyW = GetNuiScaleDimension(oPC, 50.0);
+
+    // Row content: name (elastic) + qty (fixed width)
+    json jNameLbl = NuiLabel(NuiBind(SYN_BIND_CEL_NAMES),
+                             JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    json jQtyLbl  = NuiWidth(
+        NuiLabel(NuiBind(SYN_BIND_CEL_QTYS), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE)),
+        fQtyW);
+
+    json jCellRow = JsonArray();
+    jCellRow = JsonArrayInsert(jCellRow, jNameLbl);
+    jCellRow = JsonArrayInsert(jCellRow, jQtyLbl);
+
+    // Wrap in a group so the whole row is a single clickable element
+    json jRowGrp = NuiGroup(NuiRow(jCellRow), FALSE, NUI_SCROLLBARS_NONE);
+    jRowGrp = NuiId(jRowGrp, SYN_BTN_CEL_ROW);
+    jRowGrp = NuiEncouraged(jRowGrp, NuiBind(SYN_BIND_CEL_ENC));
+
+    json jTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jRowGrp, 0.0, TRUE));
+
+    json jCelList = NuiList(jTmpl, NuiBind("syn_cel_count"), fRowH);
+    jCelList = NuiHeight(jCelList, GetNuiScaleDimension(oPC, SYN_LIST_H));
+
+    json jDrinkBtn = NuiButton(JsonString("Wypij Zaznaczony"));
+    jDrinkBtn = NuiId(jDrinkBtn, SYN_BTN_DRINK);
+    jDrinkBtn = NuiEnabled(jDrinkBtn, NuiBind(SYN_BIND_DRINK_ENA));
+    jDrinkBtn = NuiWidth(jDrinkBtn, GetNuiScaleDimension(oPC, 180.0));
+
+    json jBtnRow = JsonArray();
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+    jBtnRow = JsonArrayInsert(jBtnRow, jDrinkBtn);
+    jBtnRow = JsonArrayInsert(jBtnRow, NuiSpacer());
+
+    json jRows = JsonArray();
+    jRows = JsonArrayInsert(jRows,
+        NuiLabel(JsonString("Spiżarnia:"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)));
+    jRows = JsonArrayInsert(jRows, jCelList);
+    jRows = JsonArrayInsert(jRows, NuiSpacer());
+    jRows = JsonArrayInsert(jRows, NuiRow(jBtnRow));
+
+    return NuiCol(jRows);
+}
+
+// ----------------------------------------------------------------
+// Window construction
+// ----------------------------------------------------------------
+
+void SynOpenWindow(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, SYN_WINDOW);
+    if(nToken != 0)
+    {
+        NuiSetWindowCollapsed(oPC, nToken, FALSE);
+        return;
+    }
+
+    // Tab strip + close button (always visible at top)
+    json jTabRec  = NuiId(NuiButton(JsonString("Receptury")),  SYN_BTN_TAB_REC);
+    json jTabBrew = NuiId(NuiButton(JsonString("Warzelnia")),  SYN_BTN_TAB_BREW);
+    json jTabCel  = NuiId(NuiButton(JsonString("Spiżarnia")),  SYN_BTN_TAB_CEL);
+    json jClose   = NuiId(NuiButton(JsonString("X")),          SYN_BTN_CLOSE);
+
+    float fTabW = GetNuiScaleDimension(oPC, 90.0);
+    json jTabRow = JsonArray();
+    jTabRow = JsonArrayInsert(jTabRow, NuiWidth(jTabRec,  fTabW));
+    jTabRow = JsonArrayInsert(jTabRow, NuiWidth(jTabBrew, fTabW));
+    jTabRow = JsonArrayInsert(jTabRow, NuiWidth(jTabCel,  fTabW));
+    jTabRow = JsonArrayInsert(jTabRow, NuiSpacer());
+    jTabRow = JsonArrayInsert(jTabRow, NuiWidth(jClose, GetNuiScaleDimension(oPC, 30.0)));
+
+    // Swappable content group (placeholder; set via NuiSetGroupLayout after open)
+    json jPlaceholder = NuiSpacer();
+    json jContentGrp = NuiGroup(jPlaceholder, FALSE, NUI_SCROLLBARS_NONE);
+    jContentGrp = NuiId(jContentGrp, SYN_CONTENT_GROUP);
+
+    // Intox bar (always visible at bottom)
+    json jIntoxLbl = NuiLabel(NuiBind(SYN_BIND_INTOX_LBL),
+                              JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jIntoxLbl = NuiWidth(jIntoxLbl, GetNuiScaleDimension(oPC, 180.0));
+
+    json jBar = NuiProgressBar(NuiBind(SYN_BIND_INTOX_VAL));
+    jBar = NuiStyleForegroundColor(jBar, NuiBind(SYN_BIND_INTOX_COL));
+
+    json jBarRow = JsonArray();
+    jBarRow = JsonArrayInsert(jBarRow,
+        NuiWidth(NuiLabel(JsonString("Upojenie:"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)),
+                 GetNuiScaleDimension(oPC, 70.0)));
+    jBarRow = JsonArrayInsert(jBarRow, jIntoxLbl);
+    jBarRow = JsonArrayInsert(jBarRow, jBar);
+
+    // Root layout
+    json jRoot = JsonArray();
+    jRoot = JsonArrayInsert(jRoot, NuiHeight(NuiRow(jTabRow),    GetNuiScaleDimension(oPC, 32.0)));
+    jRoot = JsonArrayInsert(jRoot, NuiRow(JsonArrayInsert(JsonArray(), jContentGrp)));
+    jRoot = JsonArrayInsert(jRoot, NuiHeight(NuiRow(jBarRow),   GetNuiScaleDimension(oPC, 30.0)));
+
+    json jGeom = NuiRect(
+        GetNuiScaleDimension(oPC, 80.0),
+        GetNuiScaleDimension(oPC, 80.0),
+        GetNuiScaleDimension(oPC, SYN_WIN_W),
+        GetNuiScaleDimension(oPC, SYN_WIN_H));
+
+    nToken = NuiCreate(oPC, NuiCol(jRoot), JsonString("Warzelnia"), SYN_WIN_GEOM, TRUE, SYN_EV_SCRIPT);
+    if(nToken == 0) return;
+
+    NuiSetBind(oPC, nToken, SYN_WIN_GEOM, jGeom);
+
+    SetLocalInt(oPC, SYN_LVAR_SEL_REC,    -1);
+    SetLocalInt(oPC, SYN_LVAR_SEL_CEL_ID,  0);
+    SetLocalInt(oPC, SYN_LVAR_ACTIVE_TAB,  0);
+
+    // Populate intox bar immediately
+    int nLevel = GetLocalInt(oPC, "SYN_INTOX_CACHE");
+    SynUpdateIntoxBar(oPC, nToken, nLevel);
+
+    // Show recipes tab by default
+    SynFeedRecipesGroup(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Feed functions — repopulate binds for each tab
+// ----------------------------------------------------------------
+
+void SynFeedRecipesGroup(object oPC, int nToken)
+{
+    NuiSetGroupLayout(oPC, nToken, SYN_CONTENT_GROUP, SynBuildRecipesLayout(oPC));
+
+    // Static count (always SYN_REC_COUNT rows)
+    NuiSetBind(oPC, nToken, "syn_rec_count", JsonInt(SYN_REC_COUNT));
+
+    // Recipe name array
+    int  nSel   = GetLocalInt(oPC, SYN_LVAR_SEL_REC);
+    json jNames = JsonArray();
+    json jEnc   = JsonArray();
+    int i;
+    for(i = 0; i < SYN_REC_COUNT; i++)
+    {
+        jNames = JsonArrayInsert(jNames, JsonString(SynRecipeName(i)));
+        jEnc   = JsonArrayInsert(jEnc,   JsonBool(i == nSel));
+    }
+    NuiSetBind(oPC, nToken, SYN_BIND_REC_NAMES, jNames);
+    NuiSetBind(oPC, nToken, SYN_BIND_REC_ENC,   jEnc);
+
+    // Detail panel
+    if(nSel >= 0 && nSel < SYN_REC_COUNT)
+    {
+        NuiSetBind(oPC, nToken, SYN_BIND_DET_NAME,
+            JsonString(SynRecipeName(nSel)));
+        NuiSetBind(oPC, nToken, SYN_BIND_DET_FLAV,
+            JsonString(SynRecipeFlavor(nSel)));
+        NuiSetBind(oPC, nToken, SYN_BIND_DET_INGS,
+            JsonString(SynIngListText(nSel)));
+        NuiSetBind(oPC, nToken, SYN_BIND_DET_EFFS,
+            JsonString(SynRecipeEffects(nSel)));
+        NuiSetBind(oPC, nToken, SYN_BIND_DET_INTOX,
+            JsonString("Upojenie: +" + IntToString(SynRecipeIntox(nSel)) + " pkt"));
+    }
+    else
+    {
+        NuiSetBind(oPC, nToken, SYN_BIND_DET_NAME,  JsonString(""));
+        NuiSetBind(oPC, nToken, SYN_BIND_DET_FLAV,
+            JsonString("Wybierz recepturę z listy po lewej."));
+        NuiSetBind(oPC, nToken, SYN_BIND_DET_INGS,  JsonString(""));
+        NuiSetBind(oPC, nToken, SYN_BIND_DET_EFFS,  JsonString(""));
+        NuiSetBind(oPC, nToken, SYN_BIND_DET_INTOX, JsonString(""));
+    }
+}
+
+void SynFeedBrewGroup(object oPC, int nToken)
+{
+    NuiSetGroupLayout(oPC, nToken, SYN_CONTENT_GROUP, SynBuildBrewLayout(oPC));
+
+    int nSel = GetLocalInt(oPC, SYN_LVAR_SEL_REC);
+    if(nSel < 0 || nSel >= SYN_REC_COUNT)
+    {
+        NuiSetBind(oPC, nToken, SYN_BIND_BREW_NAME,
+            JsonString("Brak wybranej receptury"));
+        NuiSetBind(oPC, nToken, SYN_BIND_BREW_LINES,
+            JsonString("Wybierz recepturę w zakładce Receptury."));
+        NuiSetBind(oPC, nToken, SYN_BIND_BREW_ENA, JsonBool(FALSE));
+        return;
+    }
+
+    NuiSetBind(oPC, nToken, SYN_BIND_BREW_NAME, JsonString(SynRecipeName(nSel)));
+
+    json jIngs  = SynGetRecipeIngredients(nSel);
+    int  nCount = JsonGetLength(jIngs);
+    string sLines  = "";
+    int bCanBrew = TRUE;
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jIng   = JsonArrayGet(jIngs, i);
+        string sN   = JsonGetString(JsonObjectGet(jIng, "name"));
+        int    nReq = JsonGetInt   (JsonObjectGet(jIng, "qty"));
+        int    nHas = SynCountInInventory(oPC, JsonGetString(JsonObjectGet(jIng, "tag")));
+        if(sLines != "") sLines += "\n";
+        string sMark = (nHas >= nReq) ? "[OK] " : "[--] ";
+        sLines += sMark + sN + " — " + IntToString(nHas) + "/" + IntToString(nReq);
+        if(nHas < nReq) bCanBrew = FALSE;
+    }
+    NuiSetBind(oPC, nToken, SYN_BIND_BREW_LINES, JsonString(sLines));
+    NuiSetBind(oPC, nToken, SYN_BIND_BREW_ENA,   JsonBool(bCanBrew));
+}
+
+void SynFeedCellarGroup(object oPC, int nToken)
+{
+    NuiSetGroupLayout(oPC, nToken, SYN_CONTENT_GROUP, SynBuildCellarLayout(oPC));
+
+    json jCellar = SynGetCellar(oPC);
+    int  nCount  = JsonGetLength(jCellar);
+    int  nSelId  = GetLocalInt(oPC, SYN_LVAR_SEL_CEL_ID);
+
+    json jNames = JsonArray();
+    json jQtys  = JsonArray();
+    json jEnc   = JsonArray();
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jRow = JsonArrayGet(jCellar, i);
+        int  nId  = JsonGetInt(JsonObjectGet(jRow, "id"));
+        int  nRec = JsonGetInt(JsonObjectGet(jRow, "recipe_id"));
+        int  nQty = JsonGetInt(JsonObjectGet(jRow, "qty"));
+
+        jNames = JsonArrayInsert(jNames, JsonString(SynRecipeName(nRec)));
+        jQtys  = JsonArrayInsert(jQtys,  JsonString("x" + IntToString(nQty)));
+        jEnc   = JsonArrayInsert(jEnc,   JsonBool(nId == nSelId));
+    }
+
+    NuiSetBind(oPC, nToken, SYN_BIND_CEL_NAMES, jNames);
+    NuiSetBind(oPC, nToken, SYN_BIND_CEL_QTYS,  jQtys);
+    NuiSetBind(oPC, nToken, SYN_BIND_CEL_ENC,   jEnc);
+    NuiSetBind(oPC, nToken, "syn_cel_count",     JsonInt(nCount));
+    NuiSetBind(oPC, nToken, SYN_BIND_DRINK_ENA,  JsonBool(nSelId != 0 && nCount > 0));
+}
+
+// ----------------------------------------------------------------
+// Intox bar (refreshed after any intox change and on tab switch)
+// ----------------------------------------------------------------
+
+void SynUpdateIntoxBar(object oPC, int nToken, int nLevel)
+{
+    string sLbl = SynIntoxLabel(nLevel) + " (" + IntToString(nLevel) + "/100)";
+    NuiSetBind(oPC, nToken, SYN_BIND_INTOX_LBL, JsonString(sLbl));
+    NuiSetBind(oPC, nToken, SYN_BIND_INTOX_VAL, JsonFloat(IntToFloat(nLevel) / 100.0));
+    NuiSetBind(oPC, nToken, SYN_BIND_INTOX_COL, SynIntoxColor(nLevel));
+}
+
+// ----------------------------------------------------------------
+// Brewing action
+// ----------------------------------------------------------------
+
+void SynBrew(object oPC, int nToken)
+{
+    int nSel = GetLocalInt(oPC, SYN_LVAR_SEL_REC);
+    if(nSel < 0 || nSel >= SYN_REC_COUNT)
+    {
+        SendMessageToPC(oPC, "[Warzelnia] Brak wybranej receptury.");
+        return;
+    }
+    if(!SynCanBrew(oPC, nSel))
+    {
+        SendMessageToPC(oPC, "[Warzelnia] Brakuje składników.");
+        NuiSetBind(oPC, nToken, SYN_BIND_BREW_ENA, JsonBool(FALSE));
+        return;
+    }
+
+    SynConsumeIngredients(oPC, nSel);
+    SynAddCellarDrink(oPC, nSel);
+
+    PlaySound("al_cv_stirpot2");
+    SendMessageToPC(oPC, "[Warzelnia] Uwarzono: " + SynRecipeName(nSel)
+                       + ". Trunek trafił do spiżarni.");
+
+    // Refresh ingredient availability for next brew
+    SynFeedBrewGroup(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Drink-specific effects
+// ----------------------------------------------------------------
+
+void SynApplyDrinkEffect(object oPC, int nRecipeId)
+{
+    float fDur5  = RoundsToSeconds(10);
+    float fDur10 = RoundsToSeconds(20);
+    float fDur15 = RoundsToSeconds(30);
+    float fDur30 = RoundsToSeconds(60);
+    string sTag  = "SYN_DRINK_" + IntToString(nRecipeId);
+
+    switch(nRecipeId)
+    {
+        case SYN_REC_ALE:
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectAbilityIncrease(ABILITY_STRENGTH,  1), sTag), oPC, fDur10);
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectAbilityDecrease(ABILITY_DEXTERITY, 1), sTag), oPC, fDur10);
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectAbilityIncrease(ABILITY_CHARISMA,  1), sTag), oPC, fDur10);
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectTemporaryHitpoints(5), sTag), oPC, fDur10);
+            break;
+
+        case SYN_REC_GRAVEDIGGER:
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectAbilityIncrease(ABILITY_STRENGTH,  2), sTag), oPC, fDur10);
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectAbilityDecrease(ABILITY_DEXTERITY, 2), sTag), oPC, fDur10);
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectDamageResistance(DAMAGE_TYPE_COLD, 5, 0), sTag), oPC, fDur10);
+            break;
+
+        case SYN_REC_GRAVE_MEAD:
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectImmunity(IMMUNITY_TYPE_FRIGHTENED), sTag), oPC, fDur15);
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectSavingThrowIncrease(SAVING_THROW_ALL, 3, SAVING_THROW_TYPE_DEATH),
+                          sTag), oPC, fDur15);
+            break;
+
+        case SYN_REC_BLOOD_WINE:
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectAttackIncrease(1, ATTACK_BONUS_MISC), sTag), oPC, fDur5);
+            SetLocalInt(oPC, "SYN_BLOOD_WINE", 1);
+            DelayCommand(fDur5, DeleteLocalInt(oPC, "SYN_BLOOD_WINE"));
+            break;
+
+        case SYN_REC_WRAITHWATER:
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectConcealment(25, MISS_CHANCE_TYPE_NORMAL), sTag), oPC, fDur5);
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectAbilityDecrease(ABILITY_WISDOM, 4), sTag), oPC, fDur5);
+            break;
+
+        case SYN_REC_IRON_BREW:
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectAbilityIncrease(ABILITY_CONSTITUTION, 2), sTag), oPC, fDur10);
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectDamageResistance(DAMAGE_TYPE_SLASHING, 5, 0), sTag), oPC, fDur10);
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectAbilityDecrease(ABILITY_INTELLIGENCE, 1), sTag), oPC, fDur10);
+            break;
+
+        case SYN_REC_SPIDER_GIN:
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectImmunity(IMMUNITY_TYPE_POISON), sTag), oPC, fDur30);
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectAbilityIncrease(ABILITY_DEXTERITY, 2), sTag), oPC, fDur30);
+            break;
+
+        case SYN_REC_WARLOCK_VOD:
+            // +1 caster level is best approximated by a bonus spell; use visual + AC here
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectSpellLevelAbsorption(9, 0, SPELL_SCHOOL_GENERAL), sTag), oPC, fDur5);
+            int nVFX;
+            switch(d4(1))
+            {
+                case 1: nVFX = VFX_IMP_LIGHTNING_S;       break;
+                case 2: nVFX = VFX_IMP_EVIL_HELP;         break;
+                case 3: nVFX = VFX_IMP_MAGIC_PROTECTION;  break;
+                default: nVFX = VFX_IMP_HOLY_AID;         break;
+            }
+            ApplyEffectToObject(DURATION_TYPE_INSTANT, EffectVisualEffect(nVFX), oPC);
+            break;
+    }
+
+    // Flavor floating text
+    string sFlavor;
+    switch(nRecipeId)
+    {
+        case SYN_REC_ALE:
+            sFlavor = "Piwo ścieka po gardle — ciepłe i złe. Mięśnie się rozluźniają."; break;
+        case SYN_REC_GRAVEDIGGER:
+            sFlavor = "Pali jak ogień. Zęby szczękają mimo woli — ze strachu czy z zimna?"; break;
+        case SYN_REC_GRAVE_MEAD:
+            sFlavor = "Słodki proch na języku. Strach odpływa jak mgła nad mogiłą."; break;
+        case SYN_REC_BLOOD_WINE:
+            sFlavor = "Ciepłe i ciężkie. Wzrok wyostrza się na bijące serca wokół."; break;
+        case SYN_REC_WRAITHWATER:
+            sFlavor = "Chłód wchodzi w kości — i pozostaje. Twój cień się nie porusza razem z tobą."; break;
+        case SYN_REC_IRON_BREW:
+            sFlavor = "Zęby cię boli. Żołądek protestuje. Skóra twardnieje jak kuta blacha."; break;
+        case SYN_REC_SPIDER_GIN:
+            sFlavor = "Mroźny ukłucie w gardle. Trucizna jak antidotum — albo odwrotnie."; break;
+        case SYN_REC_WARLOCK_VOD:
+            sFlavor = "Iskry za oczami. Możesz przysiąc, że widzisz nitki magii w powietrzu."; break;
+        default:
+            sFlavor = "Trunek smakuje jak przeznaczenie."; break;
+    }
+    FloatingTextStringOnCreature(sFlavor, oPC, FALSE);
+}
+
+// ----------------------------------------------------------------
+// Intox threshold passive effects
+// ----------------------------------------------------------------
+
+// Removes all effects tagged with the given threshold tag
+void SynRemoveIntoxThresholdFX(object oPC, int nThr)
+{
+    string sTag = "SYN_INTOX_" + IntToString(nThr);
+    effect eChk = GetFirstEffect(oPC);
+    while(GetIsEffectValid(eChk))
+    {
+        if(GetEffectTag(eChk) == sTag)
+            RemoveEffect(oPC, eChk);
+        eChk = GetNextEffect(oPC);
+    }
+}
+
+void SynApplyIntoxEffects(object oPC, int nOldThr, int nNewThr)
+{
+    if(nOldThr == nNewThr) return;
+
+    SynRemoveIntoxThresholdFX(oPC, nOldThr);
+
+    if(nNewThr <= 0) // sober
+    {
+        if(nOldThr > 0)
+            SendMessageToPC(oPC, "[Warzelnia] Upojenie minęło. Powrót do trzeźwości.");
+        return;
+    }
+
+    string sTag  = "SYN_INTOX_" + IntToString(nNewThr);
+    float  fPerm = HoursToSeconds(24); // stays until removed by decay
+
+    switch(nNewThr)
+    {
+        case 1: // tipsy
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectAbilityIncrease(ABILITY_CHARISMA, 1), sTag), oPC, fPerm);
+            SendMessageToPC(oPC, "[Warzelnia] Lekko w głowie. Świat wygląda przyjemniej.");
+            break;
+
+        case 2: // drunk
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectAbilityIncrease(ABILITY_STRENGTH,     2), sTag), oPC, fPerm);
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectAbilityDecrease(ABILITY_DEXTERITY,    2), sTag), oPC, fPerm);
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectAbilityDecrease(ABILITY_INTELLIGENCE, 2), sTag), oPC, fPerm);
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectAbilityIncrease(ABILITY_CHARISMA,     2), sTag), oPC, fPerm);
+            SendMessageToPC(oPC, "[Warzelnia] Pijany. Nogi trochę nie słuchają, ale w rękach czuć moc.");
+            break;
+
+        case 3: // heavy
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectAbilityIncrease(ABILITY_STRENGTH,     3), sTag), oPC, fPerm);
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectAbilityDecrease(ABILITY_DEXTERITY,    4), sTag), oPC, fPerm);
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectAbilityDecrease(ABILITY_INTELLIGENCE, 4), sTag), oPC, fPerm);
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectAbilityIncrease(ABILITY_CHARISMA,     2), sTag), oPC, fPerm);
+            SendMessageToPC(oPC, "[Warzelnia] Mocno pijany. Rzeczywistość faluje jak woda w beczce.");
+            break;
+
+        case 4: // severe
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectAbilityDecrease(ABILITY_DEXTERITY,    5), sTag), oPC, fPerm);
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectAbilityDecrease(ABILITY_INTELLIGENCE, 6), sTag), oPC, fPerm);
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectAbilityDecrease(ABILITY_WISDOM,       4), sTag), oPC, fPerm);
+            SendMessageToPC(oPC, "[Warzelnia] Totalnie pijany. Ziemia się kręci. Czas się położyć.");
+            break;
+
+        case 5: // blackout
+            SendMessageToPC(oPC, "[Warzelnia] Zbyt dużo... Oczy się zamykają same.");
+            ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+                TagEffect(EffectSleep(), "SYN_INTOX_5"), oPC, 30.0);
+            break;
+    }
+}
+
+// ----------------------------------------------------------------
+// Drinking action
+// ----------------------------------------------------------------
+
+void SynDrink(object oPC, int nToken, int nRowId, int nRecipeId)
+{
+    if(nRowId == 0) return;
+
+    SynRemoveCellarDrink(oPC, nRowId);
+    SetLocalInt(oPC, SYN_LVAR_SEL_CEL_ID, 0);
+
+    SynApplyDrinkEffect(oPC, nRecipeId);
+
+    int nOldLevel = GetLocalInt(oPC, "SYN_INTOX_CACHE");
+    int nOldThr   = SynIntoxThreshold(nOldLevel);
+    SynAddIntox(oPC, SynRecipeIntox(nRecipeId));
+    int nNewLevel = GetLocalInt(oPC, "SYN_INTOX_CACHE");
+    int nNewThr   = SynIntoxThreshold(nNewLevel);
+
+    SynApplyIntoxEffects(oPC, nOldThr, nNewThr);
+    SetLocalInt(oPC, SYN_LVAR_INTOX_THR, nNewThr);
+
+    SynUpdateIntoxBar(oPC, nToken, nNewLevel);
+    SynFeedCellarGroup(oPC, nToken);
+}
+
+// ----------------------------------------------------------------
+// Login / heartbeat hooks
+// ----------------------------------------------------------------
+
+void SynOnClientEnter(object oPC)
+{
+    int nLevel = SynGetIntox(oPC);
+    SetLocalInt(oPC, "SYN_INTOX_CACHE", nLevel);
+    int nThr = SynIntoxThreshold(nLevel);
+    SetLocalInt(oPC, SYN_LVAR_INTOX_THR, nThr);
+    // Re-apply passive effects for persisted intox (no old threshold to remove)
+    if(nThr > 0)
+        SynApplyIntoxEffects(oPC, 0, nThr);
+}
+
+void SynOnHeartbeat(object oPC)
+{
+    int nTick = GetLocalInt(oPC, SYN_LVAR_HB_TICK) + 1;
+    if(nTick < SYN_HB_DECAY_EVERY)
+    {
+        SetLocalInt(oPC, SYN_LVAR_HB_TICK, nTick);
+        return;
+    }
+    SetLocalInt(oPC, SYN_LVAR_HB_TICK, 0);
+
+    int nOldLevel = GetLocalInt(oPC, "SYN_INTOX_CACHE");
+    if(nOldLevel <= 0) return;
+
+    SynDecayIntox(oPC);
+    int nNewLevel = GetLocalInt(oPC, "SYN_INTOX_CACHE");
+    int nOldThr   = SynIntoxThreshold(nOldLevel);
+    int nNewThr   = SynIntoxThreshold(nNewLevel);
+
+    if(nOldThr != nNewThr)
+    {
+        SynApplyIntoxEffects(oPC, nOldThr, nNewThr);
+        SetLocalInt(oPC, SYN_LVAR_INTOX_THR, nNewThr);
+    }
+
+    // Live-update the open window's intox bar
+    int nToken = NuiFindWindow(oPC, SYN_WINDOW);
+    if(nToken != 0)
+        SynUpdateIntoxBar(oPC, nToken, nNewLevel);
+}

--- a/Szynkarz/Scripts/lib_syn_def.nss
+++ b/Szynkarz/Scripts/lib_syn_def.nss
@@ -1,0 +1,355 @@
+// lib_syn_def.nss — Szynkarz: constants, recipes, ingredient helpers
+
+#include "lib_nui"
+#include "sql_syn"
+
+// Forward declarations (defined in lib_syn.nss)
+void SynOpenWindow(object oPC);
+void SynFeedRecipesGroup(object oPC, int nToken);
+void SynFeedBrewGroup(object oPC, int nToken);
+void SynFeedCellarGroup(object oPC, int nToken);
+void SynUpdateIntoxBar(object oPC, int nToken, int nLevel);
+
+// ----------------------------------------------------------------
+// Window / bind / button IDs
+// ----------------------------------------------------------------
+
+const string SYN_WINDOW          = "SYN_MAIN";
+const string SYN_EV_SCRIPT       = "lib_syn_ev";
+const string SYN_WIN_GEOM        = "syn_win_geom";
+
+const string SYN_CONTENT_GROUP   = "syn_content";      // NuiId of swappable group
+
+// Tab strip buttons
+const string SYN_BTN_TAB_REC     = "syn_tab_rec";
+const string SYN_BTN_TAB_BREW    = "syn_tab_brew";
+const string SYN_BTN_TAB_CEL     = "syn_tab_cel";
+const string SYN_BTN_CLOSE       = "syn_btn_close";
+
+// Intox bar (always visible at bottom of window)
+const string SYN_BIND_INTOX_LBL  = "syn_intox_lbl";   // "Trzeźwy" / "Pijany" etc.
+const string SYN_BIND_INTOX_VAL  = "syn_intox_val";   // float 0.0-1.0 for progress bar
+const string SYN_BIND_INTOX_COL  = "syn_intox_col";   // NuiColor JSON
+
+// Recipes tab
+const string SYN_BTN_REC_ROW     = "syn_rec_row";
+const string SYN_BIND_REC_NAMES  = "syn_rec_names";
+const string SYN_BIND_REC_ENC    = "syn_rec_enc";
+const string SYN_BIND_DET_NAME   = "syn_det_name";
+const string SYN_BIND_DET_FLAV   = "syn_det_flav";
+const string SYN_BIND_DET_INGS   = "syn_det_ings";
+const string SYN_BIND_DET_EFFS   = "syn_det_effs";
+const string SYN_BIND_DET_INTOX  = "syn_det_intox";
+
+// Brew tab
+const string SYN_BIND_BREW_NAME  = "syn_brew_name";
+const string SYN_BIND_BREW_LINES = "syn_brew_lines";  // ingredient status rows label
+const string SYN_BIND_BREW_ENA   = "syn_brew_ena";    // bool: brew button enabled
+const string SYN_BTN_BREW        = "syn_btn_brew";
+
+// Cellar tab
+const string SYN_BTN_CEL_ROW     = "syn_cel_row";
+const string SYN_BIND_CEL_NAMES  = "syn_cel_names";
+const string SYN_BIND_CEL_QTYS   = "syn_cel_qtys";
+const string SYN_BIND_CEL_ENC    = "syn_cel_enc";
+const string SYN_BTN_DRINK       = "syn_btn_drink";
+const string SYN_BIND_DRINK_ENA  = "syn_drink_ena";
+
+// LVARs on PC
+const string SYN_LVAR_SEL_REC    = "SYN_SEL_REC";     // selected recipe id (−1 = none)
+const string SYN_LVAR_SEL_CEL_ID = "SYN_SEL_CEL_ID";  // selected cellar row id (0 = none)
+const string SYN_LVAR_SEL_CEL_RI = "SYN_SEL_CEL_RI";  // recipe_id of selected cellar row
+const string SYN_LVAR_HB_TICK    = "SYN_HB_TICK";     // heartbeat counter
+const string SYN_LVAR_INTOX_THR  = "SYN_INTOX_THR";   // last applied threshold (0-5)
+const string SYN_LVAR_ACTIVE_TAB = "SYN_ACTIVE_TAB";  // 0=recipes 1=brew 2=cellar
+
+// ----------------------------------------------------------------
+// Intox thresholds and decay
+// ----------------------------------------------------------------
+
+const int SYN_INTOX_TIPSY        = 10;   // lekko wstawiony
+const int SYN_INTOX_DRUNK        = 30;   // pijany
+const int SYN_INTOX_HEAVY        = 55;   // mocno pijany
+const int SYN_INTOX_SEVERE       = 75;   // totalnie pijany
+const int SYN_INTOX_BLACKOUT     = 90;   // nieprzytomny
+
+const int SYN_HB_DECAY_EVERY     = 5;    // decay 1 point every N heartbeats (≈30 s)
+
+// ----------------------------------------------------------------
+// Recipe IDs
+// ----------------------------------------------------------------
+
+const int SYN_REC_ALE            = 0;
+const int SYN_REC_GRAVEDIGGER    = 1;
+const int SYN_REC_GRAVE_MEAD     = 2;
+const int SYN_REC_BLOOD_WINE     = 3;
+const int SYN_REC_WRAITHWATER    = 4;
+const int SYN_REC_IRON_BREW      = 5;
+const int SYN_REC_SPIDER_GIN     = 6;
+const int SYN_REC_WARLOCK_VOD    = 7;
+const int SYN_REC_COUNT          = 8;
+
+// ----------------------------------------------------------------
+// Ingredient item tags
+// ----------------------------------------------------------------
+
+const string SYN_ING_HOP         = "syn_hop";
+const string SYN_ING_BARLEY      = "syn_barley";
+const string SYN_ING_MIDNIGHT    = "syn_midnight";
+const string SYN_ING_HONEY       = "syn_honey";
+const string SYN_ING_WORMWOOD    = "syn_wormwood";
+const string SYN_ING_BONE_DUST   = "syn_bone_dust";
+const string SYN_ING_GRAPES      = "syn_grapes";
+const string SYN_ING_BLOOD       = "syn_blood";
+const string SYN_ING_GHOST_ESS   = "syn_ghost_ess";
+const string SYN_ING_MOONWATER   = "syn_moonwater";
+const string SYN_ING_IRON_FIL    = "syn_iron_fil";
+const string SYN_ING_CINDER      = "syn_cinder";
+const string SYN_ING_SPIDER_VEN  = "syn_spider_ven";
+const string SYN_ING_ARCANE_CRY  = "syn_arcane_cry";
+
+// ----------------------------------------------------------------
+// Recipe metadata
+// ----------------------------------------------------------------
+
+string SynRecipeName(int nId)
+{
+    switch(nId)
+    {
+        case SYN_REC_ALE:         return "Karczmarskie Piwo";
+        case SYN_REC_GRAVEDIGGER: return "Gorzałka Grabacza";
+        case SYN_REC_GRAVE_MEAD:  return "Miód Grobowy";
+        case SYN_REC_BLOOD_WINE:  return "Wino Krwi";
+        case SYN_REC_WRAITHWATER: return "Woda Zjaw";
+        case SYN_REC_IRON_BREW:   return "Żelazny Napar";
+        case SYN_REC_SPIDER_GIN:  return "Dżin Pająka";
+        case SYN_REC_WARLOCK_VOD: return "Wódka Czarnoksiężnika";
+    }
+    return "Nieznana receptura";
+}
+
+string SynRecipeFlavor(int nId)
+{
+    switch(nId)
+    {
+        case SYN_REC_ALE:
+            return "Cierpkie piwo z karczemnych beczek. Pachnie pleśnią i starym drewnem."
+                 + " Rozgrzewa żołądek, koi nerwy przed bitwą.";
+        case SYN_REC_GRAVEDIGGER:
+            return "Mocna gorzała destylowana przy blasku pochodni na cmentarzu."
+                 + " Grabarze twierdzą, że chroni przed zimnem — i przed strachem.";
+        case SYN_REC_GRAVE_MEAD:
+            return "Miód warzony w kryptach, fermentowany miesiącami wśród kości."
+                 + " Słodkawy, z gorzkawym posmakiem prochu. Martwe pszczoły nigdy nie przestają pracować.";
+        case SYN_REC_BLOOD_WINE:
+            return "Wino wzbogacone kroplą bitewnej krwi. Wzmacnia i pobudza łowieckie instynkty."
+                 + " Nie pytaj, czyja to krew.";
+        case SYN_REC_WRAITHWATER:
+            return "Przezroczysta ciecz, jakby woda — ale chłodna jak śmierć."
+                 + " Esencja zaklętej zjawy schwytanej w flaszkę. Sprawia, że cień wyprzedza ciało.";
+        case SYN_REC_IRON_BREW:
+            return "Krasnoludzkiej tradycji napar — gorzki od opiłków żelaza, piekący jak kuźnia."
+                 + " Nikt nie wie, czy smakuje, czy tylko tak strasznie boli.";
+        case SYN_REC_SPIDER_GIN:
+            return "Destylat z jadu pająka, rozrzedzony wodą księżycową."
+                 + " Trucizna i antidotum w jednym. Mróz w żyłach.";
+        case SYN_REC_WARLOCK_VOD:
+            return "Czysta jak kryształ, ale w środku tańczą niebieskie iskry."
+                 + " Czarownicy dodają kryształ arkanistyczny do alembika i milczą o tym, co widzą w dymie.";
+    }
+    return "";
+}
+
+string SynRecipeEffects(int nId)
+{
+    switch(nId)
+    {
+        case SYN_REC_ALE:         return "+1 STR, -1 DEX, +1 CHA, +5 max HP (10 min)";
+        case SYN_REC_GRAVEDIGGER: return "+2 STR, -2 DEX, odporność na zimno 5/- (10 min)";
+        case SYN_REC_GRAVE_MEAD:  return "Odporność na Strach, +3 do rzutów obronnych vs. nieumarli (15 min)";
+        case SYN_REC_BLOOD_WINE:  return "+1 do ataku vs. żywe istoty, regeneracja 2 PZ po zabiciu (5 min)";
+        case SYN_REC_WRAITHWATER: return "Niewidzialność częściowa 25% (5 min), -4 WIS";
+        case SYN_REC_IRON_BREW:   return "+2 CON, odporność na cięcie 5/- (10 min), -1 INT";
+        case SYN_REC_SPIDER_GIN:  return "Pełna odporność na trucizny (30 min), +2 DEX";
+        case SYN_REC_WARLOCK_VOD: return "+1 poziom rzucającego (5 min), losowe przesunięcie magiczne";
+    }
+    return "";
+}
+
+int SynRecipeIntox(int nId)
+{
+    switch(nId)
+    {
+        case SYN_REC_ALE:         return 10;
+        case SYN_REC_GRAVEDIGGER: return 20;
+        case SYN_REC_GRAVE_MEAD:  return 15;
+        case SYN_REC_BLOOD_WINE:  return 10;
+        case SYN_REC_WRAITHWATER: return 30;
+        case SYN_REC_IRON_BREW:   return 20;
+        case SYN_REC_SPIDER_GIN:  return 20;
+        case SYN_REC_WARLOCK_VOD: return 25;
+    }
+    return 10;
+}
+
+// ----------------------------------------------------------------
+// Ingredient list helpers
+// ----------------------------------------------------------------
+
+json SynMakeIng(string sTag, int nQty, string sName)
+{
+    json j = JsonObject();
+    j = JsonObjectSet(j, "tag",  JsonString(sTag));
+    j = JsonObjectSet(j, "qty",  JsonInt(nQty));
+    j = JsonObjectSet(j, "name", JsonString(sName));
+    return j;
+}
+
+// Returns JsonArray of {tag, qty, name} for the recipe
+json SynGetRecipeIngredients(int nId)
+{
+    json jList = JsonArray();
+    switch(nId)
+    {
+        case SYN_REC_ALE:
+            jList = JsonArrayInsert(jList, SynMakeIng(SYN_ING_HOP,       2, "Chmiel"));
+            jList = JsonArrayInsert(jList, SynMakeIng(SYN_ING_BARLEY,    1, "Słód Jęczmienny"));
+            break;
+        case SYN_REC_GRAVEDIGGER:
+            jList = JsonArrayInsert(jList, SynMakeIng(SYN_ING_BARLEY,    1, "Słód Jęczmienny"));
+            jList = JsonArrayInsert(jList, SynMakeIng(SYN_ING_MIDNIGHT,  1, "Korzeń Północy"));
+            break;
+        case SYN_REC_GRAVE_MEAD:
+            jList = JsonArrayInsert(jList, SynMakeIng(SYN_ING_HONEY,     1, "Miód Dzikich Pszczół"));
+            jList = JsonArrayInsert(jList, SynMakeIng(SYN_ING_WORMWOOD,  1, "Piołun"));
+            jList = JsonArrayInsert(jList, SynMakeIng(SYN_ING_BONE_DUST, 1, "Proch Kostny"));
+            break;
+        case SYN_REC_BLOOD_WINE:
+            jList = JsonArrayInsert(jList, SynMakeIng(SYN_ING_GRAPES,    2, "Czarne Winogrona"));
+            jList = JsonArrayInsert(jList, SynMakeIng(SYN_ING_BLOOD,     1, "Świeża Krew"));
+            break;
+        case SYN_REC_WRAITHWATER:
+            jList = JsonArrayInsert(jList, SynMakeIng(SYN_ING_GHOST_ESS, 1, "Esencja Zjaw"));
+            jList = JsonArrayInsert(jList, SynMakeIng(SYN_ING_MOONWATER, 1, "Woda Księżycowa"));
+            break;
+        case SYN_REC_IRON_BREW:
+            jList = JsonArrayInsert(jList, SynMakeIng(SYN_ING_IRON_FIL,  1, "Opiłki Żelaza"));
+            jList = JsonArrayInsert(jList, SynMakeIng(SYN_ING_BARLEY,    1, "Słód Jęczmienny"));
+            jList = JsonArrayInsert(jList, SynMakeIng(SYN_ING_CINDER,    1, "Korzeń Żużlowy"));
+            break;
+        case SYN_REC_SPIDER_GIN:
+            jList = JsonArrayInsert(jList, SynMakeIng(SYN_ING_SPIDER_VEN,1, "Jad Pająka"));
+            jList = JsonArrayInsert(jList, SynMakeIng(SYN_ING_MOONWATER, 1, "Woda Księżycowa"));
+            break;
+        case SYN_REC_WARLOCK_VOD:
+            jList = JsonArrayInsert(jList, SynMakeIng(SYN_ING_ARCANE_CRY,1, "Kryształ Arkanistyczny"));
+            jList = JsonArrayInsert(jList, SynMakeIng(SYN_ING_BARLEY,    2, "Słód Jęczmienny"));
+            break;
+    }
+    return jList;
+}
+
+// ----------------------------------------------------------------
+// Inventory helpers
+// ----------------------------------------------------------------
+
+int SynCountInInventory(object oPC, string sTag)
+{
+    int nCount = 0;
+    object oItem = GetFirstItemInInventory(oPC);
+    while(GetIsObjectValid(oItem))
+    {
+        if(GetTag(oItem) == sTag)
+            nCount += GetItemStackSize(oItem);
+        oItem = GetNextItemInInventory(oPC);
+    }
+    return nCount;
+}
+
+int SynCanBrew(object oPC, int nRecipeId)
+{
+    json jIngs  = SynGetRecipeIngredients(nRecipeId);
+    int  nCount = JsonGetLength(jIngs);
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jIng   = JsonArrayGet(jIngs, i);
+        string sTag = JsonGetString(JsonObjectGet(jIng, "tag"));
+        int nReq    = JsonGetInt   (JsonObjectGet(jIng, "qty"));
+        if(SynCountInInventory(oPC, sTag) < nReq)
+            return FALSE;
+    }
+    return TRUE;
+}
+
+void SynConsumeIngredients(object oPC, int nRecipeId)
+{
+    json jIngs  = SynGetRecipeIngredients(nRecipeId);
+    int  nCount = JsonGetLength(jIngs);
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jIng    = JsonArrayGet(jIngs, i);
+        string sTag  = JsonGetString(JsonObjectGet(jIng, "tag"));
+        int nNeeded  = JsonGetInt   (JsonObjectGet(jIng, "qty"));
+        int nLeft    = nNeeded;
+
+        object oItem = GetFirstItemInInventory(oPC);
+        while(GetIsObjectValid(oItem) && nLeft > 0)
+        {
+            if(GetTag(oItem) == sTag)
+            {
+                int nStack = GetItemStackSize(oItem);
+                if(nStack <= nLeft)
+                {
+                    nLeft -= nStack;
+                    DestroyObject(oItem);
+                    oItem = GetFirstItemInInventory(oPC);
+                }
+                else
+                {
+                    SetItemStackSize(oItem, nStack - nLeft);
+                    nLeft = 0;
+                }
+            }
+            else
+                oItem = GetNextItemInInventory(oPC);
+        }
+    }
+}
+
+// ----------------------------------------------------------------
+// Intox display helpers
+// ----------------------------------------------------------------
+
+string SynIntoxLabel(int nLevel)
+{
+    if(nLevel >= SYN_INTOX_BLACKOUT) return "Nieprzytomny";
+    if(nLevel >= SYN_INTOX_SEVERE)   return "Totalnie Pijany";
+    if(nLevel >= SYN_INTOX_HEAVY)    return "Mocno Pijany";
+    if(nLevel >= SYN_INTOX_DRUNK)    return "Pijany";
+    if(nLevel >= SYN_INTOX_TIPSY)    return "Lekko Wstawiony";
+    return "Trzeźwy";
+}
+
+// 0=sober 1=tipsy 2=drunk 3=heavy 4=severe 5=blackout
+int SynIntoxThreshold(int nLevel)
+{
+    if(nLevel >= SYN_INTOX_BLACKOUT) return 5;
+    if(nLevel >= SYN_INTOX_SEVERE)   return 4;
+    if(nLevel >= SYN_INTOX_HEAVY)    return 3;
+    if(nLevel >= SYN_INTOX_DRUNK)    return 2;
+    if(nLevel >= SYN_INTOX_TIPSY)    return 1;
+    return 0;
+}
+
+// Color: green → amber → red as intox rises
+json SynIntoxColor(int nLevel)
+{
+    if(nLevel >= SYN_INTOX_BLACKOUT) return NuiColor(200,  20,  20);
+    if(nLevel >= SYN_INTOX_SEVERE)   return NuiColor(220,  60,  40);
+    if(nLevel >= SYN_INTOX_HEAVY)    return NuiColor(210, 140,  30);
+    if(nLevel >= SYN_INTOX_DRUNK)    return NuiColor(200, 180,  40);
+    if(nLevel >= SYN_INTOX_TIPSY)    return NuiColor(140, 200,  60);
+    return NuiColor(80, 160, 80);
+}

--- a/Szynkarz/Scripts/lib_syn_ev.nss
+++ b/Szynkarz/Scripts/lib_syn_ev.nss
@@ -1,0 +1,138 @@
+// lib_syn_ev.nss — Szynkarz: NUI event handler
+// Hook: NuiCreate(..., "lib_syn_ev")
+
+#include "lib_syn"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    if(nToken != NuiFindWindow(oPC, SYN_WINDOW)) return;
+
+    // ---- Window opened ----
+    if(sEvent == EVENT_TYPE_OPEN)
+    {
+        int nLevel = SynGetIntox(oPC);
+        SynUpdateIntoxBar(oPC, nToken, nLevel);
+        return;
+    }
+
+    // ---- Window closed ----
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalInt(oPC, SYN_LVAR_SEL_REC);
+        DeleteLocalInt(oPC, SYN_LVAR_SEL_CEL_ID);
+        DeleteLocalInt(oPC, SYN_LVAR_SEL_CEL_RI);
+        DeleteLocalInt(oPC, SYN_LVAR_ACTIVE_TAB);
+        return;
+    }
+
+    if(sEvent != EVENT_TYPE_CLICK && sEvent != EVENT_TYPE_MOUSEDOWN) return;
+
+    // ---- Tab strip ----
+    if(sElem == SYN_BTN_CLOSE)
+    {
+        NuiDestroy(oPC, nToken);
+        return;
+    }
+
+    if(sElem == SYN_BTN_TAB_REC)
+    {
+        SetLocalInt(oPC, SYN_LVAR_ACTIVE_TAB, 0);
+        SynFeedRecipesGroup(oPC, nToken);
+        int nLevel = SynGetIntox(oPC);
+        SynUpdateIntoxBar(oPC, nToken, nLevel);
+        return;
+    }
+
+    if(sElem == SYN_BTN_TAB_BREW)
+    {
+        SetLocalInt(oPC, SYN_LVAR_ACTIVE_TAB, 1);
+        SynFeedBrewGroup(oPC, nToken);
+        int nLevel = SynGetIntox(oPC);
+        SynUpdateIntoxBar(oPC, nToken, nLevel);
+        return;
+    }
+
+    if(sElem == SYN_BTN_TAB_CEL)
+    {
+        SetLocalInt(oPC, SYN_LVAR_ACTIVE_TAB, 2);
+        SynFeedCellarGroup(oPC, nToken);
+        int nLevel = SynGetIntox(oPC);
+        SynUpdateIntoxBar(oPC, nToken, nLevel);
+        return;
+    }
+
+    // ---- Recipes tab: row click ----
+    if(sElem == SYN_BTN_REC_ROW)
+    {
+        if(nIdx < 0 || nIdx >= SYN_REC_COUNT) return;
+        SetLocalInt(oPC, SYN_LVAR_SEL_REC, nIdx);
+        // Refresh detail panel without rebuilding the entire group
+        NuiSetBind(oPC, nToken, SYN_BIND_DET_NAME,  JsonString(SynRecipeName(nIdx)));
+        NuiSetBind(oPC, nToken, SYN_BIND_DET_FLAV,  JsonString(SynRecipeFlavor(nIdx)));
+        NuiSetBind(oPC, nToken, SYN_BIND_DET_INGS,  JsonString(SynIngListText(nIdx)));
+        NuiSetBind(oPC, nToken, SYN_BIND_DET_EFFS,  JsonString(SynRecipeEffects(nIdx)));
+        NuiSetBind(oPC, nToken, SYN_BIND_DET_INTOX,
+            JsonString("Upojenie: +" + IntToString(SynRecipeIntox(nIdx)) + " pkt"));
+        // Update selection highlight
+        json jEnc = JsonArray();
+        int i;
+        for(i = 0; i < SYN_REC_COUNT; i++)
+            jEnc = JsonArrayInsert(jEnc, JsonBool(i == nIdx));
+        NuiSetBind(oPC, nToken, SYN_BIND_REC_ENC, jEnc);
+        return;
+    }
+
+    // ---- Brew tab: brew button ----
+    if(sElem == SYN_BTN_BREW)
+    {
+        SynBrew(oPC, nToken);
+        return;
+    }
+
+    // ---- Cellar tab: row click ----
+    if(sElem == SYN_BTN_CEL_ROW)
+    {
+        json jCellar = SynGetCellar(oPC);
+        if(nIdx < 0 || nIdx >= JsonGetLength(jCellar)) return;
+
+        json jRow = JsonArrayGet(jCellar, nIdx);
+        int  nId  = JsonGetInt(JsonObjectGet(jRow, "id"));
+        int  nRec = JsonGetInt(JsonObjectGet(jRow, "recipe_id"));
+
+        SetLocalInt(oPC, SYN_LVAR_SEL_CEL_ID, nId);
+        SetLocalInt(oPC, SYN_LVAR_SEL_CEL_RI, nRec);
+
+        // Update selection highlight
+        int  nCount = JsonGetLength(jCellar);
+        json jEnc   = JsonArray();
+        int i;
+        for(i = 0; i < nCount; i++)
+        {
+            int nRowId = JsonGetInt(JsonObjectGet(JsonArrayGet(jCellar, i), "id"));
+            jEnc = JsonArrayInsert(jEnc, JsonBool(nRowId == nId));
+        }
+        NuiSetBind(oPC, nToken, SYN_BIND_CEL_ENC,   jEnc);
+        NuiSetBind(oPC, nToken, SYN_BIND_DRINK_ENA,  JsonBool(TRUE));
+        return;
+    }
+
+    // ---- Cellar tab: drink button ----
+    if(sElem == SYN_BTN_DRINK)
+    {
+        int nSelId = GetLocalInt(oPC, SYN_LVAR_SEL_CEL_ID);
+        int nSelRi = GetLocalInt(oPC, SYN_LVAR_SEL_CEL_RI);
+        if(nSelId == 0)
+        {
+            SendMessageToPC(oPC, "[Warzelnia] Zaznacz trunek, który chcesz wypić.");
+            return;
+        }
+        SynDrink(oPC, nToken, nSelId, nSelRi);
+        return;
+    }
+}

--- a/Szynkarz/Scripts/sql_syn.nss
+++ b/Szynkarz/Scripts/sql_syn.nss
@@ -1,0 +1,125 @@
+// sql_syn.nss — Szynkarz DB schema and queries
+// Campaign DB name: "szynkarz"
+
+void SynCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("szynkarz",
+        "CREATE TABLE IF NOT EXISTS syn_intox ("
+        "  uuid    TEXT    PRIMARY KEY,"
+        "  level   INTEGER NOT NULL DEFAULT 0"
+        ")");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("szynkarz",
+        "CREATE TABLE IF NOT EXISTS syn_cellar ("
+        "  id        INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "  uuid      TEXT    NOT NULL,"
+        "  recipe_id INTEGER NOT NULL,"
+        "  qty       INTEGER NOT NULL DEFAULT 1"
+        ")");
+    SqlStep(q);
+}
+
+// ----------------------------------------------------------------
+// Intoxication
+// ----------------------------------------------------------------
+
+int SynGetIntox(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("szynkarz",
+        "SELECT level FROM syn_intox WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+void SynSetIntox(object oPC, int nLevel)
+{
+    if(nLevel < 0)   nLevel = 0;
+    if(nLevel > 100) nLevel = 100;
+    sqlquery q = SqlPrepareQueryCampaign("szynkarz",
+        "INSERT OR REPLACE INTO syn_intox (uuid, level) VALUES (@uuid, @lvl)");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@lvl",  nLevel);
+    SqlStep(q);
+    SetLocalInt(oPC, "SYN_INTOX_CACHE", nLevel);
+}
+
+void SynAddIntox(object oPC, int nPoints)
+{
+    int nCurrent = SynGetIntox(oPC);
+    SynSetIntox(oPC, nCurrent + nPoints);
+}
+
+// Decrements intox by 1; no-op if already 0.
+void SynDecayIntox(object oPC)
+{
+    int nLevel = GetLocalInt(oPC, "SYN_INTOX_CACHE");
+    if(nLevel <= 0) return;
+    SynSetIntox(oPC, nLevel - 1);
+}
+
+// ----------------------------------------------------------------
+// Cellar (stored brewed drinks per character)
+// ----------------------------------------------------------------
+
+// Returns JsonArray of {id, recipe_id, qty}
+json SynGetCellar(object oPC)
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("szynkarz",
+        "SELECT id, recipe_id, qty FROM syn_cellar"
+        " WHERE uuid = @uuid AND qty > 0 ORDER BY recipe_id");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    while(SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "id",        JsonInt(SqlGetInt(q, 0)));
+        jRow = JsonObjectSet(jRow, "recipe_id", JsonInt(SqlGetInt(q, 1)));
+        jRow = JsonObjectSet(jRow, "qty",       JsonInt(SqlGetInt(q, 2)));
+        jRows = JsonArrayInsert(jRows, jRow);
+    }
+    return jRows;
+}
+
+void SynAddCellarDrink(object oPC, int nRecipeId)
+{
+    // Find existing row
+    sqlquery q = SqlPrepareQueryCampaign("szynkarz",
+        "SELECT id, qty FROM syn_cellar WHERE uuid = @uuid AND recipe_id = @rid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@rid",  nRecipeId);
+
+    if(SqlStep(q))
+    {
+        int nId  = SqlGetInt(q, 0);
+        int nQty = SqlGetInt(q, 1);
+        sqlquery qu = SqlPrepareQueryCampaign("szynkarz",
+            "UPDATE syn_cellar SET qty = @qty WHERE id = @id");
+        SqlBindInt(qu, "@qty", nQty + 1);
+        SqlBindInt(qu, "@id",  nId);
+        SqlStep(qu);
+    }
+    else
+    {
+        sqlquery qi = SqlPrepareQueryCampaign("szynkarz",
+            "INSERT INTO syn_cellar (uuid, recipe_id, qty) VALUES (@uuid, @rid, 1)");
+        SqlBindString(qi, "@uuid", GetObjectUUID(oPC));
+        SqlBindInt   (qi, "@rid",  nRecipeId);
+        SqlStep(qi);
+    }
+}
+
+void SynRemoveCellarDrink(object oPC, int nRowId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("szynkarz",
+        "UPDATE syn_cellar SET qty = qty - 1 WHERE id = @id AND uuid = @uuid");
+    SqlBindInt   (q, "@id",   nRowId);
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign("szynkarz",
+        "DELETE FROM syn_cellar WHERE id = @id AND qty <= 0");
+    SqlBindInt(q, "@id", nRowId);
+    SqlStep(q);
+}

--- a/Szynkarz/Scripts/sys_module_hb.nss
+++ b/Szynkarz/Scripts/sys_module_hb.nss
@@ -1,0 +1,20 @@
+// sys_module_hb.nss — Szynkarz: per-heartbeat intox decay
+// Hook: Module Properties -> Events -> OnHeartbeat
+// Fires every 6 seconds; decay logic runs every SYN_HB_DECAY_EVERY ticks (~30 s).
+
+#include "lib_syn"
+
+void main()
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        if(!GetIsDM(oPC))
+        {
+            // Only process if PC has nonzero cached intox (avoids SQL per tick)
+            if(GetLocalInt(oPC, "SYN_INTOX_CACHE") > 0)
+                SynOnHeartbeat(oPC);
+        }
+        oPC = GetNextPC();
+    }
+}

--- a/Szynkarz/Scripts/sys_on_enter.nss
+++ b/Szynkarz/Scripts/sys_on_enter.nss
@@ -1,0 +1,12 @@
+// sys_on_enter.nss — Szynkarz: restore intox state on login
+// Hook: Module Properties -> Events -> OnClientEnter
+
+#include "lib_syn"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC) || GetIsDM(oPC)) return;
+
+    SynOnClientEnter(oPC);
+}

--- a/Szynkarz/Scripts/sys_on_load.nss
+++ b/Szynkarz/Scripts/sys_on_load.nss
@@ -1,0 +1,9 @@
+// sys_on_load.nss — Szynkarz module init
+// Hook: Module Properties -> Events -> OnModuleLoad
+
+#include "lib_syn_def"
+
+void main()
+{
+    SynCreateTables();
+}

--- a/Szynkarz/Scripts/test_syn.nss
+++ b/Szynkarz/Scripts/test_syn.nss
@@ -1,0 +1,33 @@
+// test_syn.nss — Szynkarz demo: placeable OnUsed script
+// Place a "Brewing Kit" placeable in the toolset and set this as its OnUsed script.
+// Activating it opens the Warzelnia window.
+// Also seeds the PC's inventory with one of each ingredient for easy testing.
+
+#include "lib_syn"
+
+void SeedTestIngredients(object oPC)
+{
+    // Creates one stack of each ingredient so the brewer can test all recipes.
+    // In a real module these items must exist in a palette/hak with matching tags.
+    string sIngs = SYN_ING_HOP + "," + SYN_ING_BARLEY + "," + SYN_ING_MIDNIGHT + ","
+                 + SYN_ING_HONEY + "," + SYN_ING_WORMWOOD + "," + SYN_ING_BONE_DUST + ","
+                 + SYN_ING_GRAPES + "," + SYN_ING_BLOOD + "," + SYN_ING_GHOST_ESS + ","
+                 + SYN_ING_MOONWATER + "," + SYN_ING_IRON_FIL + "," + SYN_ING_CINDER + ","
+                 + SYN_ING_SPIDER_VEN + "," + SYN_ING_ARCANE_CRY;
+
+    SendMessageToPC(oPC, "[Warzelnia/Test] Składniki do testów: próba tworzenia przedmiotów o tagach:");
+    SendMessageToPC(oPC, sIngs);
+    SendMessageToPC(oPC, "[Warzelnia/Test] Dodaj przedmioty z odpowiednimi tagami do haka i ekwipunku ręcznie.");
+}
+
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC) || GetIsDM(oPC)) return;
+
+    // Shift+Use seeds test ingredients (only if debug mode is on)
+    if(GetLocalInt(GetModule(), "SYN_DEBUG"))
+        SeedTestIngredients(oPC);
+
+    SynOpenWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

System warzenia napojów alkoholowych z klimatem dark fantasy. Gracze zbierają składniki, warzą trunki przy placeable „Brewing Kit", przechowują je w osobistej spiżarni (SQL, per-postać) i piją z efektami mechanicznymi. Upojenie narasta i opada w czasie rzeczywistym przez heartbeat, a kolejne progi przełączają pasywne efekty statystyk.

## Mechanika

**Receptury (8 trunek ów):**

| Trunek | Kluczowe efekty | Upojenie |
|---|---|---|
| Karczmarskie Piwo | +1 STR/CHA, -1 DEX, +5 HP | +10 |
| Gorzałka Grabacza | +2 STR, -2 DEX, odporność na zimno 5/- | +20 |
| Miód Grobowy | Odporność na Strach, +3 do rzutów vs. nieumarli | +15 |
| Wino Krwi | +1 ataku vs. żywe, regeneracja po zabiciu | +10 |
| Woda Zjaw | Niewidzialność 25%, -4 WIS | +30 |
| Żelazny Napar | +2 CON, odporność na cięcie 5/-, -1 INT | +20 |
| Dżin Pająka | Odporność na trucizny (30 min), +2 DEX | +20 |
| Wódka Czarnoksiężnika | Absorpcja czarów (5 min), losowy efekt wizualny | +25 |

**Skala upojenia (0–100):**
- **10 – Lekko Wstawiony**: +1 CHA
- **30 – Pijany**: +2 STR, -2 DEX/INT, +2 CHA
- **55 – Mocno Pijany**: +3 STR, -4 DEX/INT, +2 CHA
- **75 – Totalnie Pijany**: -5 DEX, -6 INT, -4 WIS
- **90 – Nieprzytomny**: Sleep 30s

Heartbeat (co ~30 s) obniża upojenie o 1 pkt. Progi są przełączane przez usunięcie tagowanych efektów i nałożenie nowych. Dane upojenia persystują w SQL między sesjami i są przywracane na `OnClientEnter`.

**NUI — okno „Warzelnia" (3 zakładki):**
- **Receptury**: lista 8 receptur po lewej (klikalna, highlighted selection) + panel szczegółów po prawej (opis klimatyczny, lista składników, efekty, koszt upojenia)
- **Warzelnia**: check składników w ekwipunku ([OK]/[--] per składnik), przycisk „Warzyj Trunek" aktywny tylko gdy wszystko jest
- **Spiżarnia**: lista uwarzonych trunków z ilościami, przycisk „Wypij Zaznaczony"

Pasek upojenia (kolor: zielony→żółty→czerwony, label tekstowy) widoczny na stałe pod zakładkami.

## Pliki

```
Szynkarz/
  Scripts/
    sql_syn.nss          — tabele syn_intox + syn_cellar, CRUD queries
    lib_syn_def.nss      — stałe NUI, receptury, teksty polskie, helpery
    lib_syn.nss          — NUI layout builders, SynBrew, SynDrink, efekty intox
    lib_syn_ev.nss       — handler NUI: kliknięcia zakładek, wierszy listy, przycisków
    sys_on_load.nss      — SynCreateTables()
    sys_on_enter.nss     — SynOnClientEnter() (restore intox + efektów)
    sys_module_hb.nss    — SynOnHeartbeat() (decay intox)
    test_syn.nss         — OnUsed placeable demo (Brewing Kit)
  INTEGRATION.md         — instrukcja podłączenia hooków i lista tagów składników
```

**1365 LOC łącznie** (cel ≥400 LOC).

## Zależności (NWNX? SQL?)

- **NWNX**: brak. Cały persistence przez `SqlPrepareQueryCampaign("szynkarz", ...)` (vanilla EE campaign DB).
- **SQL**: dwie tabele (`syn_intox`, `syn_cellar`), idempotentne `CREATE TABLE IF NOT EXISTS`.

## Jak włączyć w istniejącym module

1. Skopiować `Szynkarz/Scripts/*.nss` do haka lub scripts modułu.
2. W `OnModuleLoad` wywołać `SynCreateTables()` (lub użyć `sys_on_load.nss`).
3. W `OnClientEnter` wywołać `SynOnClientEnter(GetEnteringObject())`.
4. W `OnHeartbeat` wywołać pętlę z `sys_module_hb.nss`.
5. Placeable z `test_syn.nss` jako `OnUsed` otwiera okno Warzelni.
6. Stworzyć przedmioty ze składnikami (tagi: `syn_hop`, `syn_barley`, ...) — lista w `INTEGRATION.md`.

## Co celowo pominięto

- **Mechanizm uzależnienia** — śledzone spożycie mogłoby dawać wycofanie przy abstynencji; rozszerzalny przez kolumnę w `syn_intox`
- **Fizyczne przedmioty trunków** — trunki żyją tylko w SQL; `CreateItemOnObject` można dodać jeśli potrzebny trading między graczami
- **Minigra warzenia** — timing/skill check jako rozszerzenie przycisku „Warzyj"
- **Panel DM** — brak widoku DM do inspekcji/resetu upojenia graczy
- **Limit dziennych trunek ów** — brak kary za wielokrotne picie; balans do decyzji serwera

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGMztTdxRu8JFALfu6QwRt)_