### PR TITLE
feat: Thread of Fate (Nić Przeznaczenia)

### DIFF
--- a/Thread of Fate/INTEGRATION.md
+++ b/Thread of Fate/INTEGRATION.md
@@ -1,0 +1,109 @@
+# Thread of Fate — Nić Przeznaczenia
+
+## Opis
+
+System śledzenia życiowej siły duszy postaci (0–100 punktów). Nić jest drenowana przez długi pobyt na przekletych obszarach lub użycie ciemnych przedmiotów. Przy niższych warstwach nakładają się rosnące kary do rzutów obronnych, KP i Siły. Przy 0 postać staje się „Dotkniętą Śmiercią" — w stanie liminalnym między żywym a nieumarłym. Przywrócenie następuje przez przedmioty oczyszczające lub święte miejsca.
+
+## Wymagania
+
+- NWN: Enhanced Edition (1.84+) — wymaga NUI API, `EffectSavingThrowDecrease`, `TagEffect`, `GetEffectTag`
+- NWNX: **nie wymagany**
+- SQL: kampania SQLite (`nit`), tworzona przy starcie modułu
+
+## Podpinanie hooków w toolsecie
+
+| Zdarzenie modułu     | Skrypt         |
+|----------------------|----------------|
+| OnModuleLoad         | `sys_on_load`  |
+| OnClientEnter        | `sys_on_enter` |
+| OnClientLeave        | `sys_on_leave` |
+| OnModuleHeartbeat    | `sys_module_hb`|
+
+Jeśli w module są już inne skrypty dla tych zdarzeń, wywołaj funkcje z `lib_nit.nss` z poziomu istniejących skryptów:
+
+```nwscript
+// W OnClientEnter:
+#include "lib_nit"
+void main() {
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC)) return;
+    NitOnClientEnter(oPC);
+    // ... reszta kodu
+}
+```
+
+## Konfiguracja obszarów (toolset)
+
+W Właściwościach obszaru → Zmienne ustaw:
+
+| Zmienna         | Typ  | Wartość | Efekt                                              |
+|-----------------|------|---------|----------------------------------------------------|
+| `NIT_AREA_DRAIN` | INT  | 1–5     | Drenaż X punktów co ~60s przy pobycie w obszarze  |
+| `NIT_AREA_RESTORE` | INT | 1–5   | Bierny przyrost 1 pkt co ~12 min (tylko jeśli brak drenażu) |
+
+Przykładowe wartości:
+- Loch z nieumarłymi: `NIT_AREA_DRAIN = 2`
+- Nekromantyczna arena: `NIT_AREA_DRAIN = 5`
+- Świątynia: `NIT_AREA_RESTORE = 3`
+
+## Przedmioty
+
+| Tag             | Działanie                                      |
+|-----------------|------------------------------------------------|
+| `nit_cleanse`   | Użycie konsumuje przedmiot, przywraca +15 pkt  |
+
+Utwórz przedmiot (np. butelkę z wodą święconą) z tagiem `nit_cleanse` i umieść go u kupców/kapłanów.
+
+## Otwieranie okna UI
+
+Gracze mogą otworzyć okno w dowolnym momencie, wywołując:
+
+```nwscript
+#include "lib_nit"
+NitOpenWindow(oPC);
+```
+
+Podepnij to do placeable, rozmowy z NPC, lub skrótu klawiszowego (action/radial script).
+
+## Zewnętrzna integracja drenażu
+
+Inne skrypty mogą drenować lub przywracać Nić gracza:
+
+```nwscript
+#include "lib_nit"
+
+// Przy użyciu zaklęcia nekromancji:
+NitDrainThread(oPC, 5, "Zaklęcie nekromancji");
+
+// Przy odpoczynku w świątyni:
+NitRestoreThread(oPC, 10);
+```
+
+## Flaga Dotknięty Śmiercią
+
+Gdy nić gracza osiągnie 0, na obiekcie gracza ustawiana jest zmienna:
+
+```
+NIT_DEATH_TOUCHED = 1
+```
+
+Możesz jej używać w innych skryptach (np. by modyfikować efekty leczenia):
+
+```nwscript
+if(GetLocalInt(oPC, "NIT_DEATH_TOUCHED"))
+    // gracz jest Dotkniętym Śmiercią — leczenie o 50% słabsze (logika po stronie twórcy)
+```
+
+## Test
+
+Umieść obiekt (placeable) z tagiem dowolnym, skryptem `OnUsed = test_nit`. Po użyciu:
+- Drain 20 pkt per kliknięcie
+- Automatyczny reset po osiągnięciu 0
+- Okno Nić Przeznaczenia otwiera się automatycznie
+
+## Co celowo pominięto
+
+- Wizualne zmiany Appearance przy Death-Touched (zależy od Appearance module)
+- Automatyczny drenaż przy pobliżu nieumarłych NPC (ryzyko nadmiernej kary w typowych lochach)
+- Trwała przemiana morphologiczna przy 0 (zrealizowana jako flaga, logika po stronie modułu)
+- Permanentność statusu Death-Touched (jest resetowalna przez oczyszczanie)

--- a/Thread of Fate/Scripts/lib_nit.nss
+++ b/Thread of Fate/Scripts/lib_nit.nss
@@ -1,0 +1,384 @@
+#include "lib_nit_def"
+
+// ----------------------------------------------------------------
+// PC-object value cache
+// ----------------------------------------------------------------
+
+int NitGetValue(object oPC)
+{
+    return GetLocalInt(oPC, NIT_LVAR_VALUE);
+}
+
+// bPersist: write through to SQL campaign db immediately
+void NitSetValue(object oPC, int nVal, int bPersist)
+{
+    if(nVal < 0)       nVal = 0;
+    if(nVal > NIT_MAX) nVal = NIT_MAX;
+    SetLocalInt(oPC, NIT_LVAR_VALUE, nVal);
+    if(bPersist) NitPersist(oPC, nVal);
+}
+
+// ----------------------------------------------------------------
+// Effect management
+// ----------------------------------------------------------------
+
+void NitRemoveEffects(object oPC)
+{
+    effect e     = GetFirstEffect(oPC);
+    effect eNext;
+    while(GetIsEffectValid(e))
+    {
+        eNext = GetNextEffect(oPC);
+        string sTag = GetEffectTag(e);
+        if(sTag == NIT_ETAG_SAVES || sTag == NIT_ETAG_AC ||
+           sTag == NIT_ETAG_STR   || sTag == NIT_ETAG_TOUCH)
+            RemoveEffect(oPC, e);
+        e = eNext;
+    }
+}
+
+void NitApplyTierEffects(object oPC, int nTier)
+{
+    NitRemoveEffects(oPC);
+
+    // Death-Touched flag checked externally by healing/spell scripts
+    if(nTier == 0)
+        SetLocalInt(oPC, "NIT_DEATH_TOUCHED", 1);
+    else
+        DeleteLocalInt(oPC, "NIT_DEATH_TOUCHED");
+
+    if(nTier >= 5) return;
+
+    int nSavePen = 0;
+    int nACPen   = 0;
+    int nStrPen  = 0;
+
+    switch(nTier)
+    {
+        case 4: nSavePen = 1;                        break;
+        case 3: nSavePen = 2; nACPen = 1;            break;
+        case 2: nSavePen = 3; nACPen = 2;            break;
+        case 1: /* falls through */
+        case 0: nSavePen = 5; nACPen = 3; nStrPen = 2; break;
+    }
+
+    if(nSavePen > 0)
+    {
+        effect eSave = EffectSavingThrowDecrease(SAVING_THROW_ALL, nSavePen);
+        eSave = TagEffect(eSave, NIT_ETAG_SAVES);
+        eSave = ExtraordinaryEffect(eSave);
+        eSave = HideEffectIcon(eSave);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eSave, oPC);
+    }
+    if(nACPen > 0)
+    {
+        effect eAC = EffectACDecrease(nACPen, AC_DODGE_BONUS);
+        eAC = TagEffect(eAC, NIT_ETAG_AC);
+        eAC = ExtraordinaryEffect(eAC);
+        eAC = HideEffectIcon(eAC);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eAC, oPC);
+    }
+    if(nStrPen > 0)
+    {
+        effect eStr = EffectAbilityDecrease(ABILITY_STRENGTH, nStrPen);
+        eStr = TagEffect(eStr, NIT_ETAG_STR);
+        eStr = ExtraordinaryEffect(eStr);
+        eStr = HideEffectIcon(eStr);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eStr, oPC);
+    }
+
+    // Death-Touched: dazed icon repurposed as ghostly-presence visual
+    if(nTier == 0)
+    {
+        effect eTouch = EffectIcon(EFFECT_ICON_DAZED);
+        eTouch = TagEffect(eTouch, NIT_ETAG_TOUCH);
+        eTouch = ExtraordinaryEffect(eTouch);
+        ApplyEffectToObject(DURATION_TYPE_PERMANENT, eTouch, oPC);
+    }
+}
+
+// ----------------------------------------------------------------
+// Drain / Restore
+// ----------------------------------------------------------------
+
+void NitDrainThread(object oPC, int nAmount, string sSource)
+{
+    int nCurrent = NitGetValue(oPC);
+    if(nCurrent <= 0) return;
+
+    int nOldTier = NitGetTier(nCurrent);
+    int nNew     = nCurrent - nAmount;
+    if(nNew < 0) nNew = 0;
+    int nNewTier = NitGetTier(nNew);
+
+    NitSetValue(oPC, nNew, TRUE);
+
+    if(nOldTier != nNewTier)
+    {
+        NitApplyTierEffects(oPC, nNewTier);
+        string sMsg = NitDropMessage(nNewTier);
+        if(sMsg != "") SendMessageToPC(oPC, sMsg);
+    }
+
+    int nToken = NuiFindWindow(oPC, NIT_WINDOW);
+    if(nToken != 0) FeedNitWindow(oPC, nToken, nNew);
+}
+
+void NitRestoreThread(object oPC, int nAmount)
+{
+    int nCurrent = NitGetValue(oPC);
+    if(nCurrent >= NIT_MAX) return;
+
+    int nOldTier = NitGetTier(nCurrent);
+    int nNew     = nCurrent + nAmount;
+    if(nNew > NIT_MAX) nNew = NIT_MAX;
+    int nNewTier = NitGetTier(nNew);
+
+    NitSetValue(oPC, nNew, TRUE);
+
+    if(nOldTier != nNewTier)
+    {
+        NitApplyTierEffects(oPC, nNewTier);
+        string sMsg = NitRiseMessage(nNewTier);
+        if(sMsg != "") SendMessageToPC(oPC, sMsg);
+    }
+
+    int nToken = NuiFindWindow(oPC, NIT_WINDOW);
+    if(nToken != 0) FeedNitWindow(oPC, nToken, nNew);
+}
+
+// ----------------------------------------------------------------
+// NUI window construction
+// ----------------------------------------------------------------
+
+json NitBuildWindow(object oPC)
+{
+    float fW       = GetNuiScaleDimension(oPC, 400.0);
+    float fH       = GetNuiScaleDimension(oPC, 350.0);
+    float fBtnH    = GetNuiScaleDimension(oPC, 30.0);
+    float fBarH    = GetNuiScaleDimension(oPC, 22.0);
+    float fTierH   = GetNuiScaleDimension(oPC, 26.0);
+    float fFlavorH = GetNuiScaleDimension(oPC, 100.0);
+    float fEffH    = GetNuiScaleDimension(oPC, 22.0);
+    float fValW    = GetNuiScaleDimension(oPC, 80.0);
+    float fCleanseW= GetNuiScaleDimension(oPC, 130.0);
+    float fCloseW  = GetNuiScaleDimension(oPC, 90.0);
+
+    // --- Progress bar ---
+    json jBar = NuiProgressBar(NuiBind(NIT_BIND_PROGRESS));
+    jBar = NuiStyleForegroundColor(jBar, NuiBind(NIT_BIND_COLOR));
+    jBar = NuiHeight(jBar, fBarH);
+
+    // --- Tier name label + value (same row) ---
+    json jTierLbl = NuiLabel(NuiBind(NIT_BIND_TIER_NAME),
+                             JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jTierLbl = NuiStyleForegroundColor(jTierLbl, NuiBind(NIT_BIND_COLOR));
+    jTierLbl = NuiHeight(jTierLbl, fTierH);
+
+    json jValLbl = NuiLabel(NuiBind(NIT_BIND_VALUE),
+                            JsonInt(NUI_HALIGN_RIGHT), JsonInt(NUI_VALIGN_MIDDLE));
+    jValLbl = NuiWidth (jValLbl, fValW);
+    jValLbl = NuiHeight(jValLbl, fTierH);
+
+    json jTierRowArr = JsonArray();
+    jTierRowArr = JsonArrayInsert(jTierRowArr, jTierLbl);
+    jTierRowArr = JsonArrayInsert(jTierRowArr, jValLbl);
+    json jTierRow = NuiRow(jTierRowArr);
+
+    // --- Flavor text ---
+    json jFlavor = NuiLabel(NuiBind(NIT_BIND_FLAVOR),
+                            JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_TOP));
+    jFlavor = NuiHeight(jFlavor, fFlavorH);
+
+    // --- Effects header ---
+    json jEffHeader = NuiLabel(JsonString("Aktywne kary:"),
+                               JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jEffHeader = NuiHeight(jEffHeader, fEffH);
+
+    // --- Effects value ---
+    json jEffLbl = NuiLabel(NuiBind(NIT_BIND_EFFECTS),
+                            JsonInt(NUI_HALIGN_LEFT), JsonInt(NUI_VALIGN_MIDDLE));
+    jEffLbl = NuiStyleForegroundColor(jEffLbl, NuiBind(NIT_BIND_COLOR));
+    jEffLbl = NuiHeight(jEffLbl, fEffH);
+
+    // --- Buttons ---
+    json jCleanse = NuiButton(JsonString("Oczyszczenie"));
+    jCleanse = NuiId     (jCleanse, NIT_BTN_CLEANSE);
+    jCleanse = NuiEnabled(jCleanse, NuiBind(NIT_BIND_CLEANSE_ENA));
+    jCleanse = NuiTooltip(jCleanse, NuiBind(NIT_BIND_CLEANSE_TIP));
+    jCleanse = NuiWidth  (jCleanse, fCleanseW);
+    jCleanse = NuiHeight (jCleanse, fBtnH);
+
+    json jClose = NuiButton(JsonString("Zamknij"));
+    jClose = NuiId    (jClose, NIT_BTN_CLOSE);
+    jClose = NuiWidth (jClose, fCloseW);
+    jClose = NuiHeight(jClose, fBtnH);
+
+    json jBtnArr = JsonArray();
+    jBtnArr = JsonArrayInsert(jBtnArr, jCleanse);
+    jBtnArr = JsonArrayInsert(jBtnArr, NuiSpacer());
+    jBtnArr = JsonArrayInsert(jBtnArr, jClose);
+    json jBtnRow = NuiRow(jBtnArr);
+
+    // --- Assemble root column ---
+    json jCol = JsonArray();
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jBar)));
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, jTierRow);
+    jCol = JsonArrayInsert(jCol, CreateEmptyRow(oPC, 4.0));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jFlavor)));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jEffHeader)));
+    jCol = JsonArrayInsert(jCol, NuiRow(JsonArrayInsert(JsonArray(), jEffLbl)));
+    jCol = JsonArrayInsert(jCol, NuiSpacer());
+    jCol = JsonArrayInsert(jCol, jBtnRow);
+
+    json jRoot = NuiCol(jCol);
+
+    return NuiWindow(jRoot,
+                     JsonString("Nić Przeznaczenia"),
+                     NuiBind(NIT_WIN_GEOM),
+                     JsonBool(FALSE),
+                     JsonBool(FALSE),
+                     JsonBool(TRUE),
+                     JsonBool(FALSE),
+                     JsonBool(TRUE));
+}
+
+void FeedNitWindow(object oPC, int nToken, int nVal)
+{
+    int   nTier    = NitGetTier(nVal);
+    json  jColor   = NitTierColor(nTier);
+    float fProgress = IntToFloat(nVal) / IntToFloat(NIT_MAX);
+
+    NuiSetBind(oPC, nToken, NIT_BIND_TIER_NAME, JsonString(NitTierName(nTier)));
+    NuiSetBind(oPC, nToken, NIT_BIND_VALUE,     JsonString(IntToString(nVal) + " / " + IntToString(NIT_MAX)));
+    NuiSetBind(oPC, nToken, NIT_BIND_FLAVOR,    JsonString(NitTierFlavor(nTier)));
+    NuiSetBind(oPC, nToken, NIT_BIND_EFFECTS,   JsonString(NitTierEffects(nTier)));
+    NuiSetBind(oPC, nToken, NIT_BIND_PROGRESS,  JsonFloat(fProgress));
+    NuiSetBind(oPC, nToken, NIT_BIND_COLOR,     jColor);
+
+    // Cleanse button availability
+    int bHasItem  = GetIsObjectValid(GetItemPossessedBy(oPC, NIT_ITEM_CLEANSE));
+    int bHolyArea = (GetLocalInt(GetArea(oPC), NIT_AVAR_RESTORE) > 0);
+    int bCanClean = (nVal < NIT_MAX) && (bHasItem || bHolyArea);
+    NuiSetBind(oPC, nToken, NIT_BIND_CLEANSE_ENA, JsonBool(bCanClean));
+
+    string sTip;
+    if(nVal >= NIT_MAX)
+        sTip = "Nić jest w pełni żywa.";
+    else if(bHasItem)
+        sTip = "Użyj przedmiotu oczyszczającego. Doda +" + IntToString(NIT_CLEANSE_RESTORE) + " punktów.";
+    else if(bHolyArea)
+        sTip = "Jesteś na świętym terenie — oczyszczenie jest możliwe.";
+    else
+        sTip = "Brak przedmiotu oczyszczającego. Szukaj kapłana lub świętego miejsca.";
+    NuiSetBind(oPC, nToken, NIT_BIND_CLEANSE_TIP, JsonString(sTip));
+}
+
+void NitOpenWindow(object oPC)
+{
+    int nToken = NuiFindWindow(oPC, NIT_WINDOW);
+    if(nToken != 0)
+    {
+        FeedNitWindow(oPC, nToken, NitGetValue(oPC));
+        return;
+    }
+
+    json jWin  = NitBuildWindow(oPC);
+    nToken = NuiCreate(oPC, jWin, NIT_WINDOW, NIT_EV_SCRIPT);
+
+    float fW = GetNuiScaleDimension(oPC, 400.0);
+    float fH = GetNuiScaleDimension(oPC, 350.0);
+    NuiSetBind(oPC, nToken, NIT_WIN_GEOM, NuiRect(80.0, 80.0, fW, fH));
+    FeedNitWindow(oPC, nToken, NitGetValue(oPC));
+}
+
+// ----------------------------------------------------------------
+// Cleanse action (called from NUI event handler)
+// ----------------------------------------------------------------
+
+void NitTryCleanse(object oPC, int nToken)
+{
+    int nVal = NitGetValue(oPC);
+    if(nVal >= NIT_MAX)
+    {
+        SendMessageToPC(oPC, "[Nić] Twoja dusza jest już w pełni żywa.");
+        return;
+    }
+
+    object oItem = GetItemPossessedBy(oPC, NIT_ITEM_CLEANSE);
+    if(GetIsObjectValid(oItem))
+    {
+        SendMessageToPC(oPC, "[Nić] Zużywasz przedmiot oczyszczający — pieczęć krwi blaknie…");
+        DestroyObject(oItem);
+        NitRestoreThread(oPC, NIT_CLEANSE_RESTORE);
+        return;
+    }
+
+    int nAreaRestore = GetLocalInt(GetArea(oPC), NIT_AVAR_RESTORE);
+    if(nAreaRestore > 0)
+    {
+        SendMessageToPC(oPC, "[Nić] Moc świętego miejsca przenika twoją duszę…");
+        NitRestoreThread(oPC, nAreaRestore * NIT_HOLY_CLEANSE_BONUS);
+        return;
+    }
+
+    SendMessageToPC(oPC, "[Nić] Nie masz niczego, czym mógłbyś oczyścić duszę. Szukaj kapłana lub świętego miejsca.");
+    NuiSetBind(oPC, nToken, NIT_BIND_CLEANSE_ENA, JsonBool(FALSE));
+}
+
+// ----------------------------------------------------------------
+// Lifecycle hooks (called from sys_on_*.nss)
+// ----------------------------------------------------------------
+
+void NitOnClientEnter(object oPC)
+{
+    int nVal = NitLoad(oPC);
+    NitSetValue(oPC, nVal, FALSE);
+    NitApplyTierEffects(oPC, NitGetTier(nVal));
+
+    if(nVal <= 0)
+        DelayCommand(5.0, SendMessageToPC(oPC,
+            "[Nić] Jesteś Dotknięty Śmiercią. Twoja nić jest zerwana (0/100)."));
+    else if(nVal < 60)
+        DelayCommand(5.0, SendMessageToPC(oPC,
+            "[Nić] Twoja dusza nosi ślady ciemności (Nić: " + IntToString(nVal) + "/100). Szukaj oczyszczenia."));
+}
+
+void NitOnClientLeave(object oPC)
+{
+    NitPersist(oPC, NitGetValue(oPC));
+    NitRemoveEffects(oPC);
+    DeleteLocalInt(oPC, "NIT_DEATH_TOUCHED");
+}
+
+// ----------------------------------------------------------------
+// Heartbeat (called from sys_module_hb.nss for each PC)
+// ----------------------------------------------------------------
+
+void NitHeartbeatTick(object oPC)
+{
+    int nDrainCtr = GetLocalInt(oPC, NIT_LVAR_HB_CTR) + 1;
+    int nRstCtr   = GetLocalInt(oPC, NIT_LVAR_RST_CTR) + 1;
+    SetLocalInt(oPC, NIT_LVAR_HB_CTR, nDrainCtr);
+    SetLocalInt(oPC, NIT_LVAR_RST_CTR, nRstCtr);
+
+    object oArea  = GetArea(oPC);
+    int nDrain    = GetLocalInt(oArea, NIT_AVAR_DRAIN);
+    int nRestore  = GetLocalInt(oArea, NIT_AVAR_RESTORE);
+
+    if(nDrainCtr >= NIT_DRAIN_INTERVAL)
+    {
+        SetLocalInt(oPC, NIT_LVAR_HB_CTR, 0);
+        if(nDrain > 0)
+            NitDrainThread(oPC, nDrain, "Mroczna aura obszaru");
+    }
+
+    if(nRstCtr >= NIT_RST_INTERVAL)
+    {
+        SetLocalInt(oPC, NIT_LVAR_RST_CTR, 0);
+        // Passive restore only in holy areas without concurrent drain
+        if(nRestore > 0 && nDrain == 0)
+            NitRestoreThread(oPC, 1);
+    }
+}

--- a/Thread of Fate/Scripts/lib_nit_def.nss
+++ b/Thread of Fate/Scripts/lib_nit_def.nss
@@ -1,0 +1,180 @@
+#include "lib_nui"
+#include "sql_nit"
+
+// Forward declarations
+void NitOpenWindow(object oPC);
+void FeedNitWindow(object oPC, int nToken, int nVal);
+void NitApplyTierEffects(object oPC, int nTier);
+void NitDrainThread(object oPC, int nAmount, string sSource);
+void NitRestoreThread(object oPC, int nAmount);
+int  NitGetTier(int nVal);
+void NitOnClientEnter(object oPC);
+void NitOnClientLeave(object oPC);
+void NitHeartbeatTick(object oPC);
+void NitTryCleanse(object oPC, int nToken);
+
+// ----------------------------------------------------------------
+// Window / bind / button IDs
+// ----------------------------------------------------------------
+
+const string NIT_WINDOW          = "NIT_WIN";
+const string NIT_EV_SCRIPT       = "lib_nit_ev";
+const string NIT_WIN_GEOM        = "nit_geom";
+
+const string NIT_BIND_TIER_NAME  = "nit_tier_name";
+const string NIT_BIND_VALUE      = "nit_value";
+const string NIT_BIND_FLAVOR     = "nit_flavor";
+const string NIT_BIND_EFFECTS    = "nit_effects";
+const string NIT_BIND_PROGRESS   = "nit_progress";
+const string NIT_BIND_COLOR      = "nit_color";
+const string NIT_BIND_CLEANSE_ENA= "nit_cleanse_ena";
+const string NIT_BIND_CLEANSE_TIP= "nit_cleanse_tip";
+
+const string NIT_BTN_CLOSE       = "nit_btn_close";
+const string NIT_BTN_CLEANSE     = "nit_btn_cleanse";
+
+// ----------------------------------------------------------------
+// Local variables on PC
+// ----------------------------------------------------------------
+
+const string NIT_LVAR_VALUE      = "NIT_VAL";
+const string NIT_LVAR_HB_CTR     = "NIT_HB_CTR";
+const string NIT_LVAR_RST_CTR    = "NIT_RST_CTR";
+
+// ----------------------------------------------------------------
+// Area variables (set in toolset per area)
+// ----------------------------------------------------------------
+
+// INT: drain points per drain-interval tick while PC is in this area
+const string NIT_AVAR_DRAIN      = "NIT_AREA_DRAIN";
+// INT: restore points per restore-interval tick (holy ground)
+const string NIT_AVAR_RESTORE    = "NIT_AREA_RESTORE";
+
+// ----------------------------------------------------------------
+// Item tags
+// ----------------------------------------------------------------
+
+// Item with this exact tag: consumed to restore NIT_CLEANSE_RESTORE points
+const string NIT_ITEM_CLEANSE    = "nit_cleanse";
+
+// Effect tags for RemoveEffect loop
+const string NIT_ETAG_SAVES      = "NIT_EFF_SAVES";
+const string NIT_ETAG_AC         = "NIT_EFF_AC";
+const string NIT_ETAG_STR        = "NIT_EFF_STR";
+const string NIT_ETAG_TOUCH      = "NIT_EFF_TOUCH";
+
+// ----------------------------------------------------------------
+// Numeric constants
+// ----------------------------------------------------------------
+
+const int NIT_MAX                = 100;
+// One drain-interval ≈ NIT_DRAIN_INTERVAL * 6s ≈ 60s
+const int NIT_DRAIN_INTERVAL     = 10;
+// One restore-interval ≈ NIT_RST_INTERVAL * 6s ≈ 12 min
+const int NIT_RST_INTERVAL       = 120;
+// Points restored by a single cleanse item
+const int NIT_CLEANSE_RESTORE    = 15;
+// Points restored by manual Cleanse button in a holy area
+const int NIT_HOLY_CLEANSE_BONUS = 3;
+
+// ----------------------------------------------------------------
+// Tier boundaries (inclusive lower bounds)
+// ----------------------------------------------------------------
+// tier 5: 80-100  tier 4: 60-79  tier 3: 40-59
+// tier 2: 20-39   tier 1:  1-19  tier 0: 0 (Death-Touched)
+
+int NitGetTier(int nVal)
+{
+    if(nVal >= 80) return 5;
+    if(nVal >= 60) return 4;
+    if(nVal >= 40) return 3;
+    if(nVal >= 20) return 2;
+    if(nVal >= 1)  return 1;
+    return 0;
+}
+
+string NitTierName(int nTier)
+{
+    switch(nTier)
+    {
+        case 5: return "Żywa Nić";
+        case 4: return "Strzępek";
+        case 3: return "Rozdarta";
+        case 2: return "Postrzępiona";
+        case 1: return "Rozwijająca się";
+        case 0: return "Dotknięta Śmiercią";
+    }
+    return "—";
+}
+
+string NitTierFlavor(int nTier)
+{
+    switch(nTier)
+    {
+        case 5: return "Twoja dusza płonie pełnym blaskiem. Mrok nie zdołał wedrzeć się w jej tkankę. Żywa Nić wibruje ciepłem.";
+        case 4: return "Czujesz ledwie wyczuwalny chłód — jakby ktoś delikatnie ciągnął za coś bardzo głęboko. Nić drżała, lecz jeszcze trzyma.";
+        case 3: return "Zimno pełza od kości ku skórze. Sny są niespokojne, a w lustrach zamiast twarzy widzisz cień. Coś nadgryza twoją istotę.";
+        case 2: return "Postrzępione resztki duszy trzepocą jak płomień na wietrze. Każdy cios wroga i każde ciemne zaklęcie dorzucają kolejne pęknięcia.";
+        case 1: return "Nić jest prawie zerwana. Słyszysz głosy umarłych i rozumiesz ich słowa. Kapłan lub święty przedmiot to jedyna droga.";
+        case 0: return "Puste miejsce tam, gdzie tlił się ogień. Jesteś Dotknięty Śmiercią — coś między żywym a umarłym. Pieczęć krwi pulsuje słabo…";
+    }
+    return "";
+}
+
+string NitTierEffects(int nTier)
+{
+    switch(nTier)
+    {
+        case 5: return "Brak kar";
+        case 4: return "-1 do rzutów obronnych";
+        case 3: return "-2 do rzutów obronnych  ·  -1 KP";
+        case 2: return "-3 do rzutów obronnych  ·  -2 KP";
+        case 1: return "-5 do rzutów obronnych  ·  -3 KP  ·  -2 Siły";
+        case 0: return "-5 do rzutów  ·  -3 KP  ·  -2 Siły  ·  [Dotknięty Śmiercią]";
+    }
+    return "";
+}
+
+json NitTierColor(int nTier)
+{
+    switch(nTier)
+    {
+        case 5: return NuiColor(140, 210, 140);  // jasna zieleń
+        case 4: return NuiColor(220, 220, 80);   // żółty
+        case 3: return NuiColor(220, 150, 50);   // pomarańczowy
+        case 2: return NuiColor(210, 70,  70);   // czerwony
+        case 1: return NuiColor(160, 60,  200);  // fiolet
+        case 0: return NuiColor(100, 100, 140);  // ciemny błękit
+    }
+    return NuiColor(128, 128, 128);
+}
+
+// ----------------------------------------------------------------
+// Player notification text on tier change
+// ----------------------------------------------------------------
+
+string NitDropMessage(int nNewTier)
+{
+    switch(nNewTier)
+    {
+        case 4: return "[Nić] Twoja dusza zaczyna strzępić się. Czujesz zimno, którego nie sposób ogrzać.";
+        case 3: return "[Nić] Nić jest rozdarta. Kary się nasilają. Szukaj kapłana.";
+        case 2: return "[Nić] Twoja dusza ledwo trzyma się w całości. Bez oczyszczenia grozi ci przemiana.";
+        case 1: return "[Nić] OSTRZEŻENIE: Nić na skraju zerwania! Natychmiast poszukaj kapłana lub świętego przedmiotu!";
+        case 0: return "[Nić] Nić zerwana. Jesteś Dotknięty Śmiercią. Powrót jest możliwy, lecz kosztowny.";
+    }
+    return "";
+}
+
+string NitRiseMessage(int nNewTier)
+{
+    switch(nNewTier)
+    {
+        case 5: return "[Nić] Dusza odzyskała pełnię. Żywa Nić płonie jasno.";
+        case 4: return "[Nić] Oczyszczenie przyniosło ulgę. Nić jest słabsza, lecz mniej rozdarta.";
+        case 3: return "[Nić] Poczułeś ciepło powracającego życia. Nić jest częściowo przywrócona.";
+        case 2: return "[Nić] Rysa jest mniejsza. Kontynuuj oczyszczanie.";
+        case 1: return "[Nić] Nić drżała, lecz nie pękła. Rysy wciąż widoczne — bądź ostrożny.";
+    }
+    return "";
+}

--- a/Thread of Fate/Scripts/lib_nit_ev.nss
+++ b/Thread of Fate/Scripts/lib_nit_ev.nss
@@ -1,0 +1,28 @@
+#include "lib_nit"
+
+void main()
+{
+    object oPC    = NuiGetEventPlayer();
+    int    nToken = NuiGetEventWindow();
+    string sEvent = NuiGetEventType();
+    string sElem  = NuiGetEventElement();
+
+    if(nToken != NuiFindWindow(oPC, NIT_WINDOW)) return;
+
+    if(sEvent == EVENT_TYPE_CLOSE)
+        return;
+
+    if(sEvent != EVENT_TYPE_CLICK) return;
+
+    if(sElem == NIT_BTN_CLOSE)
+    {
+        NuiDestroy(oPC, nToken);
+        return;
+    }
+
+    if(sElem == NIT_BTN_CLEANSE)
+    {
+        NitTryCleanse(oPC, nToken);
+        return;
+    }
+}

--- a/Thread of Fate/Scripts/lib_nui.nss
+++ b/Thread of Fate/Scripts/lib_nui.nss
@@ -1,0 +1,108 @@
+#include "nw_inc_nui"
+#include "lib_nui_utility"
+
+const string LABEL_WINDOW = "LABEL_WINDOW";
+const string STATMENT = "STATMENT";
+const string GEOMETRY = "GEOMETRY";
+const string CLOSE = "CLOSE";
+const string ENABLED = "ENABLED";
+
+const string PROGRESS = "PROGRESS";
+const string COLORBAR = "COLORBAR";
+const string TOOLTIP = "TOOLTIP";
+
+const string TIMER_WINDOW = "TIMER_WINDOW";
+const string STARTING_MINUTES = "STARTING MINUTES";
+const string MINUTES = "MINUTES";
+const string SECONDS = "SECONDS";
+
+const string EVENT_TYPE_WATCH = "watch";
+const string EVENT_TYPE_OPEN = "open";
+const string EVENT_TYPE_CLOSE = "close";
+const string EVENT_TYPE_CLICK = "click";
+const string EVENT_TYPE_MOUSEUP = "mouseup";
+const string EVENT_TYPE_MOUSEDOWN = "mousedown";
+const string EVENT_TYPE_MOUSESCROLL = "mousescroll";
+const string EVENT_TYPE_RANGE = "range";
+const string EVENT_TYPE_FOCUS = "focus";
+const string EVENT_TYPE_BLUR = "blur";
+
+const string WINDOW_TITLE = "title";
+const string WINDOW_GEOMETRY = "geometry";
+const string WINDOW_RESIZABLE = "resizable";
+const string WINDOW_COLLAPSED = "collapsed";
+const string WINDOW_CLOSABLE = "closable";
+const string WINDOW_TRANSPARENT = "transparent";
+const string WINDOW_BORDER = "border";
+
+const int EVENT_BUTTON_LEFT = 0;
+const int EVENT_BUTTON_MIDDLE = 1;
+const int EVENT_BUTTON_RIGHT = 2;
+
+const string NUI_INFO_BUTTON_ID = "NUI_INFO_BUTTON_ID";
+const string NUI_INFO_IMAGE = "information64";
+const float NUI_INFO_IMAGE_WIDTH = 64.0;
+const float NUI_INFO_IMAGE_HEIGHT = 64.0;
+const string NUI_INFO_WINDOW = "NUI_INFO_WINDOW";
+const string NUI_INFO_NUI_EVENT_SCRIPT = "lib_nui_ev";
+const string NUI_INFO_MODAL_WINDOW = "NUI_INFO_MODAL_WINDOW";
+const string NUI_INFO_MODAL_OBJECT_UUID = "NUI_INFO_MODAL_OBJECT_UUID";
+const string NUI_INFO_MODAL_INT = "NUI_INFO_MODAL_INT";
+const string NUI_INFO_MODAL_OBJECTS = "NUI_INFO_MODAL_OBJECTS";
+const string NUI_GIF_WINDOW = "NUI_GIF_WINDOW";
+
+// GetNuiScaleDimension(oPC, fDimension, fScaleMax=1.5) — skaluje wymiary widgetow wg GUI scale gracza
+float GetNuiScaleDimension(object oPC, float fDemension, float fScaleMax = 1.5)
+{
+    int nScaleGui = GetPlayerDeviceProperty(oPC, PLAYER_DEVICE_PROPERTY_GUI_SCALE);
+    float fScaleGui = nScaleGui / 100.0;
+    fScaleGui = fScaleGui > fScaleMax ? fScaleMax : fScaleGui;
+    return (fDemension / fScaleGui);
+}
+
+// CreateEmptyRow(oPC, fHeight) — fixed-height spacer row (scale-aware)
+json CreateEmptyRow(object oPC, float fHeight, float fScaleMax = 1.5)
+{
+    json jRow = JsonArray();
+    if(fHeight <= 0.0)
+        jRow = JsonArrayInsert(jRow, NuiSpacer());
+    else
+        jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), GetNuiScaleDimension(oPC, fHeight)));
+    return NuiRow(jRow);
+}
+
+json GetNuiColorNwnGold()
+{
+    return NuiColor(185, 150, 100);
+}
+
+// NuiAddInfoRow() — zwraca wiersz z przyciskiem info (?) do dolaczenia do title row
+json NuiAddInfoRow()
+{
+    float fButtonWidth = NUI_INFO_IMAGE_WIDTH - 30.0;
+    float fButtonHeight = NUI_INFO_IMAGE_HEIGHT - 15.0;
+    json jRow = JsonArray();
+    json jButton = NuiId(NuiButton(JsonString("")), NUI_INFO_BUTTON_ID);
+    jButton = NuiWidth(jButton, fButtonWidth);
+    jButton = NuiHeight(jButton, fButtonHeight);
+    jButton = NuiTooltip(jButton, JsonString("Nacisnij by otrzymac wiecej informacji."));
+    jRow = JsonArrayInsert(jRow, NuiHeight(NuiSpacer(), fButtonWidth));
+    jRow = JsonArrayInsert(jRow, jButton);
+    jRow = JsonArrayInsert(jRow, NuiWidth(NuiSpacer(), 15.0));
+    return NuiRow(jRow);
+}
+
+// NuiAddInfoImage(fWindowWidth, jImageList, nImageWidthOffset) — dodaje ikone info do DrawList
+json NuiAddInfoImage(float fWindowWidth, json jImageList, float nImageWidthOffset)
+{
+    json jImageInfo = NuiDrawListImage(
+        JsonBool(TRUE), JsonString(NUI_INFO_IMAGE),
+        NuiRect(fWindowWidth - (NUI_INFO_IMAGE_WIDTH + nImageWidthOffset), 0.0, NUI_INFO_IMAGE_WIDTH, NUI_INFO_IMAGE_HEIGHT),
+        JsonInt(NUI_ASPECT_STRETCH), JsonInt(NUI_HALIGN_CENTER), JsonInt(NUI_VALIGN_MIDDLE),
+        NUI_DRAW_LIST_ITEM_ORDER_AFTER, NUI_DRAW_LIST_ITEM_RENDER_ALWAYS);
+    return JsonArrayInsert(jImageList, jImageInfo);
+}
+
+// CreateWindowInfo(oPC, sStatment) — otwiera okno info (500x400) z tekstem i przyciskiem Zamknij
+// Obslugiwane przez lib_nui_ev.nss (NUI_INFO_NUI_EVENT_SCRIPT)
+void CreateWindowInfo(object oPC, string sStatment);

--- a/Thread of Fate/Scripts/lib_nui_utility.nss
+++ b/Thread of Fate/Scripts/lib_nui_utility.nss
@@ -1,0 +1,98 @@
+// lib_nui_utility.nss
+
+const string NUI_DATA_ENCOURAGED = "NUI_DATA_ENCOURAGED";
+const string NUI_DATA_CELL       = "NUI_DATA_CELL";
+const string NUI_DATA_ROW        = "NUI_DATA_ROW";
+
+void NuiOffEncouragedData(object oPC, int nToken)
+{
+    int nRow = GetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken));
+    if(nRow < 0) return;
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(FALSE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+void NuiOnEncouragedData(object oPC, int nToken, int nRow)
+{
+    SetLocalInt(oPC, NUI_DATA_ROW + IntToString(nToken), nRow);
+    json jEnc = NuiGetBind(oPC, nToken, NUI_DATA_ENCOURAGED);
+    if(JsonGetType(jEnc) != JSON_TYPE_ARRAY) return;
+    jEnc = JsonArraySet(jEnc, nRow, JsonBool(TRUE));
+    NuiSetBind(oPC, nToken, NUI_DATA_ENCOURAGED, jEnc);
+}
+
+string GetIconResref(object oItem, json jItem, int nBaseItem)
+{
+    string sIcon = Get2DAString("baseitems", "DefaultIcon", nBaseItem);
+    return sIcon;
+}
+
+string GetItemPropertyDescription(itemproperty ip)
+{
+    int nType = GetItemPropertyType(ip);
+    return Get2DAString("itempropdef", "Name", nType);
+}
+
+struct ClassesPC
+{
+    string FirstClassName;
+    string SecondClassName;
+    string ThirdClassName;
+};
+
+struct ClassesPC GetClassesPC(object oPC)
+{
+    struct ClassesPC s;
+    int nClass1 = GetClassByPosition(1, oPC);
+    int nClass2 = GetClassByPosition(2, oPC);
+    int nClass3 = GetClassByPosition(3, oPC);
+    if(nClass1 != CLASS_TYPE_INVALID)
+        s.FirstClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass1)));
+    if(nClass2 != CLASS_TYPE_INVALID)
+        s.SecondClassName = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass2)));
+    if(nClass3 != CLASS_TYPE_INVALID)
+        s.ThirdClassName  = GetStringByStrRef(StringToInt(Get2DAString("classes", "Name", nClass3)));
+    return s;
+}
+
+string IntToPaddedString(int nX, int nLength = 4, int nSigned = FALSE)
+{
+    string s = IntToString(nX);
+    if(nSigned && nX >= 0) s = "+" + s;
+    while(GetStringLength(s) < nLength)
+        s = "0" + s;
+    return s;
+}
+
+void GetNextPreviousValueFromCombo(object oPC, int nToken, string sBindId, string sBindEntries, int nMax, int nPlus)
+{
+    int nCurrent = JsonGetInt(NuiGetBind(oPC, nToken, sBindId));
+    nCurrent += nPlus;
+    if(nCurrent < 0)    nCurrent = nMax - 1;
+    if(nCurrent >= nMax) nCurrent = 0;
+    NuiSetBind(oPC, nToken, sBindId, JsonInt(nCurrent));
+}
+
+string Util_Get2DAStringByStrRef(string s2DA, string sColumn, int nRow)
+{
+    return GetStringByStrRef(StringToInt(Get2DAString(s2DA, sColumn, nRow)));
+}
+
+string Util_GetItemName(object oItem, int bIdentified)
+{
+    if(bIdentified)
+        return GetName(oItem);
+    return GetStringByStrRef(StringToInt(Get2DAString("baseitems", "Name", GetBaseItemType(oItem))));
+}
+
+void Util_SendDebugMessage(string sMessage)
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        SendMessageToPC(oPC, sMessage);
+        oPC = GetNextPC();
+    }
+}

--- a/Thread of Fate/Scripts/sql_nit.nss
+++ b/Thread of Fate/Scripts/sql_nit.nss
@@ -1,0 +1,28 @@
+void NitCreateTables()
+{
+    sqlquery q = SqlPrepareQueryCampaign("nit",
+        "CREATE TABLE IF NOT EXISTS nit_chars ("
+        "  uuid        TEXT PRIMARY KEY,"
+        "  thread_val  INTEGER NOT NULL DEFAULT 100"
+        ")");
+    SqlStep(q);
+}
+
+void NitPersist(object oPC, int nVal)
+{
+    sqlquery q = SqlPrepareQueryCampaign("nit",
+        "INSERT OR REPLACE INTO nit_chars (uuid, thread_val)"
+        " VALUES (@uuid, @val)");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    SqlBindInt   (q, "@val",  nVal);
+    SqlStep(q);
+}
+
+int NitLoad(object oPC)
+{
+    sqlquery q = SqlPrepareQueryCampaign("nit",
+        "SELECT thread_val FROM nit_chars WHERE uuid = @uuid");
+    SqlBindString(q, "@uuid", GetObjectUUID(oPC));
+    if(SqlStep(q)) return SqlGetInt(q, 0);
+    return 100;
+}

--- a/Thread of Fate/Scripts/sys_module_hb.nss
+++ b/Thread of Fate/Scripts/sys_module_hb.nss
@@ -1,0 +1,11 @@
+#include "lib_nit"
+
+void main()
+{
+    object oPC = GetFirstPC();
+    while(GetIsObjectValid(oPC))
+    {
+        NitHeartbeatTick(oPC);
+        oPC = GetNextPC();
+    }
+}

--- a/Thread of Fate/Scripts/sys_on_enter.nss
+++ b/Thread of Fate/Scripts/sys_on_enter.nss
@@ -1,0 +1,8 @@
+#include "lib_nit"
+
+void main()
+{
+    object oPC = GetEnteringObject();
+    if(!GetIsPC(oPC)) return;
+    NitOnClientEnter(oPC);
+}

--- a/Thread of Fate/Scripts/sys_on_leave.nss
+++ b/Thread of Fate/Scripts/sys_on_leave.nss
@@ -1,0 +1,8 @@
+#include "lib_nit"
+
+void main()
+{
+    object oPC = GetExitingObject();
+    if(!GetIsPC(oPC)) return;
+    NitOnClientLeave(oPC);
+}

--- a/Thread of Fate/Scripts/sys_on_load.nss
+++ b/Thread of Fate/Scripts/sys_on_load.nss
@@ -1,0 +1,6 @@
+#include "sql_nit"
+
+void main()
+{
+    NitCreateTables();
+}

--- a/Thread of Fate/Scripts/test_nit.nss
+++ b/Thread of Fate/Scripts/test_nit.nss
@@ -1,0 +1,28 @@
+#include "lib_nit"
+
+// OnUsed on a placeable — applies a test drain then opens the window.
+// Place in the module for demonstration / QA purposes.
+// Remove or disable this placeable in production.
+void main()
+{
+    object oPC = GetLastUsedBy();
+    if(!GetIsPC(oPC)) return;
+
+    int nVal = NitGetValue(oPC);
+
+    // Cycle through states for testing: drain 20 each use, reset at 0
+    if(nVal <= 0)
+    {
+        SendMessageToPC(oPC, "[Nić TEST] Resetowanie do 100...");
+        NitSetValue(oPC, NIT_MAX, TRUE);
+        NitApplyTierEffects(oPC, NitGetTier(NIT_MAX));
+    }
+    else
+    {
+        int nDrain = 20;
+        SendMessageToPC(oPC, "[Nić TEST] Stosowanie drenażu " + IntToString(nDrain) + " punktów (było: " + IntToString(nVal) + ")...");
+        NitDrainThread(oPC, nDrain, "Test");
+    }
+
+    DelayCommand(0.3, NitOpenWindow(oPC));
+}


### PR DESCRIPTION
## Co to robi

System śledzący stan **życiowej siły duszy** każdej postaci — „Nić Przeznaczenia" (0–100 pkt). Długi pobyt na przeklętych obszarach lub użycie ciemnych przedmiotów stopniowo drenauje Nić. Gdy opada poniżej kolejnych progów, postać otrzymuje rosnące kary do rzutów obronnych, KP i Siły. Przy 0 postać staje się **Dotkniętą Śmiercią** — w stanie liminalnym między żywym a nieumarłym. Przywrócenie Nici następuje przez przedmioty oczyszczające (tag `nit_cleanse`) lub pobyt na świętym terenie.

## Mechanika

| Tier | Wartość | Nazwa              | Kary                                      |
|------|---------|--------------------|--------------------------------------------|
| 5    | 80–100  | Żywa Nić           | brak                                       |
| 4    | 60–79   | Strzępek           | -1 do rzutów obronnych                     |
| 3    | 40–59   | Rozdarta           | -2 rzuty, -1 KP                            |
| 2    | 20–39   | Postrzępiona       | -3 rzuty, -2 KP                            |
| 1    |  1–19   | Rozwijająca się    | -5 rzuty, -3 KP, -2 Siły                  |
| 0    |  0      | Dotknięta Śmiercią | -5 rzuty, -3 KP, -2 Siły + flaga specjalna|

Drenaż wywoływany przez:
- Zmienna obszaru `NIT_AREA_DRAIN = N` → drenaż N pkt co ~60 s podczas pobytu
- Zewnętrzne wywołanie `NitDrainThread(oPC, N, "źródło")` z innych skryptów

Przywracanie przez:
- Przedmiot o tagu `nit_cleanse` (konsumowany: +15 pkt)
- Przycisk „Oczyszczenie" w świętym obszarze (`NIT_AREA_RESTORE = N`, 3× tick)
- Pasywny przyrost 1 pkt co ~12 min w świętym obszarze (bez równoczesnego drenażu)

Okno NUI (400×350 px): pasek postępu w kolorze tieru, nazwa tieru, wartość liczbowa, tekst fabularny po polsku, aktywne kary, przycisk Oczyszczenie (aktywny gdy jest ku temu możliwość) i Zamknij.

## Pliki

```
Thread of Fate/
├── INTEGRATION.md
└── Scripts/
    ├── sql_nit.nss          — schemat SQLite (nit_chars) + CRUD
    ├── lib_nit_def.nss      — stałe, progi tierów, helpery kolorów/tekstów
    ├── lib_nit.nss          — rdzeń: efekty, drain/restore, NUI, lifecycle
    ├── lib_nit_ev.nss       — handler zdarzeń NUI
    ├── lib_nui.nss          — wspólne narzędzia NUI (kopia z Mailbox)
    ├── lib_nui_utility.nss  — wspólne narzędzia NUI (kopia z Mailbox)
    ├── sys_on_load.nss      — tworzy tabele SQL
    ├── sys_on_enter.nss     — ładuje stan z SQL, aplikuje efekty
    ├── sys_on_leave.nss     — persystuje stan, usuwa efekty
    ├── sys_module_hb.nss    — tick drenażu/przywrócenia co heartbeat
    └── test_nit.nss         — placeable demo: drain 20 pkt, otwiera okno
```

Łącznie ~681 linii oryginalnego NWScript (bez skopiowanych narzędzi NUI).

## Zależności

- **NWN: Enhanced Edition 1.84+** — wymaga NUI API, `EffectSavingThrowDecrease`, `TagEffect`, `GetEffectTag`, `HideEffectIcon`
- **NWNX**: nie wymagany
- **SQL**: kampania `nit` (SQLite, tworzona automatycznie przez `sys_on_load`)

## Jak włączyć w istniejącym module

| Zdarzenie modułu   | Skrypt           |
|--------------------|------------------|
| OnModuleLoad       | `sys_on_load`    |
| OnClientEnter      | `sys_on_enter`   |
| OnClientLeave      | `sys_on_leave`   |
| OnModuleHeartbeat  | `sys_module_hb`  |

W obszarach docelowych ustaw zmienne w toolsecie:
- `NIT_AREA_DRAIN = 2` (lochy, nekromantyczne ruiny)
- `NIT_AREA_RESTORE = 3` (świątynia, kaplica)

Szczegóły w `INTEGRATION.md`.

## Co celowo pominięto

- Automatyczny drenaż od pobliskich nieumarłych NPC (zbyt karające w typowych lochach; DM decyduje przez zmienną obszaru)
- Wizualne zmiany Appearance przy tier 0 (zależy od modułu Appearance; flaga `NIT_DEATH_TOUCHED` dostępna dla zewnętrznych skryptów)
- Trwała, nieodwracalna przemiana morphologiczna przy 0 (byłaby frustrująca w testach; w produkcji twórca modułu może rozszerzyć)
- Własne assety graficzne w haku (progres bar używa kolorów NUI, bez obrazków)

---
_Generated by [Claude Code](https://claude.ai/code/session_018LFHXKEepvZ62VwEU5gMn5)_