### PR TITLE
feat: Węzły Mocy

### DIFF
--- a/Ley Nodes/INTEGRATION.md
+++ b/Ley Nodes/INTEGRATION.md
@@ -1,0 +1,64 @@
+# Węzły Mocy — Integracja
+
+## Co to robi
+
+Gracze odkrywają starożytne **Węzły Mocy** (placeables) rozmieszczone w module.
+Mogą się do nich nastroić za 100 złotych, tworząc trwałą więź (SQLite).
+Stojąc przy nastroj onym węźle, mogą wchłonąć jego energię (koszt 25 ładunku),
+zdobywając 10-minutową premię mechaniczną.
+Węzeł regeneruje 1 ładunek / minutę, max 100.
+
+| Typ      | Efekt                                          |
+|----------|------------------------------------------------|
+| Arkaniczny (1) | +2 do rzutów obronnych vs czary (10 min) |
+| Wojenny (2)    | +2 do rzutów trafienia (10 min)         |
+| Witalny (3)    | Regeneracja 1 PŻ / 10 s (10 min)       |
+| Cieniowy (4)   | +4 do Ukrywania i Cichego Chodu (10 min)|
+
+Gracz może mieć maks. 5 nastrojeń. Zwolnienie węzła jest trwałe i nie zwraca złota.
+
+## Zależności
+
+- Standardowy NWScript + NUI (nw_inc_nui).
+- SQLite campaign DB `leynodes` — tworzona automatycznie.
+- Brak wymagań NWNX.
+
+## Pliki
+
+```
+Ley Nodes/scripts/
+├── sql_ln.nss       — schemat SQL i wszystkie zapytania
+├── lib_ln_def.nss   — stałe, ID bindów, forward declarations
+├── lib_ln.nss       — logika główna + budowanie NUI + feedery
+├── lib_ln_ev.nss    — handler eventów NUI (script na NuiCreate)
+├── sys_on_load.nss  — OnModuleLoad: CREATE TABLE IF NOT EXISTS
+├── sys_on_enter.nss — OnClientEnter: powiadomienie o nastrojeniach
+└── test_ln.nss      — OnUsed placeable: rejestruje węzeł, otwiera panel
+```
+
+Skopiuj do scripts/ modułu również `lib_nui.nss` i `lib_nui_utility.nss`
+(znajdziesz je w `Mailbox/Scripts/`).
+
+## Jak włączyć
+
+1. **Hooki modułu**:
+   - `OnModuleLoad` → `sys_on_load` (lub dołącz `LnCreateTables()` do istniejącego)
+   - `OnClientEnter` → `sys_on_enter` (lub dołącz call do istniejącego)
+
+2. **Placeables węzłów** — w Toolsecie utwórz placeable (np. kamienny słup, runiczna stela):
+   - **Tag** — unikalny string, np. `LN_OGROD_01` (staje się kluczem DB)
+   - **Name** — wyświetlana nazwa, np. `Kamienny Krąg Mocy`
+   - **Local Int** `LN_TYPE` — typ węzła: `1/2/3/4`
+   - **OnUsed** → `test_ln`
+
+3. Umieść dowolną liczbę węzłów na mapach; każdy musi mieć unikalny tag.
+
+## Co celowo pominięto
+
+- **Cooldown między sycyfonami** — wystarczy ograniczenie ładunku węzła.
+- **Animacja rytuału** — ActionPlayAnimation przed sycyfonem można dodać.
+- **Efekt wizualny na węźle** (pulsujące światło) — wymaga dodatkowego
+  heartbeat lub VFX placeable; dobrze pasuje jako rozszerzenie.
+- **Degeneracja nastrojenia** — więź jest permanentna; korozja w czasie
+  byłaby kolejną warstwą mechaniki.
+- **Panel DM** — Mistrz Gry może ręcznie UPDATE ln_nodes.charge w DB.

--- a/Ley Nodes/scripts/lib_ln.nss
+++ b/Ley Nodes/scripts/lib_ln.nss
@@ -1,0 +1,463 @@
+#include "lib_ln_def"
+
+// ------------------------------------------------------------------
+// Text helpers
+// ------------------------------------------------------------------
+
+string LnGetTypeName(int nType)
+{
+    if(nType == LN_TYPE_ARCANE)  return "Arkaniczny";
+    if(nType == LN_TYPE_MARTIAL) return "Wojenny";
+    if(nType == LN_TYPE_VITAL)   return "Witalny";
+    if(nType == LN_TYPE_SHADOW)  return "Cieniowy";
+    return "Nieznany";
+}
+
+string LnGetTypeGlyph(int nType)
+{
+    if(nType == LN_TYPE_ARCANE)  return "[A]";
+    if(nType == LN_TYPE_MARTIAL) return "[W]";
+    if(nType == LN_TYPE_VITAL)   return "[V]";
+    if(nType == LN_TYPE_SHADOW)  return "[C]";
+    return "[?]";
+}
+
+string LnGetBoostDesc(int nType)
+{
+    if(nType == LN_TYPE_ARCANE)  return "+2 do rzutów obronnych vs czary (10 min)";
+    if(nType == LN_TYPE_MARTIAL) return "+2 do rzutów trafienia (10 min)";
+    if(nType == LN_TYPE_VITAL)   return "Regeneracja 1 PŻ / 10 s (10 min)";
+    if(nType == LN_TYPE_SHADOW)  return "+4 do Ukrywania i Cichego Chodu (10 min)";
+    return "";
+}
+
+// ------------------------------------------------------------------
+// Mechanics
+// ------------------------------------------------------------------
+
+// Returns TRUE if oPC is within LN_ATTUNE_RANGE of the named node placeable.
+int LnCheckProximity(object oPC, string sTag)
+{
+    object oNode = GetObjectByTag(sTag);
+    if(!GetIsObjectValid(oNode)) return FALSE;
+    return GetDistanceBetween(oPC, oNode) <= LN_ATTUNE_RANGE;
+}
+
+// Reads LN_TYPE local int from placeable and upserts a row in ln_nodes.
+// Safe to call repeatedly (INSERT OR IGNORE).
+void LnEnsureNodeRegistered(object oNode)
+{
+    if(!GetIsObjectValid(oNode)) return;
+    string sTag  = GetTag(oNode);
+    string sName = GetName(oNode);
+    int    nType = GetLocalInt(oNode, "LN_TYPE");
+    if(nType < 1 || nType > 4) nType = LN_TYPE_ARCANE;
+    LnRegisterNode(sTag, sName, nType);
+}
+
+// Applies a timed boost effect and schedules cleanup of the local var.
+void LnApplyBoost(object oPC, int nType)
+{
+    float fDur = IntToFloat(LN_BOOST_DURATION);
+    effect eBoost;
+    int    nVFX;
+
+    if(nType == LN_TYPE_ARCANE)
+    {
+        eBoost = EffectSavingThrowIncrease(SAVING_THROW_ALL, 2, SAVING_THROW_TYPE_SPELL);
+        nVFX   = VFX_IMP_PULSE_ELECTRICITY;
+    }
+    else if(nType == LN_TYPE_MARTIAL)
+    {
+        eBoost = EffectAttackIncrease(2, ATTACK_BONUS_MISC);
+        nVFX   = VFX_IMP_PULSE_RED;
+    }
+    else if(nType == LN_TYPE_VITAL)
+    {
+        eBoost = EffectRegenerate(1, 10.0);
+        nVFX   = VFX_IMP_PULSE_GREEN;
+    }
+    else if(nType == LN_TYPE_SHADOW)
+    {
+        effect eH = EffectSkillIncrease(SKILL_HIDE, 4);
+        effect eM = EffectSkillIncrease(SKILL_MOVE_SILENTLY, 4);
+        eBoost    = EffectLinkEffects(eH, eM);
+        nVFX      = VFX_IMP_PULSE_NEGATIVE;
+    }
+    else return;
+
+    eBoost = SupernaturalEffect(eBoost);
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY, eBoost, oPC, fDur);
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,   EffectVisualEffect(nVFX), oPC);
+
+    SetLocalInt(oPC, LN_LVAR_BOOST_TYPE, nType);
+    // Clear the local flag when the effect expires so the UI reflects the truth.
+    DelayCommand(fDur, DeleteLocalInt(oPC, LN_LVAR_BOOST_TYPE));
+}
+
+// ------------------------------------------------------------------
+// NUI — list column (left pane)
+// ------------------------------------------------------------------
+
+json LnBuildListPane(object oPC)
+{
+    float fRowH  = GetNuiScaleDimension(oPC, 30.0);
+    float fListH = GetNuiScaleDimension(oPC, LN_H - 80.0);
+    float fListW = GetNuiScaleDimension(oPC, LN_LIST_W);
+
+    json jGlyph = NuiLabel(NuiBind(LN_BIND_ROW_TYPE), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jGlyph = NuiWidth(jGlyph, GetNuiScaleDimension(oPC, 38.0));
+    jGlyph = NuiStyleForegroundColor(jGlyph, NuiBind(LN_BIND_ROW_COLOR));
+
+    json jName = NuiLabel(NuiBind(LN_BIND_ROW_NAME), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jName = NuiStyleForegroundColor(jName, NuiBind(LN_BIND_ROW_COLOR));
+
+    json jCharge = NuiLabel(NuiBind(LN_BIND_ROW_CHARGE), JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jCharge = NuiWidth(jCharge, GetNuiScaleDimension(oPC, 44.0));
+    jCharge = NuiStyleForegroundColor(jCharge, NuiBind(LN_BIND_ROW_COLOR));
+
+    json jCellRow = JsonArray();
+    jCellRow = JsonArrayInsert(jCellRow, jGlyph);
+    jCellRow = JsonArrayInsert(jCellRow, jName);
+    jCellRow = JsonArrayInsert(jCellRow, jCharge);
+
+    json jCell = NuiGroup(NuiRow(jCellRow), TRUE, NUI_SCROLLBARS_NONE);
+    jCell = NuiId(jCell, LN_BTN_ROW);
+    jCell = NuiEncouraged(jCell, NuiBind(LN_BIND_ROW_ENC));
+    jCell = NuiHeight(jCell, fRowH);
+
+    json jTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jCell, 0.0, TRUE));
+    json jList = NuiList(jTmpl, NuiBind(LN_BIND_ROW_COUNT), fRowH);
+    jList = NuiHeight(jList, fListH);
+
+    json jHeader = NuiLabel(JsonString("Twoje Węzły"), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jHeader = NuiHeight(jHeader, GetNuiScaleDimension(oPC, 26.0));
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, jHeader);
+    jCol = JsonArrayInsert(jCol, jList);
+    return NuiWidth(NuiCol(jCol), fListW);
+}
+
+// ------------------------------------------------------------------
+// NUI — detail pane (right side)
+// ------------------------------------------------------------------
+
+json LnBuildDetailPane(object oPC)
+{
+    float fBtnH = GetNuiScaleDimension(oPC, 30.0);
+    float fLblH = GetNuiScaleDimension(oPC, 24.0);
+
+    json jNameLbl = NuiLabel(NuiBind(LN_BIND_DET_NAME), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jNameLbl = NuiHeight(jNameLbl, GetNuiScaleDimension(oPC, 32.0));
+
+    json jTypeLbl = NuiLabel(NuiBind(LN_BIND_DET_TYPE), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jTypeLbl = NuiHeight(jTypeLbl, fLblH);
+
+    json jPBar = NuiProgressBar(NuiBind(LN_BIND_DET_PBAR));
+    jPBar = NuiHeight(jPBar, GetNuiScaleDimension(oPC, 16.0));
+    jPBar = NuiTooltip(jPBar, NuiBind(LN_BIND_DET_CHARGE));
+
+    json jChargeLbl = NuiLabel(NuiBind(LN_BIND_DET_CHARGE), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jChargeLbl = NuiHeight(jChargeLbl, fLblH);
+
+    json jStatusLbl = NuiLabel(NuiBind(LN_BIND_DET_STATUS), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE));
+    jStatusLbl = NuiHeight(jStatusLbl, fLblH);
+
+    json jSiphonBtn = NuiButton(JsonString("Sycyfon Mocy"));
+    jSiphonBtn = NuiId(jSiphonBtn, LN_BTN_SIPHON);
+    jSiphonBtn = NuiEnabled(jSiphonBtn, NuiBind(LN_BIND_SIPHON_ENA));
+    jSiphonBtn = NuiHeight(jSiphonBtn, fBtnH);
+    jSiphonBtn = NuiTooltip(jSiphonBtn, JsonString("Wchłoń energię węzła (wymaga bliskości, koszt " + IntToString(LN_DRAW_COST) + " ładunku)"));
+
+    json jReleaseBtn = NuiButton(JsonString("Uwolnij Więź"));
+    jReleaseBtn = NuiId(jReleaseBtn, LN_BTN_RELEASE);
+    jReleaseBtn = NuiEnabled(jReleaseBtn, NuiBind(LN_BIND_RELEASE_ENA));
+    jReleaseBtn = NuiHeight(jReleaseBtn, fBtnH);
+    jReleaseBtn = NuiTooltip(jReleaseBtn, JsonString("Zerwij połączenie z tym węzłem (trwałe)"));
+
+    json jAttuneBtn = NuiButton(JsonString("Nastroić (" + IntToString(LN_ATTUNE_COST) + " zł)"));
+    jAttuneBtn = NuiId(jAttuneBtn, LN_BTN_ATTUNE);
+    jAttuneBtn = NuiEnabled(jAttuneBtn, NuiBind(LN_BIND_ATTUNE_ENA));
+    jAttuneBtn = NuiVisible(jAttuneBtn, NuiBind(LN_BIND_ATTUNE_VIS));
+    jAttuneBtn = NuiHeight(jAttuneBtn, fBtnH);
+    jAttuneBtn = NuiTooltip(jAttuneBtn, JsonString("Nastrojenie trwa wiecznie; kosztuje " + IntToString(LN_ATTUNE_COST) + " złotych i wymaga bliskości"));
+
+    json jActionRow = JsonArray();
+    jActionRow = JsonArrayInsert(jActionRow, jSiphonBtn);
+    jActionRow = JsonArrayInsert(jActionRow, jReleaseBtn);
+
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jNameLbl)));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jTypeLbl)));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 6.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jPBar)));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jChargeLbl)));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jStatusLbl)));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 16.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(jActionRow));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 8.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jAttuneBtn)));
+    return NuiCol(jCol);
+}
+
+// ------------------------------------------------------------------
+// NUI — window creation
+// ------------------------------------------------------------------
+
+void LnOpenPanel(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, LN_WINDOW);
+    if(nToken != 0)
+    {
+        LnFeedList(oPC, nToken);
+        LnFeedDetail(oPC, nToken, GetLocalString(oPC, LN_LVAR_SEL_TAG));
+        return;
+    }
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))  - GetNuiScaleDimension(oPC, LN_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT)) - GetNuiScaleDimension(oPC, LN_H)) / 2.0;
+    json  jGeom = NuiRect(fCX, fCY, GetNuiScaleDimension(oPC, LN_W), GetNuiScaleDimension(oPC, LN_H));
+
+    float fBtnH = GetNuiScaleDimension(oPC, 28.0);
+    json jCloseBtn = NuiButton(JsonString("X"));
+    jCloseBtn = NuiId(jCloseBtn, LN_BTN_CLOSE);
+    jCloseBtn = NuiWidth(jCloseBtn, fBtnH);
+    jCloseBtn = NuiHeight(jCloseBtn, fBtnH);
+
+    json jTitleRow = JsonArray();
+    jTitleRow = JsonArrayInsert(jTitleRow, NuiLabel(JsonString("Sieć Węzłów Mocy"), JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)));
+    jTitleRow = JsonArrayInsert(jTitleRow, jCloseBtn);
+
+    json jMainRow = JsonArray();
+    jMainRow = JsonArrayInsert(jMainRow, LnBuildListPane(oPC));
+    jMainRow = JsonArrayInsert(jMainRow, NuiWidth(NuiSpacer(), GetNuiScaleDimension(oPC, 10.0)));
+    jMainRow = JsonArrayInsert(jMainRow, LnBuildDetailPane(oPC));
+
+    json jRoot = JsonArray();
+    jRoot = JsonArrayInsert(jRoot, NuiRow(jTitleRow));
+    jRoot = JsonArrayInsert(jRoot, CreateEmptyRow(oPC, 4.0));
+    jRoot = JsonArrayInsert(jRoot, NuiRow(jMainRow));
+
+    json jWin = NuiWindow(NuiCol(jRoot),
+        JsonBool(FALSE),
+        NuiBind(LN_WIN_GEOM),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(FALSE),
+        JsonBool(TRUE),
+        JsonBool(FALSE));
+
+    nToken = NuiCreate(oPC, jWin, LN_WINDOW, LN_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, LN_WIN_GEOM, jGeom);
+
+    LnFeedList(oPC, nToken);
+    LnFeedDetail(oPC, nToken, GetLocalString(oPC, LN_LVAR_SEL_TAG));
+}
+
+// ------------------------------------------------------------------
+// Feed — populate list pane
+// ------------------------------------------------------------------
+
+void LnFeedList(object oPC, int nToken)
+{
+    json jRows   = LnGetAttunements(oPC);
+    int  nCount  = JsonGetLength(jRows);
+    string sSelTag = GetLocalString(oPC, LN_LVAR_SEL_TAG);
+
+    json jNames   = JsonArray();
+    json jTypes   = JsonArray();
+    json jCharges = JsonArray();
+    json jColors  = JsonArray();
+    json jEncs    = JsonArray();
+    json jWhite   = NuiColor(255, 255, 255);
+
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jRow    = JsonArrayGet(jRows, i);
+        string sTag  = JsonGetString(JsonObjectGet(jRow, "tag"));
+        string sName = JsonGetString(JsonObjectGet(jRow, "name"));
+        int    nType = JsonGetInt   (JsonObjectGet(jRow, "type"));
+        int    nCharge = LnGetUpdatedCharge(sTag, LN_CHARGE_REGEN, LN_CHARGE_MAX);
+
+        jNames   = JsonArrayInsert(jNames,   JsonString(sName));
+        jTypes   = JsonArrayInsert(jTypes,   JsonString(LnGetTypeGlyph(nType)));
+        jCharges = JsonArrayInsert(jCharges, JsonString(IntToString(nCharge)));
+        jColors  = JsonArrayInsert(jColors,  jWhite);
+        jEncs    = JsonArrayInsert(jEncs,    JsonBool(sTag == sSelTag));
+    }
+
+    NuiSetBind(oPC, nToken, LN_BIND_ROW_NAME,   jNames);
+    NuiSetBind(oPC, nToken, LN_BIND_ROW_TYPE,   jTypes);
+    NuiSetBind(oPC, nToken, LN_BIND_ROW_CHARGE, jCharges);
+    NuiSetBind(oPC, nToken, LN_BIND_ROW_COLOR,  jColors);
+    NuiSetBind(oPC, nToken, LN_BIND_ROW_ENC,    jEncs);
+    NuiSetBind(oPC, nToken, LN_BIND_ROW_COUNT,  JsonInt(nCount));
+}
+
+// ------------------------------------------------------------------
+// Feed — populate detail pane for a single node tag
+// ------------------------------------------------------------------
+
+void LnFeedDetail(object oPC, int nToken, string sTag)
+{
+    if(sTag == "")
+    {
+        NuiSetBind(oPC, nToken, LN_BIND_DET_NAME,    JsonString("— wybierz węzeł —"));
+        NuiSetBind(oPC, nToken, LN_BIND_DET_TYPE,    JsonString(""));
+        NuiSetBind(oPC, nToken, LN_BIND_DET_CHARGE,  JsonString(""));
+        NuiSetBind(oPC, nToken, LN_BIND_DET_PBAR,    JsonFloat(0.0));
+        NuiSetBind(oPC, nToken, LN_BIND_DET_STATUS,  JsonString("Użyj placeable węzła, by go zidentyfikować."));
+        NuiSetBind(oPC, nToken, LN_BIND_SIPHON_ENA,  JsonBool(FALSE));
+        NuiSetBind(oPC, nToken, LN_BIND_RELEASE_ENA, JsonBool(FALSE));
+        NuiSetBind(oPC, nToken, LN_BIND_ATTUNE_ENA,  JsonBool(FALSE));
+        NuiSetBind(oPC, nToken, LN_BIND_ATTUNE_VIS,  JsonBool(FALSE));
+        return;
+    }
+
+    string sName    = LnGetNodeName(sTag);
+    int    nType    = LnGetNodeType(sTag);
+    int    nCharge  = LnGetUpdatedCharge(sTag, LN_CHARGE_REGEN, LN_CHARGE_MAX);
+    int    bAttuned = LnIsAttuned(oPC, sTag);
+    int    bNear    = LnCheckProximity(oPC, sTag);
+    int    nBoost   = GetLocalInt(oPC, LN_LVAR_BOOST_TYPE);
+    int    bBoosted = (nBoost != 0);
+
+    string sStatus;
+    if(bBoosted)
+        sStatus = "Aktywna moc: " + LnGetTypeName(nBoost) + " — odczekaj, aż wygaśnie.";
+    else if(!bAttuned && !bNear)
+        sStatus = "Zbliż się, by nastroić.";
+    else if(!bAttuned && bNear)
+        sStatus = "Jesteś przy węźle. Możesz się nastroić.";
+    else if(bAttuned && !bNear)
+        sStatus = "Zbliż się do węzła, by sycyfonować.";
+    else if(bAttuned && bNear && nCharge < LN_DRAW_COST)
+        sStatus = "Węzeł się ładuje... (" + IntToString(nCharge) + "/" + IntToString(LN_DRAW_COST) + ")";
+    else if(bAttuned && bNear)
+        sStatus = "Gotowy do sycyfonowania.";
+
+    float fPbar = IntToFloat(nCharge) / IntToFloat(LN_CHARGE_MAX);
+
+    NuiSetBind(oPC, nToken, LN_BIND_DET_NAME,    JsonString(sName));
+    NuiSetBind(oPC, nToken, LN_BIND_DET_TYPE,    JsonString(LnGetTypeName(nType) + " — " + LnGetBoostDesc(nType)));
+    NuiSetBind(oPC, nToken, LN_BIND_DET_CHARGE,  JsonString("Ładunek: " + IntToString(nCharge) + " / " + IntToString(LN_CHARGE_MAX)));
+    NuiSetBind(oPC, nToken, LN_BIND_DET_PBAR,    JsonFloat(fPbar));
+    NuiSetBind(oPC, nToken, LN_BIND_DET_STATUS,  JsonString(sStatus));
+    NuiSetBind(oPC, nToken, LN_BIND_SIPHON_ENA,
+        JsonBool(bAttuned && bNear && nCharge >= LN_DRAW_COST && !bBoosted));
+    NuiSetBind(oPC, nToken, LN_BIND_RELEASE_ENA, JsonBool(bAttuned));
+    NuiSetBind(oPC, nToken, LN_BIND_ATTUNE_ENA,
+        JsonBool(!bAttuned && bNear
+                 && GetGold(oPC) >= LN_ATTUNE_COST
+                 && LnGetAttunementCount(oPC) < LN_MAX_ATTUNEMENTS));
+    NuiSetBind(oPC, nToken, LN_BIND_ATTUNE_VIS,  JsonBool(!bAttuned));
+}
+
+// ------------------------------------------------------------------
+// Actions — called from lib_ln_ev.nss
+// ------------------------------------------------------------------
+
+void LnSiphonPower(object oPC, int nToken)
+{
+    string sTag = GetLocalString(oPC, LN_LVAR_SEL_TAG);
+    if(sTag == "")
+    {
+        SendMessageToPC(oPC, "[Węzły] Nie wybrano węzła.");
+        return;
+    }
+    if(!LnIsAttuned(oPC, sTag))
+    {
+        SendMessageToPC(oPC, "[Węzły] Nie jesteś nastrojony do tego węzła. Nastrojenie wymagane.");
+        return;
+    }
+    if(!LnCheckProximity(oPC, sTag))
+    {
+        SendMessageToPC(oPC, "[Węzły] Zbliż się do węzła, by wchłonąć jego moc.");
+        return;
+    }
+    int nCharge = LnGetUpdatedCharge(sTag, LN_CHARGE_REGEN, LN_CHARGE_MAX);
+    if(nCharge < LN_DRAW_COST)
+    {
+        SendMessageToPC(oPC, "[Węzły] Węzeł jest zbyt słaby (" + IntToString(nCharge) + "/" + IntToString(LN_DRAW_COST) + "). Poczekaj na regenerację.");
+        return;
+    }
+    if(GetLocalInt(oPC, LN_LVAR_BOOST_TYPE) != 0)
+    {
+        SendMessageToPC(oPC, "[Węzły] Masz już aktywną moc węzła. Poczekaj, aż wygaśnie.");
+        return;
+    }
+
+    int nType = LnGetNodeType(sTag);
+    LnDrainCharge(sTag, LN_DRAW_COST);
+    LnApplyBoost(oPC, nType);
+
+    string sMsg = "Energia węzła przepływa przez ciebie... " + LnGetBoostDesc(nType) + ".";
+    FloatingTextStringOnCreature(sMsg, oPC, FALSE);
+    SendMessageToPC(oPC, "[Węzły] " + sMsg);
+
+    LnFeedList(oPC, nToken);
+    LnFeedDetail(oPC, nToken, sTag);
+}
+
+void LnAttuneSelected(object oPC, int nToken)
+{
+    string sTag = GetLocalString(oPC, LN_LVAR_SEL_TAG);
+    if(sTag == "")
+    {
+        SendMessageToPC(oPC, "[Węzły] Najpierw użyj placeable węzła, by go zidentyfikować.");
+        return;
+    }
+    if(LnIsAttuned(oPC, sTag))
+    {
+        SendMessageToPC(oPC, "[Węzły] Jesteś już nastrojony do tego węzła.");
+        return;
+    }
+    if(LnGetAttunementCount(oPC) >= LN_MAX_ATTUNEMENTS)
+    {
+        SendMessageToPC(oPC, "[Węzły] Możesz być nastrojony do maksymalnie " + IntToString(LN_MAX_ATTUNEMENTS) + " węzłów. Uwolnij jeden, by dodać nowy.");
+        return;
+    }
+    if(!LnCheckProximity(oPC, sTag))
+    {
+        SendMessageToPC(oPC, "[Węzły] Zbliż się do węzła, by przeprowadzić rytuał nastrojenia.");
+        return;
+    }
+    if(GetGold(oPC) < LN_ATTUNE_COST)
+    {
+        SendMessageToPC(oPC, "[Węzły] Potrzebujesz " + IntToString(LN_ATTUNE_COST) + " złotych na rytuał nastrojenia.");
+        return;
+    }
+
+    AssignCommand(oPC, TakeGoldFromCreature(LN_ATTUNE_COST, oPC, TRUE));
+    LnAddAttunement(oPC, sTag);
+
+    string sNodeName = LnGetNodeName(sTag);
+    string sMsg = "Pieczęć żyłki wiąże się z twoją duszą — węzeł \"" + sNodeName + "\" jest teraz twój.";
+    FloatingTextStringOnCreature(sMsg, oPC, FALSE);
+    SendMessageToPC(oPC, "[Węzły] " + sMsg);
+
+    LnFeedList(oPC, nToken);
+    LnFeedDetail(oPC, nToken, sTag);
+}
+
+void LnReleaseAttunement(object oPC, int nToken)
+{
+    string sTag = GetLocalString(oPC, LN_LVAR_SEL_TAG);
+    if(sTag == "") return;
+    if(!LnIsAttuned(oPC, sTag))
+    {
+        SendMessageToPC(oPC, "[Węzły] Nie jesteś nastrojony do tego węzła.");
+        return;
+    }
+
+    LnRemoveAttunement(oPC, sTag);
+    string sNodeName = LnGetNodeName(sTag);
+    SendMessageToPC(oPC, "[Węzły] Więź z węzłem \"" + sNodeName + "\" zerwana. Złoto rytuału przepadło.");
+
+    DeleteLocalString(oPC, LN_LVAR_SEL_TAG);
+    LnFeedList(oPC, nToken);
+    LnFeedDetail(oPC, nToken, "");
+}

--- a/Ley Nodes/scripts/lib_ln_def.nss
+++ b/Ley Nodes/scripts/lib_ln_def.nss
@@ -1,0 +1,81 @@
+#include "lib_nui"
+#include "sql_ln"
+
+// ------------------------------------------------------------------
+// Node types — set as local int "LN_TYPE" on each node placeable.
+// ------------------------------------------------------------------
+const int LN_TYPE_ARCANE  = 1;
+const int LN_TYPE_MARTIAL = 2;
+const int LN_TYPE_VITAL   = 3;
+const int LN_TYPE_SHADOW  = 4;
+
+// ------------------------------------------------------------------
+// Tuneable constants
+// ------------------------------------------------------------------
+const int   LN_CHARGE_MAX      = 100;
+const int   LN_CHARGE_REGEN    = 1;    // points per real minute
+const int   LN_DRAW_COST       = 25;   // charge consumed per siphon
+const int   LN_ATTUNE_COST     = 100;  // gold for attunement ritual
+const float LN_ATTUNE_RANGE    = 5.0;  // metres
+const int   LN_BOOST_DURATION  = 600;  // seconds (10 minutes)
+const int   LN_MAX_ATTUNEMENTS = 5;
+
+// ------------------------------------------------------------------
+// NUI identifiers — window names
+// ------------------------------------------------------------------
+const string LN_WINDOW    = "LN_WINDOW";
+const string LN_EV_SCRIPT = "lib_ln_ev";
+const string LN_WIN_GEOM  = "ln_win_geom";
+
+// List-column bind names (per-row arrays fed into NuiList)
+const string LN_BIND_ROW_NAME   = "ln_row_name";
+const string LN_BIND_ROW_TYPE   = "ln_row_type";
+const string LN_BIND_ROW_CHARGE = "ln_row_charge";
+const string LN_BIND_ROW_ENC    = "ln_row_enc";
+const string LN_BIND_ROW_COLOR  = "ln_row_color";
+const string LN_BIND_ROW_COUNT  = "ln_rowcount";
+
+// Detail-panel binds
+const string LN_BIND_DET_NAME    = "ln_det_name";
+const string LN_BIND_DET_TYPE    = "ln_det_type";
+const string LN_BIND_DET_CHARGE  = "ln_det_charge";
+const string LN_BIND_DET_PBAR    = "ln_det_pbar";
+const string LN_BIND_DET_STATUS  = "ln_det_status";
+const string LN_BIND_SIPHON_ENA  = "ln_siphon_ena";
+const string LN_BIND_RELEASE_ENA = "ln_release_ena";
+const string LN_BIND_ATTUNE_ENA  = "ln_attune_ena";
+const string LN_BIND_ATTUNE_VIS  = "ln_attune_vis";
+
+// Button IDs
+const string LN_BTN_ROW     = "ln_btn_row";
+const string LN_BTN_SIPHON  = "ln_btn_siphon";
+const string LN_BTN_RELEASE = "ln_btn_release";
+const string LN_BTN_ATTUNE  = "ln_btn_attune";
+const string LN_BTN_CLOSE   = "ln_btn_close";
+
+// Local variables stored on the PC object
+const string LN_LVAR_SEL_TAG   = "LN_SEL_TAG";    // tag of node shown in detail panel
+const string LN_LVAR_BOOST_TYPE= "LN_BOOST_TYPE"; // active boost type (0 = none)
+
+// ------------------------------------------------------------------
+// Layout dimensions (pre-scale)
+// ------------------------------------------------------------------
+const float LN_W      = 620.0;
+const float LN_H      = 400.0;
+const float LN_LIST_W = 210.0;
+
+// ------------------------------------------------------------------
+// Forward declarations
+// ------------------------------------------------------------------
+void LnOpenPanel(object oPC);
+void LnFeedList(object oPC, int nToken);
+void LnFeedDetail(object oPC, int nToken, string sTag);
+void LnSiphonPower(object oPC, int nToken);
+void LnAttuneSelected(object oPC, int nToken);
+void LnReleaseAttunement(object oPC, int nToken);
+void LnApplyBoost(object oPC, int nType);
+void LnEnsureNodeRegistered(object oNode);
+int  LnCheckProximity(object oPC, string sTag);
+string LnGetTypeName(int nType);
+string LnGetTypeGlyph(int nType);
+string LnGetBoostDesc(int nType);

--- a/Ley Nodes/scripts/lib_ln_ev.nss
+++ b/Ley Nodes/scripts/lib_ln_ev.nss
@@ -1,0 +1,62 @@
+#include "lib_ln"
+
+// Main NUI event handler — set as the event script on NuiCreate.
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    if(nToken != NuiFindWindow(oPC, LN_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+        return; // local vars persist for next open
+
+    // Row click — select a node from the attunements list
+    if(sEvent == EVENT_TYPE_MOUSEDOWN && sElem == LN_BTN_ROW)
+    {
+        json jRows = LnGetAttunements(oPC);
+        if(nIdx < 0 || nIdx >= JsonGetLength(jRows)) return;
+
+        json   jRow  = JsonArrayGet(jRows, nIdx);
+        string sTag  = JsonGetString(JsonObjectGet(jRow, "tag"));
+        SetLocalString(oPC, LN_LVAR_SEL_TAG, sTag);
+
+        // Update highlights
+        int    nCount = JsonGetLength(jRows);
+        json   jEncs  = JsonArray();
+        int    i;
+        for(i = 0; i < nCount; i++)
+            jEncs = JsonArrayInsert(jEncs, JsonBool(i == nIdx));
+        NuiSetBind(oPC, nToken, LN_BIND_ROW_ENC, jEncs);
+
+        LnFeedDetail(oPC, nToken, sTag);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == LN_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+        if(sElem == LN_BTN_SIPHON)
+        {
+            LnSiphonPower(oPC, nToken);
+            return;
+        }
+        if(sElem == LN_BTN_ATTUNE)
+        {
+            LnAttuneSelected(oPC, nToken);
+            return;
+        }
+        if(sElem == LN_BTN_RELEASE)
+        {
+            LnReleaseAttunement(oPC, nToken);
+            return;
+        }
+    }
+}

--- a/Ley Nodes/scripts/sql_ln.nss
+++ b/Ley Nodes/scripts/sql_ln.nss
@@ -1,0 +1,151 @@
+const string LN_DB = "leynodes";
+
+void LnCreateTables()
+{
+    sqlquery q;
+
+    q = SqlPrepareQueryCampaign(LN_DB,
+        "CREATE TABLE IF NOT EXISTS ln_nodes ("
+        "  tag TEXT PRIMARY KEY, "
+        "  name TEXT NOT NULL DEFAULT '', "
+        "  node_type INTEGER NOT NULL DEFAULT 1, "
+        "  charge INTEGER NOT NULL DEFAULT 100, "
+        "  last_regen_at INTEGER NOT NULL DEFAULT (strftime('%s','now'))"
+        ")");
+    SqlStep(q);
+
+    q = SqlPrepareQueryCampaign(LN_DB,
+        "CREATE TABLE IF NOT EXISTS ln_attunements ("
+        "  pc_uuid TEXT NOT NULL, "
+        "  node_tag TEXT NOT NULL, "
+        "  attuned_at INTEGER NOT NULL DEFAULT (strftime('%s','now')), "
+        "  PRIMARY KEY (pc_uuid, node_tag)"
+        ")");
+    SqlStep(q);
+}
+
+void LnRegisterNode(string sTag, string sName, int nType)
+{
+    sqlquery q = SqlPrepareQueryCampaign(LN_DB,
+        "INSERT OR IGNORE INTO ln_nodes (tag, name, node_type, charge, last_regen_at) "
+        "VALUES (@tag, @name, @type, 100, strftime('%s','now'))");
+    SqlBindString(q, "@tag",  sTag);
+    SqlBindString(q, "@name", sName);
+    SqlBindInt   (q, "@type", nType);
+    SqlStep(q);
+}
+
+// Recalculates charge from elapsed time and persists; returns current charge.
+int LnGetUpdatedCharge(string sTag, int nRegenPerMin, int nMax)
+{
+    sqlquery q = SqlPrepareQueryCampaign(LN_DB,
+        "SELECT charge, CAST((strftime('%s','now') - last_regen_at) / 60 AS INTEGER) "
+        "FROM ln_nodes WHERE tag = @tag");
+    SqlBindString(q, "@tag", sTag);
+    if(!SqlStep(q)) return 0;
+
+    int nCharge = SqlGetInt(q, 0);
+    int nMins   = SqlGetInt(q, 1);
+    if(nMins <= 0) return nCharge;
+
+    int nNew = nCharge + nMins * nRegenPerMin;
+    if(nNew > nMax) nNew = nMax;
+
+    // Advance last_regen_at by whole elapsed minutes so sub-minute progress persists.
+    sqlquery qUpd = SqlPrepareQueryCampaign(LN_DB,
+        "UPDATE ln_nodes "
+        "SET charge = @charge, last_regen_at = last_regen_at + @mins * 60 "
+        "WHERE tag = @tag");
+    SqlBindInt   (qUpd, "@charge", nNew);
+    SqlBindInt   (qUpd, "@mins",   nMins);
+    SqlBindString(qUpd, "@tag",    sTag);
+    SqlStep(qUpd);
+
+    return nNew;
+}
+
+void LnDrainCharge(string sTag, int nAmount)
+{
+    sqlquery q = SqlPrepareQueryCampaign(LN_DB,
+        "UPDATE ln_nodes SET charge = MAX(0, charge - @amount) WHERE tag = @tag");
+    SqlBindInt   (q, "@amount", nAmount);
+    SqlBindString(q, "@tag",    sTag);
+    SqlStep(q);
+}
+
+int LnGetNodeType(string sTag)
+{
+    sqlquery q = SqlPrepareQueryCampaign(LN_DB,
+        "SELECT node_type FROM ln_nodes WHERE tag = @tag");
+    SqlBindString(q, "@tag", sTag);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+string LnGetNodeName(string sTag)
+{
+    sqlquery q = SqlPrepareQueryCampaign(LN_DB,
+        "SELECT name FROM ln_nodes WHERE tag = @tag");
+    SqlBindString(q, "@tag", sTag);
+    if(SqlStep(q)) return SqlGetString(q, 0);
+    return sTag;
+}
+
+void LnAddAttunement(object oPC, string sTag)
+{
+    sqlquery q = SqlPrepareQueryCampaign(LN_DB,
+        "INSERT OR IGNORE INTO ln_attunements (pc_uuid, node_tag) VALUES (@uuid, @tag)");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindString(q, "@tag",  sTag);
+    SqlStep(q);
+}
+
+void LnRemoveAttunement(object oPC, string sTag)
+{
+    sqlquery q = SqlPrepareQueryCampaign(LN_DB,
+        "DELETE FROM ln_attunements WHERE pc_uuid = @uuid AND node_tag = @tag");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindString(q, "@tag",  sTag);
+    SqlStep(q);
+}
+
+int LnIsAttuned(object oPC, string sTag)
+{
+    sqlquery q = SqlPrepareQueryCampaign(LN_DB,
+        "SELECT 1 FROM ln_attunements WHERE pc_uuid = @uuid AND node_tag = @tag");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindString(q, "@tag",  sTag);
+    return SqlStep(q) ? 1 : 0;
+}
+
+int LnGetAttunementCount(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign(LN_DB,
+        "SELECT COUNT(*) FROM ln_attunements WHERE pc_uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// Returns JsonArray of {tag, name, node_type, charge} for all of oPC's attunements.
+json LnGetAttunements(object oPC)
+{
+    json jRows = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign(LN_DB,
+        "SELECT a.node_tag, n.name, n.node_type, n.charge "
+        "FROM ln_attunements a "
+        "JOIN ln_nodes n ON n.tag = a.node_tag "
+        "WHERE a.pc_uuid = @uuid "
+        "ORDER BY a.attuned_at ASC");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    while(SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "tag",    JsonString(SqlGetString(q, 0)));
+        jRow = JsonObjectSet(jRow, "name",   JsonString(SqlGetString(q, 1)));
+        jRow = JsonObjectSet(jRow, "type",   JsonInt   (SqlGetInt   (q, 2)));
+        jRow = JsonObjectSet(jRow, "charge", JsonInt   (SqlGetInt   (q, 3)));
+        jRows = JsonArrayInsert(jRows, jRow);
+    }
+    return jRows;
+}

--- a/Ley Nodes/scripts/sys_on_enter.nss
+++ b/Ley Nodes/scripts/sys_on_enter.nss
@@ -1,0 +1,16 @@
+#include "lib_ln"
+
+// Module OnClientEnter — remind attuned players that their network awaits.
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC)) return;
+
+    int nCount = LnGetAttunementCount(oPC);
+    if(nCount > 0)
+    {
+        string sMsg = "[Węzły] Masz " + IntToString(nCount)
+            + " nastrojenie(ń) do węzłów mocy. Użyj dowolnego węzła, by otworzyć panel.";
+        DelayCommand(4.0, SendMessageToPC(oPC, sMsg));
+    }
+}

--- a/Ley Nodes/scripts/sys_on_load.nss
+++ b/Ley Nodes/scripts/sys_on_load.nss
@@ -1,0 +1,7 @@
+#include "lib_ln_def"
+
+// Module OnModuleLoad — initialise the database schema.
+void main()
+{
+    LnCreateTables();
+}

--- a/Ley Nodes/scripts/test_ln.nss
+++ b/Ley Nodes/scripts/test_ln.nss
@@ -1,0 +1,22 @@
+#include "lib_ln"
+
+// Placeable OnUsed script for a Ley Node.
+//
+// Builder setup:
+//   Tag       — any unique string; becomes the node's DB key.
+//   Name      — displayed in the NUI panel (e.g. "Kamień Mgły").
+//   Local Int "LN_TYPE" — 1 Arcane, 2 Martial, 3 Vital, 4 Shadow.
+//   OnUsed    — set to this script ("test_ln").
+void main()
+{
+    object oPC   = GetLastUsedBy();
+    object oSelf = OBJECT_SELF;
+    if(!GetIsPC(oPC)) return;
+
+    LnEnsureNodeRegistered(oSelf);
+
+    // Pin the selected tag so the detail pane opens on this node.
+    SetLocalString(oPC, LN_LVAR_SEL_TAG, GetTag(oSelf));
+
+    LnOpenPanel(oPC);
+}


### PR DESCRIPTION
## Co to robi

System starożytnych **Węzłów Mocy** rozsianych po module. Gracze odnajdują kamienne placeables, nastrajaują się do nich za złoto (więź zapisana w SQLite) i mogą czerpać z ich energii, zdobywając tymczasową premię mechaniczną. Węzły powoli regenerują ładunek w czasie, wymuszając strategiczne planowanie odwiedzin.

## Mechanika

- **Nastrojenie** (100 zł, raz na węzeł): tworzy trwałą więź gracz↔węzeł w DB. Maks. 5 nastrojeń na gracza.
- **Sycyfon Mocy** (koszt 25 ładunku, wymaga bliskości 5m): wchłania energię węzła i nakłada efekt na 10 minut. Jeden aktywny efekt naraz.
- **Ładunek**: węzeł startuje z 100, regeneruje 1/minutę realnego czasu. Wyliczany on-demand z timestampa, bez heartbeatu.
- **Cztery typy węzłów** (ustawiany jako local int `LN_TYPE` na placeablu):

| Typ | Efekt |
|-----|-------|
| 1 Arkaniczny | +2 do rzutów obronnych vs czary |
| 2 Wojenny | +2 do rzutów trafienia |
| 3 Witalny | Regeneracja 1 PŻ co 10 s |
| 4 Cieniowy | +4 do Ukrywania i Cichego Chodu |

- **Uwolnienie więzi**: trwałe, złoto nie wraca.
- Powiadomienie przy logowaniu jeśli gracz ma aktywne nastrojenia.

## Pliki

```
Ley Nodes/
├── INTEGRATION.md
└── scripts/
    ├── sql_ln.nss       — schemat SQLite + wszystkie zapytania
    ├── lib_ln_def.nss   — stałe, ID bindów NUI, forward declarations
    ├── lib_ln.nss       — logika + budowanie okna NUI + feedery
    ├── lib_ln_ev.nss    — router eventów NUI (main handler)
    ├── sys_on_load.nss  — OnModuleLoad: CREATE TABLE IF NOT EXISTS
    ├── sys_on_enter.nss — OnClientEnter: powiadomienie o nastrojeniach
    └── test_ln.nss      — OnUsed placeable: rejestruje węzeł, otwiera panel
```

## Zależności (NWNX? SQL?)

- **Brak NWNX** — wyłącznie standardowy NWScript + NUI.
- **SQLite**: campaign DB `leynodes`, 2 tabele (`ln_nodes`, `ln_attunements`), tworzenie idempotentne.
- Wymaga `lib_nui.nss` + `lib_nui_utility.nss` (skopiuj z `Mailbox/Scripts/`).

## Jak włączyć w istniejącym module

1. Skopiuj `scripts/` do katalogu skryptów modułu; dołącz `lib_nui.nss` z Mailbox.
2. W `OnModuleLoad` wywołaj `LnCreateTables()` lub podepnij `sys_on_load`.
3. W `OnClientEnter` wywołaj `LnEnterNotify()` (patrz `sys_on_enter`) lub podepnij cały skrypt.
4. W Toolsecie stwórz placeable węzła: ustaw unikalny tag, local int `LN_TYPE` (1–4), name = wyświetlana nazwa, OnUsed = `test_ln`.

## Co celowo pominięto

- Animacja rytuału przed sycyfonem (ActionPlayAnimation) — można dodać w `LnSiphonPower`.
- Efekt wizualny pulsowania na samym placeablu węzła — wymaga heartbeat, dobry punkt rozbudowy.
- Cooldown między sycyfonami — ograniczenie ładunku wystarczy jako regulator tempa.
- Degeneracja nastrojenia w czasie — więź jest permanentna by default.
- Panel DM/admin — modyfikacja ładunku możliwa przez bezpośredni SQL UPDATE.


---
_Generated by [Claude Code](https://claude.ai/code/session_019nVdezWxmwHZ22z3nC9Ts5)_