### PR TITLE
feat: Chimera Workshop

### DIFF
--- a/Chimera Workshop/INTEGRATION.md
+++ b/Chimera Workshop/INTEGRATION.md
@@ -1,0 +1,73 @@
+# Chimera Workshop — Integracja
+
+## Hooki modułu
+
+| Zdarzenie modułu | Skrypt | Opis |
+|---|---|---|
+| `OnModuleLoad` | `sys_on_load.nss` | Tworzy tabelę SQL `chim_grafts` (idempotentne `CREATE TABLE IF NOT EXISTS`) |
+| `OnClientEnter` | `sys_on_enter.nss` | Ponownie nakłada efekty graftów po restarcie serwera lub zalogowaniu |
+
+## Jak otworzyć okno
+
+Z NPC dialog node, triggera lub placeable OnUsed:
+
+```nss
+#include "lib_chim"
+ChimOpenWindow(GetPC());
+```
+
+`ChimOpenWindow` działa jak toggle — ponowne wywołanie zamyka okno.
+
+## Wymagane trofea (tagi przedmiotów)
+
+Każdy przeszczep konsumuje jeden przedmiot z odpowiednim tagiem:
+
+| Tag przedmiotu | Przeszczep | Slot |
+|---|---|---|
+| `ds_basilisk_eye` | Oko Bazyliszka | Głowa |
+| `ds_mind_flayer_brain` | Koreks Umysłożercy | Głowa |
+| `ds_troll_heart` | Ciało Trolla | Tułów |
+| `ds_dragon_scale` | Łuski Smoka | Tułów |
+| `ds_ghoul_claw` | Szpony Ghula | Ramiona |
+| `ds_wyvern_spine` | Jadowity Gruczoł Wiwerna | Ramiona |
+| `ds_ogre_tendon` | Mięśnie Ogra | Ramiona |
+| `ds_phase_spider_gland` | Ścięgna Pająka Fazowego | Nogi |
+| `ds_frost_giant_bone` | Kości Lodowego Giganta | Nogi |
+| `ds_shadow_essence` | Esencja Cienia | Nogi |
+
+Przedmioty muszą istnieć w HAK lub module (jako blueprinty z tymi tagami).  
+Polecany drop: system loot z odpowiednich potworów (bazyliszek, troll, smok itd.).
+
+## Baza danych
+
+Campaign DB: `"chimera"` → plik `chimera.fptl` lub `chimera.sqlite` w katalogu user data serwera.
+
+```sql
+CREATE TABLE IF NOT EXISTS chim_grafts (
+    uuid       TEXT NOT NULL,
+    slot       TEXT NOT NULL,   -- 'head' | 'torso' | 'arms' | 'legs'
+    graft_id   INTEGER NOT NULL,
+    applied_at INTEGER DEFAULT 0,
+    PRIMARY KEY (uuid, slot)
+);
+```
+
+## Zależności NWNX
+
+Brak. Moduł używa wyłącznie natywnego NWScript + NUI API + SQLite (`SqlPrepareQueryCampaign`).  
+Wymaga NWN EE build 8193.14+ dla `SetEffectTag` / `GetEffectTag`.
+
+## Mechanika — podsumowanie
+
+- 4 sloty ciała (Głowa / Tułów / Ramiona / Nogi), każdy przyjmuje co najwyżej 1 przeszczep.
+- 10 graftów do wyboru (2–3 na slot).
+- Instalacja: trofeum + 500 zp; trwały efekt na postaci; stary przeszczep w slocie jest zastąpiony.
+- Usunięcie: 1000 zp + 20 HP (zabieg boli); trofeum przepadło bezpowrotnie.
+- Efekty przeżywają restart serwera — `sys_on_enter.nss` nakłada je na nowo przy każdym logowaniu.
+
+## Celowo pominięto
+
+- Animacje chimeryzacji (wymagałyby dedykowanych plików animacji w HAK).
+- Zmiany appearance po grafcie (możliwe przez NWNX::Appearance — poza zakresem).
+- Limit łącznej liczby graftów poniżej 4 (każdy z 4 slotów może mieć po 1).
+- Zwrot trofeum przy usunięciu (design decision: każda operacja jest stratą zasobów).

--- a/Chimera Workshop/scripts/lib_chim.nss
+++ b/Chimera Workshop/scripts/lib_chim.nss
@@ -1,0 +1,521 @@
+#include "lib_chim_def"
+
+// ================================================================
+// Effect helpers
+// ================================================================
+
+// Removes all graft effects tagged for a specific slot.
+void ChimRemoveSlotEffects(object oPC, string sSlot)
+{
+    string sTag  = CHIM_EFFECT_TAG_PFX + sSlot;
+    effect eCurr = GetFirstEffect(oPC);
+    while(GetIsEffectValid(eCurr))
+    {
+        effect eNext = GetNextEffect(oPC);
+        if(GetEffectTag(eCurr) == sTag)
+            RemoveEffect(oPC, eCurr);
+        eCurr = eNext;
+    }
+}
+
+// Applies the mechanical bonus and penalty effects for one graft.
+// Each effect is tagged so ChimRemoveSlotEffects can strip them cleanly.
+void ChimApplySlotEffect(object oPC, int nGraftId, string sSlot)
+{
+    string sTag = CHIM_EFFECT_TAG_PFX + sSlot;
+    effect e;
+
+    switch(nGraftId)
+    {
+        case 1: // Oko Bazyliszka — paralysis immunity / -2 CHA
+            e = SetEffectTag(EffectImmunity(IMMUNITY_TYPE_PARALYSIS), sTag);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, e, oPC);
+            e = SetEffectTag(EffectAbilityDecrease(ABILITY_CHARISMA, 2), sTag);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, e, oPC);
+            break;
+
+        case 2: // Koreks Umysłożercy — +2 INT / -2 STR
+            e = SetEffectTag(EffectAbilityIncrease(ABILITY_INTELLIGENCE, 2), sTag);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, e, oPC);
+            e = SetEffectTag(EffectAbilityDecrease(ABILITY_STRENGTH, 2), sTag);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, e, oPC);
+            break;
+
+        case 3: // Ciało Trolla — regen 1 HP/6s / -50% fire immunity
+            e = SetEffectTag(EffectRegenerate(1, 6.0f), sTag);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, e, oPC);
+            e = SetEffectTag(EffectDamageImmunityDecrease(DAMAGE_TYPE_FIRE, 50), sTag);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, e, oPC);
+            break;
+
+        case 4: // Łuski Smoka — +2 natural AC / -1 STR
+            e = SetEffectTag(EffectACIncrease(2, AC_NATURAL_BONUS), sTag);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, e, oPC);
+            e = SetEffectTag(EffectAbilityDecrease(ABILITY_STRENGTH, 1), sTag);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, e, oPC);
+            break;
+
+        case 5: // Szpony Ghula — +2 attack / -1 CON
+            e = SetEffectTag(EffectAttackIncrease(2), sTag);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, e, oPC);
+            e = SetEffectTag(EffectAbilityDecrease(ABILITY_CONSTITUTION, 1), sTag);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, e, oPC);
+            break;
+
+        case 6: // Jadowity Gruczoł Wiwerna — +1d6 acid on hit / -1 DEX
+            e = SetEffectTag(EffectDamageBonus(DAMAGE_BONUS_1d6, DAMAGE_TYPE_ACID), sTag);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, e, oPC);
+            e = SetEffectTag(EffectAbilityDecrease(ABILITY_DEXTERITY, 1), sTag);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, e, oPC);
+            break;
+
+        case 7: // Mięśnie Ogra — +2 STR / -1 INT
+            e = SetEffectTag(EffectAbilityIncrease(ABILITY_STRENGTH, 2), sTag);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, e, oPC);
+            e = SetEffectTag(EffectAbilityDecrease(ABILITY_INTELLIGENCE, 1), sTag);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, e, oPC);
+            break;
+
+        case 8: // Ścięgna Pająka Fazowego — +2 Spot/Search / -1 WIS
+            e = SetEffectTag(EffectSkillIncrease(SKILL_SPOT, 2), sTag);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, e, oPC);
+            e = SetEffectTag(EffectSkillIncrease(SKILL_SEARCH, 2), sTag);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, e, oPC);
+            e = SetEffectTag(EffectAbilityDecrease(ABILITY_WISDOM, 1), sTag);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, e, oPC);
+            break;
+
+        case 9: // Kości Lodowego Giganta — cold resist 10 / -2 DEX
+            e = SetEffectTag(EffectDamageResistance(DAMAGE_TYPE_COLD, 10, 0), sTag);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, e, oPC);
+            e = SetEffectTag(EffectAbilityDecrease(ABILITY_DEXTERITY, 2), sTag);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, e, oPC);
+            break;
+
+        case 10: // Esencja Cienia — +4 Hide/MS / -2 Will
+            e = SetEffectTag(EffectSkillIncrease(SKILL_HIDE, 4), sTag);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, e, oPC);
+            e = SetEffectTag(EffectSkillIncrease(SKILL_MOVE_SILENTLY, 4), sTag);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, e, oPC);
+            e = SetEffectTag(EffectSavingThrowDecrease(SAVING_THROW_WILL, 2), sTag);
+            ApplyEffectToObject(DURATION_TYPE_PERMANENT, e, oPC);
+            break;
+    }
+}
+
+// Reads all installed grafts from the DB and reapplies their effects.
+// Called on client enter to survive server restarts.
+void ChimReapplyEffects(object oPC)
+{
+    ChimRemoveSlotEffects(oPC, CHIM_SLOT_HEAD);
+    ChimRemoveSlotEffects(oPC, CHIM_SLOT_TORSO);
+    ChimRemoveSlotEffects(oPC, CHIM_SLOT_ARMS);
+    ChimRemoveSlotEffects(oPC, CHIM_SLOT_LEGS);
+
+    json jAll  = ChimGetAllGrafts(GetObjectUUID(oPC));
+    int nCount = JsonGetLength(jAll);
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json jRow   = JsonArrayGet(jAll, i);
+        string sSlot = JsonGetString(JsonObjectGet(jRow, "slot"));
+        int nGraftId = JsonGetInt   (JsonObjectGet(jRow, "graft_id"));
+        ChimApplySlotEffect(oPC, nGraftId, sSlot);
+    }
+}
+
+// ================================================================
+// NUI layout
+// ================================================================
+
+json ChimBuildLayout(object oPC)
+{
+    float fBtnH  = GetNuiScaleDimension(oPC, 30.0);
+    float fRowH  = GetNuiScaleDimension(oPC, 28.0);
+    float fListH = GetNuiScaleDimension(oPC, 130.0);
+    float fDetH  = GetNuiScaleDimension(oPC, 140.0);
+    float fLeftW = GetNuiScaleDimension(oPC, 195.0);
+
+    // ---- Header: title + close ----
+    json jTitle = NuiLabel(JsonString("WARSZTAT CHIMERYSTY"),
+                           JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTitle = NuiStyleForegroundColor(jTitle, GetNuiColorNwnGold());
+
+    json jClose = NuiButton(JsonString("X"));
+    jClose = NuiId(jClose, CHIM_BTN_CLOSE);
+    jClose = NuiWidth(jClose, GetNuiScaleDimension(oPC, 30.0));
+    jClose = NuiHeight(jClose, fBtnH);
+
+    json jHdr = JsonArray();
+    jHdr = JsonArrayInsert(jHdr, jTitle);
+    jHdr = JsonArrayInsert(jHdr, NuiSpacer());
+    jHdr = JsonArrayInsert(jHdr, jClose);
+
+    // ---- Left column: 4 slot buttons ----
+    json jHead = NuiButton(NuiBind(CHIM_BIND_HEAD_LBL));
+    jHead = NuiId(jHead, CHIM_BTN_HEAD);
+    jHead = NuiEncouraged(jHead, NuiBind(CHIM_BIND_HEAD_ENC));
+    jHead = NuiHeight(jHead, fBtnH);
+
+    json jTorso = NuiButton(NuiBind(CHIM_BIND_TORSO_LBL));
+    jTorso = NuiId(jTorso, CHIM_BTN_TORSO);
+    jTorso = NuiEncouraged(jTorso, NuiBind(CHIM_BIND_TORSO_ENC));
+    jTorso = NuiHeight(jTorso, fBtnH);
+
+    json jArms = NuiButton(NuiBind(CHIM_BIND_ARMS_LBL));
+    jArms = NuiId(jArms, CHIM_BTN_ARMS);
+    jArms = NuiEncouraged(jArms, NuiBind(CHIM_BIND_ARMS_ENC));
+    jArms = NuiHeight(jArms, fBtnH);
+
+    json jLegs = NuiButton(NuiBind(CHIM_BIND_LEGS_LBL));
+    jLegs = NuiId(jLegs, CHIM_BTN_LEGS);
+    jLegs = NuiEncouraged(jLegs, NuiBind(CHIM_BIND_LEGS_ENC));
+    jLegs = NuiHeight(jLegs, fBtnH);
+
+    json jSlotHdr = NuiLabel(JsonString("Sloty przeszczepu:"),
+                             JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jSlotHdr = NuiHeight(jSlotHdr, GetNuiScaleDimension(oPC, 22.0));
+
+    json jLeftCol = JsonArray();
+    jLeftCol = JsonArrayInsert(jLeftCol, NuiRow(JsonArrayInsert(JsonArray(), jSlotHdr)));
+    jLeftCol = JsonArrayInsert(jLeftCol, NuiRow(JsonArrayInsert(JsonArray(), jHead)));
+    jLeftCol = JsonArrayInsert(jLeftCol, NuiRow(JsonArrayInsert(JsonArray(), jTorso)));
+    jLeftCol = JsonArrayInsert(jLeftCol, NuiRow(JsonArrayInsert(JsonArray(), jArms)));
+    jLeftCol = JsonArrayInsert(jLeftCol, NuiRow(JsonArrayInsert(JsonArray(), jLegs)));
+    jLeftCol = JsonArrayInsert(jLeftCol, NuiSpacer());
+
+    json jLeftGrp = NuiGroup(NuiCol(jLeftCol), TRUE, NUI_SCROLLBARS_NONE);
+    jLeftGrp = NuiWidth(jLeftGrp, fLeftW);
+
+    // ---- Right column ----
+
+    // Selected-slot header label
+    json jSelLbl = NuiLabel(NuiBind(CHIM_BIND_SEL_LBL),
+                            JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jSelLbl = NuiHeight(jSelLbl, GetNuiScaleDimension(oPC, 22.0));
+
+    // Scrollable graft list
+    json jListCell = NuiGroup(
+        NuiRow(JsonArrayInsert(JsonArray(),
+            NuiLabel(NuiBind(CHIM_BIND_LST_NAME),
+                     JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE)))),
+        TRUE, NUI_SCROLLBARS_NONE);
+    jListCell = NuiId(jListCell, CHIM_BTN_ROW);
+    jListCell = NuiEncouraged(jListCell, NuiBind(CHIM_BIND_LST_ENC));
+
+    json jTmpl = JsonArrayInsert(JsonArray(), NuiListTemplateCell(jListCell, 0.0, TRUE));
+    json jList = NuiList(jTmpl, NuiBind(CHIM_BIND_LST_CNT), fRowH);
+    jList = NuiHeight(jList, fListH);
+
+    // Detail area: name / flavor / effects / requirement
+    json jInfoName = NuiLabel(NuiBind(CHIM_BIND_INFO_NAME),
+                              JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jInfoName = NuiStyleForegroundColor(jInfoName, GetNuiColorNwnGold());
+    jInfoName = NuiHeight(jInfoName, GetNuiScaleDimension(oPC, 22.0));
+
+    json jInfoFlavor = NuiGroup(NuiText(NuiBind(CHIM_BIND_INFO_FLAVOR), FALSE),
+                                FALSE, NUI_SCROLLBARS_NONE);
+    jInfoFlavor = NuiHeight(jInfoFlavor, GetNuiScaleDimension(oPC, 50.0));
+
+    json jInfoFx = NuiLabel(NuiBind(CHIM_BIND_INFO_FX),
+                            JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jInfoFx = NuiHeight(jInfoFx, GetNuiScaleDimension(oPC, 22.0));
+
+    json jInfoReq = NuiLabel(NuiBind(CHIM_BIND_INFO_REQ),
+                             JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jInfoReq = NuiHeight(jInfoReq, GetNuiScaleDimension(oPC, 22.0));
+
+    json jDetCol = JsonArray();
+    jDetCol = JsonArrayInsert(jDetCol, NuiRow(JsonArrayInsert(JsonArray(), jInfoName)));
+    jDetCol = JsonArrayInsert(jDetCol, jInfoFlavor);
+    jDetCol = JsonArrayInsert(jDetCol, NuiRow(JsonArrayInsert(JsonArray(), jInfoFx)));
+    jDetCol = JsonArrayInsert(jDetCol, NuiRow(JsonArrayInsert(JsonArray(), jInfoReq)));
+
+    json jDetGrp = NuiGroup(NuiCol(jDetCol), TRUE, NUI_SCROLLBARS_NONE);
+    jDetGrp = NuiHeight(jDetGrp, fDetH);
+
+    // Action buttons
+    json jGraftBtn = NuiButton(JsonString("Zainstaluj"));
+    jGraftBtn = NuiId(jGraftBtn, CHIM_BTN_GRAFT);
+    jGraftBtn = NuiEnabled(jGraftBtn, NuiBind(CHIM_BIND_GRAFT_ENA));
+    jGraftBtn = NuiHeight(jGraftBtn, fBtnH);
+
+    string sRemoveLbl = "Usuń (−" + IntToString(CHIM_REMOVE_COST) + " zp / −" + IntToString(CHIM_REMOVE_HP) + " HP)";
+    json jRemoveBtn = NuiButton(JsonString(sRemoveLbl));
+    jRemoveBtn = NuiId(jRemoveBtn, CHIM_BTN_REMOVE);
+    jRemoveBtn = NuiEnabled(jRemoveBtn, NuiBind(CHIM_BIND_REMOVE_ENA));
+    jRemoveBtn = NuiHeight(jRemoveBtn, fBtnH);
+
+    json jActRow = JsonArray();
+    jActRow = JsonArrayInsert(jActRow, jGraftBtn);
+    jActRow = JsonArrayInsert(jActRow, NuiSpacer());
+    jActRow = JsonArrayInsert(jActRow, jRemoveBtn);
+
+    // Status line
+    json jStatus = NuiLabel(NuiBind(CHIM_BIND_STATUS),
+                            JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jStatus = NuiHeight(jStatus, GetNuiScaleDimension(oPC, 22.0));
+
+    json jRightCol = JsonArray();
+    jRightCol = JsonArrayInsert(jRightCol, NuiRow(JsonArrayInsert(JsonArray(), jSelLbl)));
+    jRightCol = JsonArrayInsert(jRightCol, jList);
+    jRightCol = JsonArrayInsert(jRightCol, jDetGrp);
+    jRightCol = JsonArrayInsert(jRightCol, NuiRow(jActRow));
+    jRightCol = JsonArrayInsert(jRightCol, NuiRow(JsonArrayInsert(JsonArray(), jStatus)));
+
+    // ---- Assemble: header + two columns ----
+    json jBodyRow = JsonArray();
+    jBodyRow = JsonArrayInsert(jBodyRow, jLeftGrp);
+    jBodyRow = JsonArrayInsert(jBodyRow, NuiCol(jRightCol));
+
+    json jRoot = JsonArray();
+    jRoot = JsonArrayInsert(jRoot, NuiRow(jHdr));
+    jRoot = JsonArrayInsert(jRoot, NuiRow(jBodyRow));
+
+    return NuiCol(jRoot);
+}
+
+// ================================================================
+// Feed functions
+// ================================================================
+
+void ChimFeedSlots(object oPC, int nToken)
+{
+    string sSel = GetLocalString(oPC, CHIM_LVAR_SEL_SLOT);
+    NuiSetBind(oPC, nToken, CHIM_BIND_HEAD_LBL,  JsonString(ChimSlotButtonLabel(oPC, CHIM_SLOT_HEAD)));
+    NuiSetBind(oPC, nToken, CHIM_BIND_TORSO_LBL, JsonString(ChimSlotButtonLabel(oPC, CHIM_SLOT_TORSO)));
+    NuiSetBind(oPC, nToken, CHIM_BIND_ARMS_LBL,  JsonString(ChimSlotButtonLabel(oPC, CHIM_SLOT_ARMS)));
+    NuiSetBind(oPC, nToken, CHIM_BIND_LEGS_LBL,  JsonString(ChimSlotButtonLabel(oPC, CHIM_SLOT_LEGS)));
+    NuiSetBind(oPC, nToken, CHIM_BIND_HEAD_ENC,  JsonBool(sSel == CHIM_SLOT_HEAD));
+    NuiSetBind(oPC, nToken, CHIM_BIND_TORSO_ENC, JsonBool(sSel == CHIM_SLOT_TORSO));
+    NuiSetBind(oPC, nToken, CHIM_BIND_ARMS_ENC,  JsonBool(sSel == CHIM_SLOT_ARMS));
+    NuiSetBind(oPC, nToken, CHIM_BIND_LEGS_ENC,  JsonBool(sSel == CHIM_SLOT_LEGS));
+}
+
+void ChimFeedGraftList(object oPC, int nToken, string sSlot)
+{
+    json jGrafts = ChimGetGraftsForSlot(sSlot);
+    SetLocalJson(oPC, CHIM_LVAR_AVAIL, jGrafts);
+    int nCount  = JsonGetLength(jGrafts);
+    int nSelId  = GetLocalInt(oPC, CHIM_LVAR_SEL_GRAFT);
+    int nInstId = ChimGetInstalledGraft(GetObjectUUID(oPC), sSlot);
+
+    json jNames = JsonArray();
+    json jEncs  = JsonArray();
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json g    = JsonArrayGet(jGrafts, i);
+        int nId   = JsonGetInt   (JsonObjectGet(g, "id"));
+        string sN = JsonGetString(JsonObjectGet(g, "name"));
+        // Prefix asterisk for the currently installed graft
+        if(nId == nInstId) sN = "[*] " + sN;
+        jNames = JsonArrayInsert(jNames, JsonString(sN));
+        jEncs  = JsonArrayInsert(jEncs, JsonBool(nId == nSelId));
+    }
+
+    NuiSetBind(oPC, nToken, CHIM_BIND_LST_NAME, jNames);
+    NuiSetBind(oPC, nToken, CHIM_BIND_LST_ENC,  jEncs);
+    NuiSetBind(oPC, nToken, CHIM_BIND_LST_CNT,  JsonInt(nCount));
+}
+
+void ChimFeedDetail(object oPC, int nToken, json jGraft)
+{
+    if(JsonGetType(jGraft) == JSON_TYPE_NULL)
+    {
+        NuiSetBind(oPC, nToken, CHIM_BIND_INFO_NAME,   JsonString(""));
+        NuiSetBind(oPC, nToken, CHIM_BIND_INFO_FLAVOR, JsonString("Wybierz przeszczep z listy."));
+        NuiSetBind(oPC, nToken, CHIM_BIND_INFO_FX,     JsonString(""));
+        NuiSetBind(oPC, nToken, CHIM_BIND_INFO_REQ,    JsonString(""));
+        NuiSetBind(oPC, nToken, CHIM_BIND_GRAFT_ENA,   JsonBool(FALSE));
+        NuiSetBind(oPC, nToken, CHIM_BIND_REMOVE_ENA,  JsonBool(FALSE));
+        return;
+    }
+
+    int    nId      = JsonGetInt   (JsonObjectGet(jGraft, "id"));
+    string sName    = JsonGetString(JsonObjectGet(jGraft, "name"));
+    string sFlavor  = JsonGetString(JsonObjectGet(jGraft, "flavor"));
+    string sFxDesc  = JsonGetString(JsonObjectGet(jGraft, "fx_desc"));
+    string sTrophy  = JsonGetString(JsonObjectGet(jGraft, "trophy"));
+    string sTrophyN = JsonGetString(JsonObjectGet(jGraft, "trophy_n"));
+    string sSlot    = JsonGetString(JsonObjectGet(jGraft, "slot"));
+
+    NuiSetBind(oPC, nToken, CHIM_BIND_INFO_NAME,   JsonString(sName));
+    NuiSetBind(oPC, nToken, CHIM_BIND_INFO_FLAVOR,  JsonString(sFlavor));
+    NuiSetBind(oPC, nToken, CHIM_BIND_INFO_FX,      JsonString("Efekty: " + sFxDesc));
+    NuiSetBind(oPC, nToken, CHIM_BIND_INFO_REQ,
+        JsonString("Trofeum: " + sTrophyN + "   |   Koszt: " + IntToString(CHIM_GRAFT_COST) + " zp"));
+
+    int nInstalled  = ChimGetInstalledGraft(GetObjectUUID(oPC), sSlot);
+    int bHasTrophy  = GetIsObjectValid(GetItemPossessedBy(oPC, sTrophy));
+    // Can install if a different (or no) graft is in the slot and we own the trophy
+    int bCanInstall = (nInstalled != nId) && bHasTrophy;
+    int bCanRemove  = (nInstalled == nId);
+
+    NuiSetBind(oPC, nToken, CHIM_BIND_GRAFT_ENA,  JsonBool(bCanInstall));
+    NuiSetBind(oPC, nToken, CHIM_BIND_REMOVE_ENA, JsonBool(bCanRemove));
+}
+
+// ================================================================
+// Window management
+// ================================================================
+
+void ChimOpenWindow(object oPC)
+{
+    // Toggle: close if already open
+    int nToken = NuiFindWindow(oPC, CHIM_WINDOW);
+    if(nToken != 0)
+    {
+        NuiDestroy(oPC, nToken);
+        return;
+    }
+
+    float fCX = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_WIDTH))
+                 - GetNuiScaleDimension(oPC, CHIM_WIN_W)) / 2.0;
+    float fCY = (IntToFloat(GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_HEIGHT))
+                 - GetNuiScaleDimension(oPC, CHIM_WIN_H)) / 2.0;
+    json jGeom = NuiRect(fCX, fCY,
+                         GetNuiScaleDimension(oPC, CHIM_WIN_W),
+                         GetNuiScaleDimension(oPC, CHIM_WIN_H));
+
+    json jRoot = ChimBuildLayout(oPC);
+    json jWin  = NuiWindow(jRoot,
+        JsonBool(FALSE),          // no system title bar
+        NuiBind(CHIM_BIND_GEOM),
+        JsonBool(FALSE),          // not resizable
+        JsonBool(FALSE),          // not collapsed
+        JsonBool(FALSE),          // no system close button
+        JsonBool(FALSE),          // not transparent
+        JsonBool(TRUE));          // show border
+
+    nToken = NuiCreate(oPC, jWin, CHIM_WINDOW, CHIM_EV_SCRIPT);
+    NuiSetBind(oPC, nToken, CHIM_BIND_GEOM, jGeom);
+
+    // Reset PC state
+    DeleteLocalString(oPC, CHIM_LVAR_SEL_SLOT);
+    DeleteLocalInt   (oPC, CHIM_LVAR_SEL_GRAFT);
+    SetLocalJson     (oPC, CHIM_LVAR_AVAIL, JsonArray());
+
+    // Initial binds
+    ChimFeedSlots(oPC, nToken);
+    NuiSetBind(oPC, nToken, CHIM_BIND_SEL_LBL,
+        JsonString("Wybierz slot ciała, by zobaczyć dostępne przeszczepy."));
+    NuiSetBind(oPC, nToken, CHIM_BIND_LST_CNT,   JsonInt(0));
+    NuiSetBind(oPC, nToken, CHIM_BIND_LST_NAME,  JsonArray());
+    NuiSetBind(oPC, nToken, CHIM_BIND_LST_ENC,   JsonArray());
+    NuiSetBind(oPC, nToken, CHIM_BIND_INFO_NAME,  JsonString(""));
+    NuiSetBind(oPC, nToken, CHIM_BIND_INFO_FLAVOR,
+        JsonString("Przeszczepy łączą twoją biologię z materią potworów.\nKażdy niesie moc — i cenę."));
+    NuiSetBind(oPC, nToken, CHIM_BIND_INFO_FX,    JsonString(""));
+    NuiSetBind(oPC, nToken, CHIM_BIND_INFO_REQ,   JsonString(""));
+    NuiSetBind(oPC, nToken, CHIM_BIND_GRAFT_ENA,  JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, CHIM_BIND_REMOVE_ENA, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, CHIM_BIND_STATUS,      JsonString(""));
+}
+
+// ================================================================
+// Install handler
+// ================================================================
+
+void ChimHandleInstall(object oPC, int nToken)
+{
+    int nGraftId = GetLocalInt(oPC, CHIM_LVAR_SEL_GRAFT);
+    if(nGraftId == 0)
+    {
+        NuiSetBind(oPC, nToken, CHIM_BIND_STATUS,
+            JsonString("Najpierw wybierz przeszczep z listy."));
+        return;
+    }
+
+    json jGraft = ChimGetGraftById(nGraftId);
+    if(JsonGetType(jGraft) == JSON_TYPE_NULL) return;
+
+    string sSlot    = JsonGetString(JsonObjectGet(jGraft, "slot"));
+    string sTrophy  = JsonGetString(JsonObjectGet(jGraft, "trophy"));
+    string sTrophyN = JsonGetString(JsonObjectGet(jGraft, "trophy_n"));
+    string sName    = JsonGetString(JsonObjectGet(jGraft, "name"));
+
+    if(GetGold(oPC) < CHIM_GRAFT_COST)
+    {
+        NuiSetBind(oPC, nToken, CHIM_BIND_STATUS,
+            JsonString("Potrzebujesz co najmniej " + IntToString(CHIM_GRAFT_COST) + " zp."));
+        return;
+    }
+
+    object oTrophy = GetItemPossessedBy(oPC, sTrophy);
+    if(!GetIsObjectValid(oTrophy))
+    {
+        NuiSetBind(oPC, nToken, CHIM_BIND_STATUS,
+            JsonString("Brak trofeum: " + sTrophyN + "."));
+        return;
+    }
+
+    // Remove any existing graft in this slot before installing the new one
+    int nOldGraft = ChimGetInstalledGraft(GetObjectUUID(oPC), sSlot);
+    if(nOldGraft != 0)
+    {
+        ChimRemoveSlotEffects(oPC, sSlot);
+        ChimRemoveGraft(GetObjectUUID(oPC), sSlot);
+    }
+
+    DestroyObject(oTrophy);
+    AssignCommand(oPC, TakeGoldFromCreature(CHIM_GRAFT_COST, oPC, TRUE));
+
+    ChimInstallGraft(GetObjectUUID(oPC), sSlot, nGraftId);
+    ChimApplySlotEffect(oPC, nGraftId, sSlot);
+
+    ApplyEffectToObject(DURATION_TYPE_TEMPORARY,
+        EffectVisualEffect(VFX_COM_BLOOD_CRT_RED), oPC, 2.0f);
+
+    NuiSetBind(oPC, nToken, CHIM_BIND_STATUS,
+        JsonString("Przeszczep zainstalowany: " + sName + ". Pieczęć krwi pulsuje słabo..."));
+
+    ChimFeedSlots(oPC, nToken);
+    ChimFeedGraftList(oPC, nToken, sSlot);
+    ChimFeedDetail(oPC, nToken, jGraft);
+}
+
+// ================================================================
+// Remove handler
+// ================================================================
+
+void ChimHandleRemove(object oPC, int nToken)
+{
+    int nGraftId = GetLocalInt(oPC, CHIM_LVAR_SEL_GRAFT);
+    if(nGraftId == 0) return;
+
+    json jGraft = ChimGetGraftById(nGraftId);
+    if(JsonGetType(jGraft) == JSON_TYPE_NULL) return;
+
+    string sSlot = JsonGetString(JsonObjectGet(jGraft, "slot"));
+    string sName = JsonGetString(JsonObjectGet(jGraft, "name"));
+
+    if(GetGold(oPC) < CHIM_REMOVE_COST)
+    {
+        NuiSetBind(oPC, nToken, CHIM_BIND_STATUS,
+            JsonString("Usunięcie kosztuje " + IntToString(CHIM_REMOVE_COST) + " zp."));
+        return;
+    }
+
+    if(GetCurrentHitPoints(oPC) <= CHIM_REMOVE_HP)
+    {
+        NuiSetBind(oPC, nToken, CHIM_BIND_STATUS,
+            JsonString("Za mało HP, by przeżyć zabieg usunięcia."));
+        return;
+    }
+
+    AssignCommand(oPC, TakeGoldFromCreature(CHIM_REMOVE_COST, oPC, TRUE));
+    ApplyEffectToObject(DURATION_TYPE_INSTANT,
+        EffectDamage(CHIM_REMOVE_HP, DAMAGE_TYPE_SLASHING), oPC);
+
+    ChimRemoveSlotEffects(oPC, sSlot);
+    ChimRemoveGraft(GetObjectUUID(oPC), sSlot);
+
+    NuiSetBind(oPC, nToken, CHIM_BIND_STATUS,
+        JsonString("Przeszczep usunięty: " + sName + ". Rana zaczyna krwawić."));
+
+    SetLocalInt(oPC, CHIM_LVAR_SEL_GRAFT, 0);
+    ChimFeedSlots(oPC, nToken);
+    ChimFeedGraftList(oPC, nToken, sSlot);
+    ChimFeedDetail(oPC, nToken, JsonNull());
+}

--- a/Chimera Workshop/scripts/lib_chim_def.nss
+++ b/Chimera Workshop/scripts/lib_chim_def.nss
@@ -1,0 +1,272 @@
+#include "lib_nui"
+#include "sql_chim"
+
+// Forward declarations for functions defined in lib_chim.nss
+void ChimOpenWindow(object oPC);
+void ChimFeedSlots(object oPC, int nToken);
+void ChimFeedGraftList(object oPC, int nToken, string sSlot);
+void ChimFeedDetail(object oPC, int nToken, json jGraft);
+void ChimReapplyEffects(object oPC);
+void ChimHandleInstall(object oPC, int nToken);
+void ChimHandleRemove(object oPC, int nToken);
+
+// ================================================================
+// Window / event IDs
+// ================================================================
+const string CHIM_WINDOW       = "CHIM_WINDOW";
+const string CHIM_EV_SCRIPT    = "lib_chim_ev";
+
+// ================================================================
+// Body slot names
+// ================================================================
+const string CHIM_SLOT_HEAD    = "head";
+const string CHIM_SLOT_TORSO   = "torso";
+const string CHIM_SLOT_ARMS    = "arms";
+const string CHIM_SLOT_LEGS    = "legs";
+
+// ================================================================
+// NUI bind names
+// ================================================================
+const string CHIM_BIND_HEAD_LBL    = "chim_head_lbl";
+const string CHIM_BIND_TORSO_LBL   = "chim_torso_lbl";
+const string CHIM_BIND_ARMS_LBL    = "chim_arms_lbl";
+const string CHIM_BIND_LEGS_LBL    = "chim_legs_lbl";
+const string CHIM_BIND_HEAD_ENC    = "chim_head_enc";
+const string CHIM_BIND_TORSO_ENC   = "chim_torso_enc";
+const string CHIM_BIND_ARMS_ENC    = "chim_arms_enc";
+const string CHIM_BIND_LEGS_ENC    = "chim_legs_enc";
+
+const string CHIM_BIND_SEL_LBL     = "chim_sel_lbl";
+
+const string CHIM_BIND_LST_NAME    = "chim_lst_name";
+const string CHIM_BIND_LST_ENC     = "chim_lst_enc";
+const string CHIM_BIND_LST_CNT     = "chim_lst_cnt";
+
+const string CHIM_BIND_INFO_NAME   = "chim_info_name";
+const string CHIM_BIND_INFO_FLAVOR = "chim_info_flavor";
+const string CHIM_BIND_INFO_FX     = "chim_info_fx";
+const string CHIM_BIND_INFO_REQ    = "chim_info_req";
+
+const string CHIM_BIND_GRAFT_ENA   = "chim_graft_ena";
+const string CHIM_BIND_REMOVE_ENA  = "chim_remove_ena";
+const string CHIM_BIND_STATUS      = "chim_status";
+const string CHIM_BIND_GEOM        = "chim_geom";
+
+// ================================================================
+// Button element IDs
+// ================================================================
+const string CHIM_BTN_CLOSE        = "chim_btn_close";
+const string CHIM_BTN_HEAD         = "chim_btn_head";
+const string CHIM_BTN_TORSO        = "chim_btn_torso";
+const string CHIM_BTN_ARMS         = "chim_btn_arms";
+const string CHIM_BTN_LEGS         = "chim_btn_legs";
+const string CHIM_BTN_GRAFT        = "chim_btn_graft";
+const string CHIM_BTN_REMOVE       = "chim_btn_remove";
+const string CHIM_BTN_ROW          = "chim_btn_row";
+
+// ================================================================
+// PC-local variable names
+// ================================================================
+const string CHIM_LVAR_SEL_SLOT    = "CHIM_SEL_SLOT";
+const string CHIM_LVAR_SEL_GRAFT   = "CHIM_SEL_GRAFT";
+const string CHIM_LVAR_AVAIL       = "CHIM_AVAIL_JSON";
+
+// ================================================================
+// Economy / costs
+// ================================================================
+const int   CHIM_GRAFT_COST        = 500;
+const int   CHIM_REMOVE_COST       = 1000;
+const int   CHIM_REMOVE_HP         = 20;
+
+// ================================================================
+// Effect tag prefix; full tag = prefix + slot name, e.g. "CHIM_head"
+// ================================================================
+const string CHIM_EFFECT_TAG_PFX   = "CHIM_";
+
+// ================================================================
+// Window dimensions
+// ================================================================
+const float CHIM_WIN_W             = 620.0;
+const float CHIM_WIN_H             = 510.0;
+
+// ================================================================
+// Graft catalog
+// Each entry is a JsonObject with keys:
+//   id       int     unique graft identifier
+//   name     string  Polish display name
+//   slot     string  head / torso / arms / legs
+//   trophy   string  item tag consumed on install
+//   trophy_n string  trophy display name
+//   flavor   string  Polish flavor text (shown in detail panel)
+//   fx_desc  string  Polish effects summary line
+// ================================================================
+
+json ChimBuildGraftTable()
+{
+    json jT = JsonArray();
+    json g;
+
+    // ---- HEAD ----
+
+    g = JsonObject();
+    g = JsonObjectSet(g, "id",      JsonInt(1));
+    g = JsonObjectSet(g, "name",    JsonString("Oko Bazyliszka"));
+    g = JsonObjectSet(g, "slot",    JsonString(CHIM_SLOT_HEAD));
+    g = JsonObjectSet(g, "trophy",  JsonString("ds_basilisk_eye"));
+    g = JsonObjectSet(g, "trophy_n",JsonString("Oko Bazyliszka"));
+    g = JsonObjectSet(g, "flavor",  JsonString("Martwe złote oko wbudowuje się w twój oczodół. Widzisz zbyt wiele. Zbyt wyraźnie."));
+    g = JsonObjectSet(g, "fx_desc", JsonString("+ Odporność na Paraliż  |  − 2 Charyzmy"));
+    jT = JsonArrayInsert(jT, g);
+
+    g = JsonObject();
+    g = JsonObjectSet(g, "id",      JsonInt(2));
+    g = JsonObjectSet(g, "name",    JsonString("Koreks Umysłożercy"));
+    g = JsonObjectSet(g, "slot",    JsonString(CHIM_SLOT_HEAD));
+    g = JsonObjectSet(g, "trophy",  JsonString("ds_mind_flayer_brain"));
+    g = JsonObjectSet(g, "trophy_n",JsonString("Mózg Umysłożercy"));
+    g = JsonObjectSet(g, "flavor",  JsonString("Purpurowe włókna splatają się z twoimi zwojami. Myśli stają się ostrzejsze — i bardziej obce."));
+    g = JsonObjectSet(g, "fx_desc", JsonString("+ 2 Inteligencji  |  − 2 Siły"));
+    jT = JsonArrayInsert(jT, g);
+
+    // ---- TORSO ----
+
+    g = JsonObject();
+    g = JsonObjectSet(g, "id",      JsonInt(3));
+    g = JsonObjectSet(g, "name",    JsonString("Ciało Trolla"));
+    g = JsonObjectSet(g, "slot",    JsonString(CHIM_SLOT_TORSO));
+    g = JsonObjectSet(g, "trophy",  JsonString("ds_troll_heart"));
+    g = JsonObjectSet(g, "trophy_n",JsonString("Serce Trolla"));
+    g = JsonObjectSet(g, "flavor",  JsonString("Zieleń trolla przetacza się pod skórą jak żywy porost. Rany zatykają się same — dopóki nie dosięgnie ich ogień."));
+    g = JsonObjectSet(g, "fx_desc", JsonString("+ Regeneracja 1 HP/6s  |  − 50% odporności na Ogień"));
+    jT = JsonArrayInsert(jT, g);
+
+    g = JsonObject();
+    g = JsonObjectSet(g, "id",      JsonInt(4));
+    g = JsonObjectSet(g, "name",    JsonString("Łuski Smoka"));
+    g = JsonObjectSet(g, "slot",    JsonString(CHIM_SLOT_TORSO));
+    g = JsonObjectSet(g, "trophy",  JsonString("ds_dragon_scale"));
+    g = JsonObjectSet(g, "trophy_n",JsonString("Łuska Smoka"));
+    g = JsonObjectSet(g, "flavor",  JsonString("Łuski wrastają między żebra. Każdy ruch skrzypi jak pancerz kowala — ciężki, niezawodny."));
+    g = JsonObjectSet(g, "fx_desc", JsonString("+ 2 Zbroja Naturalna  |  − 1 Siły"));
+    jT = JsonArrayInsert(jT, g);
+
+    // ---- ARMS ----
+
+    g = JsonObject();
+    g = JsonObjectSet(g, "id",      JsonInt(5));
+    g = JsonObjectSet(g, "name",    JsonString("Szpony Ghula"));
+    g = JsonObjectSet(g, "slot",    JsonString(CHIM_SLOT_ARMS));
+    g = JsonObjectSet(g, "trophy",  JsonString("ds_ghoul_claw"));
+    g = JsonObjectSet(g, "trophy_n",JsonString("Szpon Ghula"));
+    g = JsonObjectSet(g, "flavor",  JsonString("Zakrzywione kości wysuwają się z opuszków palców o zmierzchu. W dzień chowają się — prawie."));
+    g = JsonObjectSet(g, "fx_desc", JsonString("+ 2 do Ataku  |  − 1 Konstytucji"));
+    jT = JsonArrayInsert(jT, g);
+
+    g = JsonObject();
+    g = JsonObjectSet(g, "id",      JsonInt(6));
+    g = JsonObjectSet(g, "name",    JsonString("Jadowity Gruczoł Wiwerna"));
+    g = JsonObjectSet(g, "slot",    JsonString(CHIM_SLOT_ARMS));
+    g = JsonObjectSet(g, "trophy",  JsonString("ds_wyvern_spine"));
+    g = JsonObjectSet(g, "trophy_n",JsonString("Kręgosłup Wiwerna"));
+    g = JsonObjectSet(g, "flavor",  JsonString("Gruczoły jadowe sączą się w nadgarstkach. Ukłucie boli jeszcze przez dwa dni."));
+    g = JsonObjectSet(g, "fx_desc", JsonString("+ 1k6 trucizny (kwas) do ataku wręcz  |  − 1 Zręczności"));
+    jT = JsonArrayInsert(jT, g);
+
+    g = JsonObject();
+    g = JsonObjectSet(g, "id",      JsonInt(7));
+    g = JsonObjectSet(g, "name",    JsonString("Mięśnie Ogra"));
+    g = JsonObjectSet(g, "slot",    JsonString(CHIM_SLOT_ARMS));
+    g = JsonObjectSet(g, "trophy",  JsonString("ds_ogre_tendon"));
+    g = JsonObjectSet(g, "trophy_n",JsonString("Ścięgno Ogra"));
+    g = JsonObjectSet(g, "flavor",  JsonString("Żyły grubieją jak postronki. Siła gromadzi się w ramionach — ciężka, tępa, niezawodna."));
+    g = JsonObjectSet(g, "fx_desc", JsonString("+ 2 Siły  |  − 1 Inteligencji"));
+    jT = JsonArrayInsert(jT, g);
+
+    // ---- LEGS ----
+
+    g = JsonObject();
+    g = JsonObjectSet(g, "id",      JsonInt(8));
+    g = JsonObjectSet(g, "name",    JsonString("Ścięgna Pająka Fazowego"));
+    g = JsonObjectSet(g, "slot",    JsonString(CHIM_SLOT_LEGS));
+    g = JsonObjectSet(g, "trophy",  JsonString("ds_phase_spider_gland"));
+    g = JsonObjectSet(g, "trophy_n",JsonString("Gruczoł Pająka Fazowego"));
+    g = JsonObjectSet(g, "flavor",  JsonString("Stawy migoczą w przyćmionym świetle. Krok nie zostawia śladu — przez chwilę przynajmniej."));
+    g = JsonObjectSet(g, "fx_desc", JsonString("+ 2 Spostrzegawczości i Poszukiwania  |  − 1 Mądrości"));
+    jT = JsonArrayInsert(jT, g);
+
+    g = JsonObject();
+    g = JsonObjectSet(g, "id",      JsonInt(9));
+    g = JsonObjectSet(g, "name",    JsonString("Kości Lodowego Giganta"));
+    g = JsonObjectSet(g, "slot",    JsonString(CHIM_SLOT_LEGS));
+    g = JsonObjectSet(g, "trophy",  JsonString("ds_frost_giant_bone"));
+    g = JsonObjectSet(g, "trophy_n",JsonString("Kość Lodowego Giganta"));
+    g = JsonObjectSet(g, "flavor",  JsonString("Kolana trzeszczą jak lód w mrozie. Za to krok ma ciężar lawiny."));
+    g = JsonObjectSet(g, "fx_desc", JsonString("+ Odporność na Zimno 10/—  |  − 2 Zręczności"));
+    jT = JsonArrayInsert(jT, g);
+
+    g = JsonObject();
+    g = JsonObjectSet(g, "id",      JsonInt(10));
+    g = JsonObjectSet(g, "name",    JsonString("Esencja Cienia"));
+    g = JsonObjectSet(g, "slot",    JsonString(CHIM_SLOT_LEGS));
+    g = JsonObjectSet(g, "trophy",  JsonString("ds_shadow_essence"));
+    g = JsonObjectSet(g, "trophy_n",JsonString("Esencja Cienia"));
+    g = JsonObjectSet(g, "flavor",  JsonString("Twoje nogi rzucają cień nie tam, gdzie powinny. Nocą znikają niemal zupełnie."));
+    g = JsonObjectSet(g, "fx_desc", JsonString("+ 4 Ukrywania i Cichego Ruchu  |  − 2 Woli"));
+    jT = JsonArrayInsert(jT, g);
+
+    return jT;
+}
+
+// Returns the graft entry for the given id, or JsonNull() if not found.
+json ChimGetGraftById(int nId)
+{
+    json jT = ChimBuildGraftTable();
+    int nCount = JsonGetLength(jT);
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json g = JsonArrayGet(jT, i);
+        if(JsonGetInt(JsonObjectGet(g, "id")) == nId)
+            return g;
+    }
+    return JsonNull();
+}
+
+// Returns all grafts for a given body slot.
+json ChimGetGraftsForSlot(string sSlot)
+{
+    json jT = ChimBuildGraftTable();
+    json jResult = JsonArray();
+    int nCount = JsonGetLength(jT);
+    int i;
+    for(i = 0; i < nCount; i++)
+    {
+        json g = JsonArrayGet(jT, i);
+        if(JsonGetString(JsonObjectGet(g, "slot")) == sSlot)
+            jResult = JsonArrayInsert(jResult, g);
+    }
+    return jResult;
+}
+
+// Polish display name for a slot.
+string ChimSlotDisplayName(string sSlot)
+{
+    if(sSlot == CHIM_SLOT_HEAD)  return "Głowa";
+    if(sSlot == CHIM_SLOT_TORSO) return "Tułów";
+    if(sSlot == CHIM_SLOT_ARMS)  return "Ramiona";
+    if(sSlot == CHIM_SLOT_LEGS)  return "Nogi";
+    return sSlot;
+}
+
+// Label text for one slot button: "Głowa: Oko Bazyliszka" or "Głowa: — pusty —".
+string ChimSlotButtonLabel(object oPC, string sSlot)
+{
+    int nInstalled = ChimGetInstalledGraft(GetObjectUUID(oPC), sSlot);
+    string sDisp   = ChimSlotDisplayName(sSlot);
+    if(nInstalled == 0)
+        return sDisp + ": — pusty —";
+    json jGraft = ChimGetGraftById(nInstalled);
+    if(JsonGetType(jGraft) == JSON_TYPE_NULL)
+        return sDisp + ": — błąd —";
+    return sDisp + ": " + JsonGetString(JsonObjectGet(jGraft, "name"));
+}

--- a/Chimera Workshop/scripts/lib_chim_ev.nss
+++ b/Chimera Workshop/scripts/lib_chim_ev.nss
@@ -1,0 +1,78 @@
+#include "lib_chim"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+    int    nIdx   = NuiGetEventArrayIndex();
+
+    if(nToken != NuiFindWindow(oPC, CHIM_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+    {
+        DeleteLocalString(oPC, CHIM_LVAR_SEL_SLOT);
+        DeleteLocalInt   (oPC, CHIM_LVAR_SEL_GRAFT);
+        DeleteLocalJson  (oPC, CHIM_LVAR_AVAIL);
+        return;
+    }
+
+    if(sEvent == EVENT_TYPE_CLICK)
+    {
+        if(sElem == CHIM_BTN_CLOSE)
+        {
+            NuiDestroy(oPC, nToken);
+            return;
+        }
+
+        // Slot selector buttons
+        string sClickedSlot = "";
+        if(sElem == CHIM_BTN_HEAD)  sClickedSlot = CHIM_SLOT_HEAD;
+        if(sElem == CHIM_BTN_TORSO) sClickedSlot = CHIM_SLOT_TORSO;
+        if(sElem == CHIM_BTN_ARMS)  sClickedSlot = CHIM_SLOT_ARMS;
+        if(sElem == CHIM_BTN_LEGS)  sClickedSlot = CHIM_SLOT_LEGS;
+
+        if(sClickedSlot != "")
+        {
+            SetLocalString(oPC, CHIM_LVAR_SEL_SLOT,  sClickedSlot);
+            SetLocalInt   (oPC, CHIM_LVAR_SEL_GRAFT, 0);
+            NuiSetBind(oPC, nToken, CHIM_BIND_SEL_LBL,
+                JsonString("Slot: " + ChimSlotDisplayName(sClickedSlot)));
+            NuiSetBind(oPC, nToken, CHIM_BIND_STATUS, JsonString(""));
+            ChimFeedSlots    (oPC, nToken);
+            ChimFeedGraftList(oPC, nToken, sClickedSlot);
+            ChimFeedDetail   (oPC, nToken, JsonNull());
+            return;
+        }
+
+        if(sElem == CHIM_BTN_GRAFT)
+        {
+            ChimHandleInstall(oPC, nToken);
+            return;
+        }
+
+        if(sElem == CHIM_BTN_REMOVE)
+        {
+            ChimHandleRemove(oPC, nToken);
+            return;
+        }
+    }
+
+    // List row click
+    if(sEvent == EVENT_TYPE_MOUSEDOWN && sElem == CHIM_BTN_ROW)
+    {
+        json jAvail = GetLocalJson(oPC, CHIM_LVAR_AVAIL);
+        if(nIdx < 0 || nIdx >= JsonGetLength(jAvail)) return;
+
+        json jGraft  = JsonArrayGet(jAvail, nIdx);
+        int  nGraftId = JsonGetInt(JsonObjectGet(jGraft, "id"));
+        SetLocalInt(oPC, CHIM_LVAR_SEL_GRAFT, nGraftId);
+        NuiSetBind(oPC, nToken, CHIM_BIND_STATUS, JsonString(""));
+
+        string sSlot = GetLocalString(oPC, CHIM_LVAR_SEL_SLOT);
+        ChimFeedGraftList(oPC, nToken, sSlot);
+        ChimFeedDetail   (oPC, nToken, jGraft);
+        return;
+    }
+}

--- a/Chimera Workshop/scripts/lib_nui.nss
+++ b/Chimera Workshop/scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Chimera Workshop/scripts/lib_nui_utility.nss
+++ b/Chimera Workshop/scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Chimera Workshop/scripts/sql_chim.nss
+++ b/Chimera Workshop/scripts/sql_chim.nss
@@ -1,0 +1,63 @@
+// sql_chim.nss
+// Campaign DB name: "chimera"
+
+void ChimCreateTable()
+{
+    sqlquery q = SqlPrepareQueryCampaign("chimera",
+        "CREATE TABLE IF NOT EXISTS chim_grafts ("
+        "  uuid       TEXT NOT NULL,"
+        "  slot       TEXT NOT NULL,"
+        "  graft_id   INTEGER NOT NULL,"
+        "  applied_at INTEGER DEFAULT 0,"
+        "  PRIMARY KEY (uuid, slot)"
+        ")");
+    SqlStep(q);
+}
+
+// Returns installed graft_id for the slot, or 0 if empty.
+int ChimGetInstalledGraft(string sUuid, string sSlot)
+{
+    sqlquery q = SqlPrepareQueryCampaign("chimera",
+        "SELECT graft_id FROM chim_grafts WHERE uuid = @uuid AND slot = @slot");
+    SqlBindString(q, "@uuid", sUuid);
+    SqlBindString(q, "@slot", sSlot);
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 0;
+}
+
+// Returns JsonArray of {slot, graft_id} rows for all installed grafts on this PC.
+json ChimGetAllGrafts(string sUuid)
+{
+    json jResult = JsonArray();
+    sqlquery q = SqlPrepareQueryCampaign("chimera",
+        "SELECT slot, graft_id FROM chim_grafts WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", sUuid);
+    while(SqlStep(q))
+    {
+        json jRow = JsonObject();
+        jRow = JsonObjectSet(jRow, "slot",     JsonString(SqlGetString(q, 0)));
+        jRow = JsonObjectSet(jRow, "graft_id", JsonInt   (SqlGetInt   (q, 1)));
+        jResult = JsonArrayInsert(jResult, jRow);
+    }
+    return jResult;
+}
+
+void ChimInstallGraft(string sUuid, string sSlot, int nGraftId)
+{
+    sqlquery q = SqlPrepareQueryCampaign("chimera",
+        "INSERT OR REPLACE INTO chim_grafts (uuid, slot, graft_id, applied_at)"
+        " VALUES (@uuid, @slot, @id, strftime('%s','now'))");
+    SqlBindString(q, "@uuid", sUuid);
+    SqlBindString(q, "@slot", sSlot);
+    SqlBindInt   (q, "@id",   nGraftId);
+    SqlStep(q);
+}
+
+void ChimRemoveGraft(string sUuid, string sSlot)
+{
+    sqlquery q = SqlPrepareQueryCampaign("chimera",
+        "DELETE FROM chim_grafts WHERE uuid = @uuid AND slot = @slot");
+    SqlBindString(q, "@uuid", sUuid);
+    SqlBindString(q, "@slot", sSlot);
+    SqlStep(q);
+}

--- a/Chimera Workshop/scripts/sys_on_enter.nss
+++ b/Chimera Workshop/scripts/sys_on_enter.nss
@@ -1,0 +1,19 @@
+#include "lib_chim"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC)) return;
+
+    // Reapply graft effects in case the server restarted since the last login.
+    ChimReapplyEffects(oPC);
+
+    json jAll  = ChimGetAllGrafts(GetObjectUUID(oPC));
+    int nCount = JsonGetLength(jAll);
+    if(nCount > 0)
+    {
+        string sMsg = "[Chimeryzacja] " + IntToString(nCount)
+            + " przeszczep(y) aktywne. Pieczęć krwi pulsuje słabo...";
+        DelayCommand(2.0f, SendMessageToPC(oPC, sMsg));
+    }
+}

--- a/Chimera Workshop/scripts/sys_on_load.nss
+++ b/Chimera Workshop/scripts/sys_on_load.nss
@@ -1,0 +1,6 @@
+#include "lib_chim_def"
+
+void main()
+{
+    ChimCreateTable();
+}

--- a/Chimera Workshop/scripts/test_chim.nss
+++ b/Chimera Workshop/scripts/test_chim.nss
@@ -1,0 +1,29 @@
+#include "lib_chim"
+
+// OnUsed script for the "Warsztat Chimerysty" demo placeable.
+// In a real module, place this on an alchemist's workbench or NPC dialog node.
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    // Spawn one of each trophy item so a developer can test all grafts immediately.
+    // Remove this block in production; trophies should come from monster loot.
+    CreateItemOnObject("ds_basilisk_eye",      oPC);
+    CreateItemOnObject("ds_mind_flayer_brain", oPC);
+    CreateItemOnObject("ds_troll_heart",       oPC);
+    CreateItemOnObject("ds_dragon_scale",      oPC);
+    CreateItemOnObject("ds_ghoul_claw",        oPC);
+    CreateItemOnObject("ds_wyvern_spine",      oPC);
+    CreateItemOnObject("ds_ogre_tendon",       oPC);
+    CreateItemOnObject("ds_phase_spider_gland",oPC);
+    CreateItemOnObject("ds_frost_giant_bone",  oPC);
+    CreateItemOnObject("ds_shadow_essence",    oPC);
+
+    GiveGoldToCreature(oPC, 10000);
+
+    SendMessageToPC(oPC,
+        "[Test] Dodano trofea (tagi: ds_*) i 10000 zp. Otwieranie warsztatu...");
+
+    ChimOpenWindow(oPC);
+}


### PR DESCRIPTION
## Co to robi

Warsztat Chimerysty to moduł, w którym ciemny alchemik może przeszczepiać PC fragmenty ciał potworów. Każdy przeszczep nadaje postaci trwały efekt mechaniczny (bonus i karę) i wymaga skonsumowania trofeum z odpowiedniego potwora oraz zapłaty złotem.

## Mechanika

- **4 sloty ciała**: Głowa, Tułów, Ramiona, Nogi — każdy przyjmuje co najwyżej 1 przeszczep.
- **10 graftów** (2–3 na slot), np. Ciało Trolla (regen 1 HP/6s, −50% odporności na ogień), Łuski Smoka (+2 AC naturalna, −1 SIŁ), Esencja Cienia (+4 Ukrywanie/Cichy Ruch, −2 Wola).
- **Instalacja**: trofeum (tag `ds_*`) + 500 zp; stary przeszczep w slocie zostaje zastąpiony bez zwrotu.
- **Usunięcie**: 1000 zp + 20 HP (zabieg jest bolesny i kosztowny); trofeum przepada bezpowrotnie.
- Efekty są trwałe (`DURATION_TYPE_PERMANENT`), tagowane per-slot (`CHIM_head`, `CHIM_torso`…) i ponownie nakładane przy każdym logowaniu przez `sys_on_enter.nss`.
- Dane persystentne w campaign DB `"chimera"` — tabela `chim_grafts(uuid, slot, graft_id, applied_at)`.

## Pliki

| Plik | Rola |
|---|---|
| `scripts/sql_chim.nss` | Schema SQL + CRUD: `ChimCreateTable`, `ChimGetInstalledGraft`, `ChimGetAllGrafts`, `ChimInstallGraft`, `ChimRemoveGraft` |
| `scripts/lib_chim_def.nss` | Stałe (window ID, bindy, przyciski, koszty), katalog graftów (`ChimBuildGraftTable`), helpery |
| `scripts/lib_chim.nss` | Budowanie NUI, feed functions, aplikacja/usunięcie efektów, `ChimOpenWindow`, handlery Install/Remove |
| `scripts/lib_chim_ev.nss` | Handler zdarzeń NUI (switch po element ID) |
| `scripts/sys_on_load.nss` | Init: `ChimCreateTable()` |
| `scripts/sys_on_enter.nss` | Reaplikacja efektów po zalogowaniu / restarcie serwera |
| `scripts/test_chim.nss` | OnUsed demo: tworzy wszystkie trofea + 10k zp, otwiera okno |
| `INTEGRATION.md` | Instrukcja integracji: hooki, tagi trofeów, schemat DB, wymagania |

## Zależności (NWNX? SQL?)

- **Brak NWNX**. Tylko natywny NWScript + NUI API + `SqlPrepareQueryCampaign`.
- Wymaga **NWN EE build 8193.14+** dla `SetEffectTag` / `GetEffectTag` (użyte do tagowania efektów per-slot).

## Jak włączyć w istniejącym module

1. `OnModuleLoad` → wywołaj `sys_on_load.nss` (lub dodaj `ChimCreateTable()` do istniejącego hooka).
2. `OnClientEnter` → wywołaj `sys_on_enter.nss`.
3. Na NPC / placeable OnUsed: `#include "lib_chim"` + `ChimOpenWindow(GetPC())`.
4. Dodaj blueprinty trofeów (`ds_basilisk_eye`, `ds_troll_heart` itp.) do module/HAK — szczegóły w `INTEGRATION.md`.

## Co celowo pominięto

- Animacje chimeryzacji (wymagają dedykowanych zasobów HAK).
- Zmiana appearance postaci po grafcie (możliwa przez NWNX::Appearance, poza zakresem).
- Limit łącznej liczby graftów poniżej 4 — każdy z 4 slotów może mieć po jednym.
- Zwrot trofeum przy usunięciu (design: każda operacja jest nieodwracalną stratą zasobów).


---
_Generated by [Claude Code](https://claude.ai/code/session_01X2arNtNhGCzyNXJQdVCXdH)_